### PR TITLE
Add configurable sleep timer

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -86,18 +86,18 @@ class BackgroundImportThread(BaseThread):
         time_import('seedsigner.views.settings_views')
 
 
-class SleepTimerThread(BaseThread):
+class WipeTimerThread(BaseThread):
     def run(self):
         from seedsigner.hardware.buttons import HardwareButtons
         controller = Controller.get_instance()
         buttons = HardwareButtons.get_instance()
         while self.keep_running:
-            sleep_minutes = controller.settings.get_value(SettingsConstants.SETTING__SLEEP_TIMER)
-            if sleep_minutes and sleep_minutes != SettingsConstants.SLEEP_TIMER__DISABLED:
-                controller.sleep_timer_ms = sleep_minutes * 60 * 1000
+            wipe_minutes = controller.settings.get_value(SettingsConstants.SETTING__WIPE_TIMER)
+            if wipe_minutes and wipe_minutes != SettingsConstants.WIPE_TIMER__DISABLED:
+                controller.wipe_timer_ms = wipe_minutes * 60 * 1000
                 cur = int(time.time() * 1000)
-                if controller.sleep_timer_ms and cur - buttons.last_input_time > controller.sleep_timer_ms:
-                    controller.handle_sleep_timeout()
+                if controller.wipe_timer_ms and cur - buttons.last_input_time > controller.wipe_timer_ms:
+                    controller.handle_wipe_timeout()
                     buttons.update_last_input_time()
             time.sleep(1)
 
@@ -163,8 +163,8 @@ class Controller(Singleton):
     back_stack: BackStack = None
     screensaver: ScreensaverScreen = None
     toast_notification_thread: BaseToastOverlayManagerThread = None
-    sleep_timer_thread: BaseThread = None
-    sleep_timer_ms: int = None
+    wipe_timer_thread: BaseThread = None
+    wipe_timer_ms: int = None
     auto_wiped: bool = False
 
 
@@ -222,8 +222,8 @@ class Controller(Singleton):
         background_import_thread = BackgroundImportThread()
         background_import_thread.start()
 
-        controller.sleep_timer_thread = SleepTimerThread()
-        controller.sleep_timer_thread.start()
+        controller.wipe_timer_thread = WipeTimerThread()
+        controller.wipe_timer_thread.start()
 
         return cls._instance
 
@@ -413,8 +413,8 @@ class Controller(Singleton):
             if self.toast_notification_thread and self.toast_notification_thread.is_alive():
                 self.toast_notification_thread.stop()
 
-            if self.sleep_timer_thread and self.sleep_timer_thread.is_alive():
-                self.sleep_timer_thread.stop()
+            if self.wipe_timer_thread and self.wipe_timer_thread.is_alive():
+                self.wipe_timer_thread.stop()
 
             # Clear the screen when exiting
             logger.info("Clearing screen, exiting")
@@ -475,12 +475,12 @@ class Controller(Singleton):
         self.toast_notification_thread.start()
 
 
-    def handle_sleep_timeout(self):
+    def handle_wipe_timeout(self):
         from seedsigner.gui.toast import InfoToast
         from seedsigner.views import MainMenuView
         from seedsigner.hardware.buttons import HardwareButtons
 
-        logger.info("Controller: sleep timer triggered; wiping data")
+        logger.info("Controller: wipe timer triggered; wiping data")
 
         # Wipe sensitive in-memory data
         self.storage.seeds = []
@@ -495,6 +495,10 @@ class Controller(Singleton):
         self.unverified_address = None
         self.address_explorer_data = None
         self.sign_message_data = None
+        self.resume_main_flow = None
+        self.Satochip_PIN = None
+        self.Satochip_Last_UID_SHA1 = None
+        self.Satochip_Connector = None
 
         # Return to main menu
         self.clear_back_stack()
@@ -503,7 +507,7 @@ class Controller(Singleton):
         self.auto_wiped = True
 
         # Notify user
-        self.activate_toast(InfoToast(label_text=_("Seeds cleared after inactivity")))
+        self.activate_toast(InfoToast(label_text=_("Data wiped after inactivity")))
 
         # Ensure any running screens break out of wait loops
         HardwareButtons.get_instance().trigger_override()

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import traceback
+from gettext import gettext as _
 
 from embit.descriptor import Descriptor
 from embit.psbt import PSBT
@@ -85,6 +86,21 @@ class BackgroundImportThread(BaseThread):
         time_import('seedsigner.views.settings_views')
 
 
+class SleepTimerThread(BaseThread):
+    def run(self):
+        from seedsigner.hardware.buttons import HardwareButtons
+        controller = Controller.get_instance()
+        buttons = HardwareButtons.get_instance()
+        while self.keep_running:
+            sleep_minutes = controller.settings.get_value(SettingsConstants.SETTING__SLEEP_TIMER)
+            if sleep_minutes and sleep_minutes != SettingsConstants.SLEEP_TIMER__DISABLED:
+                controller.sleep_timer_ms = sleep_minutes * 60 * 1000
+                cur = int(time.time() * 1000)
+                if controller.sleep_timer_ms and cur - buttons.last_input_time > controller.sleep_timer_ms:
+                    controller.handle_sleep_timeout()
+                    buttons.update_last_input_time()
+            time.sleep(1)
+
 
 class Controller(Singleton):
     """
@@ -147,6 +163,9 @@ class Controller(Singleton):
     back_stack: BackStack = None
     screensaver: ScreensaverScreen = None
     toast_notification_thread: BaseToastOverlayManagerThread = None
+    sleep_timer_thread: BaseThread = None
+    sleep_timer_ms: int = None
+    auto_wiped: bool = False
 
 
     @classmethod
@@ -199,9 +218,12 @@ class Controller(Singleton):
 
         # Other behavior constants
         controller.screensaver_activation_ms = 2 * 60 * 1000  # two minutes
-    
+
         background_import_thread = BackgroundImportThread()
         background_import_thread.start()
+
+        controller.sleep_timer_thread = SleepTimerThread()
+        controller.sleep_timer_thread.start()
 
         return cls._instance
 
@@ -391,6 +413,9 @@ class Controller(Singleton):
             if self.toast_notification_thread and self.toast_notification_thread.is_alive():
                 self.toast_notification_thread.stop()
 
+            if self.sleep_timer_thread and self.sleep_timer_thread.is_alive():
+                self.sleep_timer_thread.stop()
+
             # Clear the screen when exiting
             logger.info("Clearing screen, exiting")
             Renderer.get_instance().display_blank_screen()
@@ -448,6 +473,40 @@ class Controller(Singleton):
         self.toast_notification_thread = toast_manager_thread
         logger.info(f"Controller: starting {self.toast_notification_thread.__class__.__name__}")
         self.toast_notification_thread.start()
+
+
+    def handle_sleep_timeout(self):
+        from seedsigner.gui.toast import InfoToast
+        from seedsigner.views import MainMenuView
+        from seedsigner.hardware.buttons import HardwareButtons
+
+        logger.info("Controller: sleep timer triggered; wiping data")
+
+        # Wipe sensitive in-memory data
+        self.storage.seeds = []
+        self.storage.clear_pending_seed()
+        if self._storage2:
+            self._storage2.clear_encryptedqr()
+
+        self.psbt = None
+        self.psbt_parser = None
+        self.psbt_seed = None
+        self.multisig_wallet_descriptor = None
+        self.unverified_address = None
+        self.address_explorer_data = None
+        self.sign_message_data = None
+
+        # Return to main menu
+        self.clear_back_stack()
+        self.back_stack.append(Destination(MainMenuView))
+
+        self.auto_wiped = True
+
+        # Notify user
+        self.activate_toast(InfoToast(label_text=_("Seeds cleared after inactivity")))
+
+        # Ensure any running screens break out of wait loops
+        HardwareButtons.get_instance().trigger_override()
 
 
     def handle_exception(self, e) -> Destination:

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -285,16 +285,16 @@ class SettingsConstants:
     PERSISTENT_SETTINGS__SD_INSERTED__HELP_TEXT = _mft("Store Settings on SD card")
     PERSISTENT_SETTINGS__SD_REMOVED__HELP_TEXT = _mft("Insert SD card to enable")
 
-    # Sleep timer constants (minutes)
-    SLEEP_TIMER__DISABLED = 0
-    SLEEP_TIMER__FIVE_MINUTES = 5
-    SLEEP_TIMER__TEN_MINUTES = 10
-    SLEEP_TIMER__FIFTEEN_MINUTES = 15
-    ALL_SLEEP_TIMERS = [
-        (SLEEP_TIMER__DISABLED, _mft("Disabled")),
-        (SLEEP_TIMER__FIVE_MINUTES, _mft("5 minutes")),
-        (SLEEP_TIMER__TEN_MINUTES, _mft("10 minutes")),
-        (SLEEP_TIMER__FIFTEEN_MINUTES, _mft("15 minutes")),
+    # Wipe timer constants (minutes)
+    WIPE_TIMER__DISABLED = 0
+    WIPE_TIMER__FIVE_MINUTES = 5
+    WIPE_TIMER__TEN_MINUTES = 10
+    WIPE_TIMER__FIFTEEN_MINUTES = 15
+    ALL_WIPE_TIMERS = [
+        (WIPE_TIMER__DISABLED, _mft("Disabled")),
+        (WIPE_TIMER__FIVE_MINUTES, _mft("5 minutes")),
+        (WIPE_TIMER__TEN_MINUTES, _mft("10 minutes")),
+        (WIPE_TIMER__FIFTEEN_MINUTES, _mft("15 minutes")),
     ]
 
     SINGLE_SIG = "ss"
@@ -345,7 +345,7 @@ class SettingsConstants:
     SETTING__BTC_DENOMINATION = "denomination"
     SETTING__SMARTCARD_INTERFACES = "smartcard_interfaces"
     SETTING__CACHE_SCARD_PIN = "cache_scard_pin"
-    SETTING__SLEEP_TIMER = "sleep_timer"
+    SETTING__WIPE_TIMER = "wipe_timer"
 
     SETTING__DISPLAY_CONFIGURATION = "display_config"
     SETTING__DISPLAY_COLOR_INVERTED = "color_inverted"
@@ -637,12 +637,12 @@ class SettingsDefinition:
                     default_value=SettingsConstants.OPTION__DISABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__SYSTEM,
-                    attr_name=SettingsConstants.SETTING__SLEEP_TIMER,
-                    abbreviated_name="sleep",
-                    display_name=_mft("Sleep timer"),
+                    attr_name=SettingsConstants.SETTING__WIPE_TIMER,
+                    abbreviated_name="wipe",
+                    display_name=_mft("Wipe timer"),
                     type=SettingsConstants.TYPE__SELECT_1,
-                    selection_options=SettingsConstants.ALL_SLEEP_TIMERS,
-                    default_value=SettingsConstants.SLEEP_TIMER__TEN_MINUTES),
+                    selection_options=SettingsConstants.ALL_WIPE_TIMERS,
+                    default_value=SettingsConstants.WIPE_TIMER__TEN_MINUTES),
 
         # Advanced options
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -285,6 +285,18 @@ class SettingsConstants:
     PERSISTENT_SETTINGS__SD_INSERTED__HELP_TEXT = _mft("Store Settings on SD card")
     PERSISTENT_SETTINGS__SD_REMOVED__HELP_TEXT = _mft("Insert SD card to enable")
 
+    # Sleep timer constants (minutes)
+    SLEEP_TIMER__DISABLED = 0
+    SLEEP_TIMER__FIVE_MINUTES = 5
+    SLEEP_TIMER__TEN_MINUTES = 10
+    SLEEP_TIMER__FIFTEEN_MINUTES = 15
+    ALL_SLEEP_TIMERS = [
+        (SLEEP_TIMER__DISABLED, _mft("Disabled")),
+        (SLEEP_TIMER__FIVE_MINUTES, _mft("5 minutes")),
+        (SLEEP_TIMER__TEN_MINUTES, _mft("10 minutes")),
+        (SLEEP_TIMER__FIFTEEN_MINUTES, _mft("15 minutes")),
+    ]
+
     SINGLE_SIG = "ss"
     MULTISIG = "ms"
     ALL_SIG_TYPES = [
@@ -333,6 +345,7 @@ class SettingsConstants:
     SETTING__BTC_DENOMINATION = "denomination"
     SETTING__SMARTCARD_INTERFACES = "smartcard_interfaces"
     SETTING__CACHE_SCARD_PIN = "cache_scard_pin"
+    SETTING__SLEEP_TIMER = "sleep_timer"
 
     SETTING__DISPLAY_CONFIGURATION = "display_config"
     SETTING__DISPLAY_COLOR_INVERTED = "color_inverted"
@@ -622,6 +635,14 @@ class SettingsDefinition:
                     type=SettingsConstants.TYPE__SELECT_1,
                     selection_options=SettingsConstants.OPTIONS__ENABLED_DISABLED,
                     default_value=SettingsConstants.OPTION__DISABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__SYSTEM,
+                    attr_name=SettingsConstants.SETTING__SLEEP_TIMER,
+                    abbreviated_name="sleep",
+                    display_name=_mft("Sleep timer"),
+                    type=SettingsConstants.TYPE__SELECT_1,
+                    selection_options=SettingsConstants.ALL_SLEEP_TIMERS,
+                    default_value=SettingsConstants.SLEEP_TIMER__TEN_MINUTES),
 
         # Advanced options
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -290,11 +290,13 @@ class SettingsConstants:
     WIPE_TIMER__FIVE_MINUTES = 5
     WIPE_TIMER__TEN_MINUTES = 10
     WIPE_TIMER__FIFTEEN_MINUTES = 15
+    WIPE_TIMER__THIRTY_MINUTES = 30
     ALL_WIPE_TIMERS = [
         (WIPE_TIMER__DISABLED, _mft("Disabled")),
         (WIPE_TIMER__FIVE_MINUTES, _mft("5 minutes")),
         (WIPE_TIMER__TEN_MINUTES, _mft("10 minutes")),
         (WIPE_TIMER__FIFTEEN_MINUTES, _mft("15 minutes")),
+        (WIPE_TIMER__THIRTY_MINUTES, _mft("30 minutes")),
     ]
 
     SINGLE_SIG = "ss"
@@ -642,7 +644,7 @@ class SettingsDefinition:
                     display_name=_mft("Wipe timer"),
                     type=SettingsConstants.TYPE__SELECT_1,
                     selection_options=SettingsConstants.ALL_WIPE_TIMERS,
-                    default_value=SettingsConstants.WIPE_TIMER__TEN_MINUTES),
+                    default_value=SettingsConstants.WIPE_TIMER__DISABLED),
 
         # Advanced options
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -4,8 +4,6 @@ from typing import Type
 
 from seedsigner.helpers.l10n import mark_for_translation as _mft
 from seedsigner.gui.components import SeedSignerIconConstants
-from seedsigner.gui.toast import InfoToast
-from seedsigner.controller import Controller
 from seedsigner.gui.screens import RET_CODE__POWER_BUTTON, RET_CODE__BACK_BUTTON
 from seedsigner.gui.screens.screen import BaseScreen, ButtonOption, LargeButtonScreen, WarningScreen, ErrorScreen
 from seedsigner.models.settings import Settings, SettingsConstants
@@ -193,6 +191,9 @@ class MainMenuView(View):
 
     def run(self):
         from seedsigner.gui.screens.screen import MainMenuScreen
+        from seedsigner.controller import Controller
+        from seedsigner.gui.toast import InfoToast
+
         controller = Controller.get_instance()
         if controller.auto_wiped:
             controller.auto_wiped = False

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -197,7 +197,7 @@ class MainMenuView(View):
         controller = Controller.get_instance()
         if controller.auto_wiped:
             controller.auto_wiped = False
-            controller.activate_toast(InfoToast(label_text=_("Seeds cleared after inactivity")))
+            controller.activate_toast(InfoToast(label_text=_("Data wiped after inactivity")))
         button_data = [self.SCAN, self.SEEDS, self.TOOLS, self.SETTINGS]
         selected_menu_num = self.run_screen(
             MainMenuScreen,

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -4,6 +4,8 @@ from typing import Type
 
 from seedsigner.helpers.l10n import mark_for_translation as _mft
 from seedsigner.gui.components import SeedSignerIconConstants
+from seedsigner.gui.toast import InfoToast
+from seedsigner.controller import Controller
 from seedsigner.gui.screens import RET_CODE__POWER_BUTTON, RET_CODE__BACK_BUTTON
 from seedsigner.gui.screens.screen import BaseScreen, ButtonOption, LargeButtonScreen, WarningScreen, ErrorScreen
 from seedsigner.models.settings import Settings, SettingsConstants
@@ -191,6 +193,10 @@ class MainMenuView(View):
 
     def run(self):
         from seedsigner.gui.screens.screen import MainMenuScreen
+        controller = Controller.get_instance()
+        if controller.auto_wiped:
+            controller.auto_wiped = False
+            controller.activate_toast(InfoToast(label_text=_("Seeds cleared after inactivity")))
         button_data = [self.SCAN, self.SEEDS, self.TOOLS, self.SETTINGS]
         selected_menu_num = self.run_screen(
             MainMenuScreen,


### PR DESCRIPTION
## Summary
- introduce sleep timer setting with 5/10/15 minute options
- run background thread to wipe seeds after the configured idle time
- notify user when seeds are cleared

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688246724ad88322ad6012774dcf48cd