### PR TITLE
Add Android build support with Kivy adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Support and discussion relating to this fork can happen via this [Telegram Group
 * [SeedQR Printable Templates](#seedqr-printable-templates)
 * [Build from Source](#build-from-source)
 * [Developer Local Build Instructions](#developer-local-build-instructions)
+* [Android Build Instructions](docs/android_build.md)
 
 ---------------
 
@@ -433,3 +434,5 @@ See the [SeedSigner OS repo](https://github.com/SeedSigner/seedsigner-os/) for i
 
 # Developer Local Build Instructions
 Raspberry Pi OS is commonly used for development. See the [Raspberry Pi OS Build Instructions](docs/raspberry_pi_os_build_instructions.md)
+
+For running SeedSigner on Android see the [Android Build Instructions](docs/android_build.md).

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -1,0 +1,34 @@
+[app]
+# (str) Title of your application
+title = SeedSigner
+
+# (str) Package name
+package.name = seedsigner
+
+# (str) Package domain (needed for android/ios packaging)
+package.domain = org.seedsigner
+
+# (str) Source code where the main.py live
+source.dir = .
+
+# (str) Application entry point
+entrypoint = src/main.py
+
+# (list) Application requirements
+requirements = python3,kivy,opencv-python,Pillow
+
+# (str) Supported orientation (portrait, landscape or all)
+orientation = portrait
+
+# (str) Android API to use
+android.api = 33
+
+# (str) Minimum API your APK will support
+android.minapi = 21
+
+# (str) Android NDK version to use
+android.ndk = 25b
+
+[buildozer]
+log_level = 2
+warn_on_root = 1

--- a/docs/android_build.md
+++ b/docs/android_build.md
@@ -1,0 +1,38 @@
+# Android Build
+
+This repository includes an experimental Android build that wraps the SeedSigner
+core using Kivy. The phone's display, camera and touchscreen act as replacements
+for the original hardware.
+
+## Prerequisites
+
+* Python 3.10 or newer
+* [Buildozer](https://github.com/kivy/buildozer) (`pip install buildozer`)
+* Android SDK/NDK (automatically downloaded the first time buildozer runs)
+
+On Debian based distributions you can install the base packages and buildozer
+with:
+
+```bash
+sudo apt update
+sudo apt install python3 python3-pip git openjdk-8-jdk
+pip install buildozer
+```
+
+## Building
+
+From the project root run:
+
+```bash
+buildozer android debug
+```
+
+The resulting APK will be placed in the `bin/` directory. Install it on your
+device with:
+
+```bash
+adb install bin/SeedSigner-0.0.1-debug.apk
+```
+
+Launching the app will show the SeedSigner display on screen and allow using the
+phone camera and touchscreen as input.

--- a/src/main.py
+++ b/src/main.py
@@ -28,6 +28,11 @@ def main(sys_argv=None):
             "being written to stderr"
         ),
     )
+    parser.add_argument(
+        "--android",
+        action="store_true",
+        help="Use Android hardware adapters (Kivy display, camera and buttons)"
+    )
 
     args = parser.parse_args(sys_argv)
 
@@ -38,6 +43,19 @@ def main(sys_argv=None):
         logging.Formatter("%(asctime)s %(levelname)8s [%(name)s %(funcName)s (%(lineno)d)]: %(message)s")
     )
     root_logger.addHandler(console_handler)
+
+    if args.android:
+        logger.info("Enabling Android hardware adapters")
+        from seedsigner.hardware import displays
+        from seedsigner.hardware import camera as camera_module
+        from seedsigner.hardware import buttons as buttons_module
+        from seedsigner.hardware.android_display import AndroidDisplay
+        from seedsigner.hardware.android_camera import AndroidCamera
+        from seedsigner.hardware.android_buttons import HardwareButtons
+
+        displays.DisplayDriver = AndroidDisplay
+        camera_module.Camera = AndroidCamera
+        buttons_module.HardwareButtons = HardwareButtons
 
     # Set log levels for specific modules
     for module, level in DEFAULT_MODULE_LOG_LEVELS.items():

--- a/src/seedsigner/hardware/android_buttons.py
+++ b/src/seedsigner/hardware/android_buttons.py
@@ -1,0 +1,84 @@
+import time
+from collections import deque
+
+
+class HardwareButtonsConstants:
+    KEY_UP = 1
+    KEY_DOWN = 2
+    KEY_LEFT = 3
+    KEY_RIGHT = 4
+    KEY_PRESS = 5
+    KEY1 = 6
+    KEY2 = 7
+    KEY3 = 8
+    OVERRIDE = 1000
+
+    ALL_KEYS = [KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT, KEY_PRESS, KEY1, KEY2, KEY3]
+    KEYS__LEFT_RIGHT_UP_DOWN = [KEY_LEFT, KEY_RIGHT, KEY_UP, KEY_DOWN]
+    KEYS__ANYCLICK = [KEY_PRESS, KEY1, KEY2, KEY3]
+
+
+class HardwareButtons:
+    """Touchscreen-based button interface for Android."""
+
+    def __init__(self, width: int = 320, height: int = 240):
+        from kivy.core.window import Window
+        self.width = width
+        self.height = height
+        self._queue = deque()
+        self.override_ind = False
+        Window.bind(on_touch_down=self._on_touch_down)
+
+    def _on_touch_down(self, window, touch):
+        x, y = touch.pos
+        w, h = self.width, self.height
+        key = None
+        if y > h * 0.75:
+            if x < w * 0.33:
+                key = HardwareButtonsConstants.KEY1
+            elif x > w * 0.66:
+                key = HardwareButtonsConstants.KEY3
+            else:
+                key = HardwareButtonsConstants.KEY2
+        elif y < h * 0.25:
+            key = HardwareButtonsConstants.KEY_UP
+        elif x < w * 0.25:
+            key = HardwareButtonsConstants.KEY_LEFT
+        elif x > w * 0.75:
+            key = HardwareButtonsConstants.KEY_RIGHT
+        else:
+            key = HardwareButtonsConstants.KEY_PRESS
+        self._queue.append(key)
+
+    def wait_for(self, keys=None) -> int:
+        if keys is None:
+            keys = HardwareButtonsConstants.ALL_KEYS
+        while True:
+            if self.override_ind:
+                self.override_ind = False
+                return HardwareButtonsConstants.OVERRIDE
+            if self._queue:
+                key = self._queue.popleft()
+                if key in keys:
+                    return key
+            time.sleep(0.01)
+
+    def update_last_input_time(self):
+        pass
+
+    def trigger_override(self) -> bool:
+        self.override_ind = True
+        return True
+
+    def check_for_low(self, key=None, keys=None) -> bool:
+        if key:
+            keys = [key]
+        elif keys is None:
+            keys = HardwareButtonsConstants.ALL_KEYS
+        for k in list(self._queue):
+            if k in keys:
+                return True
+        return False
+
+    def has_any_input(self) -> bool:
+        return len(self._queue) > 0

--- a/src/seedsigner/hardware/android_camera.py
+++ b/src/seedsigner/hardware/android_camera.py
@@ -1,0 +1,52 @@
+import io
+from threading import Thread
+from PIL import Image
+
+
+class AndroidCamera:
+    """Camera implementation using OpenCV for Android."""
+
+    def __init__(self):
+        self._cap = None
+        self._camera_rotation = 0
+
+    # Public API mirrors seedsigner.hardware.camera.Camera
+    def start_video_stream_mode(self, resolution=(512, 384), framerate=12, format="bgr"):
+        import cv2
+        self._cap = cv2.VideoCapture(0)
+        self._cap.set(cv2.CAP_PROP_FRAME_WIDTH, resolution[0])
+        self._cap.set(cv2.CAP_PROP_FRAME_HEIGHT, resolution[1])
+        self._cap.set(cv2.CAP_PROP_FPS, framerate)
+
+    def read_video_stream(self, as_image=False):
+        import cv2
+        if self._cap is None:
+            raise Exception("Must call start_video_stream first.")
+        ret, frame = self._cap.read()
+        if not ret:
+            return None
+        if as_image:
+            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            return Image.fromarray(frame).rotate(90 + self._camera_rotation)
+        return frame
+
+    def stop_video_stream_mode(self):
+        if self._cap is not None:
+            self._cap.release()
+            self._cap = None
+
+    def start_single_frame_mode(self, resolution=(720, 480)):
+        self.start_video_stream_mode(resolution)
+
+    def capture_frame(self):
+        if self._cap is None:
+            raise Exception("Must call start_single_frame_mode first.")
+        ret, frame = self._cap.read()
+        if not ret:
+            return None
+        from cv2 import cvtColor, COLOR_BGR2RGB
+        frame = cvtColor(frame, COLOR_BGR2RGB)
+        return Image.fromarray(frame).rotate(90 + self._camera_rotation)
+
+    def stop_single_frame_mode(self):
+        self.stop_video_stream_mode()

--- a/src/seedsigner/hardware/android_display.py
+++ b/src/seedsigner/hardware/android_display.py
@@ -1,0 +1,64 @@
+import threading
+from PIL import Image
+
+
+class AndroidDisplay:
+    """Kivy based display driver for running SeedSigner on Android."""
+
+    def __init__(self, display_type: str = "android", width: int = 320, height: int = 240):
+        self.display_type = display_type
+        self._width = width
+        self._height = height
+        self._app = None
+        self._image_widget = None
+        self._start_app()
+
+    # Properties expected by Renderer
+    @property
+    def width(self):
+        return self._width
+
+    @property
+    def height(self):
+        return self._height
+
+    def invert(self, enabled: bool = True):
+        # Not implemented; colors are rendered directly
+        pass
+
+    def _start_app(self):
+        """Start a minimal Kivy app showing an Image widget."""
+        from kivy.app import App
+        from kivy.uix.image import Image as KivyImage
+        from kivy.uix.floatlayout import FloatLayout
+        from kivy.core.window import Window
+
+        display = self
+
+        class DisplayApp(App):
+            def build(self_inner):
+                Window.size = (display._width, display._height)
+                layout = FloatLayout()
+                display._image_widget = KivyImage()
+                layout.add_widget(display._image_widget)
+                return layout
+
+        self._app = DisplayApp()
+        threading.Thread(target=self._app.run, daemon=True).start()
+
+    def show_image(self, image: Image.Image, x_start: int = 0, y_start: int = 0):
+        """Render a PIL Image to the screen."""
+        from kivy.clock import Clock
+        from kivy.graphics.texture import Texture
+
+        if self._image_widget is None:
+            return
+
+        img = image.resize((self._width, self._height)).convert("RGBA")
+        tex = Texture.create(size=img.size)
+        tex.blit_buffer(img.tobytes(), colorfmt="rgba", bufferfmt="ubyte")
+
+        def update(dt):
+            self._image_widget.texture = tex
+
+        Clock.schedule_once(update, 0)


### PR DESCRIPTION
## Summary
- add simple `android_display`, `android_camera`, and `android_buttons` modules
- patch `main.py` with `--android` flag and use adapters when enabled
- add Buildozer configuration and instructions for APK build
- document Android build process in README and new doc

## Testing
- `pip install -r requirements.txt`
- `pip install -r tests/requirements.txt` *(fails: Could not connect to pypi.org)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'seedsigner')*

------
https://chatgpt.com/codex/tasks/task_e_6882ed0bcfb88322ae371e1b1865570b