### PR TITLE
Add Satochip xpub/export options

### DIFF
--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -652,7 +652,7 @@ class PSBTSatochipSignView(View):
                         continue
 
                     path = "m" + "".join(
-                        f"/{d & 0x7FFFFFFF}{'\'' if d & 0x80000000 else ''}"
+                        f"/{d & 0x7FFFFFFF}{"'" if d & 0x80000000 else ''}"
                         for d in der.derivation
                     )
                     (_, bytepath) = connector.parser.bip32path2bytes(path)

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -1,4 +1,5 @@
 from gettext import gettext as _
+import logging
 
 from seedsigner.models.psbt_parser import PSBTParser
 from seedsigner.models.settings import SettingsConstants
@@ -11,6 +12,8 @@ from seedsigner.gui.screens.screen import (
     DireWarningScreen,
     QRDisplayScreen,
 )
+
+logger = logging.getLogger(__name__)
 from seedsigner.views.view import BackStackView, MainMenuView, NotYetImplementedView, View, Destination
 
 
@@ -649,7 +652,7 @@ class PSBTSatochipSignView(View):
                         continue
 
                     path = "m" + "".join(
-                        f"/{d & 0x7FFFFFFF}{'h' if d & 0x80000000 else ''}"
+                        f"/{d & 0x7FFFFFFF}{"'" if d & 0x80000000 else ''}"
                         for d in der.derivation
                     )
                     (_, bytepath) = connector.parser.bip32path2bytes(path)
@@ -674,6 +677,7 @@ class PSBTSatochipSignView(View):
 
         except Exception as e:
             self.loading_screen.stop()
+            logger.exception("Satochip signing failed")
             self.run_screen(
                 WarningScreen,
                 title="Failed",

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -652,7 +652,7 @@ class PSBTSatochipSignView(View):
                         continue
 
                     path = "m" + "".join(
-                        f"/{d & 0x7FFFFFFF}{"'" if d & 0x80000000 else ''}"
+                        f"/{d & 0x7FFFFFFF}{'\'' if d & 0x80000000 else ''}"
                         for d in der.derivation
                     )
                     (_, bytepath) = connector.parser.bip32path2bytes(path)

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -3,7 +3,14 @@ from gettext import gettext as _
 from seedsigner.models.psbt_parser import PSBTParser
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
-from seedsigner.gui.screens.screen import (RET_CODE__BACK_BUTTON, ButtonListScreen, ButtonOption, WarningScreen, DireWarningScreen, QRDisplayScreen)
+from seedsigner.gui.screens.screen import (
+    RET_CODE__BACK_BUTTON,
+    ButtonListScreen,
+    ButtonOption,
+    WarningScreen,
+    DireWarningScreen,
+    QRDisplayScreen,
+)
 from seedsigner.views.view import BackStackView, MainMenuView, NotYetImplementedView, View, Destination
 
 
@@ -13,6 +20,7 @@ class PSBTSelectSeedView(View):
     TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD)
     TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD)
     TYPE_ELECTRUM = ButtonOption("Enter Electrum seed", FontAwesomeIconConstants.KEYBOARD)
+    SATOCHIP = ButtonOption("Use Satochip Card", SeedSignerIconConstants.FINGERPRINT)
 
 
     def run(self):
@@ -45,6 +53,7 @@ class PSBTSelectSeedView(View):
         button_data.append(self.TYPE_24WORD)
         if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_ELECTRUM)
+        button_data.append(self.SATOCHIP)
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,
@@ -79,6 +88,9 @@ class PSBTSelectSeedView(View):
         elif button_data[selected_menu_num] == self.TYPE_ELECTRUM:
             from seedsigner.views.seed_views import SeedElectrumMnemonicStartView
             return Destination(SeedElectrumMnemonicStartView)
+
+        elif button_data[selected_menu_num] == self.SATOCHIP:
+            return Destination(PSBTSatochipSignView)
 
 
 
@@ -596,3 +608,94 @@ class PSBTSigningErrorView(View):
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
+
+
+class PSBTSatochipSignView(View):
+    def run(self):
+        from embit.psbt import SIGHASH
+        from embit import hashes
+        from seedsigner.helpers import seedkeeper_utils
+        from seedsigner.gui.screens.screen import LoadingScreenThread, LargeIconStatusScreen
+
+        connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
+        if not connector:
+            return Destination(BackStackView)
+
+        psbt = self.controller.psbt
+        if psbt is None:
+            return Destination(MainMenuView)
+
+        self.loading_screen = LoadingScreenThread(text="Signing\n\n\n\n\n")
+        self.loading_screen.start()
+
+        try:
+            pubkey, _ = connector.card_bip32_get_extendedkey(b"")
+            fingerprint = hashes.hash160(pubkey.get_public_key_bytes(compressed=True))[:4]
+
+            sig_before = PSBTParser.sig_count(psbt)
+
+            for idx, inp in enumerate(psbt.inputs):
+                req_sighash = inp.sighash_type
+                if req_sighash is None:
+                    req_sighash = SIGHASH.DEFAULT if inp.is_taproot else SIGHASH.ALL
+                if not inp.is_taproot and req_sighash == SIGHASH.DEFAULT:
+                    req_sighash = SIGHASH.ALL
+
+                h = psbt.sighash(idx, sighash=req_sighash)
+
+                derivs = inp.taproot_bip32_derivations if inp.is_taproot else inp.bip32_derivations
+                for pub, der in derivs.items():
+                    if der.fingerprint != fingerprint:
+                        continue
+
+                    path = "m" + "".join(
+                        f"/{d & 0x7FFFFFFF}{'h' if d & 0x80000000 else ''}"
+                        for d in der.derivation
+                    )
+                    (_, bytepath) = connector.parser.bip32path2bytes(path)
+                    connector.card_bip32_get_extendedkey(bytepath)
+
+                    if inp.is_taproot:
+                        sig_bytes, sw1, sw2 = connector.card_sign_schnorr_hash(0xFF, list(h), None)
+                        if sw1 != 0x90 or sw2 != 0x00:
+                            continue
+                        sig = bytes(sig_bytes)
+                        if req_sighash != SIGHASH.DEFAULT:
+                            sig += bytes([req_sighash])
+                        inp.taproot_sigs[(pub, b"")] = sig
+                    else:
+                        sig_bytes, sw1, sw2 = connector.card_sign_transaction_hash(0xFF, list(h), None)
+                        if sw1 != 0x90 or sw2 != 0x00:
+                            continue
+                        sig = bytes(sig_bytes) + bytes([req_sighash])
+                        inp.partial_sigs[pub] = sig
+
+            sig_after = PSBTParser.sig_count(psbt)
+
+        except Exception as e:
+            self.loading_screen.stop()
+            self.run_screen(
+                WarningScreen,
+                title="Failed",
+                status_headline=None,
+                text=str(e),
+                show_back_button=True,
+            )
+            return Destination(BackStackView)
+
+        self.loading_screen.stop()
+
+        if sig_before == sig_after:
+            return Destination(PSBTSigningErrorView)
+
+        self.controller.psbt = PSBTParser.trim(psbt)
+
+        self.run_screen(
+            LargeIconStatusScreen,
+            title="Success",
+            status_headline=None,
+            text="PSBT Signed",
+            show_back_button=False,
+        )
+
+        return Destination(PSBTSignedQRDisplayView)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2230,7 +2230,7 @@ class ToolsSatochipEnable2FAView(View):
             )
         except Exception as e:
             self.loading_screen.stop()
-            logger.info("Enable 2fa failed:", str(e))
+            logger.exception("Enable 2FA failed")
             self.run_screen(
                 WarningScreen,
                 title="Failed",
@@ -2261,7 +2261,7 @@ class ToolsSatochipExportXpubView(View):
 
         network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
         is_mainnet = network == SettingsConstants.MAINNET
-        derivation = "m/84h/0h/0h" if is_mainnet else "m/84h/1h/0h"
+        derivation = "m/84'/0'/0'" if is_mainnet else "m/84'/1'/0'"
 
         self.loading_screen = LoadingScreenThread(text="Fetching Xpub\n\n\n\n\n\n")
         self.loading_screen.start()
@@ -2273,6 +2273,7 @@ class ToolsSatochipExportXpubView(View):
             )
         except Exception as e:
             self.loading_screen.stop()
+            logger.exception("Satochip export xpub failed")
             self.run_screen(
                 WarningScreen,
                 title="Failed",
@@ -2331,7 +2332,7 @@ class ToolsSatochipDescriptorScriptTypeView(View):
 
         hdkey = HDKey.from_string(self.xpub)
         fingerprint = hdkey.fingerprint.hex()
-        origin_path = self.derivation.replace("m/", "").replace("h", "'")
+        origin_path = self.derivation.replace("m/", "")
         origin = f"[{fingerprint}/{origin_path}]"
 
         if script_type == SettingsConstants.LEGACY_P2PKH:
@@ -2353,6 +2354,7 @@ class ToolsSatochipDescriptorScriptTypeView(View):
                 show_back_button=False,
             )
         except Exception as e:
+            logger.exception("Failed to load descriptor from Satochip xpub")
             self.run_screen(
                 WarningScreen,
                 title="Error",

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -12,28 +12,56 @@ from PIL.ImageOps import autocontrast
 from gettext import gettext as _
 
 from seedsigner.gui.components import FontAwesomeIconConstants, GUIConstants, SeedSignerIconConstants, resize_image_to_fill
-from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen, DireWarningScreen, LargeIconStatusScreen, WarningScreen)
+from seedsigner.gui.screens import (
+    RET_CODE__BACK_BUTTON,
+    ButtonListScreen,
+    DireWarningScreen,
+    LargeIconStatusScreen,
+    WarningScreen,
+)
 from seedsigner.gui.screens.scan_screens import ScanScreen
-from seedsigner.gui.screens.tools_screens import (ToolsCalcFinalWordDoneScreen, ToolsCalcFinalWordFinalizePromptScreen,
-    ToolsCalcFinalWordScreen, ToolsCoinFlipEntryScreen, ToolsDiceEntropyEntryScreen, ToolsImageEntropyFinalImageScreen,
-    ToolsImageEntropyLivePreviewScreen, ToolsAddressExplorerAddressTypeScreen, ToolsTextQRTextEntryScreen, ToolsTextQRReviewTextScreen,
-    ToolsTextQRTranscribeModePromptScreen, ToolsTranscribeTextQRWholeQRScreen, ToolsTranscribeTextQRZoomedInScreen,
-    ToolsTranscribeTextQRConfirmQRPromptScreen)
-from seedsigner.helpers import embit_utils, mnemonic_generation
+from seedsigner.gui.screens.tools_screens import (
+    ToolsCalcFinalWordDoneScreen,
+    ToolsCalcFinalWordFinalizePromptScreen,
+    ToolsCalcFinalWordScreen,
+    ToolsCoinFlipEntryScreen,
+    ToolsDiceEntropyEntryScreen,
+    ToolsImageEntropyFinalImageScreen,
+    ToolsImageEntropyLivePreviewScreen,
+    ToolsAddressExplorerAddressTypeScreen,
+    ToolsTextQRTextEntryScreen,
+    ToolsTextQRReviewTextScreen,
+    ToolsTextQRTranscribeModePromptScreen,
+    ToolsTranscribeTextQRWholeQRScreen,
+    ToolsTranscribeTextQRZoomedInScreen,
+    ToolsTranscribeTextQRConfirmQRPromptScreen,
+)
+from seedsigner.helpers import embit_utils, mnemonic_generation, seedkeeper_utils
 from seedsigner.models.decode_qr import DecodeQR
 from seedsigner.models.encode_qr import GenericStaticQrEncoder
-from seedsigner.gui.screens import RET_CODE__BACK_BUTTON, ButtonListScreen
 from seedsigner.gui.screens.screen import ButtonOption
-from seedsigner.helpers import mnemonic_generation
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings_definition import SettingsConstants
-from seedsigner.views.seed_views import SeedDiscardView, SeedFinalizeView, SeedMnemonicEntryView, SeedOptionsView, SeedWordsWarningView, SeedExportXpubScriptTypeView, LoadSeedView
+from seedsigner.views.seed_views import (
+    SeedDiscardView,
+    SeedFinalizeView,
+    SeedMnemonicEntryView,
+    SeedOptionsView,
+    SeedWordsWarningView,
+    SeedExportXpubScriptTypeView,
+    LoadSeedView,
+)
 
 from .view import View, Destination, BackStackView, MainMenuView
 
-from seedsigner.helpers import seedkeeper_utils
-from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
-    WarningScreen, DireWarningScreen, seed_screens, LargeIconStatusScreen)
+from seedsigner.gui.screens import (
+    RET_CODE__BACK_BUTTON,
+    ButtonListScreen,
+    WarningScreen,
+    DireWarningScreen,
+    seed_screens,
+    LargeIconStatusScreen,
+)
 logger = logging.getLogger(__name__)
 
 from pysatochip.JCconstants import SEEDKEEPER_DIC_TYPE, SEEDKEEPER_DIC_ORIGIN, SEEDKEEPER_DIC_EXPORT_RIGHTS, BIP39_WORDLIST_DIC
@@ -2052,9 +2080,10 @@ class ToolsSeedkeeperSaveDescriptorView(View):
 class ToolsSatochipView(View):
     IMPORT_SEED = ButtonOption("Initialise with Seed")
     ENABLE_2FA = ButtonOption("Enable 2FA")
+    EXPORT_XPUB = ButtonOption("Export Xpub")
 
     def run(self):
-        button_data = [self.IMPORT_SEED, self.ENABLE_2FA]
+        button_data = [self.IMPORT_SEED, self.ENABLE_2FA, self.EXPORT_XPUB]
         selected_menu_num = self.run_screen(
             ButtonListScreen,
             title="Satochip",
@@ -2070,6 +2099,9 @@ class ToolsSatochipView(View):
 
         elif button_data[selected_menu_num] == self.ENABLE_2FA:
             return Destination(ToolsSatochipEnable2FAView)
+
+        elif button_data[selected_menu_num] == self.EXPORT_XPUB:
+            return Destination(ToolsSatochipExportXpubView)
         
 class ToolsSatochipImportSeedView(View):
     SCAN_SEED = ButtonOption("Scan a seed", SeedSignerIconConstants.QRCODE)
@@ -2206,6 +2238,129 @@ class ToolsSatochipEnable2FAView(View):
                 text=f"Enable 2FA Failed",
                 show_back_button=False,
             )
+
+        return Destination(MainMenuView)
+
+class ToolsSatochipExportXpubView(View):
+    def run(self):
+        from seedsigner.gui.screens.screen import (
+            LoadingScreenThread,
+            QRDisplayScreen,
+            WarningScreen,
+            ButtonListScreen,
+            ButtonOption,
+            LargeIconStatusScreen,
+        )
+        from seedsigner.models.encode_qr import GenericStaticQrEncoder
+        from seedsigner.models.settings import SettingsConstants
+
+        Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
+
+        if not Satochip_Connector:
+            return Destination(BackStackView)
+
+        network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+        is_mainnet = network == SettingsConstants.MAINNET
+        derivation = "m/84h/0h/0h" if is_mainnet else "m/84h/1h/0h"
+
+        self.loading_screen = LoadingScreenThread(text="Fetching Xpub\n\n\n\n\n\n")
+        self.loading_screen.start()
+        try:
+            xpub = Satochip_Connector.card_bip32_get_xpub(
+                path=derivation,
+                xtype="p2wpkh",
+                is_mainnet=is_mainnet,
+            )
+        except Exception as e:
+            self.loading_screen.stop()
+            self.run_screen(
+                WarningScreen,
+                title="Failed",
+                status_headline=None,
+                text=str(e),
+                show_back_button=True,
+            )
+            return Destination(BackStackView)
+
+        self.loading_screen.stop()
+
+        qr_encoder = GenericStaticQrEncoder(data=xpub)
+        self.run_screen(QRDisplayScreen, qr_encoder=qr_encoder)
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title="Xpub Options",
+            is_button_text_centered=False,
+            button_data=[ButtonOption("Load Descriptor"), ButtonOption("Done")],
+        )
+
+        if selected_menu_num == 0:
+            return Destination(ToolsSatochipDescriptorScriptTypeView, view_args=dict(xpub=xpub, derivation=derivation))
+
+        return Destination(MainMenuView)
+
+
+class ToolsSatochipDescriptorScriptTypeView(View):
+    def __init__(self, xpub: str, derivation: str):
+        super().__init__()
+        self.xpub = xpub
+        self.derivation = derivation
+
+    def run(self):
+        from embit.descriptor import Descriptor
+        from embit.bip32 import HDKey
+
+        script_types = self.settings.get_value(SettingsConstants.SETTING__SCRIPT_TYPES)
+        button_data = []
+        for st, display_name in SettingsConstants.ALL_SCRIPT_TYPES:
+            if st in script_types:
+                button_data.append(ButtonOption(display_name, return_data=st))
+
+        selected = self.run_screen(
+            ButtonListScreen,
+            title="Select Script Type",
+            is_button_text_centered=False,
+            button_data=button_data,
+            is_bottom_list=True,
+        )
+
+        if selected == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        script_type = button_data[selected].return_data
+
+        hdkey = HDKey.from_string(self.xpub)
+        fingerprint = hdkey.fingerprint.hex()
+        origin_path = self.derivation.replace("m/", "").replace("h", "'")
+        origin = f"[{fingerprint}/{origin_path}]"
+
+        if script_type == SettingsConstants.LEGACY_P2PKH:
+            desc_str = f"pkh({origin}{self.xpub}/0/*)"
+        elif script_type == SettingsConstants.NESTED_SEGWIT:
+            desc_str = f"sh(wpkh({origin}{self.xpub}/0/*))"
+        elif script_type == SettingsConstants.NATIVE_SEGWIT:
+            desc_str = f"wpkh({origin}{self.xpub}/0/*)"
+        else:
+            desc_str = f"tr({origin}{self.xpub}/0/*)"
+
+        try:
+            self.controller.multisig_wallet_descriptor = Descriptor.from_string(desc_str)
+            self.run_screen(
+                LargeIconStatusScreen,
+                title="Success",
+                status_headline=None,
+                text="Descriptor Loaded",
+                show_back_button=False,
+            )
+        except Exception as e:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text=str(e),
+                show_back_button=True,
+            )
+            return Destination(BackStackView)
 
         return Destination(MainMenuView)
 


### PR DESCRIPTION
## Summary
- support exporting xpub from a Satochip card
- stub view for signing PSBTs with a Satochip card
- add menu options for Satochip tools and PSBT signing
- allow loading Satochip xpubs as descriptors
- implement PSBT signing with a Satochip smartcard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688773de46108322bdadadbc4f73bab9