### PR TITLE
Add jCardSim integration test support

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,9 +27,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r tests/requirements.txt
           pip install .
-          # Download jCardSim from GitHub packages
-          wget -q "https://github.com/licel/jcardsim/packages/1650016?filename=jcardsim-3.0.5.jar" \
-            -O jcardsim.jar
+          # Download jCardSim from Maven Central
+          wget -q https://repo1.maven.org/maven2/com/klinec/jcardsim/3.0.6.0/jcardsim-3.0.6.0.jar -O jcardsim.jar
       - name: Run SeedKeeper integration tests
         run: |
           export JCARDSIM_JAR=jcardsim.jar

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,7 +41,7 @@ jobs:
           pip install .
           # Download jCardSim jar
           wget -q https://github.com/licel/jcardsim/packages/1650016 -O jcardsim.html
-          grep -o "https://github-registry-files[^"]*\.jar" jcardsim.html | head -n 1 | xargs -r wget -O jcardsim.jar
+          grep -o 'https://github-registry-files[^"\n]*\.jar' jcardsim.html | head -n 1 | xargs -r wget -O jcardsim.jar
       - name: Run SeedKeeper integration tests
         run: |
           export JCARDSIM_JAR=jcardsim.jar

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,10 +23,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y default-jre build-essential autoconf libtool pkg-config libudev-dev libusb-1.0-0-dev
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt -r tests/requirements.txt
-          pip install .
+          sudo apt-get install -y \
+            default-jre build-essential autoconf automake libtool \
+            pkg-config libudev-dev libusb-1.0-0-dev libsystemd-dev flex
           # build pcsc-lite with polkit disabled
           wget -q https://github.com/LudovicRousseau/PCSC/archive/refs/tags/pcsc-1.9.0.tar.gz -O pcsc-lite.tar.gz
           tar -xf pcsc-lite.tar.gz
@@ -37,6 +36,9 @@ jobs:
           sudo make install
           cd ..
           sudo ldconfig
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r tests/requirements.txt
+          pip install .
           # Download jCardSim jar
           wget -q https://github.com/licel/jcardsim/packages/1650016 -O jcardsim.html
           grep -o "https://github-registry-files[^"]*\.jar" jcardsim.html | head -n 1 | xargs -r wget -O jcardsim.jar

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,12 +23,23 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y default-jre libpcsclite-dev pcscd
+          sudo apt-get install -y default-jre build-essential autoconf libtool pkg-config libudev-dev libusb-1.0-0-dev
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r tests/requirements.txt
           pip install .
-          # Download jCardSim from Maven Central
-          wget -q https://repo1.maven.org/maven2/com/klinec/jcardsim/3.0.6.0/jcardsim-3.0.6.0.jar -O jcardsim.jar
+          # build pcsc-lite with polkit disabled
+          wget -q https://github.com/LudovicRousseau/PCSC/archive/refs/tags/pcsc-1.9.0.tar.gz -O pcsc-lite.tar.gz
+          tar -xf pcsc-lite.tar.gz
+          cd PCSC-pcsc-1.9.0
+          ./bootstrap
+          ./configure --prefix=/usr --disable-polkit
+          make -j$(nproc)
+          sudo make install
+          cd ..
+          sudo ldconfig
+          # Download jCardSim jar
+          wget -q https://github.com/licel/jcardsim/packages/1650016 -O jcardsim.html
+          grep -o "https://github-registry-files[^"]*\.jar" jcardsim.html | head -n 1 | xargs -r wget -O jcardsim.jar
       - name: Run SeedKeeper integration tests
         run: |
           export JCARDSIM_JAR=jcardsim.jar

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,34 @@
+name: SeedKeeper Integration Tests
+
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y default-jre libpcsclite-dev pcscd
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r tests/requirements.txt
+          pip install .
+          wget -q https://github.com/licel/jcardsim/releases/download/v3.0.5/jcardsim-3.0.5.jar -O jcardsim.jar
+      - name: Run SeedKeeper integration tests
+        run: |
+          export JCARDSIM_JAR=jcardsim.jar
+          pytest tests/test_seedkeeper_integration.py --use-jcardsim -vv

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r tests/requirements.txt
           pip install .
-          wget -q https://github.com/licel/jcardsim/releases/download/v3.0.5/jcardsim-3.0.5.jar -O jcardsim.jar
+          # Download jCardSim from GitHub packages
+          wget -q "https://github.com/licel/jcardsim/packages/1650016?filename=jcardsim-3.0.5.jar" \
+            -O jcardsim.jar
       - name: Run SeedKeeper integration tests
         run: |
           export JCARDSIM_JAR=jcardsim.jar

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ src/seedsigner/models/settings_definition.json
 
 *.po
 *.mo
+jcardsim.jar
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -84,7 +84,9 @@ coverage html
 
 ## SeedKeeper integration tests
 
-Running the integration test suite requires Java and the jCardSim emulator. Install OpenJDK and download the jCardSim jar separately.
+Running the integration test suite requires Java and the jCardSim emulator.
+Install OpenJDK and download the jCardSim jar from
+<https://github.com/licel/jcardsim/packages/1650016>.
 If the jar is not named `jcardsim.jar`, set the `JCARDSIM_JAR` environment variable.
 Then run:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -81,3 +81,13 @@ Generate the interactive html report:
 ```bash
 coverage html
 ```
+
+## SeedKeeper integration tests
+
+Running the integration test suite requires Java and the jCardSim emulator. Install OpenJDK and download the jCardSim jar separately.
+If the jar is not named `jcardsim.jar`, set the `JCARDSIM_JAR` environment variable.
+Then run:
+
+```bash
+pytest tests/test_seedkeeper_integration.py --use-jcardsim
+```

--- a/tests/README.md
+++ b/tests/README.md
@@ -84,9 +84,9 @@ coverage html
 
 ## SeedKeeper integration tests
 
-Running the integration test suite requires Java and the jCardSim emulator.
-Install OpenJDK and download the jCardSim jar from
-<https://github.com/licel/jcardsim/packages/1650016>.
+Running the integration test suite requires Java, `pcscd` and the jCardSim emulator.
+Install OpenJDK and make sure the `pcscd` service is available.
+Download the jCardSim jar from <https://github.com/licel/jcardsim/packages/1650016>.
 If the jar is not named `jcardsim.jar`, set the `JCARDSIM_JAR` environment variable.
 Then run:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -90,7 +90,7 @@ Download the jCardSim jar from the GitHub Packages page or Maven Central, for ex
 
 ```
 wget https://github.com/licel/jcardsim/packages/1650016 -O jcardsim.html
-grep -o "https://github-registry-files[^"]*\.jar" jcardsim.html | head -n 1 | xargs -r wget -O jcardsim.jar
+grep -o 'https://github-registry-files[^"\n]*\.jar' jcardsim.html | head -n 1 | xargs -r wget -O jcardsim.jar
 ```
 
 If the jar has a different name or location, set the `JCARDSIM_JAR` environment variable.

--- a/tests/README.md
+++ b/tests/README.md
@@ -86,10 +86,11 @@ coverage html
 
 Running the integration test suite requires Java, `pcscd` and the jCardSim emulator.
 Install OpenJDK and ensure the `pcscd` service is running.
-Download the jCardSim jar from Maven Central, for example:
+Download the jCardSim jar from the GitHub Packages page or Maven Central, for example:
 
 ```
-wget https://repo1.maven.org/maven2/com/klinec/jcardsim/3.0.6.0/jcardsim-3.0.6.0.jar -O jcardsim.jar
+wget https://github.com/licel/jcardsim/packages/1650016 -O jcardsim.html
+grep -o "https://github-registry-files[^"]*\.jar" jcardsim.html | head -n 1 | xargs -r wget -O jcardsim.jar
 ```
 
 If the jar has a different name or location, set the `JCARDSIM_JAR` environment variable.

--- a/tests/README.md
+++ b/tests/README.md
@@ -85,9 +85,15 @@ coverage html
 ## SeedKeeper integration tests
 
 Running the integration test suite requires Java, `pcscd` and the jCardSim emulator.
-Install OpenJDK and make sure the `pcscd` service is available.
-Download the jCardSim jar from <https://github.com/licel/jcardsim/packages/1650016>.
-If the jar is not named `jcardsim.jar`, set the `JCARDSIM_JAR` environment variable.
+Install OpenJDK and ensure the `pcscd` service is running.
+Download the jCardSim jar from Maven Central, for example:
+
+```
+wget https://repo1.maven.org/maven2/com/klinec/jcardsim/3.0.6.0/jcardsim-3.0.6.0.jar -O jcardsim.jar
+```
+
+If the jar has a different name or location, set the `JCARDSIM_JAR` environment variable.
+The SeedKeeper CAP file must be present at `tools/javacard-cap/SeedKeeper.cap`.
 Then run:
 
 ```bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,7 @@ def jcardsim_emulator(pytestconfig):
     cap_path = Path(__file__).resolve().parents[1] / "tools" / "javacard-cap" / "SeedKeeper.cap"
 
     # Start local pcscd so pyscard can connect
-    pcscd = Popen(["pcscd", "-f"])
+    pcscd = Popen(["pcscd", "-f", "--disable-polkit"])
     time.sleep(1)
 
     jproc = Popen(["java", "-jar", jar, str(cap_path)])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,12 @@ def jcardsim_emulator(pytestconfig):
 
     jar = os.environ.get("JCARDSIM_JAR", "jcardsim.jar")
     cap_path = Path(__file__).resolve().parents[1] / "tools" / "javacard-cap" / "SeedKeeper.cap"
-    proc = Popen(["java", "-jar", jar, str(cap_path)])
+
+    # Start local pcscd so pyscard can connect
+    pcscd = Popen(["pcscd", "-f"])
+    time.sleep(1)
+
+    jproc = Popen(["java", "-jar", jar, str(cap_path)])
 
     try:
         from smartcard.System import readers
@@ -79,15 +84,17 @@ def jcardsim_emulator(pytestconfig):
         while time.time() < timeout:
             if readers():
                 break
-            if proc.poll() is not None:
+            if jproc.poll() is not None:
                 raise RuntimeError("jCardSim terminated early")
             time.sleep(0.5)
         else:
-            proc.terminate()
-            proc.wait()
+            jproc.terminate()
+            jproc.wait()
             raise RuntimeError("Timeout waiting for jCardSim")
 
-        yield proc
+        yield jproc
     finally:
-        proc.terminate()
-        proc.wait()
+        jproc.terminate()
+        jproc.wait()
+        pcscd.terminate()
+        pcscd.wait()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,14 +69,20 @@ def jcardsim_emulator(pytestconfig):
     if not use_jcardsim:
         pytest.skip("jcardsim emulator not enabled")
 
-    jar = os.environ.get("JCARDSIM_JAR", "jcardsim.jar")
+    jar = Path(os.environ.get("JCARDSIM_JAR", "jcardsim.jar"))
+    if not jar.exists():
+        pytest.skip(f"jCardSim jar not found: {jar}")
+
     cap_path = Path(__file__).resolve().parents[1] / "tools" / "javacard-cap" / "SeedKeeper.cap"
+    if not cap_path.exists():
+        pytest.skip("SeedKeeper CAP not found")
 
-    # Start local pcscd so pyscard can connect
-    pcscd = Popen(["pcscd", "-f", "--disable-polkit"])
-    time.sleep(1)
+    pcscd = None
+    if not Path("/run/pcscd/pcscd.pid").exists():
+        pcscd = Popen(["pcscd", "-f", "--disable-polkit"])
+        time.sleep(1)
 
-    jproc = Popen(["java", "-jar", jar, str(cap_path)])
+    jproc = Popen(["java", "-jar", str(jar), str(cap_path)])
 
     try:
         from smartcard.System import readers
@@ -96,5 +102,6 @@ def jcardsim_emulator(pytestconfig):
     finally:
         jproc.terminate()
         jproc.wait()
-        pcscd.terminate()
-        pcscd.wait()
+        if pcscd is not None:
+            pcscd.terminate()
+            pcscd.wait()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,39 +1,93 @@
+import os
 import sys
+from pathlib import Path
+from subprocess import Popen
+import time
+import pytest
 from unittest.mock import MagicMock
 
-# Mock hardware-dependent modules so unit tests can run without them
-sys.modules.setdefault('RPi', MagicMock())
-sys.modules.setdefault('RPi.GPIO', MagicMock())
-sys.modules.setdefault('pyzbar', MagicMock())
-sys.modules.setdefault('pyzbar.pyzbar', MagicMock())
-sys.modules.setdefault('pysatochip', MagicMock())
-sys.modules.setdefault('pysatochip.JCconstants', MagicMock())
-sys.modules.setdefault('pysatochip.util', MagicMock())
-sys.modules.setdefault('pysatochip.CardConnector', MagicMock())
-sys.modules.setdefault('smbus2', MagicMock())
-sys.modules.setdefault('smartcard', MagicMock())
-sys.modules.setdefault('smartcard.System', MagicMock())
 
-# Provide a dummy BatteryHat implementation used by the controller
-class DummyBatteryHat(MagicMock):
-    @classmethod
-    def get_instance(cls):
-        if not hasattr(cls, '_instance'):
-            cls._instance = cls()
-            cls._instance.is_alive.return_value = False
-        return cls._instance
+def pytest_addoption(parser):
+    parser.addoption(
+        "--use-jcardsim",
+        action="store_true",
+        default=False,
+        help="Run tests using jCardSim instead of mocking pysatochip and smartcard",
+    )
 
-    @classmethod
-    def reset_instance(cls):
-        cls._instance = None
 
-    def start(self):
-        pass
-    def stop(self):
-        pass
-    def join(self, *a, **k):
-        pass
-    def get_percent(self):
-        return None
+def pytest_configure(config):
+    use_jcardsim = config.getoption("--use-jcardsim") or os.environ.get("USE_JCARDSIM")
 
-sys.modules['seedsigner.hardware.battery_hat'] = MagicMock(BatteryHat=DummyBatteryHat)
+    if not use_jcardsim:
+        # Mock hardware-dependent modules so unit tests can run without them
+        for name in [
+            'RPi',
+            'RPi.GPIO',
+            'pyzbar',
+            'pyzbar.pyzbar',
+            'pysatochip',
+            'pysatochip.JCconstants',
+            'pysatochip.util',
+            'pysatochip.CardConnector',
+            'smbus2',
+            'smartcard',
+            'smartcard.System',
+        ]:
+            sys.modules.setdefault(name, MagicMock())
+
+    # Provide a dummy BatteryHat implementation used by the controller
+    class DummyBatteryHat(MagicMock):
+        @classmethod
+        def get_instance(cls):
+            if not hasattr(cls, '_instance'):
+                cls._instance = cls()
+                cls._instance.is_alive.return_value = False
+            return cls._instance
+
+        @classmethod
+        def reset_instance(cls):
+            cls._instance = None
+
+        def start(self):
+            pass
+        def stop(self):
+            pass
+        def join(self, *a, **k):
+            pass
+        def get_percent(self):
+            return None
+
+    sys.modules['seedsigner.hardware.battery_hat'] = MagicMock(BatteryHat=DummyBatteryHat)
+
+
+@pytest.fixture(scope="session")
+def jcardsim_emulator(pytestconfig):
+    """Start jCardSim emulator if requested."""
+
+    use_jcardsim = pytestconfig.getoption("--use-jcardsim") or os.environ.get("USE_JCARDSIM")
+    if not use_jcardsim:
+        pytest.skip("jcardsim emulator not enabled")
+
+    jar = os.environ.get("JCARDSIM_JAR", "jcardsim.jar")
+    cap_path = Path(__file__).resolve().parents[1] / "tools" / "javacard-cap" / "SeedKeeper.cap"
+    proc = Popen(["java", "-jar", jar, str(cap_path)])
+
+    try:
+        from smartcard.System import readers
+        timeout = time.time() + 20
+        while time.time() < timeout:
+            if readers():
+                break
+            if proc.poll() is not None:
+                raise RuntimeError("jCardSim terminated early")
+            time.sleep(0.5)
+        else:
+            proc.terminate()
+            proc.wait()
+            raise RuntimeError("Timeout waiting for jCardSim")
+
+        yield proc
+    finally:
+        proc.terminate()
+        proc.wait()

--- a/tests/test_seedkeeper_integration.py
+++ b/tests/test_seedkeeper_integration.py
@@ -1,0 +1,57 @@
+import os
+import pytest
+from pysatochip.CardConnector import CardConnector
+from embit import bip32
+
+
+def _setup_card() -> CardConnector:
+    cc = CardConnector(card_filter="seedkeeper")
+    _, _, _, status = cc.card_get_status()
+
+    pin = list(b"1234")
+    if not status.get("setup_done", False):
+        zeros = [0] * 16
+        cc.card_setup(0x05, 0x01, pin, zeros, 0x01, 0x01, zeros, zeros,
+                       32, 0x0000, 0x01, 0x01, 0x01)
+    cc.set_pin(0, pin)
+    cc.card_verify_PIN_simple()
+    return cc
+
+
+def test_seedkeeper_roundtrip(jcardsim_emulator):
+    cc = _setup_card()
+
+    seed = bytes.fromhex("00" * 32)
+    cc.card_bip32_import_seed(seed)
+    xprv = cc.card_bip32_get_xprv("m", "p2wpkh", False)
+    expected = bip32.HDKey.from_seed(seed, version=bip32.NETWORKS['test']['xprv']).to_base58()
+    assert xprv == expected
+
+
+def test_seedkeeper_save_load_seed(jcardsim_emulator):
+    cc = _setup_card()
+
+    seed = bytes.fromhex("11" * 32)
+    header = cc.make_header("Masterseed", "Plaintext export allowed", "test-seed")
+    secret_list = [len(seed)] + list(seed)
+    sid, fingerprint = cc.seedkeeper_import_secret({"header": header, "secret_list": secret_list})
+
+    exported = cc.seedkeeper_export_secret(sid, None)
+    assert exported["secret"] == seed.hex()
+
+
+def test_seedkeeper_save_load_descriptor(jcardsim_emulator):
+    cc = _setup_card()
+    seed = bytes.fromhex("22" * 32)
+    master = bip32.HDKey.from_seed(seed, version=bip32.NETWORKS['test']['xprv'])
+    xpub = master.derive("m/48h/1h/0h/2h").to_public()
+    descriptor = f"wsh({{sortedmulti(1,{xpub.to_base58()})}})"
+
+    header = cc.make_header("Data", "Plaintext export allowed", "desc")
+    data = descriptor.encode()
+    secret_list = list(len(data).to_bytes(2, "big")) + list(data)
+    sid, fp = cc.seedkeeper_import_secret({"header": header, "secret_list": secret_list})
+
+    exported = cc.seedkeeper_export_secret(sid, None)
+    retrieved = bytes.fromhex(exported["secret"])[2:].decode()
+    assert retrieved == descriptor


### PR DESCRIPTION
## Summary
- allow enabling real pysatochip/smartcard modules with `--use-jcardsim`
- start jCardSim when integration tests request it
- add SeedKeeper integration tests for seeds and descriptors
- document how to run the integration tests
- run integration tests in CI

## Testing
- `pytest --collect-only`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688813ac032483229eaf90fe3a790eb7