### PR TITLE
Fix broken backup menu after slip39 addition

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,6 @@ pycparser==2.22 --hash=sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05
 smbus2==0.4.3 \
     --hash=sha256:36f2288a8e1a363cb7a7b2244ec98d880eb5a728a2494ac9c71e9de7bf6a803a \
     --hash=sha256:a2fc29cfda4081ead2ed61ef2c4fc041d71dd40a8d917e85216f44786fca2d1d
+shamir-mnemonic==0.3.0 \
+    --hash=sha256:188c6b5bd00d5e756e12e2b186c3cb7c98ff7ff44df608d4c1d2077f6b6e730f \
+    --hash=sha256:bc04886a1ddfe2a64d8a3ec51abf0f664d98d5b557cc7e78a8ad2d10a1d87438

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -89,7 +89,10 @@ class DecodeQR:
                 self.decoder = Base43PsbtQrDecoder() # Single Segment Base43
 
             elif self.qr_type in [QRType.SEED__SEEDQR, QRType.SEED__COMPACTSEEDQR, QRType.SEED__MNEMONIC, QRType.SEED__FOUR_LETTER_MNEMONIC, QRType.SEED__UR2]:
-                self.decoder = SeedQrDecoder(wordlist_language_code=self.wordlist_language_code)          
+                self.decoder = SeedQrDecoder(wordlist_language_code=self.wordlist_language_code)
+
+            elif self.qr_type == QRType.SEED__SLIP39:
+                self.decoder = Slip39ShareDecoder()
 
             elif self.qr_type == QRType.SETTINGS:
                 self.decoder = SettingsQrDecoder()  # Settings config
@@ -212,6 +215,10 @@ class DecodeQR:
         if self.is_seed:
             return self.decoder.get_seed_phrase()
 
+    def get_slip39_share(self):
+        if self.is_slip39_share:
+            return self.decoder.get_share()
+
 
     def get_settings_data(self):
         if self.is_settings:
@@ -323,9 +330,13 @@ class DecodeQR:
             QRType.SEED__SEEDQR,
             QRType.SEED__COMPACTSEEDQR,
             QRType.SEED__UR2,
-            QRType.SEED__MNEMONIC, 
+            QRType.SEED__MNEMONIC,
             QRType.SEED__FOUR_LETTER_MNEMONIC,
         ]
+
+    @property
+    def is_slip39_share(self) -> bool:
+        return self.qr_type == QRType.SEED__SLIP39
     
 
     @property
@@ -454,6 +465,9 @@ class DecodeQR:
             except:
                 _4LETTER_WORDLIST = []
 
+            from importlib import import_module
+            slip39_wordlist = import_module("shamir_mnemonic.wordlist").WORDLIST
+
             if all(x in wordlist for x in s.strip().split(" ")):
                 # checks if all words in list are in bip39 word list
                 return QRType.SEED__MNEMONIC
@@ -461,6 +475,9 @@ class DecodeQR:
             elif all(x in _4LETTER_WORDLIST for x in s.strip().split(" ")):
                 # checks if all 4 letter words are in list are in 4 letter bip39 word list
                 return QRType.SEED__FOUR_LETTER_MNEMONIC
+
+            elif all(x in slip39_wordlist for x in s.strip().split(" ")):
+                return QRType.SEED__SLIP39
 
             elif DecodeQR.is_base43_psbt(s):
                 return QRType.PSBT__BASE43
@@ -920,17 +937,40 @@ class SeedQrDecoder(BaseSingleFrameQrDecoder):
         else:
             return DecodeQRStatus.INVALID
 
-
     def get_seed_phrase(self):
         if self.complete:
             return self.seed_phrase[:]
         return []
 
-
     def is_12_or_18_or_24_word_phrase(self):
         if len(self.seed_phrase) in (12, 18, 24):
             return True
         return False
+
+
+class Slip39ShareDecoder(BaseSingleFrameQrDecoder):
+    """Decodes a single-frame SLIP-39 share"""
+    def __init__(self):
+        super().__init__()
+        self.share = None
+
+    def add(self, segment, qr_type=QRType.SEED__SLIP39):
+        if qr_type == QRType.SEED__SLIP39:
+            try:
+                if isinstance(segment, bytes):
+                    segment = segment.decode("utf-8")
+                from shamir_mnemonic import Share as Slip39Share
+                Slip39Share.from_mnemonic(segment)
+                self.share = segment
+                self.complete = True
+                self.collected_segments = 1
+                return DecodeQRStatus.COMPLETE
+            except Exception:
+                pass
+        return DecodeQRStatus.INVALID
+
+    def get_share(self):
+        return self.share
 
 
 

--- a/src/seedsigner/models/qr_type.py
+++ b/src/seedsigner/models/qr_type.py
@@ -13,6 +13,7 @@ class QRType:
     SEED__MNEMONIC = "seed__mnemonic"
     SEED__FOUR_LETTER_MNEMONIC = "seed__four_letter_mnemonic"
     SEED__ENCRYPTEDQR = "seed__encryptedqr"
+    SEED__SLIP39 = "seed__slip39"
 
     SETTINGS = "settings"
 

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -5,6 +5,7 @@ import hmac
 
 from binascii import hexlify
 from embit import bip39, bip32, bip85
+import shamir_mnemonic
 from embit.networks import NETWORKS
 from typing import List
 
@@ -249,6 +250,53 @@ class ElectrumSeed(Seed):
     def seedqr_supported(self) -> bool:
         return False
 
+
+    @property
+    def bip85_supported(self) -> bool:
+        return False
+
+
+class Slip39Seed(Seed):
+    """Seed derived from SLIP-39 mnemonic shares."""
+
+    def __init__(self, mnemonics: List[str], passphrase: str = "") -> None:
+        self._wordlist_language_code = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH
+        if not mnemonics:
+            raise Exception("Must provide at least one SLIP-39 share")
+        self._shares: List[str] = [unicodedata.normalize("NFKD", m.strip()) for m in mnemonics]
+
+        self._passphrase: str = ""
+        self.set_passphrase(passphrase, regenerate_seed=False)
+
+        self.seed_bytes: bytes = None
+        self._generate_seed()
+
+    def _generate_seed(self):
+        try:
+            self.seed_bytes = shamir_mnemonic.combine_mnemonics(
+                self._shares, self._passphrase.encode("utf-8")
+            )
+        except Exception as e:
+            logger.info(repr(e), exc_info=True)
+            raise InvalidSeedException(repr(e))
+
+    # Expose shares as the mnemonic list/str for compatibility
+    @property
+    def mnemonic_list(self) -> List[str]:
+        return list(self._shares)
+
+    @property
+    def mnemonic_str(self) -> str:
+        return "\n".join(self._shares)
+
+    def set_passphrase(self, passphrase: str, regenerate_seed: bool = True):
+        self._passphrase = unicodedata.normalize("NFKD", passphrase) if passphrase else ""
+        if regenerate_seed:
+            self._generate_seed()
+
+    @property
+    def seedqr_supported(self) -> bool:
+        return False
 
     @property
     def bip85_supported(self) -> bool:

--- a/src/seedsigner/models/seed_storage.py
+++ b/src/seedsigner/models/seed_storage.py
@@ -1,5 +1,5 @@
 from typing import List
-from seedsigner.models.seed import Seed, ElectrumSeed, InvalidSeedException
+from seedsigner.models.seed import Seed, ElectrumSeed, Slip39Seed, InvalidSeedException
 from seedsigner.models.settings_definition import SettingsConstants
 
 
@@ -9,7 +9,12 @@ class SeedStorage:
         self.seeds: List[Seed] = []
         self.pending_seed: Seed = None
         self._pending_mnemonic: List[str] = []
-        self._pending_is_electrum : bool = False
+        self._pending_is_electrum: bool = False
+        self._pending_is_slip39: bool = False
+        self._pending_slip39_share: List[str] = []
+        self._pending_slip39_shares: List[List[str]] = []
+        self._slip39_share_length: int | None = None
+        self._slip39_first_share = None
 
 
     def set_pending_seed(self, seed: Seed):
@@ -103,3 +108,78 @@ class SeedStorage:
     def discard_pending_mnemonic(self):
         self._pending_mnemonic = []
         self._pending_is_electrum = False
+
+    """Slip39 share handling"""
+
+    def init_pending_slip39_share(self, num_words: int | None = None):
+        if num_words is None:
+            num_words = self._slip39_share_length or 33
+        self._pending_slip39_share = [None] * num_words
+        self._slip39_share_length = num_words
+        self._pending_is_slip39 = True
+
+    def update_pending_slip39_share(self, word: str, index: int):
+        if index >= len(self._pending_slip39_share):
+            raise Exception(f"index {index} is too high")
+        self._pending_slip39_share[index] = word
+
+    def get_pending_slip39_word(self, index: int) -> str:
+        if index < len(self._pending_slip39_share):
+            return self._pending_slip39_share[index]
+        return None
+
+    @property
+    def pending_slip39_share_length(self) -> int:
+        return len(self._pending_slip39_share)
+
+    def finalize_current_slip39_share(self):
+        mnemonic = " ".join(self._pending_slip39_share)
+        from shamir_mnemonic import Share as Slip39Share
+        try:
+            share_obj = Slip39Share.from_mnemonic(mnemonic)
+        except Exception:
+            self._pending_slip39_share = []
+            raise InvalidSeedException("Invalid SLIP-39 share")
+
+        if self._slip39_first_share is None:
+            self._slip39_first_share = share_obj
+
+        self._pending_slip39_shares.append(list(self._pending_slip39_share))
+        self._pending_slip39_share = []
+
+    def add_slip39_share_mnemonic(self, mnemonic: str):
+        """Add a share mnemonic directly."""
+        from shamir_mnemonic import Share as Slip39Share
+        try:
+            share_obj = Slip39Share.from_mnemonic(mnemonic)
+        except Exception:
+            raise InvalidSeedException("Invalid SLIP-39 share")
+        if self._slip39_first_share is None:
+            self._slip39_first_share = share_obj
+        self._pending_slip39_shares.append(mnemonic.split())
+        self._slip39_share_length = len(mnemonic.split())
+        self._pending_is_slip39 = True
+
+    def convert_pending_slip39_shares_to_pending_seed(self, passphrase: str = ""):
+        mnemonics = [" ".join(share) for share in self._pending_slip39_shares]
+        self.pending_seed = Slip39Seed(mnemonics=mnemonics, passphrase=passphrase)
+        self.discard_pending_slip39_shares()
+
+    def discard_pending_slip39_shares(self):
+        self._pending_slip39_share = []
+        self._pending_slip39_shares = []
+        self._pending_is_slip39 = False
+        self._slip39_share_length = None
+        self._slip39_first_share = None
+
+    @property
+    def slip39_shares_entered(self) -> int:
+        return len(self._pending_slip39_shares)
+
+    @property
+    def slip39_total_needed(self) -> int | None:
+        if self._slip39_first_share is None:
+            return None
+        g = self._slip39_first_share.group_threshold
+        m = self._slip39_first_share.member_threshold
+        return m * g if g > 1 else m

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -7,13 +7,14 @@ import time
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, ButtonListScreen, WarningScreen, DireWarningScreen
 from seedsigner.gui.screens.scan_screens import ScanEncryptedQRScreen, ScanTypeEncryptionKeyScreen, ScanReviewEncryptionKeyScreen
 from seedsigner.models.decode_qr import DecodeQR, DecodeQRStatus
-from seedsigner.models.seed import Seed
+from seedsigner.models.seed import Seed, InvalidSeedException
 
 from gettext import gettext as _
 from seedsigner.helpers.l10n import mark_for_translation as _mft
 
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.views.view import BackStackView, ErrorView, MainMenuView, NotYetImplementedView, View, Destination
+from seedsigner.views.seed_views import SeedSlip39MoreSharesView, SeedSlip39ShareInvalidView
 from seedsigner.gui.screens.screen import ButtonOption
 
 logger = logging.getLogger(__name__)
@@ -98,6 +99,15 @@ class ScanView(View):
                         return Destination(SeedAddPassphraseView)
                     else:
                         return Destination(SeedFinalizeView)
+
+            elif self.decoder.is_slip39_share:
+                share = self.decoder.get_slip39_share()
+                words = share.split()
+                self.controller.storage.init_pending_slip39_share(num_words=len(words))
+                for i, w in enumerate(words):
+                    self.controller.storage.update_pending_slip39_share(w, i)
+                self.controller.storage.finalize_current_slip39_share()
+                return Destination(SeedSlip39MoreSharesView)
             
             elif self.decoder.is_psbt:
                 from seedsigner.views.psbt_views import PSBTSelectSeedView
@@ -213,6 +223,57 @@ class ScanSeedQRView(ScanView):
     @property
     def is_valid_qr_type(self):
         return self.decoder.is_seed or self.decoder.is_encrypted_seedqr
+
+
+class ScanSlip39ShareQRView(ScanView):
+    instructions_text = _mft("Scan SLIP-39 Share")
+    invalid_qr_type_message = _mft("Expected a SLIP-39 share QR")
+
+    @property
+    def is_valid_qr_type(self):
+        return self.decoder.is_slip39_share
+
+    def run(self):
+        from seedsigner.gui.screens.scan_screens import ScanScreen
+        from seedsigner.models.qr_type import QRType
+
+        self.run_screen(
+            ScanScreen,
+            instructions_text=self.instructions_text,
+            decoder=self.decoder
+        )
+
+        self.controller.reset_screensaver_timeout()
+        time.sleep(0.1)
+
+        if self.decoder.is_complete:
+            share = self.decoder.get_slip39_share()
+            words = share.split()
+            self.controller.storage.init_pending_slip39_share(num_words=len(words))
+            for i, w in enumerate(words):
+                self.controller.storage.update_pending_slip39_share(w, i)
+            try:
+                self.controller.storage.finalize_current_slip39_share()
+            except InvalidSeedException:
+                return Destination(
+                    SeedSlip39ShareInvalidView,
+                    view_args={"length": len(words), "retry_scan": True},
+                    skip_current_view=True,
+                )
+            return Destination(SeedSlip39MoreSharesView)
+
+        elif self.decoder.qr_type == QRType.SEED__SLIP39:
+            return Destination(
+                SeedSlip39ShareInvalidView,
+                view_args={"length": 33, "retry_scan": True},
+                skip_current_view=True,
+            )
+
+        elif self.decoder.is_invalid:
+            self.controller.resume_main_flow = None
+            return Destination(ScanInvalidQRTypeView)
+
+        return Destination(MainMenuView)
 
 
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -20,7 +20,7 @@ from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
 from seedsigner.gui.screens.screen import ButtonOption
 from seedsigner.models.encode_qr import CompactSeedQrEncoder, GenericStaticQrEncoder, SeedQrEncoder, SpecterXPubQrEncoder, StaticXpubQrEncoder, UrXpubQrEncoder
 from seedsigner.models.qr_type import QRType
-from seedsigner.models.seed import Seed
+from seedsigner.models.seed import Seed, Slip39Seed
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.settings_definition import SettingsDefinition
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
@@ -87,6 +87,7 @@ class SeedSelectSeedView(View):
     TYPE_18WORD = ButtonOption("Enter 18-word seed", FontAwesomeIconConstants.KEYBOARD)
     TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD)
     TYPE_ELECTRUM = ButtonOption("Enter Electrum seed", FontAwesomeIconConstants.KEYBOARD)
+    TYPE_SLIP39 = ButtonOption("Enter SLIP-39 seed", FontAwesomeIconConstants.KEYBOARD)
 
     def __init__(self, flow: str):
         super().__init__()
@@ -125,6 +126,7 @@ class SeedSelectSeedView(View):
 
         if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_ELECTRUM)
+        button_data.append(self.TYPE_SLIP39)
 
         selected_menu_num = self.run_screen(
             seed_screens.SeedSelectSeedScreen,
@@ -166,6 +168,9 @@ class SeedSelectSeedView(View):
         elif button_data[selected_menu_num] == self.TYPE_ELECTRUM:
             return Destination(SeedElectrumMnemonicStartView)
 
+        elif button_data[selected_menu_num] == self.TYPE_SLIP39:
+            return Destination(SeedSlip39MnemonicStartView)
+
 
 
 """****************************************************************************
@@ -177,6 +182,7 @@ class LoadSeedView(View):
     TYPE_18WORD = ButtonOption("Enter 18-word seed", FontAwesomeIconConstants.KEYBOARD)
     TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD)
     TYPE_ELECTRUM = ButtonOption("Enter Electrum seed", FontAwesomeIconConstants.KEYBOARD)
+    TYPE_SLIP39 = ButtonOption("Enter SLIP-39 seed", FontAwesomeIconConstants.KEYBOARD)
     IMPORT_SEEDKEEPER = ButtonOption("From SeedKeeper", FontAwesomeIconConstants.LOCK)
     CREATE = ButtonOption(" Create a seed", SeedSignerIconConstants.PLUS)
 
@@ -187,8 +193,10 @@ class LoadSeedView(View):
             self.TYPE_18WORD,
             self.TYPE_24WORD,
             self.IMPORT_SEEDKEEPER,
-            self.CREATE,
         ]
+
+        button_data.append(self.CREATE)
+        button_data.append(self.TYPE_SLIP39)
 
         if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_ELECTRUM)
@@ -224,6 +232,9 @@ class LoadSeedView(View):
 
         elif button_data[selected_menu_num] == self.TYPE_ELECTRUM:
             return Destination(SeedElectrumMnemonicStartView)
+
+        elif button_data[selected_menu_num] == self.TYPE_SLIP39:
+            return Destination(SeedSlip39MnemonicStartView)
 
         elif button_data[selected_menu_num] == self.CREATE:
             from .tools_views import ToolsMenuView
@@ -815,6 +826,255 @@ class SeedElectrumMnemonicStartView(View):
         return Destination(SeedMnemonicEntryView)
 
 
+class SeedSlip39MnemonicStartView(View):
+    """Prompt before entering SLIP-39 shares."""
+
+    def run(self):
+        self.controller.storage.discard_pending_slip39_shares()
+        self.run_screen(
+            WarningScreen,
+            title=_("SLIP-39 warning"),
+            status_headline=None,
+            text=_("Enter each share in full. Multiple shares will be combined."),
+            show_back_button=False,
+        )
+
+        TWENTY = ButtonOption("20 words")
+        THIRTYTHREE = ButtonOption("33 words")
+        SCAN = ButtonOption("Scan QR", SeedSignerIconConstants.QRCODE)
+        SEEDKEEPER = ButtonOption("SeedKeeper", FontAwesomeIconConstants.LOCK)
+        button_data = [TWENTY, THIRTYTHREE, SCAN, SEEDKEEPER]
+
+        selected = self.run_screen(
+            ButtonListScreen,
+            title=_("Share length"),
+            is_button_text_centered=False,
+            button_data=button_data,
+        )
+
+        if button_data[selected] == SCAN:
+            from seedsigner.views.scan_views import ScanSlip39ShareQRView
+            return Destination(ScanSlip39ShareQRView)
+
+        if button_data[selected] == SEEDKEEPER:
+            from seedsigner.views.seed_views import SeedSlip39LoadFromSeedkeeperView
+            return Destination(SeedSlip39LoadFromSeedkeeperView)
+
+        length = 20 if button_data[selected] == TWENTY else 33
+        self.controller.storage.init_pending_slip39_share(num_words=length)
+        return Destination(SeedSlip39ShareEntryView)
+
+
+class SeedSlip39ShareEntryView(View):
+    def __init__(self, cur_word_index: int = 0):
+        super().__init__()
+        self.cur_word_index = cur_word_index
+        self.cur_word = self.controller.storage.get_pending_slip39_word(cur_word_index)
+
+    def run(self):
+        from importlib import import_module
+        slip39_wordlist = import_module("shamir_mnemonic.wordlist").WORDLIST
+        ret = self.run_screen(
+            seed_screens.SeedMnemonicEntryScreen,
+            title=_("Share Word #{}").format(self.cur_word_index + 1),
+            initial_letters=list(self.cur_word) if self.cur_word else ["a"],
+            wordlist=slip39_wordlist,
+        )
+
+        if ret == RET_CODE__BACK_BUTTON:
+            if self.cur_word_index > 0:
+                return Destination(BackStackView)
+            else:
+                self.controller.storage.discard_pending_slip39_shares()
+                return Destination(MainMenuView)
+
+        self.controller.storage.update_pending_slip39_share(ret, self.cur_word_index)
+
+        if self.cur_word_index < self.controller.storage.pending_slip39_share_length - 1:
+            return Destination(
+                SeedSlip39ShareEntryView,
+                view_args={"cur_word_index": self.cur_word_index + 1}
+            )
+        else:
+            from seedsigner.models.seed import InvalidSeedException
+            try:
+                self.controller.storage.finalize_current_slip39_share()
+            except InvalidSeedException:
+                length = self.controller.storage.pending_slip39_share_length
+                self.controller.storage.init_pending_slip39_share(num_words=length)
+                return Destination(
+                    SeedSlip39ShareInvalidView,
+                    view_args={"length": length, "retry_scan": False},
+                    skip_current_view=True,
+                )
+            return Destination(SeedSlip39MoreSharesView)
+
+
+class SeedSlip39MoreSharesView(View):
+    ADD = ButtonOption("Add share")
+    SCAN = ButtonOption("Scan share", SeedSignerIconConstants.QRCODE)
+    SEEDKEEPER = ButtonOption("SeedKeeper", FontAwesomeIconConstants.LOCK)
+    DONE = ButtonOption("Combine shares")
+
+    def run(self):
+        button_data = [self.ADD, self.SCAN, self.SEEDKEEPER, self.DONE]
+        entered = self.controller.storage.slip39_shares_entered
+        needed = self.controller.storage.slip39_total_needed
+        info_text = None
+        if needed:
+            info_text = _("{} of {} shares entered").format(entered, needed)
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title=_("More shares?"),
+            text=info_text,
+            is_button_text_centered=False,
+            button_data=button_data,
+        )
+
+        if button_data[selected_menu_num] == self.ADD:
+            self.controller.storage.init_pending_slip39_share()
+            return Destination(SeedSlip39ShareEntryView)
+
+        elif button_data[selected_menu_num] == self.SCAN:
+            from seedsigner.views.scan_views import ScanSlip39ShareQRView
+            return Destination(ScanSlip39ShareQRView)
+
+        elif button_data[selected_menu_num] == self.SEEDKEEPER:
+            from seedsigner.views.seed_views import SeedSlip39LoadFromSeedkeeperView
+            return Destination(SeedSlip39LoadFromSeedkeeperView)
+
+        self.controller.storage.convert_pending_slip39_shares_to_pending_seed()
+        return Destination(SeedFinalizeView)
+
+
+class SeedSlip39ShareInvalidView(View):
+    def __init__(self, length: int, retry_scan: bool):
+        super().__init__()
+        self.length = length
+        self.retry_scan = retry_scan
+
+    def run(self):
+        from seedsigner.gui.screens.screen import DireWarningScreen
+        button = ButtonOption("Try Again")
+        self.run_screen(
+            DireWarningScreen,
+            title=_("Invalid SLIP-39 Share"),
+            show_back_button=False,
+            status_icon_name=SeedSignerIconConstants.ERROR,
+            status_headline=None,
+            text=_("Checksum failure; not a valid SLIP-39 share."),
+            button_data=[button],
+        )
+
+        if self.retry_scan:
+            from seedsigner.views.scan_views import ScanSlip39ShareQRView
+            return Destination(ScanSlip39ShareQRView, skip_current_view=True)
+        else:
+            self.controller.storage.init_pending_slip39_share(num_words=self.length)
+            return Destination(SeedSlip39ShareEntryView, skip_current_view=True)
+
+
+class SeedSlip39SelectShareView(View):
+    def __init__(self, seed_num: int, next_view, **next_args):
+        super().__init__()
+        self.seed_num = seed_num
+        self.next_view = next_view
+        self.next_args = next_args
+
+    def run(self):
+        seed = self.controller.get_seed(self.seed_num)
+        button_data = [ButtonOption(f"Share {i+1}") for i in range(len(seed.mnemonic_list))]
+        selected = self.run_screen(
+            ButtonListScreen,
+            title="Select Share",
+            is_button_text_centered=False,
+            button_data=button_data,
+            show_back_button=True,
+        )
+
+        if selected == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        self.next_args.update({"seed_num": self.seed_num, "share_index": selected})
+        return Destination(self.next_view, view_args=self.next_args)
+
+
+class SeedSlip39LoadFromSeedkeeperView(View):
+    """Load a SLIP-39 share from a SeedKeeper card."""
+
+    def run(self):
+        from seedsigner.gui.screens.screen import LoadingScreenThread
+        try:
+            Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["seedkeeper"])
+            if not Satochip_Connector:
+                return Destination(BackStackView)
+
+            self.loading_screen = LoadingScreenThread(text="Listing Secrets\n\n\n\n\n\n")
+            self.loading_screen.start()
+            headers = Satochip_Connector.seedkeeper_list_secret_headers()
+            self.loading_screen.stop()
+
+            headers_parsed = []
+            button_data = []
+            for header in headers:
+                stype = SEEDKEEPER_DIC_TYPE.get(header['type'], hex(header['type']))
+                rights = SEEDKEEPER_DIC_EXPORT_RIGHTS.get(header['export_rights'], hex(header['export_rights']))
+                label = header['label']
+                if stype == "Password" and rights == 'Plaintext export allowed' and label.startswith("SLIP39:"):
+                    headers_parsed.append(header['id'])
+                    button_data.append(ButtonOption(label[len("SLIP39:"):]))
+
+            if not headers_parsed:
+                self.run_screen(
+                    WarningScreen,
+                    title="No Secrets to Load",
+                    text="No SLIP39 Shares on SeedKeeper",
+                    show_back_button=False,
+                )
+                return Destination(BackStackView)
+
+            selected = self.run_screen(
+                ButtonListScreen,
+                title="Select Share",
+                is_button_text_centered=False,
+                button_data=button_data,
+                show_back_button=True,
+            )
+            if selected == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
+
+            self.loading_screen = LoadingScreenThread(text="Loading Secret\n\n\n\n\n\n")
+            self.loading_screen.start()
+            secret_dict = Satochip_Connector.seedkeeper_export_secret(headers_parsed[selected], None)
+            self.loading_screen.stop()
+
+            length = secret_dict['secret_list'][0]
+            share = binascii.unhexlify(secret_dict['secret'])[1:length+1].decode()
+
+            from seedsigner.models.seed import InvalidSeedException
+            try:
+                self.controller.storage.add_slip39_share_mnemonic(share)
+            except InvalidSeedException:
+                return Destination(
+                    SeedSlip39ShareInvalidView,
+                    view_args={"length": len(share.split()), "retry_scan": False},
+                    skip_current_view=True,
+                )
+        except Exception as e:
+            print(e)
+            if hasattr(self, 'loading_screen'):
+                self.loading_screen.stop()
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                text=str(e),
+                show_back_button=True,
+            )
+            return Destination(BackStackView)
+
+        return Destination(SeedSlip39MoreSharesView, skip_current_view=True)
+
+
 
 """****************************************************************************
     Views for actions on individual seeds:
@@ -965,15 +1225,21 @@ class SeedBackupView(View):
             return Destination(BackStackView)
 
         elif button_data[selected_menu_num] == self.VIEW_WORDS:
+            if isinstance(self.seed, Slip39Seed):
+                return Destination(SeedSlip39SelectShareView, view_args={"seed_num": self.seed_num, "next_view": SeedWordsWarningView})
             return Destination(SeedWordsWarningView, view_args={"seed_num": self.seed_num})
 
         elif button_data[selected_menu_num] == self.EXPORT_PLAINTEXTQR:
+            if isinstance(self.seed, Slip39Seed):
+                return Destination(SeedSlip39SelectShareView, view_args={"seed_num": self.seed_num, "next_view": SeedExportPlaintextQRView})
             return Destination(SeedExportPlaintextQRView, view_args={"seed_num": self.seed_num})
 
         elif button_data[selected_menu_num] == self.EXPORT_SEEDQR:
             return Destination(SeedTranscribeSeedQRFormatView, view_args={"seed_num": self.seed_num})
 
         elif button_data[selected_menu_num] == self.TO_SEEDKEEPER:
+            if isinstance(self.seed, Slip39Seed):
+                return Destination(SeedSlip39SelectShareView, view_args={"seed_num": self.seed_num, "next_view": SaveToSeedkeeperView})
             return Destination(SaveToSeedkeeperView, view_args={"seed_num": self.seed_num})
 
 
@@ -1324,10 +1590,11 @@ class SeedExportXpubQRDisplayView(View):
     View Seed Words flow
 ****************************************************************************"""
 class SeedWordsWarningView(View):
-    def __init__(self, seed_num: int, bip85_data: dict = None):
+    def __init__(self, seed_num: int, bip85_data: dict = None, share_index: int | None = None):
         super().__init__()
         self.seed_num = seed_num
         self.bip85_data = bip85_data
+        self.share_index = share_index
 
 
     def run(self):
@@ -1336,7 +1603,8 @@ class SeedWordsWarningView(View):
             view_args=dict(
                 seed_num=self.seed_num,
                 page_index=0,
-                bip85_data=self.bip85_data
+                bip85_data=self.bip85_data,
+                share_index=self.share_index
             ),
             skip_current_view=True,  # Prevent going BACK to WarningViews
         )
@@ -1362,7 +1630,7 @@ class SeedWordsView(View):
     NEXT = ButtonOption("Next")
     DONE = ButtonOption("Done")
 
-    def __init__(self, seed_num: int, bip85_data: dict = None, page_index: int = 0):
+    def __init__(self, seed_num: int, bip85_data: dict = None, page_index: int = 0, share_index: int | None = None):
         super().__init__()
         self.seed_num = seed_num
         if self.seed_num is None:
@@ -1371,6 +1639,7 @@ class SeedWordsView(View):
             self.seed = self.controller.get_seed(self.seed_num)
         self.bip85_data = bip85_data
         self.page_index = page_index
+        self.share_index = share_index
 
 
     def run(self):
@@ -1382,7 +1651,10 @@ class SeedWordsView(View):
             # TRANSLATOR_NOTE: Inserts the child index (e.g. "Child #0")
             title = _("Child #{}").format(self.bip85_data["child_index"])
         else:
-            mnemonic = self.seed.mnemonic_display_list
+            if isinstance(self.seed, Slip39Seed) and self.share_index is not None:
+                mnemonic = self.seed.mnemonic_list[self.share_index].split()
+            else:
+                mnemonic = self.seed.mnemonic_display_list
             title = _("Seed Words")
         words = mnemonic[self.page_index*words_per_page:(self.page_index + 1)*words_per_page]
 
@@ -1408,19 +1680,19 @@ class SeedWordsView(View):
             if self.seed_num is None and self.page_index == num_pages - 1:
                 return Destination(
                     SeedWordsBackupTestPromptView,
-                    view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
+                    view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data, share_index=self.share_index),
                 )
             else:
                 return Destination(
                     SeedWordsView,
-                    view_args=dict(seed_num=self.seed_num, page_index=self.page_index + 1, bip85_data=self.bip85_data)
+                    view_args=dict(seed_num=self.seed_num, page_index=self.page_index + 1, bip85_data=self.bip85_data, share_index=self.share_index)
                 )
 
         elif button_data[selected_menu_num] == self.DONE:
             # Must clear history to avoid BACK button returning to private info
             return Destination(
                 SeedWordsBackupTestPromptView,
-                view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
+                view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data, share_index=self.share_index),
             )
 
 
@@ -1546,10 +1818,11 @@ class SeedWordsBackupTestPromptView(View):
     SKIP = ButtonOption("Skip")
     FINALIZE = ButtonOption("Finalize child")
 
-    def __init__(self, seed_num: int, bip85_data: dict = None):
+    def __init__(self, seed_num: int, bip85_data: dict = None, share_index: int | None = None):
         super().__init__()
         self.seed_num = seed_num
         self.bip85_data = bip85_data
+        self.share_index = share_index
 
 
     def run(self):
@@ -1564,13 +1837,13 @@ class SeedWordsBackupTestPromptView(View):
         if button_data[selected_menu_num] == self.VERIFY:
             return Destination(
                 SeedWordsBackupTestView,
-                view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
+                view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data, share_index=self.share_index),
             )
 
         elif button_data[selected_menu_num] == self.REVIEW:
             return Destination(
                 SeedWordsWarningView,
-                view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
+                view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data, share_index=self.share_index),
             )
 
         elif button_data[selected_menu_num] == self.SKIP:
@@ -1591,7 +1864,7 @@ class SeedWordsBackupTestPromptView(View):
 
 
 class SeedWordsBackupTestView(View):
-    def __init__(self, seed_num: int, bip85_data: dict = None, confirmed_list: list[bool] = None, cur_index: int = None, rand_seed: int = None):
+    def __init__(self, seed_num: int, bip85_data: dict = None, confirmed_list: list[bool] = None, cur_index: int = None, rand_seed: int = None, share_index: int | None = None):
         """
         Note: `rand_seed` is ONLY USED BY THE SCREENSHOT GENERATOR!!! (to ensure
         consistent screenshot results).
@@ -1603,11 +1876,15 @@ class SeedWordsBackupTestView(View):
         else:
             self.seed = self.controller.get_seed(self.seed_num)
         self.bip85_data = bip85_data
+        self.share_index = share_index
 
         if self.bip85_data is not None:
             self.mnemonic_list = self.seed.get_bip85_child_mnemonic(self.bip85_data["child_index"], self.bip85_data["num_words"]).split()
         else:
-            self.mnemonic_list = self.seed.mnemonic_display_list
+            if isinstance(self.seed, Slip39Seed) and self.share_index is not None:
+                self.mnemonic_list = self.seed.mnemonic_list[self.share_index].split()
+            else:
+                self.mnemonic_list = self.seed.mnemonic_display_list
 
         self.confirmed_list = confirmed_list
         if not self.confirmed_list:
@@ -1652,27 +1929,28 @@ class SeedWordsBackupTestView(View):
                 # Successfully confirmed the full mnemonic!
                 return Destination(
                     SeedWordsBackupTestSuccessView,
-                    view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
+                    view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data, share_index=self.share_index),
                 )
             else:
                 # Continue testing the remaining words
                 return Destination(
                     SeedWordsBackupTestView,
-                    view_args=dict(seed_num=self.seed_num, confirmed_list=self.confirmed_list, bip85_data=self.bip85_data),
+                    view_args=dict(seed_num=self.seed_num, confirmed_list=self.confirmed_list, bip85_data=self.bip85_data, share_index=self.share_index),
                 )
 
         else:
             # Picked the WRONG WORD!
-            return Destination(
-                SeedWordsBackupTestMistakeView,
-                view_args=dict(
-                    seed_num=self.seed_num,
-                    bip85_data=self.bip85_data,
-                    cur_index=self.cur_index,
-                    wrong_word=button_data[selected_menu_num].button_label,
-                    confirmed_list=self.confirmed_list,
+                return Destination(
+                    SeedWordsBackupTestMistakeView,
+                    view_args=dict(
+                        seed_num=self.seed_num,
+                        bip85_data=self.bip85_data,
+                        cur_index=self.cur_index,
+                        wrong_word=button_data[selected_menu_num].button_label,
+                        confirmed_list=self.confirmed_list,
+                        share_index=self.share_index,
+                    )
                 )
-            )
 
 
 
@@ -1680,13 +1958,14 @@ class SeedWordsBackupTestMistakeView(View):
     REVIEW = ButtonOption("Review Seed Words")
     RETRY = ButtonOption("Try Again")
 
-    def __init__(self, seed_num: int, bip85_data: dict = None, cur_index: int = None, wrong_word: str = None, confirmed_list: list[bool] = None):
+    def __init__(self, seed_num: int, bip85_data: dict = None, cur_index: int = None, wrong_word: str = None, confirmed_list: list[bool] = None, share_index: int | None = None):
         super().__init__()
         self.seed_num = seed_num
         self.bip85_data = bip85_data
         self.cur_index = cur_index
         self.wrong_word = wrong_word
         self.confirmed_list = confirmed_list
+        self.share_index = share_index
 
 
     def run(self):
@@ -1710,7 +1989,7 @@ class SeedWordsBackupTestMistakeView(View):
         if button_data[selected_menu_num] == self.REVIEW:
             return Destination(
                 SeedWordsView,
-                view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data),
+                view_args=dict(seed_num=self.seed_num, bip85_data=self.bip85_data, share_index=self.share_index),
             )
 
         elif button_data[selected_menu_num] == self.RETRY:
@@ -1721,16 +2000,18 @@ class SeedWordsBackupTestMistakeView(View):
                     confirmed_list=self.confirmed_list,
                     cur_index=self.cur_index,
                     bip85_data=self.bip85_data,
+                    share_index=self.share_index,
                 )
             )
 
 
 
 class SeedWordsBackupTestSuccessView(View):
-    def __init__(self, seed_num: int, bip85_data: dict = None):
+    def __init__(self, seed_num: int, bip85_data: dict = None, share_index: int | None = None):
         super().__init__()
         self.seed_num = seed_num
         self.bip85_data = bip85_data
+        self.share_index = share_index
 
 
     def run(self):
@@ -3186,15 +3467,19 @@ class SeedSignMessageSignedMessageQRView(View):
 
 
 class SeedExportPlaintextQRView(View):
-    def __init__(self, seed_num: int):
+    def __init__(self, seed_num: int, share_index: int | None = None):
         super().__init__()
         self.seed_num = seed_num
         self.seed = self.controller.get_seed(seed_num)
+        self.share_index = share_index
 
 
     def run(self):
         from seedsigner.gui.screens.screen import QRDisplayScreen
-        encoder_args = dict(data=self.seed.mnemonic_str)
+        data = self.seed.mnemonic_str
+        if isinstance(self.seed, Slip39Seed) and self.share_index is not None:
+            data = self.seed.mnemonic_list[self.share_index]
+        encoder_args = dict(data=data)
         e = GenericStaticQrEncoder(**encoder_args)
 
         self.run_screen(
@@ -3219,10 +3504,11 @@ class SaveToSeedkeeperView(View):
         entropy = mnemonic_obj.to_entropy(bip39_mnemonic)
 
         return entropy  # bytearray
-    def __init__(self, seed_num: int, bip85_data: dict = None):
+    def __init__(self, seed_num: int, bip85_data: dict = None, share_index: int | None = None):
         super().__init__()
         self.seed_num = seed_num
         self.bip85_data = bip85_data
+        self.share_index = share_index
 
     def run(self):
         from seedsigner.gui.screens.screen import LoadingScreenThread
@@ -3232,61 +3518,77 @@ class SaveToSeedkeeperView(View):
             if not Satochip_Connector:
                 return Destination(BackStackView)
 
-            ret = seed_screens.SeedAddPassphraseScreen(title="Seed Label").display()
-
-            if "is_back_button" in ret:
-                return Destination(BackStackView)
-
-            status = Satochip_Connector.card_get_status()[3]
-
-            print(status)
-
             seed = self.controller.get_seed(self.seed_num)
 
-            if status['protocol_minor_version'] == 1: # Format needed for Seedkeeper v1 cards
-                print("Saving to SeedKeeper V1")
-                label = ret['passphrase']
+            if isinstance(seed, Slip39Seed):
+                if self.share_index is None:
+                    button_data = [ButtonOption(f"Share {i+1}") for i in range(len(seed.mnemonic_list))]
+                    share_sel = self.run_screen(
+                        ButtonListScreen,
+                        title="Select Share",
+                        is_button_text_centered=False,
+                        button_data=button_data,
+                        show_back_button=True,
+                    )
+                    if share_sel == RET_CODE__BACK_BUTTON:
+                        return Destination(BackStackView)
+                else:
+                    share_sel = self.share_index
+
+                share = seed.mnemonic_list[share_sel]
+                ret = seed_screens.SeedAddPassphraseScreen(title="Secret Label").display()
+                if "is_back_button" in ret:
+                    return Destination(BackStackView)
+
+                label = "SLIP39:" + ret['passphrase']
                 export_rights = "Plaintext export allowed"
-                type = "BIP39 mnemonic"
-                subtype = 0
-                bip39_mnemonic = seed.mnemonic_str
-                bip39_mnemonic_list = list(bytes(bip39_mnemonic, 'utf-8'))
-                bip39_passphrase = seed.passphrase
-                bip39_passphrase_list = list(bytes(bip39_passphrase, 'utf-8'))
-                secret_list = [len(bip39_mnemonic_list)] + bip39_mnemonic_list + [len(bip39_passphrase_list)] + bip39_passphrase_list
+                header = Satochip_Connector.make_header("Password", export_rights, label)
+                share_list = list(bytes(share, 'utf-8'))
+                secret_list = [len(share_list)] + share_list
+                secret_dic = {'header': header, 'secret_list': secret_list}
 
-            else: # Seedkeeper V2 Format (Masterseed with BIP39 info)
-                print("Saving to SeedKeeper V2")
-                label = ret['passphrase']
-                export_rights = "Plaintext export allowed"
-                type = "Masterseed"
-                subtype = 0x01
-
-                # Seedisgner currently only supports English, so just hardcode
-                wordlist_byte = dict_swap_keys_values(BIP39_WORDLIST_DIC).get("english")
-                bip39_entropy_bytes = self.mnemonic_to_entropy(seed.mnemonic_str, "english")
-                bip39_entropy_list = list(bip39_entropy_bytes)
-                bip39_passphrase_list = list(bytes(seed.passphrase, 'utf-8'))
-
-                masterseed_bytes = seed.seed_bytes
-                masterseed_list = list(masterseed_bytes)
-
-                # this format is backward compatible with Masterseed, this facilitates encrypted export to satochip
-                secret_list = ([len(masterseed_list)] +
-                               masterseed_list +
-                               [wordlist_byte] +
-                               [len(bip39_entropy_list)] +
-                               bip39_entropy_list +
-                               [len(bip39_passphrase_list)] +
-                               bip39_passphrase_list
-                               )
+            else:
+                ret = seed_screens.SeedAddPassphraseScreen(title="Seed Label").display()
+                if "is_back_button" in ret:
+                    return Destination(BackStackView)
+                status = Satochip_Connector.card_get_status()[3]
+                print(status)
+                if status['protocol_minor_version'] == 1:  # Seedkeeper v1
+                    print("Saving to SeedKeeper V1")
+                    label = ret['passphrase']
+                    export_rights = "Plaintext export allowed"
+                    type = "BIP39 mnemonic"
+                    subtype = 0
+                    bip39_mnemonic = seed.mnemonic_str
+                    bip39_mnemonic_list = list(bytes(bip39_mnemonic, 'utf-8'))
+                    bip39_passphrase = seed.passphrase
+                    bip39_passphrase_list = list(bytes(bip39_passphrase, 'utf-8'))
+                    secret_list = [len(bip39_mnemonic_list)] + bip39_mnemonic_list + [len(bip39_passphrase_list)] + bip39_passphrase_list
+                else:
+                    print("Saving to SeedKeeper V2")
+                    label = ret['passphrase']
+                    export_rights = "Plaintext export allowed"
+                    type = "Masterseed"
+                    subtype = 0x01
+                    wordlist_byte = dict_swap_keys_values(BIP39_WORDLIST_DIC).get("english")
+                    bip39_entropy_bytes = self.mnemonic_to_entropy(seed.mnemonic_str, "english")
+                    bip39_entropy_list = list(bip39_entropy_bytes)
+                    bip39_passphrase_list = list(bytes(seed.passphrase, 'utf-8'))
+                    masterseed_bytes = seed.seed_bytes
+                    masterseed_list = list(masterseed_bytes)
+                    secret_list = ([len(masterseed_list)] +
+                                   masterseed_list +
+                                   [wordlist_byte] +
+                                   [len(bip39_entropy_list)] +
+                                   bip39_entropy_list +
+                                   [len(bip39_passphrase_list)] +
+                                   bip39_passphrase_list
+                                   )
+                header = Satochip_Connector.make_header(type, export_rights, label, subtype=subtype)
+                secret_dic = {'header': header, 'secret_list': secret_list}
 
             self.loading_screen = LoadingScreenThread(text="Saving Seed\n\n\n\n\n\n")
             self.loading_screen.start()
-
-            header = Satochip_Connector.make_header(type, export_rights, label, subtype= subtype)
-
-            secret_dic = {'header': header, 'secret_list': secret_list}
             (sid, fingerprint) = Satochip_Connector.seedkeeper_import_secret(secret_dic)
             print("Imported - SID:", sid, " Fingerprint:", fingerprint)
 

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -195,6 +195,7 @@ class MainMenuView(View):
         from seedsigner.gui.toast import InfoToast
 
         controller = Controller.get_instance()
+        controller.storage.discard_pending_slip39_shares()
         if controller.auto_wiped:
             controller.auto_wiped = False
             controller.activate_toast(InfoToast(label_text=_("Data wiped after inactivity")))

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,5 +1,6 @@
 import pytest
-from seedsigner.models.seed import InvalidSeedException, Seed, ElectrumSeed
+from seedsigner.models.seed import InvalidSeedException, Seed, ElectrumSeed, Slip39Seed
+import shamir_mnemonic
 
 from seedsigner.models.settings import SettingsConstants
 
@@ -83,3 +84,60 @@ def test_electrum_seed_rejects_most_bip39_mnemonics():
 	mnemonic = "only gain spot output unknown craft simple cram absorb suggest ridge famous".split()
 	Seed(mnemonic)
 	ElectrumSeed(mnemonic)
+
+def test_slip39_seed():
+        secret = bytes.fromhex("11" * 32)
+        shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret)[0]
+        seed = Slip39Seed(mnemonics=[shares[0], shares[1]])
+        assert seed.seed_bytes == secret
+
+def test_slip39_seed_20_word_share():
+        secret = bytes.fromhex("33" * 16)
+        shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret)[0]
+        seed = Slip39Seed(mnemonics=[shares[0], shares[1]])
+        assert seed.seed_bytes == secret
+
+def test_slip39_storage_reconstruction():
+       secret = bytes.fromhex("22" * 32)
+       shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret)[0]
+       from seedsigner.models.seed_storage import SeedStorage
+       storage = SeedStorage()
+       storage.init_pending_slip39_share(num_words=len(shares[0].split()))
+       for i, w in enumerate(shares[0].split()):
+               storage.update_pending_slip39_share(w, i)
+       storage.finalize_current_slip39_share()
+       storage.init_pending_slip39_share()
+       for i, w in enumerate(shares[1].split()):
+               storage.update_pending_slip39_share(w, i)
+       storage.finalize_current_slip39_share()
+       storage.convert_pending_slip39_shares_to_pending_seed()
+       assert storage.pending_seed.seed_bytes == secret
+
+def test_slip39_storage_reconstruction_20_word():
+       secret = bytes.fromhex("44" * 16)
+       shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret)[0]
+       from seedsigner.models.seed_storage import SeedStorage
+       storage = SeedStorage()
+       storage.init_pending_slip39_share(num_words=len(shares[0].split()))
+       for i, w in enumerate(shares[0].split()):
+               storage.update_pending_slip39_share(w, i)
+       storage.finalize_current_slip39_share()
+       storage.init_pending_slip39_share()
+       for i, w in enumerate(shares[1].split()):
+               storage.update_pending_slip39_share(w, i)
+       storage.finalize_current_slip39_share()
+       storage.convert_pending_slip39_shares_to_pending_seed()
+       assert storage.pending_seed.seed_bytes == secret
+
+def test_slip39_invalid_share_rejected():
+        secret = bytes.fromhex("55" * 16)
+        shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret)[0]
+        bad_share = shares[0].split()
+        bad_share[-1] = "abandon"
+        from seedsigner.models.seed_storage import SeedStorage, InvalidSeedException
+        storage = SeedStorage()
+        storage.init_pending_slip39_share(num_words=len(bad_share))
+        for i, w in enumerate(bad_share):
+                storage.update_pending_slip39_share(w, i)
+        with pytest.raises(InvalidSeedException):
+                storage.finalize_current_slip39_share()


### PR DESCRIPTION
## Summary
- import `Slip39Seed` in `seed_views`
- ensure backup menu options work for SLIP-39 seeds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887739c3e088322b096e37fa3ac24f4