### PR TITLE
Add SLIP39 seed creation features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/seedsigner/models/settings_definition.json
 
 *.po
 *.mo
+jcardsim.jar

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -557,8 +557,9 @@ class SeedWordsScreen(WarningEdgesMixin, ButtonListScreen):
 
 @dataclass
 class SeedBIP85SelectChildIndexScreen(KeyboardScreen):
+    title: str = _("BIP-85 Index")
+
     def __post_init__(self):
-        self.title = _("BIP-85 Index")
         self.user_input = ""
 
         # Specify the keys in the keyboard

--- a/src/seedsigner/helpers/mnemonic_generation.py
+++ b/src/seedsigner/helpers/mnemonic_generation.py
@@ -81,6 +81,14 @@ def generate_mnemonic_from_dice(roll_data: str, wordlist_language_code: str = Se
     return bip39.mnemonic_from_bytes(entropy_bytes, wordlist=Seed.get_wordlist(wordlist_language_code)).split()
 
 
+def generate_bytes_from_dice(roll_data: str) -> bytes:
+    """Return entropy bytes from dice rolls without converting to mnemonic."""
+    entropy_bytes = hashlib.sha256(roll_data.encode()).digest()
+    if len(roll_data) == DICE__NUM_ROLLS__12WORD:
+        entropy_bytes = entropy_bytes[:16]
+    return entropy_bytes
+
+
 
 def generate_mnemonic_from_coin_flips(coin_flips: str, wordlist_language_code: str = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH) -> list[str]:
     """

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -274,6 +274,7 @@ class Slip39Seed(Seed):
         first_share = shamir_mnemonic.Share.from_mnemonic(self._shares[0])
         self.extendable: bool = first_share.extendable
         self._member_threshold: int = first_share.member_threshold
+        self._group_threshold: int = first_share.group_threshold
 
         # Passphrase used to decrypt the shares
         self._slip39_passphrase: str = unicodedata.normalize("NFKD", slip39_passphrase) if slip39_passphrase else ""
@@ -282,27 +283,49 @@ class Slip39Seed(Seed):
         self._passphrase: str = unicodedata.normalize("NFKD", passphrase) if passphrase else ""
 
         self.seed_bytes: bytes = None
+        self.master_secret: bytes | None = None
         self._generate_seed()
 
     def _generate_seed(self):
         try:
-            combine_list = list(self._shares)
-            if len(combine_list) > self._member_threshold:
-                combine_list = combine_list[: self._member_threshold]
+            try:
+                secret = shamir_mnemonic.combine_mnemonics(
+                    self._shares, self._slip39_passphrase.encode("utf-8")
+                )
+            except Exception as e:
+                if "Wrong number of mnemonics" not in str(e):
+                    raise
+                groups: dict[int, list[str]] = {}
+                for share in self._shares:
+                    s = shamir_mnemonic.Share.from_mnemonic(share)
+                    grp = groups.setdefault(s.group_index, [])
+                    if len(grp) < self._member_threshold:
+                        grp.append(share)
+                    if (
+                        len(groups) >= self._group_threshold
+                        and all(len(v) >= self._member_threshold for v in groups.values())
+                    ):
+                        break
 
-            secret = shamir_mnemonic.combine_mnemonics(
-                combine_list, self._slip39_passphrase.encode("utf-8")
-            )
+                combine_list: list[str] = []
+                for grp_index in sorted(groups.keys())[: self._group_threshold]:
+                    combine_list.extend(groups[grp_index][: self._member_threshold])
+
+                secret = shamir_mnemonic.combine_mnemonics(
+                    combine_list, self._slip39_passphrase.encode("utf-8")
+                )
+
             self.master_secret = secret
 
-            # Convert the recovered secret to a BIP-39 seed so that applying a
-            # passphrase mirrors the behaviour of standard BIP-39 mnemonics.
-            mnemonic = bip39.mnemonic_from_bytes(secret)
-            self.seed_bytes = bip39.mnemonic_to_seed(
-                mnemonic,
-                password=self._passphrase,
-                wordlist=self.wordlist,
-            )
+            if self._passphrase:
+                mnemonic = bip39.mnemonic_from_bytes(secret)
+                self.seed_bytes = bip39.mnemonic_to_seed(
+                    mnemonic,
+                    password=self._passphrase,
+                    wordlist=self.wordlist,
+                )
+            else:
+                self.seed_bytes = secret
         except Exception as e:
             logger.info(repr(e), exc_info=True)
             raise InvalidSeedException(repr(e))

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -34,6 +34,7 @@ class Seed:
         self.set_passphrase(passphrase, regenerate_seed=False)
 
         self.seed_bytes: bytes = None
+        self.master_secret: bytes | None = None
         self._generate_seed()
 
 
@@ -257,9 +258,14 @@ class ElectrumSeed(Seed):
 
 
 class Slip39Seed(Seed):
-    """Seed derived from SLIP-39 mnemonic shares."""
+    """Seed derived from SLIP-39 mnemonic shares.
 
-    def __init__(self, mnemonics: List[str], passphrase: str = "") -> None:
+    ``passphrase`` here refers to the SLIP‑39 passphrase used when the shares
+    were originally created.  A separate BIP‑39 passphrase can be set via the
+    :py:meth:`set_passphrase` method once the master secret has been recovered.
+    """
+
+    def __init__(self, mnemonics: List[str], slip39_passphrase: str = "", passphrase: str = "") -> None:
         self._wordlist_language_code = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH
         if not mnemonics:
             raise Exception("Must provide at least one SLIP-39 share")
@@ -269,8 +275,11 @@ class Slip39Seed(Seed):
         self.extendable: bool = first_share.extendable
         self._member_threshold: int = first_share.member_threshold
 
-        self._passphrase: str = ""
-        self.set_passphrase(passphrase, regenerate_seed=False)
+        # Passphrase used to decrypt the shares
+        self._slip39_passphrase: str = unicodedata.normalize("NFKD", slip39_passphrase) if slip39_passphrase else ""
+
+        # Optional BIP-39 passphrase applied after recovering the master secret
+        self._passphrase: str = unicodedata.normalize("NFKD", passphrase) if passphrase else ""
 
         self.seed_bytes: bytes = None
         self._generate_seed()
@@ -280,8 +289,19 @@ class Slip39Seed(Seed):
             combine_list = list(self._shares)
             if len(combine_list) > self._member_threshold:
                 combine_list = combine_list[: self._member_threshold]
-            self.seed_bytes = shamir_mnemonic.combine_mnemonics(
-                combine_list, self._passphrase.encode("utf-8")
+
+            secret = shamir_mnemonic.combine_mnemonics(
+                combine_list, self._slip39_passphrase.encode("utf-8")
+            )
+            self.master_secret = secret
+
+            # Convert the recovered secret to a BIP-39 seed so that applying a
+            # passphrase mirrors the behaviour of standard BIP-39 mnemonics.
+            mnemonic = bip39.mnemonic_from_bytes(secret)
+            self.seed_bytes = bip39.mnemonic_to_seed(
+                mnemonic,
+                password=self._passphrase,
+                wordlist=self.wordlist,
             )
         except Exception as e:
             logger.info(repr(e), exc_info=True)
@@ -301,6 +321,12 @@ class Slip39Seed(Seed):
         if regenerate_seed:
             self._generate_seed()
 
+    def set_slip39_passphrase(self, passphrase: str, regenerate_seed: bool = True):
+        """Set or update the passphrase used to decrypt the SLIP-39 shares."""
+        self._slip39_passphrase = unicodedata.normalize("NFKD", passphrase) if passphrase else ""
+        if regenerate_seed:
+            self._generate_seed()
+
     @property
     def seedqr_supported(self) -> bool:
         return False
@@ -314,7 +340,10 @@ class Slip39Seed(Seed):
         if not self.extendable:
             raise InvalidSeedException("This SLIP-39 seed is not extendable")
         shares = shamir_mnemonic.generate_mnemonics(
-            1, [(threshold, num_shares)], self.seed_bytes, extendable=True
+            1,
+            [(threshold, num_shares)],
+            self.master_secret,
+            extendable=True,
         )[0]
         self._shares = shares
         self._member_threshold = threshold

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -276,6 +276,8 @@ class Slip39Seed(Seed):
 
         self.seed_bytes: bytes = None
         self.master_secret: bytes | None = None
+        self._initial_master_secret: bytes | None = None
+        self._creation_passphrase: str = self._slip39_passphrase
         self._generate_seed()
 
     def _generate_seed(self):
@@ -308,6 +310,8 @@ class Slip39Seed(Seed):
                 )
 
             self.master_secret = secret
+            if self._initial_master_secret is None:
+                self._initial_master_secret = secret
             self.seed_bytes = secret
         except Exception as e:
             logger.info(repr(e), exc_info=True)
@@ -353,18 +357,26 @@ class Slip39Seed(Seed):
         return False
 
     def regenerate_shares(self, threshold: int, num_shares: int) -> List[str]:
-        """Generate new SLIP-39 shares for the existing seed using the stored
-        master secret and passphrase."""
+        """Generate new SLIP-39 shares preserving the original identifier and
+        master secret extracted before any passphrase changes."""
         if not self.extendable:
             raise InvalidSeedException("This SLIP-39 seed is not extendable")
 
-        shares = shamir_mnemonic.generate_mnemonics(
-            1,
+        first_share = shamir_mnemonic.Share.from_mnemonic(self._shares[0])
+        ems = shamir_mnemonic.shamir.EncryptedMasterSecret.from_master_secret(
+            self._initial_master_secret,
+            self._creation_passphrase.encode("utf-8"),
+            first_share.identifier,
+            True,
+            first_share.iteration_exponent,
+        )
+
+        shares_objs = shamir_mnemonic.shamir.split_ems(
+            first_share.group_threshold,
             [(threshold, num_shares)],
-            self.master_secret,
-            passphrase=self._slip39_passphrase.encode("utf-8"),
-            extendable=True,
+            ems,
         )[0]
+        shares = [s.mnemonic() for s in shares_objs]
 
         self._shares = shares
         self._member_threshold = threshold

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -258,14 +258,9 @@ class ElectrumSeed(Seed):
 
 
 class Slip39Seed(Seed):
-    """Seed derived from SLIP-39 mnemonic shares.
+    """Seed derived from SLIP-39 mnemonic shares."""
 
-    ``passphrase`` here refers to the SLIP‑39 passphrase used when the shares
-    were originally created.  A separate BIP‑39 passphrase can be set via the
-    :py:meth:`set_passphrase` method once the master secret has been recovered.
-    """
-
-    def __init__(self, mnemonics: List[str], slip39_passphrase: str = "", passphrase: str = "") -> None:
+    def __init__(self, mnemonics: List[str], slip39_passphrase: str = "") -> None:
         self._wordlist_language_code = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH
         if not mnemonics:
             raise Exception("Must provide at least one SLIP-39 share")
@@ -278,9 +273,6 @@ class Slip39Seed(Seed):
 
         # Passphrase used to decrypt the shares
         self._slip39_passphrase: str = unicodedata.normalize("NFKD", slip39_passphrase) if slip39_passphrase else ""
-
-        # Optional BIP-39 passphrase applied after recovering the master secret
-        self._passphrase: str = unicodedata.normalize("NFKD", passphrase) if passphrase else ""
 
         self.seed_bytes: bytes = None
         self.master_secret: bytes | None = None
@@ -316,16 +308,7 @@ class Slip39Seed(Seed):
                 )
 
             self.master_secret = secret
-
-            if self._passphrase:
-                mnemonic = bip39.mnemonic_from_bytes(secret)
-                self.seed_bytes = bip39.mnemonic_to_seed(
-                    mnemonic,
-                    password=self._passphrase,
-                    wordlist=self.wordlist,
-                )
-            else:
-                self.seed_bytes = secret
+            self.seed_bytes = secret
         except Exception as e:
             logger.info(repr(e), exc_info=True)
             raise InvalidSeedException(repr(e))
@@ -339,16 +322,27 @@ class Slip39Seed(Seed):
     def mnemonic_str(self) -> str:
         return "\n".join(self._shares)
 
-    def set_passphrase(self, passphrase: str, regenerate_seed: bool = True):
-        self._passphrase = unicodedata.normalize("NFKD", passphrase) if passphrase else ""
-        if regenerate_seed:
-            self._generate_seed()
-
     def set_slip39_passphrase(self, passphrase: str, regenerate_seed: bool = True):
         """Set or update the passphrase used to decrypt the SLIP-39 shares."""
         self._slip39_passphrase = unicodedata.normalize("NFKD", passphrase) if passphrase else ""
         if regenerate_seed:
             self._generate_seed()
+
+    @property
+    def has_passphrase(self) -> bool:
+        return self._slip39_passphrase != ""
+
+    @property
+    def passphrase(self) -> str:
+        return self._slip39_passphrase
+
+    @property
+    def passphrase_display(self) -> str:
+        return unicodedata.normalize("NFC", self._slip39_passphrase)
+
+    @property
+    def passphrase_label(self) -> str:
+        return "SLIP-39 Passphrase"
 
     @property
     def seedqr_supported(self) -> bool:

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -301,3 +301,9 @@ class Slip39Seed(Seed):
     @property
     def bip85_supported(self) -> bool:
         return False
+
+    def regenerate_shares(self, threshold: int, num_shares: int) -> List[str]:
+        """Generate new SLIP-39 shares for the existing seed."""
+        shares = shamir_mnemonic.generate_mnemonics(1, [(threshold, num_shares)], self.seed_bytes)[0]
+        self._shares = shares
+        return shares

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -366,6 +366,7 @@ class Slip39Seed(Seed):
             1,
             [(threshold, num_shares)],
             self.master_secret,
+            passphrase=self._slip39_passphrase.encode("utf-8"),
             extendable=True,
         )[0]
         self._shares = shares

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -353,9 +353,11 @@ class Slip39Seed(Seed):
         return False
 
     def regenerate_shares(self, threshold: int, num_shares: int) -> List[str]:
-        """Generate new SLIP-39 shares for the existing seed."""
+        """Generate new SLIP-39 shares for the existing seed using the stored
+        master secret and passphrase."""
         if not self.extendable:
             raise InvalidSeedException("This SLIP-39 seed is not extendable")
+
         shares = shamir_mnemonic.generate_mnemonics(
             1,
             [(threshold, num_shares)],
@@ -363,6 +365,7 @@ class Slip39Seed(Seed):
             passphrase=self._slip39_passphrase.encode("utf-8"),
             extendable=True,
         )[0]
+
         self._shares = shares
         self._member_threshold = threshold
         return shares

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -265,6 +265,9 @@ class Slip39Seed(Seed):
             raise Exception("Must provide at least one SLIP-39 share")
         self._shares: List[str] = [unicodedata.normalize("NFKD", m.strip()) for m in mnemonics]
 
+        first_share = shamir_mnemonic.Share.from_mnemonic(self._shares[0])
+        self.extendable: bool = first_share.extendable
+
         self._passphrase: str = ""
         self.set_passphrase(passphrase, regenerate_seed=False)
 
@@ -304,6 +307,10 @@ class Slip39Seed(Seed):
 
     def regenerate_shares(self, threshold: int, num_shares: int) -> List[str]:
         """Generate new SLIP-39 shares for the existing seed."""
-        shares = shamir_mnemonic.generate_mnemonics(1, [(threshold, num_shares)], self.seed_bytes)[0]
+        if not self.extendable:
+            raise InvalidSeedException("This SLIP-39 seed is not extendable")
+        shares = shamir_mnemonic.generate_mnemonics(
+            1, [(threshold, num_shares)], self.seed_bytes, extendable=True
+        )[0]
         self._shares = shares
         return shares

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -357,26 +357,27 @@ class Slip39Seed(Seed):
         return False
 
     def regenerate_shares(self, threshold: int, num_shares: int) -> List[str]:
-        """Generate new SLIP-39 shares preserving the original identifier and
-        master secret extracted before any passphrase changes."""
+        """Generate new SLIP-39 shares from the original master secret."""
         if not self.extendable:
             raise InvalidSeedException("This SLIP-39 seed is not extendable")
 
+        if threshold > num_shares:
+            raise InvalidSeedException(
+                "The requested threshold must not exceed the number of shares."
+            )
+
         first_share = shamir_mnemonic.Share.from_mnemonic(self._shares[0])
-        ems = shamir_mnemonic.shamir.EncryptedMasterSecret.from_master_secret(
+
+        new_groups = shamir_mnemonic.generate_mnemonics(
+            self._group_threshold,
+            [(threshold, num_shares)],
             self._initial_master_secret,
-            self._creation_passphrase.encode("utf-8"),
-            first_share.identifier,
-            True,
-            first_share.iteration_exponent,
+            passphrase=self._creation_passphrase.encode("utf-8"),
+            extendable=True,
+            iteration_exponent=first_share.iteration_exponent,
         )
 
-        shares_objs = shamir_mnemonic.shamir.split_ems(
-            first_share.group_threshold,
-            [(threshold, num_shares)],
-            ems,
-        )[0]
-        shares = [s.mnemonic() for s in shares_objs]
+        shares = new_groups[0]
 
         self._shares = shares
         self._member_threshold = threshold

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -267,6 +267,7 @@ class Slip39Seed(Seed):
 
         first_share = shamir_mnemonic.Share.from_mnemonic(self._shares[0])
         self.extendable: bool = first_share.extendable
+        self._member_threshold: int = first_share.member_threshold
 
         self._passphrase: str = ""
         self.set_passphrase(passphrase, regenerate_seed=False)
@@ -276,8 +277,11 @@ class Slip39Seed(Seed):
 
     def _generate_seed(self):
         try:
+            combine_list = list(self._shares)
+            if len(combine_list) > self._member_threshold:
+                combine_list = combine_list[: self._member_threshold]
             self.seed_bytes = shamir_mnemonic.combine_mnemonics(
-                self._shares, self._passphrase.encode("utf-8")
+                combine_list, self._passphrase.encode("utf-8")
             )
         except Exception as e:
             logger.info(repr(e), exc_info=True)
@@ -313,4 +317,5 @@ class Slip39Seed(Seed):
             1, [(threshold, num_shares)], self.seed_bytes, extendable=True
         )[0]
         self._shares = shares
+        self._member_threshold = threshold
         return shares

--- a/src/seedsigner/models/seed_storage.py
+++ b/src/seedsigner/models/seed_storage.py
@@ -162,7 +162,10 @@ class SeedStorage:
 
     def convert_pending_slip39_shares_to_pending_seed(self, passphrase: str = ""):
         mnemonics = [" ".join(share) for share in self._pending_slip39_shares]
-        self.pending_seed = Slip39Seed(mnemonics=mnemonics, passphrase=passphrase)
+        self.pending_seed = Slip39Seed(
+            mnemonics=mnemonics,
+            slip39_passphrase=passphrase,
+        )
         self.discard_pending_slip39_shares()
 
     def discard_pending_slip39_shares(self):

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1090,14 +1090,14 @@ class SeedSlip39CreateFromBytesView(View):
 
     def run(self):
         ret = seed_screens.SeedBIP85SelectChildIndexScreen(title="Num Shares").display()
-        if isinstance(ret, dict) and "is_back_button" in ret:
+        if ret == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
-        num_shares = int(ret["text"])
+        num_shares = int(ret)
 
         ret = seed_screens.SeedBIP85SelectChildIndexScreen(title="Threshold").display()
-        if isinstance(ret, dict) and "is_back_button" in ret:
+        if ret == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
-        threshold = int(ret["text"])
+        threshold = int(ret)
 
         shares = shamir_mnemonic.generate_mnemonics(1, [(threshold, num_shares)], self.secret)[0]
         seed = Slip39Seed(mnemonics=shares)
@@ -1115,14 +1115,14 @@ class SeedSlip39RegenerateSharesView(View):
 
     def run(self):
         ret = seed_screens.SeedBIP85SelectChildIndexScreen(title="Num Shares").display()
-        if isinstance(ret, dict) and "is_back_button" in ret:
+        if ret == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
-        num_shares = int(ret["text"])
+        num_shares = int(ret)
 
         ret = seed_screens.SeedBIP85SelectChildIndexScreen(title="Threshold").display()
-        if isinstance(ret, dict) and "is_back_button" in ret:
+        if ret == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
-        threshold = int(ret["text"])
+        threshold = int(ret)
 
         self.seed.regenerate_shares(threshold, num_shares)
         return Destination(SeedWordsWarningView, view_args={"seed_num": self.seed_num, "share_index": 0})

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -566,6 +566,7 @@ class SeedAddPassphraseView(View):
             try:
                 self.seed.set_slip39_passphrase(passphrase)
             finally:
+                time.sleep(1)
                 self.loading_screen.stop()
         else:
             # The new passphrase will be the return value; it might be empty.
@@ -990,6 +991,7 @@ class SeedSlip39MoreSharesView(View):
         try:
             self.controller.storage.convert_pending_slip39_shares_to_pending_seed()
         finally:
+            time.sleep(1)
             self.loading_screen.stop()
 
         return Destination(SeedFinalizeView)

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -552,8 +552,20 @@ class SeedAddPassphraseView(View):
             initial_keyboard=self.initial_keyboard,
         )
 
-        # The new passphrase will be the return value; it might be empty.
-        self.seed.set_passphrase(ret_dict["passphrase"])
+        passphrase = ret_dict["passphrase"]
+        if isinstance(self.seed, Slip39Seed):
+            from seedsigner.gui.screens.screen import LoadingScreenThread
+            self.loading_screen = LoadingScreenThread(text="Deriving Seed\n\n\n\n\n\n")
+            self.loading_screen.start()
+            try:
+                self.seed.set_slip39_passphrase(passphrase)
+                # Store for display purposes
+                self.seed.set_passphrase(passphrase, regenerate_seed=False)
+            finally:
+                self.loading_screen.stop()
+        else:
+            # The new passphrase will be the return value; it might be empty.
+            self.seed.set_passphrase(passphrase)
 
         if "is_back_button" in ret_dict:
             if len(self.seed.passphrase) > 0:
@@ -741,7 +753,7 @@ class SeedReviewPassphraseView(View):
         fingerprint_with = self.seed.get_fingerprint(network=network)
         self.seed.set_passphrase("")
         fingerprint_without = self.seed.get_fingerprint(network=network)
-        self.seed.set_passphrase(passphrase)
+        self.seed.set_passphrase(passphrase, regenerate_seed=not isinstance(self.seed, Slip39Seed))
         
         button_data = [self.DONE, self.EDIT, self.SCAN]
 
@@ -950,7 +962,14 @@ class SeedSlip39MoreSharesView(View):
             from seedsigner.views.seed_views import SeedSlip39LoadFromSeedkeeperView
             return Destination(SeedSlip39LoadFromSeedkeeperView)
 
-        self.controller.storage.convert_pending_slip39_shares_to_pending_seed()
+        from seedsigner.gui.screens.screen import LoadingScreenThread
+        self.loading_screen = LoadingScreenThread(text="Combining Shares\n\n\n\n\n\n")
+        self.loading_screen.start()
+        try:
+            self.controller.storage.convert_pending_slip39_shares_to_pending_seed()
+        finally:
+            self.loading_screen.stop()
+
         return Destination(SeedFinalizeView)
 
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1099,7 +1099,9 @@ class SeedSlip39CreateFromBytesView(View):
             return Destination(BackStackView)
         threshold = int(ret)
 
-        shares = shamir_mnemonic.generate_mnemonics(1, [(threshold, num_shares)], self.secret)[0]
+        shares = shamir_mnemonic.generate_mnemonics(
+            1, [(threshold, num_shares)], self.secret, extendable=True
+        )[0]
         seed = Slip39Seed(mnemonics=shares)
         self.controller.storage.set_pending_seed(seed)
 
@@ -1114,6 +1116,19 @@ class SeedSlip39RegenerateSharesView(View):
         self.seed = self.controller.get_seed(seed_num)
 
     def run(self):
+        if not self.seed.extendable:
+            from seedsigner.gui.screens.screen import WarningScreen
+            self.run_screen(
+                WarningScreen,
+                title=_("Non-extendable Seed"),
+                show_back_button=False,
+                status_icon_name=SeedSignerIconConstants.ERROR,
+                status_headline=None,
+                text=_("This SLIP-39 seed cannot regenerate new shares."),
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(BackStackView)
+
         ret = seed_screens.SeedBIP85SelectChildIndexScreen(title="Num Shares").display()
         if ret == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -13,6 +13,7 @@ from embit.networks import NETWORKS
 from typing import List
 from PIL import Image
 from PIL.ImageOps import autocontrast
+import shamir_mnemonic
 
 from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
 from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
@@ -1081,6 +1082,52 @@ class SeedSlip39LoadFromSeedkeeperView(View):
         return Destination(SeedSlip39MoreSharesView, skip_current_view=True)
 
 
+class SeedSlip39CreateFromBytesView(View):
+    """Create a SLIP-39 seed from entropy bytes and start backup."""
+    def __init__(self, secret: bytes):
+        super().__init__()
+        self.secret = secret
+
+    def run(self):
+        ret = seed_screens.SeedBIP85SelectChildIndexScreen(title="Num Shares").display()
+        if isinstance(ret, dict) and "is_back_button" in ret:
+            return Destination(BackStackView)
+        num_shares = int(ret["text"])
+
+        ret = seed_screens.SeedBIP85SelectChildIndexScreen(title="Threshold").display()
+        if isinstance(ret, dict) and "is_back_button" in ret:
+            return Destination(BackStackView)
+        threshold = int(ret["text"])
+
+        shares = shamir_mnemonic.generate_mnemonics(1, [(threshold, num_shares)], self.secret)[0]
+        seed = Slip39Seed(mnemonics=shares)
+        self.controller.storage.set_pending_seed(seed)
+
+        return Destination(SeedWordsWarningView, view_args={"seed_num": None, "share_index": 0}, clear_history=True)
+
+
+class SeedSlip39RegenerateSharesView(View):
+    """Regenerate SLIP-39 shares for an existing seed."""
+    def __init__(self, seed_num: int):
+        super().__init__()
+        self.seed_num = seed_num
+        self.seed = self.controller.get_seed(seed_num)
+
+    def run(self):
+        ret = seed_screens.SeedBIP85SelectChildIndexScreen(title="Num Shares").display()
+        if isinstance(ret, dict) and "is_back_button" in ret:
+            return Destination(BackStackView)
+        num_shares = int(ret["text"])
+
+        ret = seed_screens.SeedBIP85SelectChildIndexScreen(title="Threshold").display()
+        if isinstance(ret, dict) and "is_back_button" in ret:
+            return Destination(BackStackView)
+        threshold = int(ret["text"])
+
+        self.seed.regenerate_shares(threshold, num_shares)
+        return Destination(SeedWordsWarningView, view_args={"seed_num": self.seed_num, "share_index": 0})
+
+
 
 """****************************************************************************
     Views for actions on individual seeds:
@@ -1203,6 +1250,7 @@ class SeedBackupView(View):
     EXPORT_SEEDQR = ButtonOption("Export as SeedQR")
     EXPORT_PLAINTEXTQR = ButtonOption("Export as Plaintext QR")
     TO_SEEDKEEPER = ButtonOption("To SeedKeeper")
+    REGENERATE_SHARES = ButtonOption("Regenerate Shares")
 
     def __init__(self, seed_num):
         super().__init__()
@@ -1213,6 +1261,8 @@ class SeedBackupView(View):
     def run(self):
 
         button_data = [self.VIEW_WORDS, self.TO_SEEDKEEPER]
+        if isinstance(self.seed, Slip39Seed):
+            button_data.append(self.REGENERATE_SHARES)
 
         if self.seed.seedqr_supported:
             button_data.append(self.EXPORT_SEEDQR)
@@ -1247,6 +1297,9 @@ class SeedBackupView(View):
             if isinstance(self.seed, Slip39Seed):
                 return Destination(SeedSlip39SelectShareView, view_args={"seed_num": self.seed_num, "next_view": SaveToSeedkeeperView})
             return Destination(SaveToSeedkeeperView, view_args={"seed_num": self.seed_num})
+
+        elif button_data[selected_menu_num] == self.REGENERATE_SHARES:
+            return Destination(SeedSlip39RegenerateSharesView, view_args={"seed_num": self.seed_num})
 
 
 """****************************************************************************
@@ -1853,7 +1906,9 @@ class SeedWordsBackupTestPromptView(View):
             )
 
         elif button_data[selected_menu_num] == self.SKIP:
-
+            seed = self.controller.storage.get_pending_seed() if self.seed_num is None else self.controller.get_seed(self.seed_num)
+            if isinstance(seed, Slip39Seed) and self.share_index is not None and self.share_index < len(seed.mnemonic_list) - 1:
+                return Destination(SeedWordsWarningView, view_args=dict(seed_num=self.seed_num, share_index=self.share_index + 1))
             if self.seed_num is not None:
                 return Destination(SeedOptionsView, view_args=dict(seed_num=self.seed_num))
             else:
@@ -2040,8 +2095,14 @@ class SeedWordsBackupTestSuccessView(View):
             self.seed_num = None
 
         if self.seed_num is not None:
+            seed = self.controller.get_seed(self.seed_num)
+            if isinstance(seed, Slip39Seed) and self.share_index is not None and self.share_index < len(seed.mnemonic_list) - 1:
+                return Destination(SeedWordsWarningView, view_args={"seed_num": self.seed_num, "share_index": self.share_index + 1})
             return Destination(SeedOptionsView, view_args=dict(seed_num=self.seed_num), clear_history=True)
         else:
+            seed = self.controller.storage.get_pending_seed()
+            if isinstance(seed, Slip39Seed) and self.share_index is not None and self.share_index < len(seed.mnemonic_list) - 1:
+                return Destination(SeedWordsWarningView, view_args={"seed_num": None, "share_index": self.share_index + 1})
             return Destination(SeedFinalizeView)
 
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -496,9 +496,15 @@ class SeedFinalizeView(View):
             # screenshot generator which creates a pending seed w/a passphrase already
             # set.
             passphrase = self.seed.passphrase
-            self.seed.set_passphrase("")
+            if isinstance(self.seed, Slip39Seed):
+                self.seed.set_slip39_passphrase("")
+            else:
+                self.seed.set_passphrase("")
             self.fingerprint = self.seed.get_fingerprint(network=self.settings.get_value(SettingsConstants.SETTING__NETWORK))
-            self.seed.set_passphrase(passphrase)
+            if isinstance(self.seed, Slip39Seed):
+                self.seed.set_slip39_passphrase(passphrase)
+            else:
+                self.seed.set_passphrase(passphrase)
 
 
     def run(self):
@@ -559,8 +565,6 @@ class SeedAddPassphraseView(View):
             self.loading_screen.start()
             try:
                 self.seed.set_slip39_passphrase(passphrase)
-                # Store for display purposes
-                self.seed.set_passphrase(passphrase, regenerate_seed=False)
             finally:
                 self.loading_screen.stop()
         else:
@@ -606,7 +610,10 @@ class SeedAddPassphraseExitDialogView(View):
             return Destination(SeedAddPassphraseView)
 
         elif button_data[selected_menu_num] == self.DISCARD:
-            self.seed.set_passphrase("")
+            if isinstance(self.seed, Slip39Seed):
+                self.seed.set_slip39_passphrase("")
+            else:
+                self.seed.set_passphrase("")
             return Destination(SeedFinalizeView)
 
 class SeedScanPassphraseView(View):
@@ -627,7 +634,10 @@ class SeedScanPassphraseView(View):
         time.sleep(0.1)
         if decoder.is_complete:
             passphrase = self.seed.passphrase_display + decoder.get_passphrase()
-            self.controller.storage.get_pending_seed().set_passphrase(passphrase)
+            if isinstance(self.seed, Slip39Seed):
+                self.controller.storage.get_pending_seed().set_slip39_passphrase(passphrase)
+            else:
+                self.controller.storage.get_pending_seed().set_passphrase(passphrase)
             return Destination(SeedReviewPassphraseView)
         elif decoder.is_nonUTF8:
             DireWarningScreen(
@@ -727,7 +737,10 @@ class SeedLoadSeedKeeperPassphraseView(View):
             return Destination(BackStackView)
         
         # The new passphrase will be the return value; it might be empty.
-        self.seed.set_passphrase(secret_passphrase)
+        if isinstance(self.seed, Slip39Seed):
+            self.seed.set_slip39_passphrase(secret_passphrase)
+        else:
+            self.seed.set_passphrase(secret_passphrase)
         if len(self.seed.passphrase) > 0:
             return Destination(SeedReviewPassphraseView)
         else:
@@ -751,9 +764,15 @@ class SeedReviewPassphraseView(View):
         network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
         passphrase = self.seed.passphrase
         fingerprint_with = self.seed.get_fingerprint(network=network)
-        self.seed.set_passphrase("")
+        if isinstance(self.seed, Slip39Seed):
+            self.seed.set_slip39_passphrase("")
+        else:
+            self.seed.set_passphrase("")
         fingerprint_without = self.seed.get_fingerprint(network=network)
-        self.seed.set_passphrase(passphrase, regenerate_seed=not isinstance(self.seed, Slip39Seed))
+        if isinstance(self.seed, Slip39Seed):
+            self.seed.set_slip39_passphrase(passphrase)
+        else:
+            self.seed.set_passphrase(passphrase)
         
         button_data = [self.DONE, self.EDIT, self.SCAN]
 
@@ -768,7 +787,10 @@ class SeedReviewPassphraseView(View):
         )
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
-            self.seed.set_passphrase("")
+            if isinstance(self.seed, Slip39Seed):
+                self.seed.set_slip39_passphrase("")
+            else:
+                self.seed.set_passphrase("")
             return Destination(SeedFinalizeView)
 
         elif button_data[selected_menu_num] == self.DONE:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -42,6 +42,8 @@ from binascii import unhexlify, hexlify
 class ToolsMenuView(View):
     IMAGE = ButtonOption(" New seed", FontAwesomeIconConstants.CAMERA)
     DICE = ButtonOption("New seed", FontAwesomeIconConstants.DICE)
+    SLIP39_IMAGE = ButtonOption("SLIP39 seed", FontAwesomeIconConstants.CAMERA)
+    SLIP39_DICE = ButtonOption("SLIP39 seed", FontAwesomeIconConstants.DICE)
     KEYBOARD = ButtonOption("Calc 12th/24th word", FontAwesomeIconConstants.KEYBOARD)
     ADDRESS_EXPLORER = ButtonOption("Address Explorer")
     VERIFY_ADDRESS = ButtonOption("Verify address")
@@ -52,7 +54,7 @@ class ToolsMenuView(View):
     CLEAR_DESCRIPTOR = ButtonOption("Clear Multisig Descriptor")
 
     def run(self):
-        button_data = [self.IMAGE, self.DICE, self.KEYBOARD, self.ADDRESS_EXPLORER, self.VERIFY_ADDRESS, self.TEXTQRCODE, self.SMARTCARD, self.MICROSD, self.GPG, self.CLEAR_DESCRIPTOR]
+        button_data = [self.IMAGE, self.DICE, self.SLIP39_IMAGE, self.SLIP39_DICE, self.KEYBOARD, self.ADDRESS_EXPLORER, self.VERIFY_ADDRESS, self.TEXTQRCODE, self.SMARTCARD, self.MICROSD, self.GPG, self.CLEAR_DESCRIPTOR]
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,
@@ -68,6 +70,14 @@ class ToolsMenuView(View):
             return Destination(ToolsImageEntropyLivePreviewView)
 
         elif button_data[selected_menu_num] == self.DICE:
+            return Destination(ToolsDiceEntropyMnemonicLengthView)
+
+        elif button_data[selected_menu_num] == self.SLIP39_IMAGE:
+            self.controller.create_slip39 = True
+            return Destination(ToolsImageEntropyLivePreviewView)
+
+        elif button_data[selected_menu_num] == self.SLIP39_DICE:
+            self.controller.create_slip39 = True
             return Destination(ToolsDiceEntropyMnemonicLengthView)
 
         elif button_data[selected_menu_num] == self.KEYBOARD:
@@ -212,23 +222,27 @@ class ToolsImageEntropyMnemonicLengthView(View):
             # 12-word mnemonic only uses the first 128 bits / 16 bytes of entropy
             final_hash = final_hash[:16]
 
-        # Generate the mnemonic
-        mnemonic = mnemonic_generation.generate_mnemonic_from_bytes(final_hash)
+        if getattr(self.controller, "create_slip39", False):
+            secret = final_hash
+        else:
+            mnemonic = mnemonic_generation.generate_mnemonic_from_bytes(final_hash)
 
         # Image should never get saved nor stick around in memory
         seed_entropy_image = None
         preview_images = None
-        final_hash = None
+        if not getattr(self.controller, "create_slip39", False):
+            final_hash = None
         hash_bytes = None
         self.controller.image_entropy_preview_frames = None
         self.controller.image_entropy_final_image = None
 
-        # Add the mnemonic as an in-memory Seed
-        seed = Seed(mnemonic, wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE))
-        self.controller.storage.set_pending_seed(seed)
-        
-        # Cannot return BACK to this View
-        return Destination(SeedWordsWarningView, view_args={"seed_num": None}, clear_history=True)
+        if getattr(self.controller, "create_slip39", False):
+            self.controller.create_slip39 = False
+            return Destination(SeedSlip39CreateFromBytesView, view_args=dict(secret=secret), clear_history=True)
+        else:
+            seed = Seed(mnemonic, wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE))
+            self.controller.storage.set_pending_seed(seed)
+            return Destination(SeedWordsWarningView, view_args={"seed_num": None}, clear_history=True)
 
 
 
@@ -282,14 +296,15 @@ class ToolsDiceEntropyEntryView(View):
         if ret == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
         
-        dice_seed_phrase = mnemonic_generation.generate_mnemonic_from_dice(ret)
-
-        # Add the mnemonic as an in-memory Seed
-        seed = Seed(dice_seed_phrase, wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE))
-        self.controller.storage.set_pending_seed(seed)
-
-        # Cannot return BACK to this View
-        return Destination(SeedWordsWarningView, view_args={"seed_num": None}, clear_history=True)
+        if getattr(self.controller, "create_slip39", False):
+            entropy_bytes = mnemonic_generation.generate_bytes_from_dice(ret)
+            self.controller.create_slip39 = False
+            return Destination(SeedSlip39CreateFromBytesView, view_args=dict(secret=entropy_bytes), clear_history=True)
+        else:
+            dice_seed_phrase = mnemonic_generation.generate_mnemonic_from_dice(ret)
+            seed = Seed(dice_seed_phrase, wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE))
+            self.controller.storage.set_pending_seed(seed)
+            return Destination(SeedWordsWarningView, view_args={"seed_num": None}, clear_history=True)
 
 
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -27,7 +27,17 @@ from seedsigner.gui.screens.screen import ButtonOption
 from seedsigner.helpers import mnemonic_generation
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings_definition import SettingsConstants
-from seedsigner.views.seed_views import SeedDiscardView, SeedFinalizeView, SeedMnemonicEntryView, SeedOptionsView, SeedWordsWarningView, SeedExportXpubScriptTypeView, LoadSeedView
+from seedsigner.views.seed_views import (
+    SeedDiscardView,
+    SeedFinalizeView,
+    SeedMnemonicEntryView,
+    SeedOptionsView,
+    SeedWordsWarningView,
+    SeedExportXpubScriptTypeView,
+    LoadSeedView,
+    SeedSlip39CreateFromBytesView,
+    SeedSlip39RegenerateSharesView,
+)
 
 from .view import View, Destination, BackStackView, MainMenuView
 
@@ -180,7 +190,12 @@ class ToolsImageEntropyMnemonicLengthView(View):
     TWENTYFOUR_WORDS = ButtonOption("24 words", return_data=24)
 
     def run(self):
-        button_data = [self.TWELVE_WORDS, self.TWENTYFOUR_WORDS]
+        if getattr(self.controller, "create_slip39", False):
+            twenty = ButtonOption("20 words", return_data=20)
+            thirty_three = ButtonOption("33 words", return_data=33)
+            button_data = [twenty, thirty_three]
+        else:
+            button_data = [self.TWELVE_WORDS, self.TWENTYFOUR_WORDS]
 
         selected_menu_num = ButtonListScreen(
             title=_("Mnemonic Length?"),
@@ -218,8 +233,8 @@ class ToolsImageEntropyMnemonicLengthView(View):
         # Finally build in our headline entropy via the new full-res image
         final_hash = hashlib.sha256(hash_bytes + seed_entropy_image.tobytes()).digest()
 
-        if mnemonic_length == 12:
-            # 12-word mnemonic only uses the first 128 bits / 16 bytes of entropy
+        if mnemonic_length in (12, 20):
+            # 12- or 20-word seeds only use the first 128 bits / 16 bytes of entropy
             final_hash = final_hash[:16]
 
         if getattr(self.controller, "create_slip39", False):
@@ -254,15 +269,26 @@ class ToolsDiceEntropyMnemonicLengthView(View):
         # Since we're dynamically building the ButtonOption button_labels here, it's too
         # awkward to use the usual class-level attr approach.
 
-        # TRANSLATOR_NOTE: Inserts the number of dice rolls needed for a 12-word mnemonic
-        twelve = _("12 words ({} rolls)").format(mnemonic_generation.DICE__NUM_ROLLS__12WORD)
-        TWELVE = ButtonOption(twelve, return_data=mnemonic_generation.DICE__NUM_ROLLS__12WORD)
+        if getattr(self.controller, "create_slip39", False):
+            # TRANSLATOR_NOTE: Inserts the number of dice rolls needed for a 20-word seed
+            twenty = _("20 words ({} rolls)").format(mnemonic_generation.DICE__NUM_ROLLS__12WORD)
+            TWENTY = ButtonOption(twenty, return_data=mnemonic_generation.DICE__NUM_ROLLS__12WORD)
 
-        # TRANSLATOR_NOTE: Inserts the number of dice rolls needed for a 24-word mnemonic
-        twenty_four = _("24 words ({} rolls)").format(mnemonic_generation.DICE__NUM_ROLLS__24WORD)
-        TWENTY_FOUR = ButtonOption(twenty_four, return_data=mnemonic_generation.DICE__NUM_ROLLS__24WORD)
+            # TRANSLATOR_NOTE: Inserts the number of dice rolls needed for a 33-word seed
+            thirty_three = _("33 words ({} rolls)").format(mnemonic_generation.DICE__NUM_ROLLS__24WORD)
+            THIRTY_THREE = ButtonOption(thirty_three, return_data=mnemonic_generation.DICE__NUM_ROLLS__24WORD)
 
-        button_data = [TWELVE, TWENTY_FOUR]
+            button_data = [TWENTY, THIRTY_THREE]
+        else:
+            # TRANSLATOR_NOTE: Inserts the number of dice rolls needed for a 12-word mnemonic
+            twelve = _("12 words ({} rolls)").format(mnemonic_generation.DICE__NUM_ROLLS__12WORD)
+            TWELVE = ButtonOption(twelve, return_data=mnemonic_generation.DICE__NUM_ROLLS__12WORD)
+
+            # TRANSLATOR_NOTE: Inserts the number of dice rolls needed for a 24-word mnemonic
+            twenty_four = _("24 words ({} rolls)").format(mnemonic_generation.DICE__NUM_ROLLS__24WORD)
+            TWENTY_FOUR = ButtonOption(twenty_four, return_data=mnemonic_generation.DICE__NUM_ROLLS__24WORD)
+
+            button_data = [TWELVE, TWENTY_FOUR]
         selected_menu_num = ButtonListScreen(
             title=_("Mnemonic Length"),
             is_bottom_list=True,

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -265,30 +265,28 @@ class ToolsImageEntropyMnemonicLengthView(View):
     Dice rolls Views
 ****************************************************************************"""
 class ToolsDiceEntropyMnemonicLengthView(View):
+    """Prompt for mnemonic length when using dice entropy."""
+
+    # These are defined here so they are available for equality checks later
+    TWELVE = ButtonOption("12 words", return_data=mnemonic_generation.DICE__NUM_ROLLS__12WORD)
+    TWENTY_FOUR = ButtonOption("24 words", return_data=mnemonic_generation.DICE__NUM_ROLLS__24WORD)
+    TWENTY = ButtonOption(
+        _("20 words ({} rolls)").format(mnemonic_generation.DICE__NUM_ROLLS__12WORD),
+        return_data=mnemonic_generation.DICE__NUM_ROLLS__12WORD,
+    )
+    THIRTY_THREE = ButtonOption(
+        _("33 words ({} rolls)").format(mnemonic_generation.DICE__NUM_ROLLS__24WORD),
+        return_data=mnemonic_generation.DICE__NUM_ROLLS__24WORD,
+    )
+
     def run(self):
         # Since we're dynamically building the ButtonOption button_labels here, it's too
         # awkward to use the usual class-level attr approach.
 
         if getattr(self.controller, "create_slip39", False):
-            # TRANSLATOR_NOTE: Inserts the number of dice rolls needed for a 20-word seed
-            twenty = _("20 words ({} rolls)").format(mnemonic_generation.DICE__NUM_ROLLS__12WORD)
-            TWENTY = ButtonOption(twenty, return_data=mnemonic_generation.DICE__NUM_ROLLS__12WORD)
-
-            # TRANSLATOR_NOTE: Inserts the number of dice rolls needed for a 33-word seed
-            thirty_three = _("33 words ({} rolls)").format(mnemonic_generation.DICE__NUM_ROLLS__24WORD)
-            THIRTY_THREE = ButtonOption(thirty_three, return_data=mnemonic_generation.DICE__NUM_ROLLS__24WORD)
-
-            button_data = [TWENTY, THIRTY_THREE]
+            button_data = [self.TWENTY, self.THIRTY_THREE]
         else:
-            # TRANSLATOR_NOTE: Inserts the number of dice rolls needed for a 12-word mnemonic
-            twelve = _("12 words ({} rolls)").format(mnemonic_generation.DICE__NUM_ROLLS__12WORD)
-            TWELVE = ButtonOption(twelve, return_data=mnemonic_generation.DICE__NUM_ROLLS__12WORD)
-
-            # TRANSLATOR_NOTE: Inserts the number of dice rolls needed for a 24-word mnemonic
-            twenty_four = _("24 words ({} rolls)").format(mnemonic_generation.DICE__NUM_ROLLS__24WORD)
-            TWENTY_FOUR = ButtonOption(twenty_four, return_data=mnemonic_generation.DICE__NUM_ROLLS__24WORD)
-
-            button_data = [TWELVE, TWENTY_FOUR]
+            button_data = [self.TWELVE, self.TWENTY_FOUR]
         selected_menu_num = ButtonListScreen(
             title=_("Mnemonic Length"),
             is_bottom_list=True,
@@ -299,11 +297,17 @@ class ToolsDiceEntropyMnemonicLengthView(View):
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        elif button_data[selected_menu_num] == TWELVE:
-            return Destination(ToolsDiceEntropyEntryView, view_args=dict(total_rolls=mnemonic_generation.DICE__NUM_ROLLS__12WORD))
+        elif button_data[selected_menu_num] in (self.TWELVE, self.TWENTY):
+            return Destination(
+                ToolsDiceEntropyEntryView,
+                view_args=dict(total_rolls=mnemonic_generation.DICE__NUM_ROLLS__12WORD),
+            )
 
-        elif button_data[selected_menu_num] == TWENTY_FOUR:
-            return Destination(ToolsDiceEntropyEntryView, view_args=dict(total_rolls=mnemonic_generation.DICE__NUM_ROLLS__24WORD))
+        elif button_data[selected_menu_num] in (self.TWENTY_FOUR, self.THIRTY_THREE):
+            return Destination(
+                ToolsDiceEntropyEntryView,
+                view_args=dict(total_rolls=mnemonic_generation.DICE__NUM_ROLLS__24WORD),
+            )
 
 
 

--- a/tests/data/shamir_vectors.json
+++ b/tests/data/shamir_vectors.json
@@ -1,0 +1,406 @@
+[
+  [
+    "1. Valid mnemonic without sharing (128 bits)",
+    [
+      "duckling enlarge academic academic agency result length solution fridge kidney coal piece deal husband erode duke ajar critical decision keyboard"
+    ],
+    "bb54aac4b89dc868ba37d9cc21b2cece",
+    "xprv9s21ZrQH143K4QViKpwKCpS2zVbz8GrZgpEchMDg6KME9HZtjfL7iThE9w5muQA4YPHKN1u5VM1w8D4pvnjxa2BmpGMfXr7hnRrRHZ93awZ"
+  ],
+  [
+    "2. Mnemonic with invalid checksum (128 bits)",
+    [
+      "duckling enlarge academic academic agency result length solution fridge kidney coal piece deal husband erode duke ajar critical decision kidney"
+    ],
+    "",
+    ""
+  ],
+  [
+    "3. Mnemonic with invalid padding (128 bits)",
+    [
+      "duckling enlarge academic academic email result length solution fridge kidney coal piece deal husband erode duke ajar music cargo fitness"
+    ],
+    "",
+    ""
+  ],
+  [
+    "4. Basic sharing 2-of-3 (128 bits)",
+    [
+      "shadow pistol academic always adequate wildlife fancy gross oasis cylinder mustang wrist rescue view short owner flip making coding armed",
+      "shadow pistol academic acid actress prayer class unknown daughter sweater depict flip twice unkind craft early superior advocate guest smoking"
+    ],
+    "b43ceb7e57a0ea8766221624d01b0864",
+    "xprv9s21ZrQH143K2nNuAbfWPHBtfiSCS14XQgb3otW4pX655q58EEZeC8zmjEUwucBu9dPnxdpbZLCn57yx45RBkwJHnwHFjZK4XPJ8SyeYjYg"
+  ],
+  [
+    "5. Basic sharing 2-of-3 (128 bits)",
+    [
+      "shadow pistol academic always adequate wildlife fancy gross oasis cylinder mustang wrist rescue view short owner flip making coding armed"
+    ],
+    "",
+    ""
+  ],
+  [
+    "6. Mnemonics with different identifiers (128 bits)",
+    [
+      "adequate smoking academic acid debut wine petition glen cluster slow rhyme slow simple epidemic rumor junk tracks treat olympic tolerate",
+      "adequate stay academic agency agency formal party ting frequent learn upstairs remember smear leaf damage anatomy ladle market hush corner"
+    ],
+    "",
+    ""
+  ],
+  [
+    "7. Mnemonics with different iteration exponents (128 bits)",
+    [
+      "peasant leaves academic acid desert exact olympic math alive axle trial tackle drug deny decent smear dominant desert bucket remind",
+      "peasant leader academic agency cultural blessing percent network envelope medal junk primary human pumps jacket fragment payroll ticket evoke voice"
+    ],
+    "",
+    ""
+  ],
+  [
+    "8. Mnemonics with mismatching group thresholds (128 bits)",
+    [
+      "liberty category beard echo animal fawn temple briefing math username various wolf aviation fancy visual holy thunder yelp helpful payment",
+      "liberty category beard email beyond should fancy romp founder easel pink holy hairy romp loyalty material victim owner toxic custody",
+      "liberty category academic easy being hazard crush diminish oral lizard reaction cluster force dilemma deploy force club veteran expect photo"
+    ],
+    "",
+    ""
+  ],
+  [
+    "9. Mnemonics with mismatching group counts (128 bits)",
+    [
+      "average senior academic leaf broken teacher expect surface hour capture obesity desire negative dynamic dominant pistol mineral mailman iris aide",
+      "average senior academic agency curious pants blimp spew clothes slice script dress wrap firm shaft regular slavery negative theater roster"
+    ],
+    "",
+    ""
+  ],
+  [
+    "10. Mnemonics with greater group threshold than group counts (128 bits)",
+    [
+      "music husband acrobat acid artist finance center either graduate swimming object bike medical clothes station aspect spider maiden bulb welcome",
+      "music husband acrobat agency advance hunting bike corner density careful material civil evil tactics remind hawk discuss hobo voice rainbow",
+      "music husband beard academic black tricycle clock mayor estimate level photo episode exclude ecology papa source amazing salt verify divorce"
+    ],
+    "",
+    ""
+  ],
+  [
+    "11. Mnemonics with duplicate member indices (128 bits)",
+    [
+      "device stay academic always dive coal antenna adult black exceed stadium herald advance soldier busy dryer daughter evaluate minister laser",
+      "device stay academic always dwarf afraid robin gravity crunch adjust soul branch walnut coastal dream costume scholar mortgage mountain pumps"
+    ],
+    "",
+    ""
+  ],
+  [
+    "12. Mnemonics with mismatching member thresholds (128 bits)",
+    [
+      "hour painting academic academic device formal evoke guitar random modern justice filter withdraw trouble identify mailman insect general cover oven",
+      "hour painting academic agency artist again daisy capital beaver fiber much enjoy suitable symbolic identify photo editor romp float echo"
+    ],
+    "",
+    ""
+  ],
+  [
+    "13. Mnemonics giving an invalid digest (128 bits)",
+    [
+      "guilt walnut academic acid deliver remove equip listen vampire tactics nylon rhythm failure husband fatigue alive blind enemy teaspoon rebound",
+      "guilt walnut academic agency brave hamster hobo declare herd taste alpha slim criminal mild arcade formal romp branch pink ambition"
+    ],
+    "",
+    ""
+  ],
+  [
+    "14. Insufficient number of groups (128 bits, case 1)",
+    [
+      "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice"
+    ],
+    "",
+    ""
+  ],
+  [
+    "15. Insufficient number of groups (128 bits, case 2)",
+    [
+      "eraser senior decision scared cargo theory device idea deliver modify curly include pancake both news skin realize vitamins away join",
+      "eraser senior decision roster beard treat identify grumpy salt index fake aviation theater cubic bike cause research dragon emphasis counter"
+    ],
+    "",
+    ""
+  ],
+  [
+    "16. Threshold number of groups, but insufficient number of members in one group (128 bits)",
+    [
+      "eraser senior decision shadow artist work morning estate greatest pipeline plan ting petition forget hormone flexible general goat admit surface",
+      "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice"
+    ],
+    "",
+    ""
+  ],
+  [
+    "17. Threshold number of groups and members in each group (128 bits, case 1)",
+    [
+      "eraser senior decision roster beard treat identify grumpy salt index fake aviation theater cubic bike cause research dragon emphasis counter",
+      "eraser senior ceramic snake clay various huge numb argue hesitate auction category timber browser greatest hanger petition script leaf pickup",
+      "eraser senior ceramic shaft dynamic become junior wrist silver peasant force math alto coal amazing segment yelp velvet image paces",
+      "eraser senior ceramic round column hawk trust auction smug shame alive greatest sheriff living perfect corner chest sled fumes adequate",
+      "eraser senior decision smug corner ruin rescue cubic angel tackle skin skunk program roster trash rumor slush angel flea amazing"
+    ],
+    "7c3397a292a5941682d7a4ae2d898d11",
+    "xprv9s21ZrQH143K3dzDLfeY3cMp23u5vDeFYftu5RPYZPucKc99mNEddU4w99GxdgUGcSfMpVDxhnR1XpJzZNXRN1m6xNgnzFS5MwMP6QyBRKV"
+  ],
+  [
+    "18. Threshold number of groups and members in each group (128 bits, case 2)",
+    [
+      "eraser senior decision smug corner ruin rescue cubic angel tackle skin skunk program roster trash rumor slush angel flea amazing",
+      "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice",
+      "eraser senior decision scared cargo theory device idea deliver modify curly include pancake both news skin realize vitamins away join"
+    ],
+    "7c3397a292a5941682d7a4ae2d898d11",
+    "xprv9s21ZrQH143K3dzDLfeY3cMp23u5vDeFYftu5RPYZPucKc99mNEddU4w99GxdgUGcSfMpVDxhnR1XpJzZNXRN1m6xNgnzFS5MwMP6QyBRKV"
+  ],
+  [
+    "19. Threshold number of groups and members in each group (128 bits, case 3)",
+    [
+      "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice",
+      "eraser senior acrobat romp bishop medical gesture pumps secret alive ultimate quarter priest subject class dictate spew material endless market"
+    ],
+    "7c3397a292a5941682d7a4ae2d898d11",
+    "xprv9s21ZrQH143K3dzDLfeY3cMp23u5vDeFYftu5RPYZPucKc99mNEddU4w99GxdgUGcSfMpVDxhnR1XpJzZNXRN1m6xNgnzFS5MwMP6QyBRKV"
+  ],
+  [
+    "20. Valid mnemonic without sharing (256 bits)",
+    [
+      "theory painting academic academic armed sweater year military elder discuss acne wildlife boring employer fused large satoshi bundle carbon diagnose anatomy hamster leaves tracks paces beyond phantom capital marvel lips brave detect luck"
+    ],
+    "989baf9dcaad5b10ca33dfd8cc75e42477025dce88ae83e75a230086a0e00e92",
+    "xprv9s21ZrQH143K41mrxxMT2FpiheQ9MFNmWVK4tvX2s28KLZAhuXWskJCKVRQprq9TnjzzzEYePpt764csiCxTt22xwGPiRmUjYUUdjaut8RM"
+  ],
+  [
+    "21. Mnemonic with invalid checksum (256 bits)",
+    [
+      "theory painting academic academic armed sweater year military elder discuss acne wildlife boring employer fused large satoshi bundle carbon diagnose anatomy hamster leaves tracks paces beyond phantom capital marvel lips brave detect lunar"
+    ],
+    "",
+    ""
+  ],
+  [
+    "22. Mnemonic with invalid padding (256 bits)",
+    [
+      "theory painting academic academic campus sweater year military elder discuss acne wildlife boring employer fused large satoshi bundle carbon diagnose anatomy hamster leaves tracks paces beyond phantom capital marvel lips facility obtain sister"
+    ],
+    "",
+    ""
+  ],
+  [
+    "23. Basic sharing 2-of-3 (256 bits)",
+    [
+      "humidity disease academic always aluminum jewelry energy woman receiver strategy amuse duckling lying evidence network walnut tactics forget hairy rebound impulse brother survive clothes stadium mailman rival ocean reward venture always armed unwrap",
+      "humidity disease academic agency actress jacket gross physics cylinder solution fake mortgage benefit public busy prepare sharp friar change work slow purchase ruler again tricycle involve viral wireless mixture anatomy desert cargo upgrade"
+    ],
+    "c938b319067687e990e05e0da0ecce1278f75ff58d9853f19dcaeed5de104aae",
+    "xprv9s21ZrQH143K3a4GRMgK8WnawupkwkP6gyHxRsXnMsYPTPH21fWwNcAytijtfyftqNfiaY8LgQVdBQvHZ9FBvtwdjC7LCYxjYruJFuLzyMQ"
+  ],
+  [
+    "24. Basic sharing 2-of-3 (256 bits)",
+    [
+      "humidity disease academic always aluminum jewelry energy woman receiver strategy amuse duckling lying evidence network walnut tactics forget hairy rebound impulse brother survive clothes stadium mailman rival ocean reward venture always armed unwrap"
+    ],
+    "",
+    ""
+  ],
+  [
+    "25. Mnemonics with different identifiers (256 bits)",
+    [
+      "smear husband academic acid deadline scene venture distance dive overall parking bracelet elevator justice echo burning oven chest duke nylon",
+      "smear isolate academic agency alpha mandate decorate burden recover guard exercise fatal force syndrome fumes thank guest drift dramatic mule"
+    ],
+    "",
+    ""
+  ],
+  [
+    "26. Mnemonics with different iteration exponents (256 bits)",
+    [
+      "finger trash academic acid average priority dish revenue academic hospital spirit western ocean fact calcium syndrome greatest plan losing dictate",
+      "finger traffic academic agency building lilac deny paces subject threaten diploma eclipse window unknown health slim piece dragon focus smirk"
+    ],
+    "",
+    ""
+  ],
+  [
+    "27. Mnemonics with mismatching group thresholds (256 bits)",
+    [
+      "flavor pink beard echo depart forbid retreat become frost helpful juice unwrap reunion credit math burning spine black capital lair",
+      "flavor pink beard email diet teaspoon freshman identify document rebound cricket prune headset loyalty smell emission skin often square rebound",
+      "flavor pink academic easy credit cage raisin crazy closet lobe mobile become drink human tactics valuable hand capture sympathy finger"
+    ],
+    "",
+    ""
+  ],
+  [
+    "28. Mnemonics with mismatching group counts (256 bits)",
+    [
+      "column flea academic leaf debut extra surface slow timber husky lawsuit game behavior husky swimming already paper episode tricycle scroll",
+      "column flea academic agency blessing garbage party software stadium verify silent umbrella therapy decorate chemical erode dramatic eclipse replace apart"
+    ],
+    "",
+    ""
+  ],
+  [
+    "29. Mnemonics with greater group threshold than group counts (256 bits)",
+    [
+      "smirk pink acrobat acid auction wireless impulse spine sprinkle fortune clogs elbow guest hush loyalty crush dictate tracks airport talent",
+      "smirk pink acrobat agency dwarf emperor ajar organize legs slice harvest plastic dynamic style mobile float bulb health coding credit",
+      "smirk pink beard academic alto strategy carve shame language rapids ruin smart location spray training acquire eraser endorse submit peaceful"
+    ],
+    "",
+    ""
+  ],
+  [
+    "30. Mnemonics with duplicate member indices (256 bits)",
+    [
+      "fishing recover academic always device craft trend snapshot gums skin downtown watch device sniff hour clock public maximum garlic born",
+      "fishing recover academic always aircraft view software cradle fangs amazing package plastic evaluate intend penalty epidemic anatomy quarter cage apart"
+    ],
+    "",
+    ""
+  ],
+  [
+    "31. Mnemonics with mismatching member thresholds (256 bits)",
+    [
+      "evoke garden academic academic answer wolf scandal modern warmth station devote emerald market physics surface formal amazing aquatic gesture medical",
+      "evoke garden academic agency deal revenue knit reunion decrease magazine flexible company goat repair alarm military facility clogs aide mandate"
+    ],
+    "",
+    ""
+  ],
+  [
+    "32. Mnemonics giving an invalid digest (256 bits)",
+    [
+      "river deal academic acid average forbid pistol peanut custody bike class aunt hairy merit valid flexible learn ajar very easel",
+      "river deal academic agency camera amuse lungs numb isolate display smear piece traffic worthy year patrol crush fact fancy emission"
+    ],
+    "",
+    ""
+  ],
+  [
+    "33. Insufficient number of groups (256 bits, case 1)",
+    [
+      "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium"
+    ],
+    "",
+    ""
+  ],
+  [
+    "34. Insufficient number of groups (256 bits, case 2)",
+    [
+      "wildlife deal decision scared acne fatal snake paces obtain election dryer dominant romp tactics railroad marvel trust helpful flip peanut theory theater photo luck install entrance taxi step oven network dictate intimate listen",
+      "wildlife deal decision smug ancestor genuine move huge cubic strategy smell game costume extend swimming false desire fake traffic vegan senior twice timber submit leader payroll fraction apart exact forward pulse tidy install"
+    ],
+    "",
+    ""
+  ],
+  [
+    "35. Threshold number of groups, but insufficient number of members in one group (256 bits)",
+    [
+      "wildlife deal decision shadow analysis adjust bulb skunk muscle mandate obesity total guitar coal gravity carve slim jacket ruin rebuild ancestor numerous hour mortgage require herd maiden public ceiling pecan pickup shadow club",
+      "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium"
+    ],
+    "",
+    ""
+  ],
+  [
+    "36. Threshold number of groups and members in each group (256 bits, case 1)",
+    [
+      "wildlife deal ceramic round aluminum pitch goat racism employer miracle percent math decision episode dramatic editor lily prospect program scene rebuild display sympathy have single mustang junction relate often chemical society wits estate",
+      "wildlife deal decision scared acne fatal snake paces obtain election dryer dominant romp tactics railroad marvel trust helpful flip peanut theory theater photo luck install entrance taxi step oven network dictate intimate listen",
+      "wildlife deal ceramic scatter argue equip vampire together ruin reject literary rival distance aquatic agency teammate rebound false argue miracle stay again blessing peaceful unknown cover beard acid island language debris industry idle",
+      "wildlife deal ceramic snake agree voter main lecture axis kitchen physics arcade velvet spine idea scroll promise platform firm sharp patrol divorce ancestor fantasy forbid goat ajar believe swimming cowboy symbolic plastic spelling",
+      "wildlife deal decision shadow analysis adjust bulb skunk muscle mandate obesity total guitar coal gravity carve slim jacket ruin rebuild ancestor numerous hour mortgage require herd maiden public ceiling pecan pickup shadow club"
+    ],
+    "5385577c8cfc6c1a8aa0f7f10ecde0a3318493262591e78b8c14c6686167123b",
+    "xprv9s21ZrQH143K2UspC9FRPfQC9NcDB4HPkx1XG9UEtuceYtpcCZ6ypNZWdgfxQ9dAFVeD1F4Zg4roY7nZm2LB7THPD6kaCege3M7EuS8v85c"
+  ],
+  [
+    "37. Threshold number of groups and members in each group (256 bits, case 2)",
+    [
+      "wildlife deal decision scared acne fatal snake paces obtain election dryer dominant romp tactics railroad marvel trust helpful flip peanut theory theater photo luck install entrance taxi step oven network dictate intimate listen",
+      "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium",
+      "wildlife deal decision smug ancestor genuine move huge cubic strategy smell game costume extend swimming false desire fake traffic vegan senior twice timber submit leader payroll fraction apart exact forward pulse tidy install"
+    ],
+    "5385577c8cfc6c1a8aa0f7f10ecde0a3318493262591e78b8c14c6686167123b",
+    "xprv9s21ZrQH143K2UspC9FRPfQC9NcDB4HPkx1XG9UEtuceYtpcCZ6ypNZWdgfxQ9dAFVeD1F4Zg4roY7nZm2LB7THPD6kaCege3M7EuS8v85c"
+  ],
+  [
+    "38. Threshold number of groups and members in each group (256 bits, case 3)",
+    [
+      "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium",
+      "wildlife deal acrobat romp anxiety axis starting require metric flexible geology game drove editor edge screw helpful have huge holy making pitch unknown carve holiday numb glasses survive already tenant adapt goat fangs"
+    ],
+    "5385577c8cfc6c1a8aa0f7f10ecde0a3318493262591e78b8c14c6686167123b",
+    "xprv9s21ZrQH143K2UspC9FRPfQC9NcDB4HPkx1XG9UEtuceYtpcCZ6ypNZWdgfxQ9dAFVeD1F4Zg4roY7nZm2LB7THPD6kaCege3M7EuS8v85c"
+  ],
+  [
+    "39. Mnemonic with insufficient length",
+    [
+      "junk necklace academic academic acne isolate join hesitate lunar roster dough calcium chemical ladybug amount mobile glasses verify cylinder"
+    ],
+    "",
+    ""
+  ],
+  [
+    "40. Mnemonic with invalid master secret length",
+    [
+      "fraction necklace academic academic award teammate mouse regular testify coding building member verdict purchase blind camera duration email prepare spirit quarter"
+    ],
+    "",
+    ""
+  ],
+  [
+    "41. Valid mnemonics which can detect some errors in modular arithmetic",
+    [
+      "herald flea academic cage avoid space trend estate dryer hairy evoke eyebrow improve airline artwork garlic premium duration prevent oven",
+      "herald flea academic client blue skunk class goat luxury deny presence impulse graduate clay join blanket bulge survive dish necklace",
+      "herald flea academic acne advance fused brother frozen broken game ranked ajar already believe check install theory angry exercise adult"
+    ],
+    "ad6f2ad8b59bbbaa01369b9006208d9a",
+    "xprv9s21ZrQH143K2R4HJxcG1eUsudvHM753BZ9vaGkpYCoeEhCQx147C5qEcupPHxcXYfdYMwJmsKXrHDhtEwutxTTvFzdDCZVQwHneeQH8ioH"
+  ],
+  [
+    "42. Valid extendable mnemonic without sharing (128 bits)",
+    [
+      "testify swimming academic academic column loyalty smear include exotic bedroom exotic wrist lobe cover grief golden smart junior estimate learn"
+    ],
+    "1679b4516e0ee5954351d288a838f45e",
+    "xprv9s21ZrQH143K2w6eTpQnB73CU8Qrhg6gN3D66Jr16n5uorwoV7CwxQ5DofRPyok5DyRg4Q3BfHfCgJFk3boNRPPt1vEW1ENj2QckzVLQFXu"
+  ],
+  [
+    "43. Extendable basic sharing 2-of-3 (128 bits)",
+    [
+      "enemy favorite academic acid cowboy phrase havoc level response walnut budget painting inside trash adjust froth kitchen learn tidy punish",
+      "enemy favorite academic always academic sniff script carpet romp kind promise scatter center unfair training emphasis evening belong fake enforce"
+    ],
+    "48b1a4b80b8c209ad42c33672bdaa428",
+    "xprv9s21ZrQH143K4FS1qQdXYAFVAHiSAnjj21YAKGh2CqUPJ2yQhMmYGT4e5a2tyGLiVsRgTEvajXkxhg92zJ8zmWZas9LguQWz7WZShfJg6RS"
+  ],
+  [
+    "44. Valid extendable mnemonic without sharing (256 bits)",
+    [
+      "impulse calcium academic academic alcohol sugar lyrics pajamas column facility finance tension extend space birthday rainbow swimming purple syndrome facility trial warn duration snapshot shadow hormone rhyme public spine counter easy hawk album"
+    ],
+    "8340611602fe91af634a5f4608377b5235fa2d757c51d720c0c7656249a3035f",
+    "xprv9s21ZrQH143K2yJ7S8bXMiGqp1fySH8RLeFQKQmqfmmLTRwWmAYkpUcWz6M42oGoFMJRENmvsGQmunWTdizsi8v8fku8gpbVvYSiCYJTF1Y"
+  ],
+  [
+    "45. Extendable basic sharing 2-of-3 (256 bits)",
+    [
+      "western apart academic always artist resident briefing sugar woman oven coding club ajar merit pecan answer prisoner artist fraction amount desktop mild false necklace muscle photo wealthy alpha category unwrap spew losing making",
+      "western apart academic acid answer ancient auction flip image penalty oasis beaver multiple thunder problem switch alive heat inherit superior teaspoon explain blanket pencil numb lend punish endless aunt garlic humidity kidney observe"
+    ],
+    "8dc652d6d6cd370d8c963141f6d79ba440300f25c467302c1d966bff8f62300d",
+    "xprv9s21ZrQH143K2eFW2zmu3aayWWd6MJZBG7RebW35fiKcoCZ6jFi6U5gzffB9McDdiKTecUtRqJH9GzueCXiQK1LaQXdgthS8DgWfC8Uu3z7"
+  ]
+]

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -36,7 +36,7 @@ from seedsigner.helpers import embit_utils
 from seedsigner.models.decode_qr import DecodeQR
 from seedsigner.models.psbt_parser import OPCODES, PSBTParser
 from seedsigner.models.qr_type import QRType
-from seedsigner.models.seed import Seed
+from seedsigner.models.seed import Seed, Slip39Seed
 from seedsigner.models.settings import Settings
 from seedsigner.models.settings_definition import SettingsConstants, SettingsDefinition
 from seedsigner.views import (MainMenuView, PowerOptionsView, RestartView, NotYetImplementedView, UnhandledExceptionView, 
@@ -141,6 +141,12 @@ def generate_screenshots(locale):
         controller.storage.seeds.append(seed_12b)
         controller.storage.seeds.append(seed_24)
         controller.storage.set_pending_seed(seed_24_w_passphrase)
+
+        # Add a SLIP-39 seed for share regeneration screenshots
+        slip_secret = bytes.fromhex("11" * 16)
+        slip_shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], slip_secret)[0]
+        slip39_seed = Slip39Seed(mnemonics=[slip_shares[0], slip_shares[1]])
+        controller.storage.seeds.append(slip39_seed)
 
         # Pending mnemonic for ToolsCalcFinalWordShowFinalWordView
         controller.storage.init_pending_mnemonic(num_words=12)
@@ -364,6 +370,8 @@ def generate_screenshots(locale):
                 ScreenshotConfig(seed_views.SeedSlip39MnemonicStartView),
                 ScreenshotConfig(seed_views.SeedSlip39ShareEntryView, run_before=slip39_share_entry_cb_before, run_after=slip39_cleanup_cb),
                 ScreenshotConfig(seed_views.SeedSlip39MoreSharesView, run_before=slip39_more_shares_cb_before, run_after=slip39_cleanup_cb),
+                ScreenshotConfig(seed_views.SeedSlip39CreateFromBytesView, dict(secret=bytes.fromhex("11" * 16))),
+                ScreenshotConfig(seed_views.SeedSlip39RegenerateSharesView, dict(seed_num=3)),
 
                 ScreenshotConfig(seed_views.SeedElectrumMnemonicStartView),
             ],

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -144,7 +144,9 @@ def generate_screenshots(locale):
 
         # Add a SLIP-39 seed for share regeneration screenshots
         slip_secret = bytes.fromhex("11" * 16)
-        slip_shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], slip_secret)[0]
+        slip_shares = shamir_mnemonic.generate_mnemonics(
+            1, [(2, 3)], slip_secret, extendable=True
+        )[0]
         slip39_seed = Slip39Seed(mnemonics=[slip_shares[0], slip_shares[1]])
         controller.storage.seeds.append(slip39_seed)
 
@@ -276,7 +278,9 @@ def generate_screenshots(locale):
 
         def slip39_more_shares_cb_before():
             controller.storage.discard_pending_slip39_shares()
-            shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], bytes.fromhex("11" * 16))[0]
+            shares = shamir_mnemonic.generate_mnemonics(
+                1, [(2, 3)], bytes.fromhex("11" * 16), extendable=True
+            )[0]
             controller.storage.init_pending_slip39_share(num_words=len(shares[0].split()))
             for i, w in enumerate(shares[0].split()):
                 controller.storage.update_pending_slip39_share(w, i)

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -374,6 +374,7 @@ def generate_screenshots(locale):
                 ScreenshotConfig(seed_views.SeedSlip39MnemonicStartView),
                 ScreenshotConfig(seed_views.SeedSlip39ShareEntryView, run_before=slip39_share_entry_cb_before, run_after=slip39_cleanup_cb),
                 ScreenshotConfig(seed_views.SeedSlip39MoreSharesView, run_before=slip39_more_shares_cb_before, run_after=slip39_cleanup_cb),
+                ScreenshotConfig(seed_views.SeedAddPassphraseView, screenshot_name="SeedSlip39AddPassphraseView", run_before=slip39_more_shares_cb_before, run_after=slip39_cleanup_cb),
                 ScreenshotConfig(seed_views.SeedSlip39CreateFromBytesView, dict(secret=bytes.fromhex("11" * 16))),
                 ScreenshotConfig(seed_views.SeedSlip39RegenerateSharesView, dict(seed_num=3)),
 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -207,6 +207,29 @@ class TestSeedFlows(FlowTest):
 
         self.run_sequence(sequence)
 
+    def test_slip39_passphrase_flow(self):
+        """Enter SLIP-39 share and apply passphrase afterwards."""
+        share = "testify swimming academic academic column loyalty smear include exotic bedroom exotic wrist lobe cover grief golden smart junior estimate learn".split()
+
+        sequence = [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(seed_views.SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_SLIP39),
+            FlowStep(seed_views.SeedSlip39MnemonicStartView, screen_return_value=0),
+        ]
+        for word in share:
+            sequence.append(FlowStep(seed_views.SeedSlip39ShareEntryView, screen_return_value=word))
+        sequence.append(FlowStep(seed_views.SeedSlip39MoreSharesView, button_data_selection=seed_views.SeedSlip39MoreSharesView.DONE))
+        sequence.append(FlowStep(seed_views.SeedFinalizeView, button_data_selection=seed_views.SeedFinalizeView.TYPE_PASSPHRASE))
+        sequence.append(FlowStep(seed_views.SeedAddPassphraseView, screen_return_value=dict(passphrase="test")))
+        sequence.append(FlowStep(seed_views.SeedReviewPassphraseView, button_data_selection=seed_views.SeedReviewPassphraseView.DONE))
+        sequence.append(FlowStep(seed_views.SeedOptionsView))
+
+        self.run_sequence(sequence)
+
+        seed = self.controller.storage.seeds[0]
+        assert seed.get_fingerprint() == "d9fda401"
+
 
     def test_export_xpub_standard_flow(self):
         """

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -149,7 +149,7 @@ def test_seed_passphrase_effect():
         orig = seed.seed_bytes
         seed.set_passphrase("trezor")
         from embit import bip39
-        expected = bip39.mnemonic_to_seed(mnemonic, passphrase="trezor")
+        expected = bip39.mnemonic_to_seed(mnemonic, password="trezor")
         assert seed.seed_bytes == expected
         assert seed.seed_bytes != orig
 

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -216,6 +216,13 @@ def test_slip39_regenerate_consistency():
 
     assert secret_old == secret_new == expected_secret
 
+    # Random passphrase should also yield the same result for old and new shares
+    rand_pw = os.urandom(5)
+    assert (
+        shamir_mnemonic.combine_mnemonics(old_shares, rand_pw)
+        == shamir_mnemonic.combine_mnemonics(new_shares[: seed._member_threshold], rand_pw)
+    )
+
 
 def test_slip39_regenerate_consistency_no_passphrase():
     """Vector 42 should regenerate shares without changing the master secret when no passphrase is used."""

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -194,6 +194,29 @@ def test_slip39_passphrase_fingerprint():
     assert seed.get_fingerprint() == "d9fda401"
 
 
+def test_slip39_regenerate_consistency():
+    """Old and regenerated shares should yield the same master secret."""
+    share = (
+        "testify swimming academic academic column loyalty smear include exotic "
+        "bedroom exotic wrist lobe cover grief golden smart junior estimate learn"
+    )
+    expected_secret = bytes.fromhex("1679b4516e0ee5954351d288a838f45e")
+
+    seed = Slip39Seed(mnemonics=[share])
+    seed.set_slip39_passphrase("TREZOR")
+    assert seed.master_secret == expected_secret
+
+    old_shares = seed.mnemonic_list.copy()
+    new_shares = seed.regenerate_shares(seed._member_threshold, len(old_shares))
+
+    secret_old = shamir_mnemonic.combine_mnemonics(old_shares, b"TREZOR")
+    secret_new = shamir_mnemonic.combine_mnemonics(
+        new_shares[: seed._member_threshold], b"TREZOR"
+    )
+
+    assert secret_old == secret_new == expected_secret
+
+
 VECTORS_PATH = os.path.join(os.path.dirname(__file__), "data", "shamir_vectors.json")
 
 

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -89,13 +89,13 @@ def test_slip39_seed():
         secret = bytes.fromhex("11" * 32)
         shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret)[0]
         seed = Slip39Seed(mnemonics=[shares[0], shares[1]])
-        assert seed.seed_bytes == secret
+        assert seed.master_secret == secret
 
 def test_slip39_seed_20_word_share():
         secret = bytes.fromhex("33" * 16)
         shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret)[0]
         seed = Slip39Seed(mnemonics=[shares[0], shares[1]])
-        assert seed.seed_bytes == secret
+        assert seed.master_secret == secret
 
 def test_slip39_storage_reconstruction():
        secret = bytes.fromhex("22" * 32)
@@ -111,7 +111,7 @@ def test_slip39_storage_reconstruction():
                storage.update_pending_slip39_share(w, i)
        storage.finalize_current_slip39_share()
        storage.convert_pending_slip39_shares_to_pending_seed()
-       assert storage.pending_seed.seed_bytes == secret
+       assert storage.pending_seed.master_secret == secret
 
 def test_slip39_storage_reconstruction_20_word():
        secret = bytes.fromhex("44" * 16)
@@ -127,7 +127,7 @@ def test_slip39_storage_reconstruction_20_word():
                storage.update_pending_slip39_share(w, i)
        storage.finalize_current_slip39_share()
        storage.convert_pending_slip39_shares_to_pending_seed()
-       assert storage.pending_seed.seed_bytes == secret
+       assert storage.pending_seed.master_secret == secret
 
 def test_slip39_invalid_share_rejected():
         secret = bytes.fromhex("55" * 16)
@@ -162,6 +162,7 @@ def test_slip39_regenerate_shares():
         assert len(new_shares) == 4
         combined = shamir_mnemonic.combine_mnemonics(new_shares[:2])
         assert combined == secret
+        assert seed.master_secret == secret
 
 
 def test_slip39_regenerate_shares_nonextendable():

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -246,6 +246,31 @@ def test_slip39_regenerate_consistency_no_passphrase():
     assert secret_old == secret_new == expected_secret
 
 
+def test_slip39_regenerate_random_passphrase():
+    """Regeneration should keep the master secret with any passphrase."""
+    import random, string
+    slip_pass = ''.join(random.choice(string.ascii_letters) for _ in range(8))
+    secret = os.urandom(16)
+    shares = shamir_mnemonic.generate_mnemonics(
+        1, [(2, 3)], secret, passphrase=slip_pass.encode(), extendable=True
+    )[0]
+
+    seed = Slip39Seed(mnemonics=[shares[0], shares[1]], slip39_passphrase=slip_pass)
+    old_shares = seed.mnemonic_list.copy()
+    new_shares = seed.regenerate_shares(2, 4)
+
+    secret_old = shamir_mnemonic.combine_mnemonics(old_shares, slip_pass.encode())
+    secret_new = shamir_mnemonic.combine_mnemonics(new_shares[:2], slip_pass.encode())
+
+    assert secret_old == secret_new == secret
+
+    alt_pass = os.urandom(5)
+    assert (
+        shamir_mnemonic.combine_mnemonics(old_shares, alt_pass)
+        == shamir_mnemonic.combine_mnemonics(new_shares[:2], alt_pass)
+    )
+
+
 VECTORS_PATH = os.path.join(os.path.dirname(__file__), "data", "shamir_vectors.json")
 
 

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -175,6 +175,18 @@ def test_slip39_regenerate_shares_nonextendable():
                 seed.regenerate_shares(2, 4)
 
 
+def test_slip39_passphrase_update():
+        secret = bytes.fromhex("dd" * 16)
+        shares = shamir_mnemonic.generate_mnemonics(
+            1, [(2, 3)], secret, passphrase=b"pw", extendable=True
+        )[0]
+        seed1 = Slip39Seed(mnemonics=[shares[0], shares[1]], slip39_passphrase="pw")
+        seed2 = Slip39Seed(mnemonics=[shares[0], shares[1]])
+        seed2.set_slip39_passphrase("pw")
+        assert seed2.seed_bytes == seed1.seed_bytes
+        assert seed2.master_secret == seed1.master_secret
+
+
 VECTORS_PATH = os.path.join(os.path.dirname(__file__), "data", "shamir_vectors.json")
 
 

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -217,6 +217,28 @@ def test_slip39_regenerate_consistency():
     assert secret_old == secret_new == expected_secret
 
 
+def test_slip39_regenerate_consistency_no_passphrase():
+    """Vector 42 should regenerate shares without changing the master secret when no passphrase is used."""
+    share = (
+        "testify swimming academic academic column loyalty smear include exotic"
+        " bedroom exotic wrist lobe cover grief golden smart junior estimate learn"
+    )
+    expected_secret = bytes.fromhex("642a850f4ee8508a3ef44db68ccf0d62")
+
+    seed = Slip39Seed(mnemonics=[share])
+    assert seed.master_secret == expected_secret
+
+    old_shares = seed.mnemonic_list.copy()
+    new_shares = seed.regenerate_shares(seed._member_threshold, len(old_shares))
+
+    secret_old = shamir_mnemonic.combine_mnemonics(old_shares)
+    secret_new = shamir_mnemonic.combine_mnemonics(
+        new_shares[: seed._member_threshold]
+    )
+
+    assert secret_old == secret_new == expected_secret
+
+
 VECTORS_PATH = os.path.join(os.path.dirname(__file__), "data", "shamir_vectors.json")
 
 
@@ -232,3 +254,4 @@ def test_slip39_vectors_end_to_end(desc, mnemonics, secret_hex, xprv):
                 assert seed.seed_bytes.hex() == secret_hex
                 root = bip32.HDKey.from_seed(seed.seed_bytes, version=NETWORKS["main"]["xprv"])
                 assert root.to_base58() == xprv
+

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -176,15 +176,22 @@ def test_slip39_regenerate_shares_nonextendable():
 
 
 def test_slip39_passphrase_update():
-        secret = bytes.fromhex("dd" * 16)
-        shares = shamir_mnemonic.generate_mnemonics(
-            1, [(2, 3)], secret, passphrase=b"pw", extendable=True
-        )[0]
-        seed1 = Slip39Seed(mnemonics=[shares[0], shares[1]], slip39_passphrase="pw")
-        seed2 = Slip39Seed(mnemonics=[shares[0], shares[1]])
-        seed2.set_slip39_passphrase("pw")
-        assert seed2.seed_bytes == seed1.seed_bytes
-        assert seed2.master_secret == seed1.master_secret
+    secret = bytes.fromhex("dd" * 16)
+    shares = shamir_mnemonic.generate_mnemonics(
+        1, [(2, 3)], secret, passphrase=b"pw", extendable=True
+    )[0]
+    seed1 = Slip39Seed(mnemonics=[shares[0], shares[1]], slip39_passphrase="pw")
+    seed2 = Slip39Seed(mnemonics=[shares[0], shares[1]])
+    seed2.set_slip39_passphrase("pw")
+    assert seed2.seed_bytes == seed1.seed_bytes
+    assert seed2.master_secret == seed1.master_secret
+
+def test_slip39_passphrase_fingerprint():
+    share = "testify swimming academic academic column loyalty smear include exotic bedroom exotic wrist lobe cover grief golden smart junior estimate learn"
+    seed = Slip39Seed(mnemonics=[share])
+    assert seed.get_fingerprint() == "37bb5fa5"
+    seed.set_slip39_passphrase("test")
+    assert seed.get_fingerprint() == "d9fda401"
 
 
 VECTORS_PATH = os.path.join(os.path.dirname(__file__), "data", "shamir_vectors.json")

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,3 +1,5 @@
+import os
+import json
 import pytest
 from seedsigner.models.seed import InvalidSeedException, Seed, ElectrumSeed, Slip39Seed
 import shamir_mnemonic
@@ -89,13 +91,13 @@ def test_slip39_seed():
         secret = bytes.fromhex("11" * 32)
         shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret)[0]
         seed = Slip39Seed(mnemonics=[shares[0], shares[1]])
-        assert seed.master_secret == secret
+        assert seed.seed_bytes == secret
 
 def test_slip39_seed_20_word_share():
         secret = bytes.fromhex("33" * 16)
         shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret)[0]
         seed = Slip39Seed(mnemonics=[shares[0], shares[1]])
-        assert seed.master_secret == secret
+        assert seed.seed_bytes == secret
 
 def test_slip39_storage_reconstruction():
        secret = bytes.fromhex("22" * 32)
@@ -111,7 +113,7 @@ def test_slip39_storage_reconstruction():
                storage.update_pending_slip39_share(w, i)
        storage.finalize_current_slip39_share()
        storage.convert_pending_slip39_shares_to_pending_seed()
-       assert storage.pending_seed.master_secret == secret
+       assert storage.pending_seed.seed_bytes == secret
 
 def test_slip39_storage_reconstruction_20_word():
        secret = bytes.fromhex("44" * 16)
@@ -127,7 +129,7 @@ def test_slip39_storage_reconstruction_20_word():
                storage.update_pending_slip39_share(w, i)
        storage.finalize_current_slip39_share()
        storage.convert_pending_slip39_shares_to_pending_seed()
-       assert storage.pending_seed.master_secret == secret
+       assert storage.pending_seed.seed_bytes == secret
 
 def test_slip39_invalid_share_rejected():
         secret = bytes.fromhex("55" * 16)
@@ -162,7 +164,7 @@ def test_slip39_regenerate_shares():
         assert len(new_shares) == 4
         combined = shamir_mnemonic.combine_mnemonics(new_shares[:2])
         assert combined == secret
-        assert seed.master_secret == secret
+        assert seed.seed_bytes == secret
 
 
 def test_slip39_regenerate_shares_nonextendable():
@@ -172,3 +174,20 @@ def test_slip39_regenerate_shares_nonextendable():
         assert not seed.extendable
         with pytest.raises(InvalidSeedException):
                 seed.regenerate_shares(2, 4)
+
+
+VECTORS_PATH = os.path.join(os.path.dirname(__file__), "data", "shamir_vectors.json")
+
+
+@pytest.mark.parametrize('desc,mnemonics,secret_hex,xprv', json.load(open(VECTORS_PATH)))
+def test_slip39_vectors_end_to_end(desc, mnemonics, secret_hex, xprv):
+        if not secret_hex:
+                with pytest.raises(Exception):
+                        Slip39Seed(mnemonics=mnemonics, slip39_passphrase="TREZOR")
+        else:
+                seed = Slip39Seed(mnemonics=mnemonics, slip39_passphrase="TREZOR")
+                from embit import bip32
+                from embit.networks import NETWORKS
+                assert seed.seed_bytes.hex() == secret_hex
+                root = bip32.HDKey.from_seed(seed.seed_bytes, version=NETWORKS["main"]["xprv"])
+                assert root.to_base58() == xprv

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -7,85 +7,84 @@ import shamir_mnemonic
 from seedsigner.models.settings import SettingsConstants
 
 
-# TODO: Change TAB indents to SPACE
 
 def test_seed():
-	seed = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split())
-	
-	assert seed.seed_bytes == b'q\xb3\xd1i\x0c\x9b\x9b\xdf\xa7\xd9\xd97H\xa8,\xa7\xd9>\xeck\xc2\xf5ND?, \x88-\x07\x9aa\xc5\xee\xb7\xbf\xc4x\xd6\x07 X\xb6}?M\xaa\x05\xa6\xa7(>\xbf\x03\xb0\x9d\xef\xed":\xdf\x88w7'
-	
-	assert seed.mnemonic_str == "obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash"
-	
-	assert seed.passphrase == ""
-	
-	# TODO: Not yet supported in new implementation
-	# seed.set_wordlist_language_code("es")
-	
-	# assert seed.mnemonic_str == "natural ayuda futuro nivel espejo abuelo vago bien repetir moreno relevo conga"
-	
-	# seed.set_wordlist_language_code(SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
-	
-	# seed.mnemonic_str = "height demise useless trap grow lion found off key clown transfer enroll"
-	
-	# assert seed.mnemonic_str == "height demise useless trap grow lion found off key clown transfer enroll"
-	
-	# # TODO: Not yet supported in new implementation
-	# seed.set_wordlist_language_code("es")
-	
-	# assert seed.mnemonic_str == "hebilla cría truco tigre gris llenar folio negocio laico casa tieso eludir"
-	
-	# seed.set_passphrase("test")
-	
-	# assert seed.seed_bytes == b'\xdd\r\xcb\x0b V\xb4@\xee+\x01`\xabem\xc1B\xfd\x8fba0\xab;[\xab\xc9\xf9\xba[F\x0c5,\x7fd8\xebI\x90"\xb8\x86C\x821\x01\xdb\xbe\xf3\xbc\x1cBH"%\x18\xc2{\x04\x08a]\xa5'
-	
-	# assert seed.passphrase == "test"
+    seed = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split())
+    
+    assert seed.seed_bytes == b'q\xb3\xd1i\x0c\x9b\x9b\xdf\xa7\xd9\xd97H\xa8,\xa7\xd9>\xeck\xc2\xf5ND?, \x88-\x07\x9aa\xc5\xee\xb7\xbf\xc4x\xd6\x07 X\xb6}?M\xaa\x05\xa6\xa7(>\xbf\x03\xb0\x9d\xef\xed":\xdf\x88w7'
+    
+    assert seed.mnemonic_str == "obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash"
+    
+    assert seed.passphrase == ""
+    
+    # TODO: Not yet supported in new implementation
+    # seed.set_wordlist_language_code("es")
+    
+    # assert seed.mnemonic_str == "natural ayuda futuro nivel espejo abuelo vago bien repetir moreno relevo conga"
+    
+    # seed.set_wordlist_language_code(SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+    
+    # seed.mnemonic_str = "height demise useless trap grow lion found off key clown transfer enroll"
+    
+    # assert seed.mnemonic_str == "height demise useless trap grow lion found off key clown transfer enroll"
+    
+    # # TODO: Not yet supported in new implementation
+    # seed.set_wordlist_language_code("es")
+    
+    # assert seed.mnemonic_str == "hebilla cría truco tigre gris llenar folio negocio laico casa tieso eludir"
+    
+    # seed.set_passphrase("test")
+    
+    # assert seed.seed_bytes == b'\xdd\r\xcb\x0b V\xb4@\xee+\x01`\xabem\xc1B\xfd\x8fba0\xab;[\xab\xc9\xf9\xba[F\x0c5,\x7fd8\xebI\x90"\xb8\x86C\x821\x01\xdb\xbe\xf3\xbc\x1cBH"%\x18\xc2{\x04\x08a]\xa5'
+    
+    # assert seed.passphrase == "test"
 
-	
+    
 def test_electrum_seed():
-	"""
-	ElectrumSeed should correctly parse a modern Electrum mnemonic.
-	"""
-	seed = ElectrumSeed(mnemonic="regular reject rare profit once math fringe chase until ketchup century escape".split())
+    """
+    ElectrumSeed should correctly parse a modern Electrum mnemonic.
+    """
+    seed = ElectrumSeed(mnemonic="regular reject rare profit once math fringe chase until ketchup century escape".split())
 
-	intended_seed = b'\xcan|\xf8\x8a\x8d\xf78=Pq\xc4_\xe6\x02\x91\xfcs\xb2[\xed*\xdc\xc7%\xb6[_-(~D\xe5\x1e\x85%N\x9c\x03\x9dh\xafX}\x16\xb1\x99,\xbe\xc4\x11\xfaW\x0f\xb0\x89yD\xf4\x0f\xd5?\x8eA'
+    intended_seed = b'\xcan|\xf8\x8a\x8d\xf78=Pq\xc4_\xe6\x02\x91\xfcs\xb2[\xed*\xdc\xc7%\xb6[_-(~D\xe5\x1e\x85%N\x9c\x03\x9dh\xafX}\x16\xb1\x99,\xbe\xc4\x11\xfaW\x0f\xb0\x89yD\xf4\x0f\xd5?\x8eA'
 
-	assert seed.seed_bytes == intended_seed
+    assert seed.seed_bytes == intended_seed
 
 
 def test_electrum_mnemonic_format():
-	"""
-	ElectrumSeed should reject mnemonics that are not 12 words long.
-	"""
-	with pytest.raises(InvalidSeedException):
-		ElectrumSeed(mnemonic=["regular"] * 11)
+    """
+    ElectrumSeed should reject mnemonics that are not 12 words long.
+    """
+    with pytest.raises(InvalidSeedException):
+        ElectrumSeed(mnemonic=["regular"] * 11)
 
-	with pytest.raises(InvalidSeedException):
-		ElectrumSeed(mnemonic=["regular"] * 13)
+    with pytest.raises(InvalidSeedException):
+        ElectrumSeed(mnemonic=["regular"] * 13)
 
-	with pytest.raises(InvalidSeedException):
-		ElectrumSeed(mnemonic=["regular"] * 24)
+    with pytest.raises(InvalidSeedException):
+        ElectrumSeed(mnemonic=["regular"] * 24)
 
 
 def test_electrum_seed_rejects_most_bip39_mnemonics():
-	"""
-	ElectrumSeed should throw an exception for most BIP-39 mnemonics.
+    """
+    ElectrumSeed should throw an exception for most BIP-39 mnemonics.
 
-	There are 1/16 odds that a seed will be valid for both formats.
-	"""
-	# Most BIP-39 seeds should fail; test seeds generated by bitcoiner.guide
-	with pytest.raises(InvalidSeedException):
-		ElectrumSeed(mnemonic="pioneer divide volcano art victory family grow novel mandate bicycle senior adjust".split())
+    There are 1/16 odds that a seed will be valid for both formats.
+    """
+    # Most BIP-39 seeds should fail; test seeds generated by bitcoiner.guide
+    with pytest.raises(InvalidSeedException):
+        ElectrumSeed(mnemonic="pioneer divide volcano art victory family grow novel mandate bicycle senior adjust".split())
 
-	with pytest.raises(InvalidSeedException):
-		ElectrumSeed(mnemonic="gentle combine cool hamster ghost harvest gossip lend dismiss slam any toast".split())
+    with pytest.raises(InvalidSeedException):
+        ElectrumSeed(mnemonic="gentle combine cool hamster ghost harvest gossip lend dismiss slam any toast".split())
 
-	with pytest.raises(InvalidSeedException):
-		ElectrumSeed(mnemonic="enough board blossom stamp fire buffalo digital solution sadness random number stone".split())
+    with pytest.raises(InvalidSeedException):
+        ElectrumSeed(mnemonic="enough board blossom stamp fire buffalo digital solution sadness random number stone".split())
 
-	# This one is valid for both formats
-	mnemonic = "only gain spot output unknown craft simple cram absorb suggest ridge famous".split()
-	Seed(mnemonic)
-	ElectrumSeed(mnemonic)
+    # This one is valid for both formats
+    mnemonic = "only gain spot output unknown craft simple cram absorb suggest ridge famous".split()
+    Seed(mnemonic)
+    ElectrumSeed(mnemonic)
 
 def test_slip39_seed():
         secret = bytes.fromhex("11" * 32)

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -141,3 +141,23 @@ def test_slip39_invalid_share_rejected():
                 storage.update_pending_slip39_share(w, i)
         with pytest.raises(InvalidSeedException):
                 storage.finalize_current_slip39_share()
+
+
+def test_seed_passphrase_effect():
+        mnemonic = "abandon " * 11 + "about"
+        seed = Seed(mnemonic=mnemonic.split())
+        orig = seed.seed_bytes
+        seed.set_passphrase("trezor")
+        from embit import bip39
+        expected = bip39.mnemonic_to_seed(mnemonic, passphrase="trezor")
+        assert seed.seed_bytes == expected
+        assert seed.seed_bytes != orig
+
+def test_slip39_regenerate_shares():
+        secret = bytes.fromhex("aa" * 16)
+        shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret)[0]
+        seed = Slip39Seed(mnemonics=[shares[0], shares[1]])
+        new_shares = seed.regenerate_shares(2, 4)
+        assert len(new_shares) == 4
+        combined = shamir_mnemonic.combine_mnemonics(new_shares[:2])
+        assert combined == secret

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -155,9 +155,19 @@ def test_seed_passphrase_effect():
 
 def test_slip39_regenerate_shares():
         secret = bytes.fromhex("aa" * 16)
-        shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret)[0]
+        shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret, extendable=True)[0]
         seed = Slip39Seed(mnemonics=[shares[0], shares[1]])
+        assert seed.extendable
         new_shares = seed.regenerate_shares(2, 4)
         assert len(new_shares) == 4
         combined = shamir_mnemonic.combine_mnemonics(new_shares[:2])
         assert combined == secret
+
+
+def test_slip39_regenerate_shares_nonextendable():
+        secret = bytes.fromhex("aa" * 16)
+        shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret, extendable=False)[0]
+        seed = Slip39Seed(mnemonics=[shares[0], shares[1]])
+        assert not seed.extendable
+        with pytest.raises(InvalidSeedException):
+                seed.regenerate_shares(2, 4)

--- a/tests/test_slip39_vectors.py
+++ b/tests/test_slip39_vectors.py
@@ -8,7 +8,7 @@ VECTORS_PATH = os.path.join(os.path.dirname(__file__), 'data', 'shamir_vectors.j
 @pytest.mark.parametrize('desc,mnemonics,secret_hex,xprv', json.load(open(VECTORS_PATH)))
 def test_vectors(desc, mnemonics, secret_hex, xprv):
     if secret_hex:
-        combined = shamir_mnemonic.combine_mnemonics(mnemonics)
+        combined = shamir_mnemonic.combine_mnemonics(mnemonics, b"TREZOR")
         assert combined.hex() == secret_hex
     else:
         with pytest.raises(Exception):

--- a/tests/test_slip39_vectors.py
+++ b/tests/test_slip39_vectors.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pytest
+import shamir_mnemonic
 from seedsigner.models.seed import Slip39Seed
 from embit import bip32
 from embit.networks import NETWORKS
@@ -19,3 +20,16 @@ def test_vectors(desc, mnemonics, secret_hex, xprv):
     assert seed.seed_bytes.hex() == secret_hex
     root = bip32.HDKey.from_seed(seed.seed_bytes, version=NETWORKS["main"]["xprv"])
     assert root.to_base58() == xprv
+
+    # Initialize without passphrase and apply it later
+    seed2 = Slip39Seed(mnemonics=mnemonics)
+    seed2.set_slip39_passphrase("TREZOR")
+    assert seed2.seed_bytes == seed.seed_bytes
+    assert seed2.master_secret == seed.master_secret
+
+    if seed2.extendable:
+        new_shares = seed2.regenerate_shares(seed2._member_threshold, len(seed2.mnemonic_list))
+        combined = shamir_mnemonic.combine_mnemonics(
+            new_shares[: seed2._member_threshold], b"TREZOR"
+        )
+        assert combined == seed2.master_secret

--- a/tests/test_slip39_vectors.py
+++ b/tests/test_slip39_vectors.py
@@ -1,15 +1,21 @@
 import json
 import os
 import pytest
-import shamir_mnemonic
+from seedsigner.models.seed import Slip39Seed
+from embit import bip32
+from embit.networks import NETWORKS
 
 VECTORS_PATH = os.path.join(os.path.dirname(__file__), 'data', 'shamir_vectors.json')
 
 @pytest.mark.parametrize('desc,mnemonics,secret_hex,xprv', json.load(open(VECTORS_PATH)))
 def test_vectors(desc, mnemonics, secret_hex, xprv):
-    if secret_hex:
-        combined = shamir_mnemonic.combine_mnemonics(mnemonics, b"TREZOR")
-        assert combined.hex() == secret_hex
-    else:
+    """Verify official SLIP-39 vectors using :class:`Slip39Seed`."""
+    if not secret_hex:
         with pytest.raises(Exception):
-            shamir_mnemonic.combine_mnemonics(mnemonics)
+            Slip39Seed(mnemonics=mnemonics, slip39_passphrase="TREZOR")
+        return
+
+    seed = Slip39Seed(mnemonics=mnemonics, slip39_passphrase="TREZOR")
+    assert seed.seed_bytes.hex() == secret_hex
+    root = bip32.HDKey.from_seed(seed.seed_bytes, version=NETWORKS["main"]["xprv"])
+    assert root.to_base58() == xprv

--- a/tests/test_slip39_vectors.py
+++ b/tests/test_slip39_vectors.py
@@ -1,0 +1,15 @@
+import json
+import os
+import pytest
+import shamir_mnemonic
+
+VECTORS_PATH = os.path.join(os.path.dirname(__file__), 'data', 'shamir_vectors.json')
+
+@pytest.mark.parametrize('desc,mnemonics,secret_hex,xprv', json.load(open(VECTORS_PATH)))
+def test_vectors(desc, mnemonics, secret_hex, xprv):
+    if secret_hex:
+        combined = shamir_mnemonic.combine_mnemonics(mnemonics)
+        assert combined.hex() == secret_hex
+    else:
+        with pytest.raises(Exception):
+            shamir_mnemonic.combine_mnemonics(mnemonics)


### PR DESCRIPTION
## Summary
- support dice entropy bytes extraction
- regenerate SLIP39 shares programmatically
- add SLIP39 seed options in Tools menu
- handle SLIP39 share creation from entropy
- allow regenerating SLIP39 shares from backups
- sequence through multiple SLIP39 shares when backing up
- ignore `jcardsim.jar`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895d2ee3d48322b0578fb5bab05880