### PR TITLE
Fix SLIP39 1-of-n generation

### DIFF
--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -368,16 +368,28 @@ class Slip39Seed(Seed):
 
         first_share = shamir_mnemonic.Share.from_mnemonic(self._shares[0])
 
-        new_groups = shamir_mnemonic.generate_mnemonics(
-            self._group_threshold,
-            [(threshold, num_shares)],
-            self._initial_master_secret,
-            passphrase=self._creation_passphrase.encode("utf-8"),
-            extendable=True,
-            iteration_exponent=first_share.iteration_exponent,
-        )
-
-        shares = new_groups[0]
+        if threshold == 1 and num_shares > 1:
+            groups = [(1, 1)] * num_shares
+            new_groups = shamir_mnemonic.generate_mnemonics(
+                1,
+                groups,
+                self._initial_master_secret,
+                passphrase=self._creation_passphrase.encode("utf-8"),
+                extendable=True,
+                iteration_exponent=first_share.iteration_exponent,
+            )
+            shares = [g[0] for g in new_groups]
+            self._group_threshold = 1
+        else:
+            new_groups = shamir_mnemonic.generate_mnemonics(
+                self._group_threshold,
+                [(threshold, num_shares)],
+                self._initial_master_secret,
+                passphrase=self._creation_passphrase.encode("utf-8"),
+                extendable=True,
+                iteration_exponent=first_share.iteration_exponent,
+            )
+            shares = new_groups[0]
 
         self._shares = shares
         self._member_threshold = threshold

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1142,9 +1142,16 @@ class SeedSlip39CreateFromBytesView(View):
             return Destination(BackStackView)
         threshold = int(ret)
 
-        shares = shamir_mnemonic.generate_mnemonics(
-            1, [(threshold, num_shares)], self.secret, extendable=True
-        )[0]
+        if threshold == 1 and num_shares > 1:
+            groups = [(1, 1)] * num_shares
+            share_groups = shamir_mnemonic.generate_mnemonics(
+                1, groups, self.secret, extendable=True
+            )
+            shares = [g[0] for g in share_groups]
+        else:
+            shares = shamir_mnemonic.generate_mnemonics(
+                1, [(threshold, num_shares)], self.secret, extendable=True
+            )[0]
         seed = Slip39Seed(mnemonics=shares)
         self.controller.storage.set_pending_seed(seed)
 

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -271,6 +271,17 @@ def test_slip39_regenerate_random_passphrase():
     )
 
 
+def test_slip39_regenerate_thresholds():
+    secret = os.urandom(16)
+    share = shamir_mnemonic.generate_mnemonics(1, [(1, 1)], secret, extendable=True)[0][0]
+    seed = Slip39Seed(mnemonics=[share])
+
+    for threshold in (1, 2, 3):
+        new_shares = seed.regenerate_shares(threshold, 3)
+        assert len(new_shares) == 3
+        assert shamir_mnemonic.combine_mnemonics(new_shares[:threshold]) == secret
+
+
 VECTORS_PATH = os.path.join(os.path.dirname(__file__), "data", "shamir_vectors.json")
 
 


### PR DESCRIPTION
## Summary
- support 1-of-N SLIP39 shares
- patch SLIP39 share creation view
- test regenerating SLIP39 shares with different thresholds

## Testing
- `pytest -q tests/test_seed.py::test_slip39_regenerate_thresholds -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d23cebcf48322ad4d76c20d94f663