### PR TITLE
Add entropy validation checks

### DIFF
--- a/src/seedsigner/helpers/mnemonic_generation.py
+++ b/src/seedsigner/helpers/mnemonic_generation.py
@@ -1,5 +1,7 @@
 import hashlib
 import unicodedata
+from collections import Counter
+import math
 
 from embit import bip39
 from seedsigner.models.settings_definition import SettingsConstants
@@ -129,3 +131,22 @@ def generate_mnemonic_from_image(image, wordlist_language_code: str = SettingsCo
 
     # Return as a list
     return bip39.mnemonic_from_bytes(hash.digest(), wordlist=Seed.get_wordlist(wordlist_language_code)).split()
+
+
+def _shannon_entropy(data: bytes | str) -> float:
+    """Return the Shannon entropy of the provided data."""
+    if isinstance(data, str):
+        data = data.encode()
+    counts = Counter(data)
+    length = len(data)
+    return -sum((count / length) * math.log2(count / length) for count in counts.values())
+
+
+def dice_entropy_is_sufficient(roll_data: str, threshold: float = 2.0) -> bool:
+    """Simple randomness check for dice roll input."""
+    return _shannon_entropy(roll_data) >= threshold
+
+
+def byte_entropy_is_sufficient(data: bytes, threshold: float = 3.5) -> bool:
+    """Simple randomness check for byte data."""
+    return _shannon_entropy(data) >= threshold

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -12,7 +12,14 @@ from PIL.ImageOps import autocontrast
 from gettext import gettext as _
 
 from seedsigner.gui.components import FontAwesomeIconConstants, GUIConstants, SeedSignerIconConstants, resize_image_to_fill
-from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen, DireWarningScreen, LargeIconStatusScreen, WarningScreen)
+from seedsigner.gui.screens import (
+    RET_CODE__BACK_BUTTON,
+    ButtonListScreen,
+    DireWarningScreen,
+    LargeIconStatusScreen,
+    WarningScreen,
+    ErrorScreen,
+)
 from seedsigner.gui.screens.scan_screens import ScanScreen
 from seedsigner.gui.screens.tools_screens import (ToolsCalcFinalWordDoneScreen, ToolsCalcFinalWordFinalizePromptScreen,
     ToolsCalcFinalWordScreen, ToolsCoinFlipEntryScreen, ToolsDiceEntropyEntryScreen, ToolsImageEntropyFinalImageScreen,
@@ -237,6 +244,17 @@ class ToolsImageEntropyMnemonicLengthView(View):
             # 12- or 20-word seeds only use the first 128 bits / 16 bytes of entropy
             final_hash = final_hash[:16]
 
+        if not mnemonic_generation.byte_entropy_is_sufficient(final_hash):
+            self.run_screen(
+                ErrorScreen,
+                title=_("Poor Entropy"),
+                status_headline=None,
+                text=_("Camera entropy didn't appear random enough. Please try again."),
+            )
+            self.controller.image_entropy_preview_frames = None
+            self.controller.image_entropy_final_image = None
+            return Destination(BackStackView)
+
         if getattr(self.controller, "create_slip39", False):
             secret = final_hash
         else:
@@ -325,7 +343,16 @@ class ToolsDiceEntropyEntryView(View):
 
         if ret == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
-        
+
+        if not mnemonic_generation.dice_entropy_is_sufficient(ret):
+            self.run_screen(
+                ErrorScreen,
+                title=_("Poor Entropy"),
+                status_headline=None,
+                text=_("Dice rolls didn't appear random enough. Please try again."),
+            )
+            return Destination(BackStackView)
+
         if getattr(self.controller, "create_slip39", False):
             entropy_bytes = mnemonic_generation.generate_bytes_from_dice(ret)
             self.controller.create_slip39 = False

--- a/tests/test_mnemonic_generation.py
+++ b/tests/test_mnemonic_generation.py
@@ -1,5 +1,6 @@
 import pytest
 import random
+import os
 
 from embit import bip39
 from seedsigner.helpers import mnemonic_generation
@@ -141,6 +142,14 @@ def test_verify_against_coldcard_sample():
     actual = " ".join(mnemonic)
     assert bip39.mnemonic_is_valid(actual)
     assert actual == expected
+
+
+def test_entropy_checks():
+    assert mnemonic_generation.dice_entropy_is_sufficient("123456" * 10)
+    assert not mnemonic_generation.dice_entropy_is_sufficient("1" * 50)
+
+    assert mnemonic_generation.byte_entropy_is_sufficient(os.urandom(16))
+    assert not mnemonic_generation.byte_entropy_is_sufficient(b"\x00" * 16)
 
 
 


### PR DESCRIPTION
## Description
- add entropy validation helpers
- check randomness when generating seeds from dice rolls or camera images
- test entropy validation logic

## Checklist
- [x] I've run `pytest` and all tests pass
- [x] I've added unit tests for new functionality

------
https://chatgpt.com/codex/tasks/task_e_688d3aafd19c8322b56ce1e8c433fe03