### PR TITLE
Add SLIP39 seed feature toggle

### DIFF
--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -362,6 +362,7 @@ class SettingsConstants:
     SETTING__CAMERA_ROTATION = "camera_rotation"
     SETTING__COMPACT_SEEDQR = "compact_seedqr"
     SETTING__BIP85_CHILD_SEEDS = "bip85_child_seeds"
+    SETTING__SLIP39_SEEDS = "slip39_seeds"
     SETTING__ELECTRUM_SEEDS = "electrum_seeds"
     SETTING__MESSAGE_SIGNING = "message_signing"
     SETTING__PRIVACY_WARNINGS = "privacy_warnings"
@@ -750,6 +751,13 @@ class SettingsDefinition:
                       display_name=_mft("BIP-85 child seeds"),
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__ENABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__SLIP39_SEEDS,
+                      abbreviated_name="slip39",
+                      display_name=_mft("SLIP39 seeds"),
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      default_value=SettingsConstants.OPTION__DISABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__ELECTRUM_SEEDS,

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -127,7 +127,8 @@ class SeedSelectSeedView(View):
 
         if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_ELECTRUM)
-        button_data.append(self.TYPE_SLIP39)
+        if self.settings.get_value(SettingsConstants.SETTING__SLIP39_SEEDS) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.TYPE_SLIP39)
 
         selected_menu_num = self.run_screen(
             seed_screens.SeedSelectSeedScreen,
@@ -196,7 +197,8 @@ class LoadSeedView(View):
             self.IMPORT_SEEDKEEPER,
         ]
 
-        button_data.append(self.TYPE_SLIP39)
+        if self.settings.get_value(SettingsConstants.SETTING__SLIP39_SEEDS) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.TYPE_SLIP39)
         button_data.append(self.CREATE)
 
         if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -71,7 +71,10 @@ class ToolsMenuView(View):
     CLEAR_DESCRIPTOR = ButtonOption("Clear Multisig Descriptor")
 
     def run(self):
-        button_data = [self.IMAGE, self.DICE, self.SLIP39_IMAGE, self.SLIP39_DICE, self.KEYBOARD, self.ADDRESS_EXPLORER, self.VERIFY_ADDRESS, self.TEXTQRCODE, self.SMARTCARD, self.MICROSD, self.GPG, self.CLEAR_DESCRIPTOR]
+        button_data = [self.IMAGE, self.DICE]
+        if self.settings.get_value(SettingsConstants.SETTING__SLIP39_SEEDS) == SettingsConstants.OPTION__ENABLED:
+            button_data.extend([self.SLIP39_IMAGE, self.SLIP39_DICE])
+        button_data.extend([self.KEYBOARD, self.ADDRESS_EXPLORER, self.VERIFY_ADDRESS, self.TEXTQRCODE, self.SMARTCARD, self.MICROSD, self.GPG, self.CLEAR_DESCRIPTOR])
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -183,6 +183,9 @@ class TestSeedFlows(FlowTest):
 
     def test_slip39_mnemonic_entry_flow(self):
         """Manually entering SLIP-39 shares should combine into a seed."""
+        settings = Settings.get_instance()
+        settings.set_value(SettingsConstants.SETTING__SLIP39_SEEDS, SettingsConstants.OPTION__ENABLED)
+
         secret = bytes.fromhex("11" * 16)
         shares = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret)[0]
         share1 = shares[0].split()
@@ -209,6 +212,9 @@ class TestSeedFlows(FlowTest):
 
     def test_slip39_passphrase_flow(self):
         """Enter SLIP-39 share and apply passphrase afterwards."""
+        settings = Settings.get_instance()
+        settings.set_value(SettingsConstants.SETTING__SLIP39_SEEDS, SettingsConstants.OPTION__ENABLED)
+
         share = "testify swimming academic academic column loyalty smear include exotic bedroom exotic wrist lobe cover grief golden smart junior estimate learn".split()
 
         sequence = [


### PR DESCRIPTION
## Summary
- allow SLIP39 functionality to be enabled or disabled via new setting
- hide SLIP39 options in seed and tools menus when the setting is disabled
- update seed flow tests to enable the new option when needed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e2be94ad88322a428b23a71437290