### PR TITLE
Add setting to toggle smartcard menus

### DIFF
--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -354,6 +354,7 @@ class SettingsConstants:
     SETTING__SMARTCARD_INTERFACES = "smartcard_interfaces"
     SETTING__CACHE_SCARD_PIN = "cache_scard_pin"
     SETTING__SCARD_PIN_ATTEMPTS = "scard_pin_attempts"
+    SETTING__SMARTCARD_SUPPORT = "smartcard_support"
     SETTING__WIPE_TIMER = "wipe_timer"
 
     SETTING__DISPLAY_CONFIGURATION = "display_config"
@@ -779,6 +780,13 @@ class SettingsDefinition:
                       display_name=_mft("Message signing"),
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__DISABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__SMARTCARD_SUPPORT,
+                      abbreviated_name="smartcard",
+                      display_name=_mft("Smartcard support"),
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      default_value=SettingsConstants.OPTION__ENABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__PRIVACY_WARNINGS,

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -193,8 +193,10 @@ class LoadSeedView(View):
             self.TYPE_12WORD,
             self.TYPE_18WORD,
             self.TYPE_24WORD,
-            self.IMPORT_SEEDKEEPER,
         ]
+
+        if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.IMPORT_SEEDKEEPER)
 
         button_data.append(self.TYPE_SLIP39)
         button_data.append(self.CREATE)
@@ -514,7 +516,8 @@ class SeedFinalizeView(View):
         if self.settings.get_value(SettingsConstants.SETTING__PASSPHRASE) != SettingsConstants.OPTION__DISABLED:
             button_data.append(self.TYPE_PASSPHRASE)
             button_data.append(self.SCAN_PASSPHRASE)
-            button_data.append(self.LOAD_SEEDKEEPER)
+            if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
+                button_data.append(self.LOAD_SEEDKEEPER)
 
         selected_menu_num = self.run_screen(
             seed_screens.SeedFinalizeScreen,
@@ -874,7 +877,9 @@ class SeedSlip39MnemonicStartView(View):
         THIRTYTHREE = ButtonOption("Enter 33 words")
         SCAN = ButtonOption("Scan QR", SeedSignerIconConstants.QRCODE)
         SEEDKEEPER = ButtonOption("From SeedKeeper", FontAwesomeIconConstants.LOCK)
-        button_data = [TWENTY, THIRTYTHREE, SCAN, SEEDKEEPER]
+        button_data = [TWENTY, THIRTYTHREE, SCAN]
+        if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(SEEDKEEPER)
 
         selected = self.run_screen(
             ButtonListScreen,
@@ -950,7 +955,9 @@ class SeedSlip39MoreSharesView(View):
         entered = self.controller.storage.slip39_shares_entered
         needed = self.controller.storage.slip39_total_needed
         if needed > entered:
-            button_data = [self.ADD, self.SCAN, self.SEEDKEEPER]
+            button_data = [self.ADD, self.SCAN]
+            if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
+                button_data.append(self.SEEDKEEPER)
         else:
             button_data = [self.DONE]
         info_text = None
@@ -1319,7 +1326,9 @@ class SeedBackupView(View):
 
     def run(self):
 
-        button_data = [self.VIEW_WORDS, self.TO_SEEDKEEPER]
+        button_data = [self.VIEW_WORDS]
+        if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.TO_SEEDKEEPER)
         if isinstance(self.seed, Slip39Seed):
             button_data.append(self.REGENERATE_SHARES)
 
@@ -3344,7 +3353,10 @@ class LoadMultisigWalletDescriptorView(View):
     CANCEL = ButtonOption("Cancel")
 
     def run(self):
-        button_data = [self.SCAN, self.FROM_SEEDKEEPER, self.CANCEL]
+        button_data = [self.SCAN]
+        if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.FROM_SEEDKEEPER)
+        button_data.append(self.CANCEL)
         selected_menu_num = self.run_screen(
             seed_screens.LoadMultisigWalletDescriptorScreen,
             button_data=button_data,

--- a/src/seedsigner/views/settings_views.py
+++ b/src/seedsigner/views/settings_views.py
@@ -65,7 +65,8 @@ class SettingsMenuView(View):
                 view_args={"visibility": SettingsConstants.VISIBILITY__HARDWARE},
             )
 
-            button_data.append(self.RESTART_PCSC)
+            if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
+                button_data.append(self.RESTART_PCSC)
             button_data.append(self.DONATE)
 
         elif self.visibility == SettingsConstants.VISIBILITY__ADVANCED:
@@ -84,9 +85,10 @@ class SettingsMenuView(View):
             if BatteryHat.get_instance().detect_hat():
                 button_data.append(self.BATTERY_INFO)
             button_data.append(self.IO_TEST)
-            button_data.append(self.LIST_READERS)
-            button_data.append(self.SCARD_TEST)
-            button_data.append(self.NFC_TEST)
+            if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
+                button_data.append(self.LIST_READERS)
+                button_data.append(self.SCARD_TEST)
+                button_data.append(self.NFC_TEST)
 
         elif self.visibility == SettingsConstants.VISIBILITY__DEVELOPER:
             title = _("Dev Options")

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -71,7 +71,12 @@ class ToolsMenuView(View):
     CLEAR_DESCRIPTOR = ButtonOption("Clear Multisig Descriptor")
 
     def run(self):
-        button_data = [self.IMAGE, self.DICE, self.SLIP39_IMAGE, self.SLIP39_DICE, self.KEYBOARD, self.ADDRESS_EXPLORER, self.VERIFY_ADDRESS, self.TEXTQRCODE, self.SMARTCARD, self.MICROSD, self.GPG, self.CLEAR_DESCRIPTOR]
+        button_data = [self.IMAGE, self.DICE, self.SLIP39_IMAGE, self.SLIP39_DICE, self.KEYBOARD, self.ADDRESS_EXPLORER, self.VERIFY_ADDRESS, self.TEXTQRCODE]
+
+        if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.SMARTCARD)
+
+        button_data.extend([self.MICROSD, self.GPG, self.CLEAR_DESCRIPTOR])
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,


### PR DESCRIPTION
## Summary
- add `smartcard_support` setting defaulting to enabled
- hide smartcard/SeedKeeper/Satochip menu items when disabled

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_688e54e6014c83229f6d241e17b2fba1