### PR TITLE
feat: add configurable seed word lengths

### DIFF
--- a/src/seedsigner/helpers/mnemonic_generation.py
+++ b/src/seedsigner/helpers/mnemonic_generation.py
@@ -16,8 +16,37 @@ from seedsigner.models.seed import Seed
     see: docs/dice_verification.md (the "Command Line Tool" section).
 """
 
-DICE__NUM_ROLLS__12WORD = 50
-DICE__NUM_ROLLS__24WORD = 99
+# Supported mnemonic word lengths
+SUPPORTED_WORD_LENGTHS = [12, 15, 18, 21, 24]
+
+# Dice roll counts required to generate sufficient entropy for each
+# supported mnemonic length. Each dice roll provides ~2.585 bits of
+# entropy which we round up to the next whole roll.
+DICE_ROLLS_REQUIRED = {
+    12: 50,
+    15: 62,
+    18: 75,
+    21: 87,
+    24: 99,
+}
+
+# Number of entropy bytes needed for each mnemonic length
+ENTROPY_BYTES_REQUIRED = {
+    12: 16,
+    15: 20,
+    18: 24,
+    21: 28,
+    24: 32,
+    20: 16,  # SLIP39 compatibility
+    33: 32,  # SLIP39 compatibility
+}
+
+# Reverse lookup from dice roll count to mnemonic length
+ROLL_COUNT_TO_LENGTH = {v: k for k, v in DICE_ROLLS_REQUIRED.items()}
+
+# Backwards-compatible constants
+DICE__NUM_ROLLS__12WORD = DICE_ROLLS_REQUIRED[12]
+DICE__NUM_ROLLS__24WORD = DICE_ROLLS_REQUIRED[24]
 
 
 
@@ -35,12 +64,12 @@ def calculate_checksum(mnemonic: list | str, wordlist_language_code: str = Setti
         # split on commas or spaces
         mnemonic = re.findall(r'[^,\s]+', mnemonic)
 
-    if len(mnemonic) in [11, 23]:
+    if len(mnemonic) in [11, 14, 17, 20, 23]:
         temp_final_word = Seed.get_wordlist(wordlist_language_code)[0]
         mnemonic.append(temp_final_word)
 
-    if len(mnemonic) not in [12, 24]:
-        raise Exception("Pass in a 12- or 24-word mnemonic")
+    if len(mnemonic) not in SUPPORTED_WORD_LENGTHS:
+        raise Exception("Pass in a 12, 15, 18, 21, or 24-word mnemonic")
     
     # Work on a copy of the input list
     mnemonic_copy = mnemonic.copy()
@@ -65,7 +94,7 @@ def generate_mnemonic_from_bytes(entropy_bytes, wordlist_language_code: str = Se
 
 def generate_mnemonic_from_dice(roll_data: str, wordlist_language_code: str = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH) -> list[str]:
     """
-        Takes a string of 50 or 99 dice rolls and returns a 12- or 24-word mnemonic.
+        Takes a string of dice rolls and returns a mnemonic of the appropriate length.
 
         Uses the iancoleman.io/bip39 and bitcoiner.guide/seed "Base 10" or "Hex" mode approach:
         * dice rolls are treated as string data.
@@ -75,9 +104,9 @@ def generate_mnemonic_from_dice(roll_data: str, wordlist_language_code: str = Se
     """
     entropy_bytes = hashlib.sha256(roll_data.encode()).digest()
 
-    if len(roll_data) == DICE__NUM_ROLLS__12WORD:
-        # 12-word mnemonic; only use 128bits / 16 bytes
-        entropy_bytes = entropy_bytes[:16]
+    word_length = ROLL_COUNT_TO_LENGTH.get(len(roll_data), 24)
+
+    entropy_bytes = entropy_bytes[:ENTROPY_BYTES_REQUIRED[word_length]]
 
     # Return as a list
     return bip39.mnemonic_from_bytes(entropy_bytes, wordlist=Seed.get_wordlist(wordlist_language_code)).split()
@@ -86,15 +115,15 @@ def generate_mnemonic_from_dice(roll_data: str, wordlist_language_code: str = Se
 def generate_bytes_from_dice(roll_data: str) -> bytes:
     """Return entropy bytes from dice rolls without converting to mnemonic."""
     entropy_bytes = hashlib.sha256(roll_data.encode()).digest()
-    if len(roll_data) == DICE__NUM_ROLLS__12WORD:
-        entropy_bytes = entropy_bytes[:16]
+    word_length = ROLL_COUNT_TO_LENGTH.get(len(roll_data), 24)
+    entropy_bytes = entropy_bytes[:ENTROPY_BYTES_REQUIRED[word_length]]
     return entropy_bytes
 
 
 
 def generate_mnemonic_from_coin_flips(coin_flips: str, wordlist_language_code: str = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH) -> list[str]:
     """
-        Takes a string of 128 or 256 0s and 1s and returns a 12- or 24-word mnemonic.
+        Takes a string of binary digits and returns a mnemonic of the appropriate length.
 
         Uses the iancoleman.io/bip39 and bitcoiner.guide/seed "Binary" mode approach:
         * binary digit stream is treated as string data.
@@ -102,9 +131,18 @@ def generate_mnemonic_from_coin_flips(coin_flips: str, wordlist_language_code: s
     """
     entropy_bytes = hashlib.sha256(coin_flips.encode()).digest()
 
-    if len(coin_flips) == 128:
-        # 12-word mnemonic; only use 128bits / 16 bytes
-        entropy_bytes = entropy_bytes[:16]
+    length_map = {
+        128: 12,
+        160: 15,
+        192: 18,
+        224: 21,
+        256: 24,
+    }
+    word_length = length_map.get(len(coin_flips))
+    if word_length is None:
+        raise Exception("Unsupported number of coin flips")
+
+    entropy_bytes = entropy_bytes[:ENTROPY_BYTES_REQUIRED[word_length]]
 
     # Return as a list
     return bip39.mnemonic_from_bytes(entropy_bytes, wordlist=Seed.get_wordlist(wordlist_language_code)).split()

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -496,8 +496,13 @@ class DecodeQR:
                 # Couldn't convert back to bytes; shouldn't happen
                 raise Exception("Conversion to bytes failed")
 
-        # 32 bytes for 24-word CompactSeedQR; 24 bytes for 18 word, 16 bytes for 12-word CompactSeedQR
-        if len(s) == 32 or len(s) == 24 or len(s) == 16:
+        # Byte lengths for CompactSeedQR entropy:
+        #   32 bytes for 24-word
+        #   28 bytes for 21-word
+        #   24 bytes for 18-word
+        #   20 bytes for 15-word
+        #   16 bytes for 12-word
+        if len(s) in (16, 20, 24, 28, 32):
             try:
                 bitstream = ""
                 for b in s:
@@ -847,7 +852,7 @@ class Base43PsbtQrDecoder(BaseSingleFrameQrDecoder):
 
 class SeedQrDecoder(BaseSingleFrameQrDecoder):
     """
-        Decodes single frame representing a seed.
+        Decodes a single frame representing a BIP39 seed.
         Supports SeedSigner SeedQR numeric (wordlist indices) representation of a seed.
         Supports SeedSigner CompactSeedQR entropy byte representation of a seed.
         Supports mnemonic seed phrase string data.
@@ -865,14 +870,16 @@ class SeedQrDecoder(BaseSingleFrameQrDecoder):
             try:
                 self.seed_phrase = []
 
-                # Parse 12 or 24-word QR code
+                if len(segment) % 4 != 0:
+                    return DecodeQRStatus.INVALID
+
                 num_words = int(len(segment) / 4)
                 for i in range(0, num_words):
                     index = int(segment[i * 4: (i*4) + 4])
                     word = self.wordlist[index]
                     self.seed_phrase.append(word)
                 if len(self.seed_phrase) > 0:
-                    if self.is_12_or_18_or_24_word_phrase() == False:
+                    if not self.has_valid_word_count():
                         return DecodeQRStatus.INVALID
                     self.complete = True
                     self.collected_segments = 1
@@ -886,6 +893,8 @@ class SeedQrDecoder(BaseSingleFrameQrDecoder):
             logging.info("Trying CompactSeedQR")
             try:
                 self.seed_phrase = bip39.mnemonic_from_bytes(segment).split()
+                if not self.has_valid_word_count():
+                    return DecodeQRStatus.INVALID
                 self.complete = True
                 self.collected_segments = 1
                 return DecodeQRStatus.COMPLETE
@@ -900,11 +909,10 @@ class SeedQrDecoder(BaseSingleFrameQrDecoder):
                 # embit mnemonic code to validate
                 seed = Seed(seed_phrase_list, passphrase="", wordlist_language_code=self.wordlist_language_code)
                 if not seed:
-                    # seed is not valid, return invalid
                     return DecodeQRStatus.INVALID
                 self.seed_phrase = seed_phrase_list
-                if self.is_12_or_18_or_24_word_phrase() == False:
-                        return DecodeQRStatus.INVALID
+                if not self.has_valid_word_count():
+                    return DecodeQRStatus.INVALID
                 self.complete = True
                 self.collected_segments = 1
                 return DecodeQRStatus.COMPLETE
@@ -923,11 +931,10 @@ class SeedQrDecoder(BaseSingleFrameQrDecoder):
                 # embit mnemonic code to validate
                 seed = Seed(words, passphrase="", wordlist_language_code=self.wordlist_language_code)
                 if not seed:
-                    # seed is not valid, return invalid
                     return DecodeQRStatus.INVALID
                 self.seed_phrase = words
-                if self.is_12_or_18_or_24_word_phrase() == False:
-                        return DecodeQRStatus.INVALID
+                if not self.has_valid_word_count():
+                    return DecodeQRStatus.INVALID
                 self.complete = True
                 self.collected_segments = 1
                 return DecodeQRStatus.COMPLETE
@@ -942,10 +949,8 @@ class SeedQrDecoder(BaseSingleFrameQrDecoder):
             return self.seed_phrase[:]
         return []
 
-    def is_12_or_18_or_24_word_phrase(self):
-        if len(self.seed_phrase) in (12, 18, 24):
-            return True
-        return False
+    def has_valid_word_count(self):
+        return len(self.seed_phrase) in (12, 15, 18, 21, 24)
 
 
 class Slip39ShareDecoder(BaseSingleFrameQrDecoder):

--- a/src/seedsigner/models/encode_qr.py
+++ b/src/seedsigner/models/encode_qr.py
@@ -116,14 +116,10 @@ class CompactSeedQrEncoder(SeedQrEncoder):
             # Convert index to binary, strip out '0b' prefix; zero-pad to 11 bits
             binary_str += bin(index).split('b')[1].zfill(11)
 
-        # We can exclude the checksum bits at the end
-        if len(self.mnemonic) == 24:
-            # 8 checksum bits in a 24-word seed
-            binary_str = binary_str[:-8]
-
-        elif len(self.mnemonic) == 12:
-            # 4 checksum bits in a 12-word seed
-            binary_str = binary_str[:-4]
+        # Exclude the checksum bits at the end. The checksum length is
+        # entropy_bits / 32 which equates to `word_count / 3`.
+        checksum_bits = len(self.mnemonic) // 3
+        binary_str = binary_str[:-checksum_bits]
 
         # Now convert to bytes, 8 bits at a time
         as_bytes = bytearray()

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -364,6 +364,7 @@ class SettingsConstants:
     SETTING__XPUB_EXPORT = "xpub_export"
     SETTING__SIG_TYPES = "sig_types"
     SETTING__SCRIPT_TYPES = "script_types"
+    SETTING__SEED_WORD_LENGTHS = "seed_word_lengths"
     SETTING__XPUB_DETAILS = "xpub_details"
     SETTING__PASSPHRASE = "passphrase"
     SETTING__CAMERA_ROTATION = "camera_rotation"
@@ -447,6 +448,14 @@ class SettingsConstants:
     ALL_ENCRYPTION_MODES = [
         ENCRYPTION_MODE_ECB,
         ENCRYPTION_MODE_CBC,
+    ]
+
+    ALL_SEED_WORD_LENGTHS = [
+        (12, "12 words"),
+        (15, "15 words"),
+        (18, "18 words"),
+        (21, "21 words"),
+        (24, "24 words"),
     ]
 
 
@@ -702,6 +711,15 @@ class SettingsDefinition:
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       selection_options=SettingsConstants.ALL_SCRIPT_TYPES,
                       default_value=[SettingsConstants.NATIVE_SEGWIT, SettingsConstants.NESTED_SEGWIT, SettingsConstants.TAPROOT]),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__SEED_WORD_LENGTHS,
+                      abbreviated_name="seedlen",
+                      display_name=_mft("Seed word lengths"),
+                      type=SettingsConstants.TYPE__MULTISELECT,
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      selection_options=SettingsConstants.ALL_SEED_WORD_LENGTHS,
+                      default_value=[12, 24]),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__XPUB_DETAILS,

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -10,8 +10,11 @@ from seedsigner.views.view import BackStackView, MainMenuView, NotYetImplemented
 
 class PSBTSelectSeedView(View):
     SCAN_SEED = ButtonOption("Scan a seed", SeedSignerIconConstants.QRCODE)
-    TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD)
-    TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD)
+    TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=12)
+    TYPE_15WORD = ButtonOption("Enter 15-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=15)
+    TYPE_18WORD = ButtonOption("Enter 18-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=18)
+    TYPE_21WORD = ButtonOption("Enter 21-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=21)
+    TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=24)
     TYPE_ELECTRUM = ButtonOption("Enter Electrum seed", FontAwesomeIconConstants.KEYBOARD)
 
 
@@ -41,8 +44,16 @@ class PSBTSelectSeedView(View):
             button_data.append(ButtonOption(button_str, SeedSignerIconConstants.FINGERPRINT))
 
         button_data.append(self.SCAN_SEED)
-        button_data.append(self.TYPE_12WORD)
-        button_data.append(self.TYPE_24WORD)
+        seed_lengths = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
+        options = {
+            12: self.TYPE_12WORD,
+            15: self.TYPE_15WORD,
+            18: self.TYPE_18WORD,
+            21: self.TYPE_21WORD,
+            24: self.TYPE_24WORD,
+        }
+        for l in seed_lengths:
+            button_data.append(options[l])
         if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_ELECTRUM)
 
@@ -68,12 +79,9 @@ class PSBTSelectSeedView(View):
             from seedsigner.views.scan_views import ScanSeedQRView
             return Destination(ScanSeedQRView)
 
-        elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_24WORD]:
+        elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_15WORD, self.TYPE_18WORD, self.TYPE_21WORD, self.TYPE_24WORD]:
             from seedsigner.views.seed_views import SeedMnemonicEntryView
-            if button_data[selected_menu_num] == self.TYPE_12WORD:
-                self.controller.storage.init_pending_mnemonic(num_words=12)
-            else:
-                self.controller.storage.init_pending_mnemonic(num_words=24)
+            self.controller.storage.init_pending_mnemonic(num_words=button_data[selected_menu_num].return_data)
             return Destination(SeedMnemonicEntryView)
 
         elif button_data[selected_menu_num] == self.TYPE_ELECTRUM:

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -2171,84 +2171,90 @@ class SeedWordsBackupTestSuccessView(View):
     Export as SeedQR
 ****************************************************************************"""
 class SeedTranscribeSeedQRFormatView(View):
-    # SeedQR dims for 12-word seeds
-    STANDARD_12 = ButtonOption("Standard: 25x25", return_data=25)
-    COMPACT_12 = ButtonOption("Compact: 21x21", return_data=21)
-    ENCRYPTED_12 = ButtonOption("Encrypted: 29x29", return_data=0) # Encrypted QR uses dummy return data
-
-    # SeedQR dims for 24-word seeds
-    STANDARD_24 = ButtonOption("Standard: 29x29", return_data=29)
-    COMPACT_24 = ButtonOption("Compact: 25x25", return_data=25)
-    ENCRYPTED_24 = ButtonOption("Encrypted: 33x33", return_data=0) # Encrypted QR uses dummy return data
-
     def __init__(self, seed_num: int):
         super().__init__()
         self.seed_num = seed_num
 
 
     def run(self):
+        from seedsigner.helpers.qr import QR
+
         seed = self.controller.get_seed(self.seed_num)
 
-        if (self.settings.get_value(SettingsConstants.SETTING__COMPACT_SEEDQR) != SettingsConstants.OPTION__ENABLED and
-            self.settings.get_value(SettingsConstants.SETTING__ENCRYPTED_QR) != SettingsConstants.OPTION__ENABLED):
-            # Only configured for standard SeedQR
+        encoder_args = dict(
+            mnemonic=seed.mnemonic_list,
+            wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE),
+        )
+
+        qr_helper = QR()
+        button_data = []
+
+        standard_encoder = SeedQrEncoder(**encoder_args)
+        standard_modules = qr_helper.qrsize(standard_encoder.next_part())
+        button_data.append(
+            ButtonOption(
+                f"Standard: {standard_modules}x{standard_modules}",
+                return_data=(QRType.SEED__SEEDQR, standard_modules),
+            )
+        )
+
+        if self.settings.get_value(SettingsConstants.SETTING__COMPACT_SEEDQR) == SettingsConstants.OPTION__ENABLED:
+            compact_encoder = CompactSeedQrEncoder(**encoder_args)
+            compact_modules = qr_helper.qrsize(compact_encoder.next_part())
+            button_data.append(
+                ButtonOption(
+                    f"Compact: {compact_modules}x{compact_modules}",
+                    return_data=(QRType.SEED__COMPACTSEEDQR, compact_modules),
+                )
+            )
+
+        if self.settings.get_value(SettingsConstants.SETTING__ENCRYPTED_QR) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(
+                ButtonOption(
+                    "Encrypted",
+                    return_data=(QRType.SEED__ENCRYPTEDQR, 0),
+                )
+            )
+
+        if len(button_data) == 1:
+            seedqr_format, num_modules = button_data[0].return_data
             return Destination(
                 SeedTranscribeSeedQRWarningView,
                 view_args={
                     "seed_num": self.seed_num,
-                    "seedqr_format": QRType.SEED__SEEDQR,
-                    "num_modules": self.STANDARD_12.return_data,
+                    "seedqr_format": seedqr_format,
+                    "num_modules": num_modules,
                 },
                 skip_current_view=True,
             )
 
-        if len(seed.mnemonic_list) == 12:
-            button_data = [self.STANDARD_12]
-        else:
-            button_data = [self.STANDARD_24]
-
-        if self.settings.get_value(SettingsConstants.SETTING__COMPACT_SEEDQR) == SettingsConstants.OPTION__ENABLED:
-            if len(seed.mnemonic_list) == 12:
-              button_data.append(self.COMPACT_12)
-            else:
-              button_data.append(self.COMPACT_24)
-              
-        if self.settings.get_value(SettingsConstants.SETTING__ENCRYPTED_QR) == SettingsConstants.OPTION__ENABLED:
-            if len(seed.mnemonic_list) == 12:
-              button_data.append(self.ENCRYPTED_12)
-            else:
-              button_data.append(self.ENCRYPTED_24)
-            
         selected_menu_num = self.run_screen(
             seed_screens.SeedTranscribeSeedQRFormatScreen,
             title=_("SeedQR Format"),
-            is_compactqr = (self.settings.get_value(SettingsConstants.SETTING__COMPACT_SEEDQR) == SettingsConstants.OPTION__ENABLED),
-            is_encryptedqr = (self.settings.get_value(SettingsConstants.SETTING__ENCRYPTED_QR) == SettingsConstants.OPTION__ENABLED),
-
+            is_compactqr=(
+                self.settings.get_value(SettingsConstants.SETTING__COMPACT_SEEDQR)
+                == SettingsConstants.OPTION__ENABLED
+            ),
+            is_encryptedqr=(
+                self.settings.get_value(SettingsConstants.SETTING__ENCRYPTED_QR)
+                == SettingsConstants.OPTION__ENABLED
+            ),
             button_data=button_data,
         )
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
-        
-        if button_data[selected_menu_num] in [self.STANDARD_12, self.STANDARD_24]:
-            seedqr_format = QRType.SEED__SEEDQR
-        elif button_data[selected_menu_num] in [self.COMPACT_12, self.COMPACT_24]:
-            seedqr_format = QRType.SEED__COMPACTSEEDQR
-            
-        else:
-            seedqr_format = QRType.SEED__ENCRYPTEDQR
 
-        num_modules = button_data[selected_menu_num].return_data
+        seedqr_format, num_modules = button_data[selected_menu_num].return_data
 
         return Destination(
             SeedTranscribeSeedQRWarningView,
-                view_args={
-                    "seed_num": self.seed_num,
-                    "seedqr_format": seedqr_format,
-                    "num_modules": num_modules,
-                }
-            )
+            view_args={
+                "seed_num": self.seed_num,
+                "seedqr_format": seedqr_format,
+                "num_modules": num_modules,
+            },
+        )
 
 
 
@@ -2883,16 +2889,8 @@ class SeedTranscribeSeedQRZoomedInView(View):
 
         data = e.next_part()
 
-        if len(self.seed.mnemonic_list) == 24:
-            if self.seedqr_format == QRType.SEED__COMPACTSEEDQR:
-                num_modules = 25
-            else:
-                num_modules = 29
-        else:
-            if self.seedqr_format == QRType.SEED__COMPACTSEEDQR:
-                num_modules = 21
-            else:
-                num_modules = 25
+        from seedsigner.helpers.qr import QR
+        num_modules = QR().qrsize(data)
 
         seed_screens.SeedTranscribeSeedQRZoomedInScreen(
             qr_data=data,

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -84,9 +84,11 @@ class SeedSelectSeedView(View):
                 verify single sig addr or sign message).
     """
     SCAN_SEED = ButtonOption("Scan a seed", SeedSignerIconConstants.QRCODE)
-    TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD)
-    TYPE_18WORD = ButtonOption("Enter 18-word seed", FontAwesomeIconConstants.KEYBOARD)
-    TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD)
+    TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=12)
+    TYPE_15WORD = ButtonOption("Enter 15-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=15)
+    TYPE_18WORD = ButtonOption("Enter 18-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=18)
+    TYPE_21WORD = ButtonOption("Enter 21-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=21)
+    TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=24)
     TYPE_ELECTRUM = ButtonOption("Enter Electrum seed", FontAwesomeIconConstants.KEYBOARD)
     TYPE_SLIP39 = ButtonOption("SLIP-39 Shares", FontAwesomeIconConstants.KEYBOARD)
 
@@ -121,9 +123,16 @@ class SeedSelectSeedView(View):
             button_data.append(ButtonOption(button_str, SeedSignerIconConstants.FINGERPRINT, icon_color="blue"))
         
         button_data.append(self.SCAN_SEED)
-        button_data.append(self.TYPE_12WORD)
-        button_data.append(self.TYPE_18WORD)
-        button_data.append(self.TYPE_24WORD)
+        seed_lengths = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
+        options = {
+            12: self.TYPE_12WORD,
+            15: self.TYPE_15WORD,
+            18: self.TYPE_18WORD,
+            21: self.TYPE_21WORD,
+            24: self.TYPE_24WORD,
+        }
+        for l in seed_lengths:
+            button_data.append(options[l])
 
         if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_ELECTRUM)
@@ -156,14 +165,9 @@ class SeedSelectSeedView(View):
             from seedsigner.views.scan_views import ScanView
             return Destination(ScanView)
 
-        elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_24WORD]:
+        elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_15WORD, self.TYPE_18WORD, self.TYPE_21WORD, self.TYPE_24WORD]:
             from seedsigner.views.seed_views import SeedMnemonicEntryView
-            if button_data[selected_menu_num] == self.TYPE_12WORD:
-                self.controller.storage.init_pending_mnemonic(num_words=12)
-            elif button_data[selected_menu_num] == self.TYPE_18WORD:
-                self.controller.storage.init_pending_mnemonic(num_words=18)
-            else:
-                self.controller.storage.init_pending_mnemonic(num_words=24)
+            self.controller.storage.init_pending_mnemonic(num_words=button_data[selected_menu_num].return_data)
             return Destination(SeedMnemonicEntryView)
 
         elif button_data[selected_menu_num] == self.TYPE_ELECTRUM:
@@ -179,22 +183,28 @@ class SeedSelectSeedView(View):
 ****************************************************************************"""
 class LoadSeedView(View):
     SEED_QR = ButtonOption(" Scan a SeedQR", SeedSignerIconConstants.QRCODE)
-    TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD)
-    TYPE_18WORD = ButtonOption("Enter 18-word seed", FontAwesomeIconConstants.KEYBOARD)
-    TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD)
+    TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=12)
+    TYPE_15WORD = ButtonOption("Enter 15-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=15)
+    TYPE_18WORD = ButtonOption("Enter 18-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=18)
+    TYPE_21WORD = ButtonOption("Enter 21-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=21)
+    TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=24)
     TYPE_ELECTRUM = ButtonOption("Enter Electrum seed", FontAwesomeIconConstants.KEYBOARD)
     TYPE_SLIP39 = ButtonOption("SLIP-39 Shares", FontAwesomeIconConstants.KEYBOARD)
     IMPORT_SEEDKEEPER = ButtonOption("From SeedKeeper", FontAwesomeIconConstants.LOCK)
     CREATE = ButtonOption(" Create a seed", SeedSignerIconConstants.PLUS)
 
     def run(self):
-        button_data = [
-            self.SEED_QR,
-            self.TYPE_12WORD,
-            self.TYPE_18WORD,
-            self.TYPE_24WORD,
-            self.IMPORT_SEEDKEEPER,
-        ]
+        button_data = [self.SEED_QR]
+        seed_lengths = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
+        options = {
+            12: self.TYPE_12WORD,
+            15: self.TYPE_15WORD,
+            18: self.TYPE_18WORD,
+            21: self.TYPE_21WORD,
+            24: self.TYPE_24WORD,
+        }
+        button_data.extend([options[l] for l in seed_lengths])
+        button_data.append(self.IMPORT_SEEDKEEPER)
 
         button_data.append(self.TYPE_SLIP39)
         button_data.append(self.CREATE)
@@ -216,16 +226,8 @@ class LoadSeedView(View):
             from .scan_views import ScanSeedQRView
             return Destination(ScanSeedQRView)
 
-        elif button_data[selected_menu_num] == self.TYPE_12WORD:
-            self.controller.storage.init_pending_mnemonic(num_words=12)
-            return Destination(SeedMnemonicEntryView)
-        
-        elif button_data[selected_menu_num] == self.TYPE_18WORD:
-            self.controller.storage.init_pending_mnemonic(num_words=18)
-            return Destination(SeedMnemonicEntryView)
-
-        elif button_data[selected_menu_num] == self.TYPE_24WORD:
-            self.controller.storage.init_pending_mnemonic(num_words=24)
+        elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_15WORD, self.TYPE_18WORD, self.TYPE_21WORD, self.TYPE_24WORD]:
+            self.controller.storage.init_pending_mnemonic(num_words=button_data[selected_menu_num].return_data)
             return Destination(SeedMnemonicEntryView)
 
         elif button_data[selected_menu_num] == self.IMPORT_SEEDKEEPER:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -194,6 +194,9 @@ class ToolsImageEntropyFinalImageView(View):
 
 class ToolsImageEntropyMnemonicLengthView(View):
     TWELVE_WORDS = ButtonOption("12 words", return_data=12)
+    FIFTEEN_WORDS = ButtonOption("15 words", return_data=15)
+    EIGHTEEN_WORDS = ButtonOption("18 words", return_data=18)
+    TWENTYONE_WORDS = ButtonOption("21 words", return_data=21)
     TWENTYFOUR_WORDS = ButtonOption("24 words", return_data=24)
 
     def run(self):
@@ -202,7 +205,15 @@ class ToolsImageEntropyMnemonicLengthView(View):
             thirty_three = ButtonOption("33 words", return_data=33)
             button_data = [twenty, thirty_three]
         else:
-            button_data = [self.TWELVE_WORDS, self.TWENTYFOUR_WORDS]
+            allowed = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
+            options = {
+                12: self.TWELVE_WORDS,
+                15: self.FIFTEEN_WORDS,
+                18: self.EIGHTEEN_WORDS,
+                21: self.TWENTYONE_WORDS,
+                24: self.TWENTYFOUR_WORDS,
+            }
+            button_data = [options[l] for l in allowed]
 
         selected_menu_num = ButtonListScreen(
             title=_("Mnemonic Length?"),
@@ -260,10 +271,9 @@ class ToolsImageEntropyMnemonicLengthView(View):
         mnemonic_generation.byte_entropy_is_sufficient(seed_entropy_image.tobytes())
         final_hash = hashlib.sha256(hash_bytes + seed_entropy_image.tobytes()).digest()
 
-        if mnemonic_length in (12, 20):
-            # 12- or 20-word seeds only use the first 128 bits / 16 bytes of entropy
-            final_hash = final_hash[:16]
-
+        if mnemonic_length in mnemonic_generation.ENTROPY_BYTES_REQUIRED:
+            final_hash = final_hash[:mnemonic_generation.ENTROPY_BYTES_REQUIRED[mnemonic_length]]
+        
         print("Final shannon entropy")
         if not mnemonic_generation.byte_entropy_is_sufficient(final_hash):
             self.run_screen(
@@ -306,26 +316,33 @@ class ToolsImageEntropyMnemonicLengthView(View):
 class ToolsDiceEntropyMnemonicLengthView(View):
     """Prompt for mnemonic length when using dice entropy."""
 
-    # These are defined here so they are available for equality checks later
-    TWELVE = ButtonOption("12 words", return_data=mnemonic_generation.DICE__NUM_ROLLS__12WORD)
-    TWENTY_FOUR = ButtonOption("24 words", return_data=mnemonic_generation.DICE__NUM_ROLLS__24WORD)
+    TWELVE = ButtonOption("12 words", return_data=12)
+    FIFTEEN = ButtonOption("15 words", return_data=15)
+    EIGHTEEN = ButtonOption("18 words", return_data=18)
+    TWENTY_ONE = ButtonOption("21 words", return_data=21)
+    TWENTY_FOUR = ButtonOption("24 words", return_data=24)
     TWENTY = ButtonOption(
-        _("20 words ({} rolls)").format(mnemonic_generation.DICE__NUM_ROLLS__12WORD),
-        return_data=mnemonic_generation.DICE__NUM_ROLLS__12WORD,
+        _("20 words ({} rolls)").format(mnemonic_generation.DICE_ROLLS_REQUIRED[12]),
+        return_data=mnemonic_generation.DICE_ROLLS_REQUIRED[12],
     )
     THIRTY_THREE = ButtonOption(
-        _("33 words ({} rolls)").format(mnemonic_generation.DICE__NUM_ROLLS__24WORD),
-        return_data=mnemonic_generation.DICE__NUM_ROLLS__24WORD,
+        _("33 words ({} rolls)").format(mnemonic_generation.DICE_ROLLS_REQUIRED[24]),
+        return_data=mnemonic_generation.DICE_ROLLS_REQUIRED[24],
     )
 
     def run(self):
-        # Since we're dynamically building the ButtonOption button_labels here, it's too
-        # awkward to use the usual class-level attr approach.
-
         if getattr(self.controller, "create_slip39", False):
             button_data = [self.TWENTY, self.THIRTY_THREE]
         else:
-            button_data = [self.TWELVE, self.TWENTY_FOUR]
+            allowed = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
+            options = {
+                12: self.TWELVE,
+                15: self.FIFTEEN,
+                18: self.EIGHTEEN,
+                21: self.TWENTY_ONE,
+                24: self.TWENTY_FOUR,
+            }
+            button_data = [options[l] for l in allowed]
         selected_menu_num = ButtonListScreen(
             title=_("Mnemonic Length"),
             is_bottom_list=True,
@@ -336,17 +353,15 @@ class ToolsDiceEntropyMnemonicLengthView(View):
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        elif button_data[selected_menu_num] in (self.TWELVE, self.TWENTY):
-            return Destination(
-                ToolsDiceEntropyEntryView,
-                view_args=dict(total_rolls=mnemonic_generation.DICE__NUM_ROLLS__12WORD),
-            )
-
-        elif button_data[selected_menu_num] in (self.TWENTY_FOUR, self.THIRTY_THREE):
-            return Destination(
-                ToolsDiceEntropyEntryView,
-                view_args=dict(total_rolls=mnemonic_generation.DICE__NUM_ROLLS__24WORD),
-            )
+        if getattr(self.controller, "create_slip39", False):
+            total_rolls = button_data[selected_menu_num].return_data
+        else:
+            selected_length = button_data[selected_menu_num].return_data
+            total_rolls = mnemonic_generation.DICE_ROLLS_REQUIRED[selected_length]
+        return Destination(
+            ToolsDiceEntropyEntryView,
+            view_args=dict(total_rolls=total_rolls),
+        )
 
 
 
@@ -391,10 +406,21 @@ class ToolsDiceEntropyEntryView(View):
 ****************************************************************************"""
 class ToolsCalcFinalWordNumWordsView(View):
     TWELVE = ButtonOption("12 words", return_data=12)
+    FIFTEEN = ButtonOption("15 words", return_data=15)
+    EIGHTEEN = ButtonOption("18 words", return_data=18)
+    TWENTY_ONE = ButtonOption("21 words", return_data=21)
     TWENTY_FOUR = ButtonOption("24 words", return_data=24)
 
     def run(self):
-        button_data = [self.TWELVE, self.TWENTY_FOUR]
+        allowed = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
+        options = {
+            12: self.TWELVE,
+            15: self.FIFTEEN,
+            18: self.EIGHTEEN,
+            21: self.TWENTY_ONE,
+            24: self.TWENTY_FOUR,
+        }
+        button_data = [options[l] for l in allowed]
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,
@@ -427,10 +453,8 @@ class ToolsCalcFinalWordFinalizePromptView(View):
         from seedsigner.gui.screens.tools_screens import ToolsCalcFinalWordFinalizePromptScreen
         mnemonic = self.controller.storage.pending_mnemonic
         mnemonic_length = len(mnemonic)
-        if mnemonic_length == 12:
-            num_entropy_bits = 7
-        else:
-            num_entropy_bits = 3
+        total_bits = mnemonic_generation.ENTROPY_BYTES_REQUIRED[mnemonic_length] * 8
+        num_entropy_bits = total_bits - ((mnemonic_length - 1) * 11)
 
         button_data = [self.COIN_FLIPS, self.SELECT_WORD, self.ZEROS]
         selected_menu_num = ToolsCalcFinalWordFinalizePromptScreen(
@@ -464,10 +488,8 @@ class ToolsCalcFinalWordCoinFlipsView(View):
         from seedsigner.gui.screens.tools_screens import ToolsCoinFlipEntryScreen
         mnemonic_length = len(self.controller.storage.pending_mnemonic)
 
-        if mnemonic_length == 12:
-            total_flips = 7
-        else:
-            total_flips = 3
+        total_bits = mnemonic_generation.ENTROPY_BYTES_REQUIRED[mnemonic_length] * 8
+        total_flips = total_bits - ((mnemonic_length - 1) * 11)
         
         ret_val = ToolsCoinFlipEntryScreen(
             return_after_n_chars=total_flips,
@@ -531,7 +553,9 @@ class ToolsCalcFinalWordShowFinalWordView(View):
 
         # And grab the actual final word's checksum bits
         self.actual_final_word = self.controller.storage.pending_mnemonic[-1]
-        num_checksum_bits = 4 if mnemonic_length == 12 else 8
+        total_bits = mnemonic_generation.ENTROPY_BYTES_REQUIRED[mnemonic_length] * 8
+        num_entropy_bits = total_bits - ((mnemonic_length - 1) * 11)
+        num_checksum_bits = 11 - num_entropy_bits
         self.checksum_bits = format(wordlist.index(self.actual_final_word), '011b')[-num_checksum_bits:]
 
 
@@ -598,9 +622,11 @@ class ToolsCalcFinalWordDoneView(View):
 class ToolsAddressExplorerSelectSourceView(View):
     SCAN_SEED = ButtonOption("Scan a seed", SeedSignerIconConstants.QRCODE)
     SCAN_DESCRIPTOR = ButtonOption("Scan wallet descriptor", SeedSignerIconConstants.QRCODE)
-    TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD)
-    TYPE_18WORD = ButtonOption("Enter 18-word seed", FontAwesomeIconConstants.KEYBOARD)
-    TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD)
+    TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=12)
+    TYPE_15WORD = ButtonOption("Enter 15-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=15)
+    TYPE_18WORD = ButtonOption("Enter 18-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=18)
+    TYPE_21WORD = ButtonOption("Enter 21-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=21)
+    TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=24)
     LOADED_DESCRIPTOR = ButtonOption("Loaded Multisig Descriptor")
     TYPE_ELECTRUM = ButtonOption("Electrum Seed", FontAwesomeIconConstants.KEYBOARD)
 
@@ -616,7 +642,15 @@ class ToolsAddressExplorerSelectSourceView(View):
         if self.controller.multisig_wallet_descriptor:
             button_data.append(self.LOADED_DESCRIPTOR)
 
-        button_data = button_data + [self.SCAN_SEED, self.SCAN_DESCRIPTOR, self.TYPE_12WORD, self.TYPE_18WORD, self.TYPE_24WORD]
+        seed_lengths = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
+        options = {
+            12: self.TYPE_12WORD,
+            15: self.TYPE_15WORD,
+            18: self.TYPE_18WORD,
+            21: self.TYPE_21WORD,
+            24: self.TYPE_24WORD,
+        }
+        button_data = button_data + [self.SCAN_SEED, self.SCAN_DESCRIPTOR] + [options[l] for l in seed_lengths]
         if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_ELECTRUM)
 
@@ -658,7 +692,7 @@ class ToolsAddressExplorerSelectSourceView(View):
             from seedsigner.views.scan_views import ScanWalletDescriptorView
             return Destination(ScanWalletDescriptorView)
 
-        elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_18WORD, self.TYPE_24WORD]:
+        elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_15WORD, self.TYPE_18WORD, self.TYPE_21WORD, self.TYPE_24WORD]:
             from seedsigner.views.seed_views import SeedMnemonicEntryView
 
             self.controller.storage.init_pending_mnemonic(num_words=button_data[selected_menu_num].return_data)
@@ -2159,8 +2193,11 @@ class ToolsSatochipView(View):
         
 class ToolsSatochipImportSeedView(View):
     SCAN_SEED = ButtonOption("Scan a seed", SeedSignerIconConstants.QRCODE)
-    TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD)
-    TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD)
+    TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=12)
+    TYPE_15WORD = ButtonOption("Enter 15-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=15)
+    TYPE_18WORD = ButtonOption("Enter 18-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=18)
+    TYPE_21WORD = ButtonOption("Enter 21-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=21)
+    TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=24)
 
     def run(self):
         from seedsigner.gui.screens.screen import LoadingScreenThread
@@ -2175,7 +2212,15 @@ class ToolsSatochipImportSeedView(View):
             button_str = seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
             button_data.append(ButtonOption(button_str, SeedSignerIconConstants.FINGERPRINT))
         
-        button_data = button_data + [self.SCAN_SEED, self.TYPE_12WORD, self.TYPE_24WORD]
+        seed_lengths = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
+        options = {
+            12: self.TYPE_12WORD,
+            15: self.TYPE_15WORD,
+            18: self.TYPE_18WORD,
+            21: self.TYPE_21WORD,
+            24: self.TYPE_24WORD,
+        }
+        button_data = button_data + [self.SCAN_SEED] + [options[l] for l in seed_lengths]
         
         selected_menu_num = self.run_screen(
             ButtonListScreen,
@@ -2226,12 +2271,9 @@ class ToolsSatochipImportSeedView(View):
             from seedsigner.views.scan_views import ScanSeedQRView
             return Destination(ScanSeedQRView)
 
-        elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_24WORD]:
+        elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_15WORD, self.TYPE_18WORD, self.TYPE_21WORD, self.TYPE_24WORD]:
             from seedsigner.views.seed_views import SeedMnemonicEntryView
-            if button_data[selected_menu_num] == self.TYPE_12WORD:
-                self.controller.storage.init_pending_mnemonic(num_words=12)
-            else:
-                self.controller.storage.init_pending_mnemonic(num_words=24)
+            self.controller.storage.init_pending_mnemonic(num_words=button_data[selected_menu_num].return_data)
             return Destination(SeedMnemonicEntryView)
         
         return Destination(MainMenuView)

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -495,7 +495,7 @@ class TestSeedFlows(FlowTest):
             FlowStep(seed_views.SeedsMenuView, screen_return_value=0),
             FlowStep(seed_views.SeedOptionsView, button_data_selection=seed_views.SeedOptionsView.BACKUP),
             FlowStep(seed_views.SeedBackupView, button_data_selection=seed_views.SeedBackupView.EXPORT_SEEDQR),
-            FlowStep(seed_views.SeedTranscribeSeedQRFormatView, button_data_selection=seed_views.SeedTranscribeSeedQRFormatView.STANDARD_12),
+            FlowStep(seed_views.SeedTranscribeSeedQRFormatView, screen_return_value=0),
             FlowStep(seed_views.SeedTranscribeSeedQRWarningView),
             FlowStep(seed_views.SeedTranscribeSeedQRWholeQRView, is_redirect=True),
             FlowStep(seed_views.SeedTranscribeSeedQRZoomedInView, is_redirect=True),  # Live interactive screens are a bit weird; not sure why `is_redirect` is necessary here

--- a/tests/test_mnemonic_generation.py
+++ b/tests/test_mnemonic_generation.py
@@ -4,65 +4,54 @@ import os
 
 from embit import bip39
 from seedsigner.helpers import mnemonic_generation
-from seedsigner.models.settings_definition import SettingsConstants
 
 
 
 def test_dice_rolls():
     """ Given random dice rolls, the resulting mnemonic should be valid. """
-    dice_rolls = ""
-    for i in range(0, 99):
-        # Do not need truly rigorous random for this test
-        dice_rolls += str(random.randint(1, 6))
-
-    mnemonic = mnemonic_generation.generate_mnemonic_from_dice(dice_rolls)
-
-    assert len(mnemonic) == 24
-    assert bip39.mnemonic_is_valid(" ".join(mnemonic))
-
-    dice_rolls = ""
-    for i in range(0, mnemonic_generation.DICE__NUM_ROLLS__12WORD):
-        # Do not need truly rigorous random for this test
-        dice_rolls += str(random.randint(1, 6))
-
-    mnemonic = mnemonic_generation.generate_mnemonic_from_dice(dice_rolls)
-    assert len(mnemonic) == 12
-    assert bip39.mnemonic_is_valid(" ".join(mnemonic))
+    for length, rolls in mnemonic_generation.DICE_ROLLS_REQUIRED.items():
+        dice_rolls = ''.join(str(random.randint(1, 6)) for _ in range(rolls))
+        mnemonic = mnemonic_generation.generate_mnemonic_from_dice(dice_rolls)
+        assert len(mnemonic) == length
+        assert bip39.mnemonic_is_valid(" ".join(mnemonic))
 
 
 
 def test_calculate_checksum_input_type():
     """
-        Given an 11-word or 23-word mnemonic, the calculated checksum should yield a
+        Given a partial mnemonic, the calculated checksum should yield a
         valid complete mnemonic.
-        
+
         calculate_checksum should accept the mnemonic as:
         * a list of strings
         * string: "A B C", "A, B, C", "A,B,C"
     """
-    # Test mnemonics from https://iancoleman.io/bip39/
+
     def _try_all_input_formats(partial_mnemonic: str):
-        # List of strings
         mnemonic = mnemonic_generation.calculate_checksum(partial_mnemonic.split(" "))
         assert bip39.mnemonic_is_valid(" ".join(mnemonic))
 
-        # Comma-separated string
         mnemonic = mnemonic_generation.calculate_checksum(partial_mnemonic.replace(" ", ","))
         assert bip39.mnemonic_is_valid(" ".join(mnemonic))
 
-        # Comma-separated string w/space
         mnemonic = mnemonic_generation.calculate_checksum(partial_mnemonic.replace(" ", ", "))
         assert bip39.mnemonic_is_valid(" ".join(mnemonic))
 
-        # Space-separated string
         mnemonic = mnemonic_generation.calculate_checksum(partial_mnemonic)
         assert bip39.mnemonic_is_valid(" ".join(mnemonic))
 
-    partial_mnemonic = "crawl focus rescue cable view pledge rather dinner cousin unfair day"
-    _try_all_input_formats(partial_mnemonic)
+    entropy_map = {
+        12: "3350f6ac9eeb07d2c6209932808aa7f6",
+        15: "000102030405060708090a0b0c0d0e0f10111213",
+        18: "000102030405060708090a0b0c0d0e0f1011121314151617",
+        21: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b",
+        24: "5bf41629fce815c3570955e8f45422abd7e2234141bd4d7ec63b741043b98cad",
+    }
 
-    partial_mnemonic = "bubble father debate ankle injury fence mesh evolve section wet coyote violin pyramid flower rent arrow round clutch myth safe base skin mobile"
-    _try_all_input_formats(partial_mnemonic)
+    for entropy in entropy_map.values():
+        full = mnemonic_generation.generate_mnemonic_from_bytes(bytes.fromhex(entropy))
+        partial = " ".join(full[:-1])
+        _try_all_input_formats(partial)
 
 
 
@@ -75,19 +64,19 @@ def test_calculate_checksum_invalid_mnemonics():
         # Mnemonic is too short: 10 words instead of 11
         partial_mnemonic = "abandon " * 9 + "about"
         mnemonic_generation.calculate_checksum(partial_mnemonic)
-    assert "12- or 24-word" in str(e)
+    assert "12, 15, 18, 21, or 24-word" in str(e)
 
     with pytest.raises(Exception) as e:
-        # Valid mnemonic but unsupported length
-        mnemonic = "devote myth base logic dust horse nut collect buddy element eyebrow visit empty dress jungle"
+        # Valid mnemonic but unsupported length (16 words)
+        mnemonic = "abandon " * 15 + "about"
         mnemonic_generation.calculate_checksum(mnemonic)
-    assert "12- or 24-word" in str(e)
+    assert "12, 15, 18, 21, or 24-word" in str(e)
 
     with pytest.raises(Exception) as e:
         # Mnemonic is too short: 22 words instead of 23
         partial_mnemonic = "abandon " * 21 + "about"
         mnemonic_generation.calculate_checksum(partial_mnemonic)
-    assert "12- or 24-word" in str(e)
+    assert "12, 15, 18, 21, or 24-word" in str(e)
 
     with pytest.raises(ValueError) as e:
         # Invalid BIP-39 word
@@ -130,6 +119,22 @@ def test_generate_mnemonic_from_bytes():
     expected_mnemonic = "fossil pass media what life ticket found click trophy pencil anger fish lawsuit balance agree dash estate wage mom trial aerobic system crawl review".split()
     mnemonic = mnemonic_generation.generate_mnemonic_from_bytes(bytes.fromhex(entropy))
     assert mnemonic == expected_mnemonic
+
+    # Additional supported lengths
+    entropy = "000102030405060708090a0b0c0d0e0f10111213"  # 20 bytes -> 15 words
+    mnemonic = mnemonic_generation.generate_mnemonic_from_bytes(bytes.fromhex(entropy))
+    assert len(mnemonic) == 15
+    assert bip39.mnemonic_is_valid(" ".join(mnemonic))
+
+    entropy = "000102030405060708090a0b0c0d0e0f1011121314151617"  # 24 bytes -> 18 words
+    mnemonic = mnemonic_generation.generate_mnemonic_from_bytes(bytes.fromhex(entropy))
+    assert len(mnemonic) == 18
+    assert bip39.mnemonic_is_valid(" ".join(mnemonic))
+
+    entropy = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b"  # 28 bytes -> 21 words
+    mnemonic = mnemonic_generation.generate_mnemonic_from_bytes(bytes.fromhex(entropy))
+    assert len(mnemonic) == 21
+    assert bip39.mnemonic_is_valid(" ".join(mnemonic))
 
 
 

--- a/tests/test_seedqr.py
+++ b/tests/test_seedqr.py
@@ -3,6 +3,7 @@ from embit import bip39
 from seedsigner.models.decode_qr import DecodeQR, DecodeQRStatus
 from seedsigner.models.encode_qr import SeedQrEncoder, CompactSeedQrEncoder
 from seedsigner.models.qr_type import QRType
+from seedsigner.helpers.qr import QR
 
 
 
@@ -26,28 +27,69 @@ def run_encode_decode_test(entropy: bytes, mnemonic_length, qr_type):
     assert mnemonic == decoded_seed_phrase
 
 
+def run_plaintext_decode_test(entropy: bytes, mnemonic_length):
+    mnemonic = bip39.mnemonic_from_bytes(entropy)
+    decoder = DecodeQR()
+    status = decoder.add_data(mnemonic)
+    assert status == DecodeQRStatus.COMPLETE
+    decoded_seed_phrase = decoder.get_seed_phrase()
+    assert mnemonic.split() == decoded_seed_phrase
+
+
 
 def test_standard_seedqr_encode_decode_():
-    """ Should encode 24- and 12- word mnemonics to Standard SeedQR format and decode
-        them back again to their original mnemonic seed phrase.
-    """
-    # 24-word seed
-    run_encode_decode_test(os.urandom(32), mnemonic_length=24, qr_type=QRType.SEED__SEEDQR)
+    """Should encode various mnemonic lengths to Standard SeedQR format and decode
+    them back again to their original mnemonic seed phrase."""
 
-    # 12-word seed
+    run_encode_decode_test(os.urandom(32), mnemonic_length=24, qr_type=QRType.SEED__SEEDQR)
+    run_encode_decode_test(os.urandom(28), mnemonic_length=21, qr_type=QRType.SEED__SEEDQR)
+    run_encode_decode_test(os.urandom(24), mnemonic_length=18, qr_type=QRType.SEED__SEEDQR)
+    run_encode_decode_test(os.urandom(20), mnemonic_length=15, qr_type=QRType.SEED__SEEDQR)
     run_encode_decode_test(os.urandom(16), mnemonic_length=12, qr_type=QRType.SEED__SEEDQR)
 
 
 
 def test_compact_seedqr_encode_decode():
-    """ Should encode 24- and 12- word mnemonics to CompactSeedQR format and decode
-        them back again to their original mnemonic seed phrase.
-    """
-    # 24-word seed
-    run_encode_decode_test(os.urandom(32), mnemonic_length=24, qr_type=QRType.SEED__COMPACTSEEDQR)
+    """Should encode various mnemonic lengths to CompactSeedQR format and decode them
+    back again to their original mnemonic seed phrase."""
 
-    # 12-word seed
+    run_encode_decode_test(os.urandom(32), mnemonic_length=24, qr_type=QRType.SEED__COMPACTSEEDQR)
+    run_encode_decode_test(os.urandom(28), mnemonic_length=21, qr_type=QRType.SEED__COMPACTSEEDQR)
+    run_encode_decode_test(os.urandom(24), mnemonic_length=18, qr_type=QRType.SEED__COMPACTSEEDQR)
+    run_encode_decode_test(os.urandom(20), mnemonic_length=15, qr_type=QRType.SEED__COMPACTSEEDQR)
     run_encode_decode_test(os.urandom(16), mnemonic_length=12, qr_type=QRType.SEED__COMPACTSEEDQR)
+
+
+def test_plaintext_seed_mnemonic_decode():
+    """Should decode plaintext mnemonic QRs of all supported lengths."""
+    tests = [
+        (os.urandom(32), 24),
+        (os.urandom(28), 21),
+        (os.urandom(24), 18),
+        (os.urandom(20), 15),
+        (os.urandom(16), 12),
+    ]
+    for entropy, length in tests:
+        run_plaintext_decode_test(entropy, mnemonic_length=length)
+
+
+def test_seedqr_dimensions():
+    """SeedQR module dimensions should match expected values for each word count."""
+    qr_helper = QR()
+    standard_expected = {12: 25, 15: 25, 18: 25, 21: 29, 24: 29}
+    compact_expected = {12: 21, 15: 25, 18: 25, 21: 25, 24: 25}
+
+    for length, expected in standard_expected.items():
+        entropy = os.urandom(length // 3 * 4)
+        mnemonic = bip39.mnemonic_from_bytes(entropy).split()
+        e = SeedQrEncoder(mnemonic=mnemonic)
+        assert qr_helper.qrsize(e.next_part()) == expected
+
+    for length, expected in compact_expected.items():
+        entropy = os.urandom(length // 3 * 4)
+        mnemonic = bip39.mnemonic_from_bytes(entropy).split()
+        e = CompactSeedQrEncoder(mnemonic=mnemonic)
+        assert qr_helper.qrsize(e.next_part()) == expected
 
 
 

--- a/tests/test_settings_definition.py
+++ b/tests/test_settings_definition.py
@@ -2,7 +2,7 @@ import os
 from unittest.mock import Mock
 
 from base import BaseTest
-from seedsigner.models.settings_definition import SettingsConstants
+from seedsigner.models.settings_definition import SettingsConstants, SettingsDefinition
 
 
 class TestSettingsDefinition(BaseTest):
@@ -36,3 +36,7 @@ class TestSettingsDefinition(BaseTest):
         # Recheck w/our mocked dir listing:
         detected_languages = [lang_tuple[0] for lang_tuple in SettingsConstants.get_detected_languages()]
         assert absent_language_code in detected_languages
+
+    def test_default_seed_word_lengths(self):
+        defaults = SettingsDefinition.get_defaults()
+        assert defaults[SettingsConstants.SETTING__SEED_WORD_LENGTHS] == [12, 24]


### PR DESCRIPTION
## Summary
- allow configurable seed word lengths and default to 12 & 24
- support 15/18/21-word BIP39 seeds across UI and mnemonic generation
- add tests for new seed lengths

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e554635dc83228689383efb3c0d3a