### PR TITLE
Fix LoadSeedView button initialization

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -203,6 +203,9 @@ class LoadSeedView(View):
             21: self.TYPE_21WORD,
             24: self.TYPE_24WORD,
         }
+
+        # Start with the option to scan a SeedQR
+        button_data = [self.SEED_QR]
         button_data.extend([options[l] for l in seed_lengths])
 
         if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:


### PR DESCRIPTION
## Summary
- Initialize button_data in LoadSeedView with SeedQR option to prevent NameError

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e6ec283548322afb8dbfda3851770