### PR TITLE
Add setting to control extendable SLIP39 shares

### DIFF
--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -372,6 +372,7 @@ class SettingsConstants:
     SETTING__COMPACT_SEEDQR = "compact_seedqr"
     SETTING__BIP85_CHILD_SEEDS = "bip85_child_seeds"
     SETTING__SLIP39_SEEDS = "slip39_seeds"
+    SETTING__SLIP39_EXTENDABLE = "slip39_extendable"
     SETTING__ELECTRUM_SEEDS = "electrum_seeds"
     SETTING__MESSAGE_SIGNING = "message_signing"
     SETTING__PRIVACY_WARNINGS = "privacy_warnings"
@@ -792,6 +793,13 @@ class SettingsDefinition:
                       display_name=_mft("SLIP39 seeds"),
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__DISABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__SLIP39_EXTENDABLE,
+                      abbreviated_name="slip39ext",
+                      display_name=_mft("Extendable SLIP39 shares"),
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      default_value=SettingsConstants.OPTION__ENABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__ELECTRUM_SEEDS,

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1157,8 +1157,12 @@ class SeedSlip39CreateFromBytesView(View):
                 "Multi-Share with threshold of 1 not allowed."
             )
 
+        extendable = (
+            self.settings.get_value(SettingsConstants.SETTING__SLIP39_EXTENDABLE)
+            == SettingsConstants.OPTION__ENABLED
+        )
         shares = shamir_mnemonic.generate_mnemonics(
-            1, [(threshold, num_shares)], self.secret, extendable=True
+            1, [(threshold, num_shares)], self.secret, extendable=extendable
         )[0]
         seed = Slip39Seed(mnemonics=shares)
         self.controller.storage.set_pending_seed(seed)

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -4,7 +4,9 @@ import pytest
 from seedsigner.models.seed import InvalidSeedException, Seed, ElectrumSeed, Slip39Seed
 import shamir_mnemonic
 
+from base import BaseTest
 from seedsigner.models.settings import SettingsConstants
+from seedsigner.views import seed_views
 
 
 
@@ -286,4 +288,35 @@ def test_slip39_vectors_end_to_end(desc, mnemonics, secret_hex, xprv):
                 assert seed.seed_bytes.hex() == secret_hex
                 root = bip32.HDKey.from_seed(seed.seed_bytes, version=NETWORKS["main"]["xprv"])
                 assert root.to_base58() == xprv
+
+
+class TestSlip39ExtendableSetting(BaseTest):
+    def test_create_nonextendable_slip39_seed(self, monkeypatch):
+        self.settings.set_value(
+            SettingsConstants.SETTING__SLIP39_SEEDS, SettingsConstants.OPTION__ENABLED
+        )
+        self.settings.set_value(
+            SettingsConstants.SETTING__SLIP39_EXTENDABLE, SettingsConstants.OPTION__DISABLED
+        )
+
+        responses = iter(["2", "2"])
+
+        class DummyScreen:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def display(self):
+                return next(responses)
+
+        monkeypatch.setattr(
+            seed_views.seed_screens, "SeedBIP85SelectChildIndexScreen", DummyScreen
+        )
+
+        secret = bytes.fromhex("11" * 16)
+        view = seed_views.SeedSlip39CreateFromBytesView(secret=secret)
+        view.run()
+
+        seed = self.controller.storage.get_pending_seed()
+        assert isinstance(seed, Slip39Seed)
+        assert not seed.extendable
 


### PR DESCRIPTION
## Summary
- make SLIP39 share extendability configurable via settings
- respect the setting during SLIP39 share creation
- test non-extendable share generation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e8cf38fa48322b53a75072ef20f9c