### PR TITLE
Add Satochip xpub export and address explorer integration

### DIFF
--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -612,10 +612,11 @@ class SeedExportXpubDetailsScreen(WarningEdgesMixin, ButtonListScreen):
     has_passphrase: bool = False
     derivation_path: str = "m/84'/0'/0'"
     xpub: str = "zpub6r..."
+    button_label: str = "Export Xpub"
 
     def __post_init__(self):
         # Programmatically set up other args
-        self.button_data = [ButtonOption("Export Xpub")]
+        self.button_data = [ButtonOption(self.button_label)]
         self.title = _("Xpub Details")
 
         # Initialize the base class

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -3235,11 +3235,11 @@ class SeedAddressVerificationView(View):
         self.is_multisig = self.controller.unverified_address["sig_type"] == SettingsConstants.MULTISIG
         self.seed_derivation_override = ""
         if not self.is_multisig:
-            if seed_num is None:
-                raise Exception(_("Can't validate a single sig addr without specifying a seed"))
-            self.seed_num = seed_num
-            self.seed = self.controller.get_seed(seed_num)
-            self.seed_derivation_override = self.seed.derivation_override(sig_type=SettingsConstants.SINGLE_SIG)
+            if seed_num is not None:
+                self.seed = self.controller.get_seed(seed_num)
+                self.seed_derivation_override = self.seed.derivation_override(sig_type=SettingsConstants.SINGLE_SIG)
+            else:
+                self.seed = None
         else:
             self.seed = None
         self.address = self.controller.unverified_address["address"]
@@ -3464,7 +3464,7 @@ class SeedExportXpubVerificationFailedView(View):
             button_data=[ButtonOption(_("OK"))],
             show_back_button=False,
         )
-
+        self.controller.multisig_wallet_descriptor = None
         return Destination(MainMenuView)
 
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -3440,7 +3440,7 @@ class SeedExportXpubVerificationSuccessView(View):
             button_data=[ButtonOption(_("OK"))],
             show_back_button=False,
         )
-
+        self.controller.multisig_wallet_descriptor = None
         return Destination(MainMenuView)
 
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2183,9 +2183,10 @@ class ToolsSatochipView(View):
     IMPORT_SEED = ButtonOption("Initialise with Seed")
     ENABLE_2FA = ButtonOption("Enable 2FA")
     EXPORT_XPUB = ButtonOption("Export Xpub")
+    LOAD_DESCRIPTOR = ButtonOption("Load as Descriptor")
 
     def run(self):
-        button_data = [self.IMPORT_SEED, self.ENABLE_2FA, self.EXPORT_XPUB]
+        button_data = [self.IMPORT_SEED, self.ENABLE_2FA, self.EXPORT_XPUB, self.LOAD_DESCRIPTOR]
         selected_menu_num = self.run_screen(
             ButtonListScreen,
             title="Satochip",
@@ -2204,6 +2205,9 @@ class ToolsSatochipView(View):
 
         elif button_data[selected_menu_num] == self.EXPORT_XPUB:
             return Destination(SatochipExportXpubScriptTypeView)
+
+        elif button_data[selected_menu_num] == self.LOAD_DESCRIPTOR:
+            return Destination(SatochipLoadDescriptorScriptTypeView)
         
 class ToolsSatochipImportSeedView(View):
     SCAN_SEED = ButtonOption("Scan a seed", SeedSignerIconConstants.QRCODE)
@@ -2653,6 +2657,132 @@ class SatochipExportXpubQRDisplayView(View):
             ),
             skip_current_view=True,
         )
+
+
+class SatochipLoadDescriptorScriptTypeView(View):
+    def __init__(self, script_type: str = None):
+        super().__init__()
+        self.script_type = script_type
+
+    def run(self):
+        button_data = []
+        for script_type, display_name in SettingsConstants.ALL_SCRIPT_TYPES:
+            if script_type in self.settings.get_value(SettingsConstants.SETTING__SCRIPT_TYPES):
+                button_data.append(ButtonOption(display_name, return_data=script_type))
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title="Load Descriptor",
+            is_button_text_centered=False,
+            button_data=button_data,
+            is_bottom_list=True,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        script_type = button_data[selected_menu_num].return_data
+        if script_type == SettingsConstants.CUSTOM_DERIVATION:
+            return Destination(SatochipLoadDescriptorCustomDerivationView, view_args=dict(script_type=script_type))
+        return Destination(SatochipLoadDescriptorDetailsView, view_args=dict(script_type=script_type))
+
+
+class SatochipLoadDescriptorCustomDerivationView(View):
+    def __init__(self, script_type: str):
+        super().__init__()
+        self.script_type = script_type
+        self.custom_derivation_path = "m/"
+
+    def run(self):
+        ret = self.run_screen(
+            seed_screens.SeedExportXpubCustomDerivationScreen,
+            initial_value=self.custom_derivation_path,
+        )
+
+        if ret == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        return Destination(
+            SatochipLoadDescriptorDetailsView,
+            view_args=dict(script_type=self.script_type, custom_derivation=ret),
+        )
+
+
+class SatochipLoadDescriptorDetailsView(View):
+    def __init__(self, script_type: str, custom_derivation: str = ""):
+        super().__init__()
+        self.script_type = script_type
+        self.custom_derivation = custom_derivation
+
+    def run(self):
+        Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
+        if not Satochip_Connector:
+            return Destination(BackStackView)
+
+        if self.script_type == SettingsConstants.CUSTOM_DERIVATION:
+            derivation_path = self.custom_derivation
+        else:
+            derivation_path = embit_utils.get_standard_derivation_path(
+                network=self.settings.get_value(SettingsConstants.SETTING__NETWORK),
+                wallet_type=SettingsConstants.SINGLE_SIG,
+                script_type=self.script_type,
+            )
+
+        network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+        is_mainnet = network == SettingsConstants.MAINNET
+        if self.script_type == SettingsConstants.NATIVE_SEGWIT:
+            xtype = "p2wpkh"
+        elif self.script_type == SettingsConstants.NESTED_SEGWIT:
+            xtype = "p2wpkh-p2sh"
+        elif self.script_type == SettingsConstants.LEGACY_P2PKH:
+            xtype = "standard"
+        elif self.script_type == SettingsConstants.TAPROOT:
+            xtype = "standard"
+        else:
+            xtype = "p2wpkh"
+
+        try:
+            xpub_base58 = Satochip_Connector.card_bip32_get_xpub(derivation_path, xtype, is_mainnet)
+            master_xpub = Satochip_Connector.card_bip32_get_xpub("", xtype, is_mainnet)
+        except Exception as e:
+            self.run_screen(
+                WarningScreen,
+                title="Failed",
+                status_headline=None,
+                text=str(e),
+            )
+            return Destination(BackStackView)
+
+        fingerprint = HDKey.from_string(master_xpub).my_fingerprint
+        fingerprint_hex = hexlify(fingerprint).decode("utf-8")
+
+        if self.script_type == SettingsConstants.NATIVE_SEGWIT:
+            desc_str = f"wpkh({xpub_base58}/{{0,1}}/*)"
+        elif self.script_type == SettingsConstants.NESTED_SEGWIT:
+            desc_str = f"sh(wpkh({xpub_base58}/{{0,1}}/*))"
+        elif self.script_type == SettingsConstants.LEGACY_P2PKH:
+            desc_str = f"pkh({xpub_base58}/{{0,1}}/*)"
+        elif self.script_type == SettingsConstants.TAPROOT:
+            desc_str = f"tr({xpub_base58}/{{0,1}}/*)"
+        else:
+            desc_str = f"wpkh({xpub_base58}/{{0,1}}/*)"
+
+        descriptor = Descriptor.from_string(desc_str)
+
+        selected_menu_num = self.run_screen(
+            seed_screens.SeedExportXpubDetailsScreen,
+            fingerprint=fingerprint_hex,
+            has_passphrase=False,
+            derivation_path=derivation_path,
+            xpub=xpub_base58,
+        )
+
+        if selected_menu_num != 0:
+            return Destination(BackStackView)
+
+        self.controller.multisig_wallet_descriptor = descriptor
+
+        return Destination(ToolsAddressExplorerAddressTypeView)
 
 class ToolsSatochipDIYView(View):
     BUILD_APPLETS = ButtonOption("Build Applets")

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -7,6 +7,7 @@ import binascii
 
 from embit.descriptor import Descriptor
 from embit.descriptor.checksum import checksum
+from embit.bip32 import HDKey
 from PIL import Image
 from PIL.ImageOps import autocontrast
 from gettext import gettext as _
@@ -41,6 +42,7 @@ from seedsigner.views.seed_views import (
     SeedOptionsView,
     SeedWordsWarningView,
     SeedExportXpubScriptTypeView,
+    SeedExportXpubVerifyAddressView,
     LoadSeedView,
     SeedSlip39CreateFromBytesView,
     SeedSlip39RegenerateSharesView,
@@ -2180,9 +2182,10 @@ class ToolsSeedkeeperSaveDescriptorView(View):
 class ToolsSatochipView(View):
     IMPORT_SEED = ButtonOption("Initialise with Seed")
     ENABLE_2FA = ButtonOption("Enable 2FA")
+    EXPORT_XPUB = ButtonOption("Export Xpub")
 
     def run(self):
-        button_data = [self.IMPORT_SEED, self.ENABLE_2FA]
+        button_data = [self.IMPORT_SEED, self.ENABLE_2FA, self.EXPORT_XPUB]
         selected_menu_num = self.run_screen(
             ButtonListScreen,
             title="Satochip",
@@ -2198,6 +2201,9 @@ class ToolsSatochipView(View):
 
         elif button_data[selected_menu_num] == self.ENABLE_2FA:
             return Destination(ToolsSatochipEnable2FAView)
+
+        elif button_data[selected_menu_num] == self.EXPORT_XPUB:
+            return Destination(SatochipExportXpubScriptTypeView)
         
 class ToolsSatochipImportSeedView(View):
     SCAN_SEED = ButtonOption("Scan a seed", SeedSignerIconConstants.QRCODE)
@@ -2345,6 +2351,285 @@ class ToolsSatochipEnable2FAView(View):
             )
 
         return Destination(MainMenuView)
+
+
+class SatochipExportXpubScriptTypeView(View):
+    def __init__(self, script_type: str = None):
+        super().__init__()
+        self.script_type = script_type
+
+    def run(self):
+        button_data = []
+        for script_type, display_name in SettingsConstants.ALL_SCRIPT_TYPES:
+            if script_type in self.settings.get_value(SettingsConstants.SETTING__SCRIPT_TYPES):
+                button_data.append(ButtonOption(display_name, return_data=script_type))
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title="Export Xpub",
+            is_button_text_centered=False,
+            button_data=button_data,
+            is_bottom_list=True,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        script_type = button_data[selected_menu_num].return_data
+        if script_type == SettingsConstants.CUSTOM_DERIVATION:
+            return Destination(SatochipExportXpubCustomDerivationView, view_args=dict(script_type=script_type))
+        return Destination(SatochipExportXpubCoordinatorView, view_args=dict(script_type=script_type))
+
+
+class SatochipExportXpubCustomDerivationView(View):
+    def __init__(self, script_type: str):
+        super().__init__()
+        self.script_type = script_type
+        self.custom_derivation_path = "m/"
+
+    def run(self):
+        ret = self.run_screen(
+            seed_screens.SeedExportXpubCustomDerivationScreen,
+            initial_value=self.custom_derivation_path,
+        )
+
+        if ret == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        return Destination(
+            SatochipExportXpubCoordinatorView,
+            view_args=dict(script_type=self.script_type, custom_derivation=ret),
+        )
+
+
+class SatochipExportXpubCoordinatorView(View):
+    def __init__(self, script_type: str, custom_derivation: str = ""):
+        super().__init__()
+        self.script_type = script_type
+        self.custom_derivation = custom_derivation
+
+    def run(self):
+        button_data = []
+        for coord, display_name in SettingsConstants.ALL_COORDINATORS:
+            if coord in self.settings.get_value(SettingsConstants.SETTING__COORDINATORS):
+                button_data.append(ButtonOption(display_name, return_data=coord))
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title="Coordinator",
+            is_button_text_centered=False,
+            button_data=button_data,
+            is_bottom_list=True,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        coordinator = button_data[selected_menu_num].return_data
+        coordinator_label = button_data[selected_menu_num].text
+        return Destination(
+            SatochipExportXpubWarningView,
+            view_args=dict(
+                script_type=self.script_type,
+                coordinator=coordinator,
+                custom_derivation=self.custom_derivation,
+                coordinator_label=coordinator_label,
+            ),
+        )
+
+
+class SatochipExportXpubWarningView(View):
+    def __init__(self, script_type: str, coordinator: str, custom_derivation: str, coordinator_label: str):
+        super().__init__()
+        self.script_type = script_type
+        self.coordinator = coordinator
+        self.custom_derivation = custom_derivation
+        self.coordinator_label = coordinator_label
+
+    def run(self):
+        destination = Destination(
+            SatochipExportXpubDetailsView,
+            view_args=dict(
+                script_type=self.script_type,
+                coordinator=self.coordinator,
+                custom_derivation=self.custom_derivation,
+                coordinator_label=self.coordinator_label,
+            ),
+            skip_current_view=True,
+        )
+
+        if self.settings.get_value(SettingsConstants.SETTING__PRIVACY_WARNINGS) == SettingsConstants.OPTION__DISABLED:
+            return destination
+
+        selected_menu_num = self.run_screen(
+            WarningScreen,
+            status_headline=_("Privacy Leak!"),
+            text=_("Xpub can be used to view all future transactions."),
+        )
+
+        if selected_menu_num == 0:
+            return destination
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+
+class SatochipExportXpubDetailsView(View):
+    def __init__(self, script_type: str, coordinator: str, custom_derivation: str, coordinator_label: str):
+        super().__init__()
+        self.script_type = script_type
+        self.coordinator = coordinator
+        self.custom_derivation = custom_derivation
+        self.coordinator_label = coordinator_label
+
+    def run(self):
+        Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
+        if not Satochip_Connector:
+            return Destination(BackStackView)
+
+        if self.script_type == SettingsConstants.CUSTOM_DERIVATION:
+            derivation_path = self.custom_derivation
+        else:
+            derivation_path = embit_utils.get_standard_derivation_path(
+                network=self.settings.get_value(SettingsConstants.SETTING__NETWORK),
+                wallet_type=SettingsConstants.SINGLE_SIG,
+                script_type=self.script_type,
+            )
+
+        try:
+            xpub_base58 = Satochip_Connector.card_bip32_get_extended_pubkey(derivation_path)
+        except Exception as e:
+            self.run_screen(
+                WarningScreen,
+                title="Failed",
+                status_headline=None,
+                text=str(e),
+            )
+            return Destination(BackStackView)
+
+        fingerprint = HDKey.from_string(xpub_base58).fingerprint
+        fingerprint_hex = hexlify(fingerprint).decode("utf-8")
+
+        # Build descriptor and store for address explorer
+        if self.script_type == SettingsConstants.NATIVE_SEGWIT:
+            desc_str = f"wpkh({xpub_base58}/{{0,1}}/*)"
+        elif self.script_type == SettingsConstants.NESTED_SEGWIT:
+            desc_str = f"sh(wpkh({xpub_base58}/{{0,1}}/*))"
+        elif self.script_type == SettingsConstants.LEGACY_P2PKH:
+            desc_str = f"pkh({xpub_base58}/{{0,1}}/*)"
+        elif self.script_type == SettingsConstants.TAPROOT:
+            desc_str = f"tr({xpub_base58}/{{0,1}}/*)"
+        else:
+            desc_str = f"wpkh({xpub_base58}/{{0,1}}/*)"
+
+        self.controller.multisig_wallet_descriptor = Descriptor.from_string(desc_str)
+
+        selected_menu_num = self.run_screen(
+            seed_screens.SeedExportXpubDetailsScreen,
+            fingerprint=fingerprint_hex,
+            has_passphrase=False,
+            derivation_path=derivation_path,
+            xpub=xpub_base58,
+        )
+
+        if selected_menu_num != 0:
+            return Destination(BackStackView)
+
+        return Destination(
+            SatochipExportXpubQRDisplayView,
+            view_args=dict(
+                xpub=xpub_base58,
+                derivation_path=derivation_path,
+                script_type=self.script_type,
+                coordinator=self.coordinator,
+                coordinator_label=self.coordinator_label,
+            ),
+        )
+
+
+class SatochipExportXpubQRDisplayView(View):
+    def __init__(self, xpub: str, derivation_path: str, script_type: str, coordinator: str, coordinator_label: str = ""):
+        super().__init__()
+        self.xpub = xpub
+        self.derivation_path = derivation_path
+        self.script_type = script_type
+        self.coordinator = coordinator
+        self.coordinator_label = coordinator_label
+
+    class _SpecterEncoder:
+        def __init__(self, xpubstring: str, qr_density: str):
+            density_mapping = {
+                SettingsConstants.DENSITY__LOW: 40,
+                SettingsConstants.DENSITY__MEDIUM: 65,
+                SettingsConstants.DENSITY__HIGH: 90,
+            }
+            self.qr_max_fragment_size = density_mapping.get(qr_density, 65)
+            self.parts = []
+            start = 0
+            stop = self.qr_max_fragment_size
+            qr_cnt = ((len(xpubstring) - 1) // self.qr_max_fragment_size) + 1
+            if qr_cnt == 1:
+                self.parts.append(xpubstring[start:stop])
+            cnt = 0
+            while cnt < qr_cnt and qr_cnt != 1:
+                part = "p" + str(cnt + 1) + "of" + str(qr_cnt) + " " + xpubstring[start:stop]
+                self.parts.append(part)
+                start = start + self.qr_max_fragment_size
+                stop = stop + self.qr_max_fragment_size
+                if stop > len(xpubstring):
+                    stop = len(xpubstring)
+                cnt += 1
+            self.part_num_sent = 0
+
+        def next_part(self):
+            if self.part_num_sent > (len(self.parts) - 1):
+                self.part_num_sent = 0
+            part = self.parts[self.part_num_sent]
+            self.part_num_sent += 1
+            return part
+
+        def cur_part(self):
+            if self.part_num_sent == 0:
+                self.part_num_sent = len(self.parts) - 1
+            else:
+                self.part_num_sent -= 1
+            return self.next_part()
+
+        def restart(self):
+            self.part_num_sent = 0
+
+        def is_complete(self):
+            return len(self.parts) == 1
+
+        def seq_len(self):
+            return len(self.parts)
+
+    def run(self):
+        from seedsigner.gui.screens.screen import QRDisplayScreen
+        fingerprint = hexlify(HDKey.from_string(self.xpub).fingerprint).decode("utf-8")
+        xpubstring = f"[{fingerprint}{self.derivation_path[1:]}]{self.xpub}"
+
+        if self.coordinator == SettingsConstants.COORDINATOR__SPECTER_DESKTOP:
+            encoder = self._SpecterEncoder(xpubstring, self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY))
+        else:
+            encoder = GenericStaticQrEncoder(data=xpubstring)
+
+        self.run_screen(
+            QRDisplayScreen,
+            qr_encoder=encoder,
+        )
+
+        return Destination(
+            SeedExportXpubVerifyAddressView,
+            view_args=dict(
+                seed_num=None,
+                derivation_path=self.derivation_path,
+                script_type=self.script_type,
+                sig_type=SettingsConstants.SINGLE_SIG,
+                coordinator_label=self.coordinator_label,
+            ),
+            skip_current_view=True,
+        )
 
 class ToolsSatochipDIYView(View):
     BUILD_APPLETS = ButtonOption("Build Applets")

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2426,7 +2426,7 @@ class SatochipExportXpubCoordinatorView(View):
             return Destination(BackStackView)
 
         coordinator = button_data[selected_menu_num].return_data
-        coordinator_label = button_data[selected_menu_num].text
+        coordinator_label = button_data[selected_menu_num].button_label
         return Destination(
             SatochipExportXpubWarningView,
             view_args=dict(

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2511,6 +2511,7 @@ class SatochipExportXpubDetailsView(View):
 
         try:
             xpub_base58 = Satochip_Connector.card_bip32_get_xpub(derivation_path, xtype, is_mainnet)
+            master_xpub = Satochip_Connector.card_bip32_get_xpub("", xtype, is_mainnet)
         except Exception as e:
             self.run_screen(
                 WarningScreen,
@@ -2520,7 +2521,7 @@ class SatochipExportXpubDetailsView(View):
             )
             return Destination(BackStackView)
 
-        fingerprint = HDKey.from_string(xpub_base58).fingerprint
+        fingerprint = HDKey.from_string(master_xpub).my_fingerprint
         fingerprint_hex = hexlify(fingerprint).decode("utf-8")
 
         # Build descriptor and store for address explorer
@@ -2556,18 +2557,28 @@ class SatochipExportXpubDetailsView(View):
                 script_type=self.script_type,
                 coordinator=self.coordinator,
                 coordinator_label=self.coordinator_label,
+                fingerprint=fingerprint_hex,
             ),
         )
 
 
 class SatochipExportXpubQRDisplayView(View):
-    def __init__(self, xpub: str, derivation_path: str, script_type: str, coordinator: str, coordinator_label: str = ""):
+    def __init__(
+        self,
+        xpub: str,
+        derivation_path: str,
+        script_type: str,
+        coordinator: str,
+        coordinator_label: str = "",
+        fingerprint: str = "",
+    ):
         super().__init__()
         self.xpub = xpub
         self.derivation_path = derivation_path
         self.script_type = script_type
         self.coordinator = coordinator
         self.coordinator_label = coordinator_label
+        self.fingerprint = fingerprint
 
     class _SpecterEncoder:
         def __init__(self, xpubstring: str, qr_density: str):
@@ -2619,8 +2630,7 @@ class SatochipExportXpubQRDisplayView(View):
 
     def run(self):
         from seedsigner.gui.screens.screen import QRDisplayScreen
-        fingerprint = hexlify(HDKey.from_string(self.xpub).fingerprint).decode("utf-8")
-        xpubstring = f"[{fingerprint}{self.derivation_path[1:]}]{self.xpub}"
+        xpubstring = f"[{self.fingerprint}{self.derivation_path[1:]}]{self.xpub}"
 
         if self.coordinator == SettingsConstants.COORDINATOR__SPECTER_DESKTOP:
             encoder = self._SpecterEncoder(xpubstring, self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY))

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2496,8 +2496,21 @@ class SatochipExportXpubDetailsView(View):
                 script_type=self.script_type,
             )
 
+        network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+        is_mainnet = network == SettingsConstants.MAINNET
+        if self.script_type == SettingsConstants.NATIVE_SEGWIT:
+            xtype = "p2wpkh"
+        elif self.script_type == SettingsConstants.NESTED_SEGWIT:
+            xtype = "p2wpkh-p2sh"
+        elif self.script_type == SettingsConstants.LEGACY_P2PKH:
+            xtype = "standard"
+        elif self.script_type == SettingsConstants.TAPROOT:
+            xtype = "standard"
+        else:
+            xtype = "p2wpkh"
+
         try:
-            xpub_base58 = Satochip_Connector.card_bip32_get_extended_pubkey(derivation_path)
+            xpub_base58 = Satochip_Connector.card_bip32_get_xpub(derivation_path, xtype, is_mainnet)
         except Exception as e:
             self.run_screen(
                 WarningScreen,

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2782,7 +2782,15 @@ class SatochipLoadDescriptorDetailsView(View):
 
         self.controller.multisig_wallet_descriptor = descriptor
 
-        return Destination(ToolsAddressExplorerAddressTypeView)
+        self.run_screen(
+            LargeIconStatusScreen,
+            title="Success",
+            status_headline=None,
+            text="Descriptor Loaded",
+            show_back_button=False,
+        )
+
+        return Destination(MainMenuView)
 
 class ToolsSatochipDIYView(View):
     BUILD_APPLETS = ButtonOption("Build Applets")

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2775,6 +2775,7 @@ class SatochipLoadDescriptorDetailsView(View):
             has_passphrase=False,
             derivation_path=derivation_path,
             xpub=xpub_base58,
+            button_label="Confirm",
         )
 
         if selected_menu_num != 0:

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -5,6 +5,7 @@ import shamir_mnemonic
 
 # Must import test base before the Controller
 from base import BaseTest, FlowTest, FlowStep
+from unittest.mock import Mock
 from base import FlowTestInvalidButtonDataSelectionException
 
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, ButtonOption
@@ -853,5 +854,42 @@ class TestMessageSigningFlows(FlowTest):
 
         self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.MAINNET)
         expect_unsupported_derivation(self.load_custom_derivation_into_decoder)
+
+
+class TestSatochipDescriptorVerification(BaseTest):
+    def test_address_verification_with_descriptor(self):
+        from embit.bip32 import HDKey
+        from embit.descriptor import Descriptor
+        from embit import bip39, networks
+        from seedsigner.models.settings_definition import SettingsConstants
+        from seedsigner.views import seed_views
+        from seedsigner.controller import Controller
+
+        seed_bytes = bip39.mnemonic_to_seed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about")
+        root = HDKey.from_seed(seed_bytes, version=networks.NETWORKS['main']['xprv'])
+        xpub = root.derive("m/84h/0h/0h").to_public().to_string()
+        descriptor = Descriptor.from_string(f"wpkh({xpub}/{{0,1}}/*)")
+
+        controller = Controller.get_instance()
+        controller.multisig_wallet_descriptor = descriptor
+        addr = descriptor.derive(0, branch_index=0).script_pubkey().address()
+        controller.unverified_address = dict(
+            address=addr,
+            script_type=SettingsConstants.NATIVE_SEGWIT,
+            network=SettingsConstants.MAINNET,
+            sig_type=SettingsConstants.SINGLE_SIG,
+            derivation_path="m/84'/0'/0'",
+        )
+
+        view = seed_views.SeedAddressVerificationView(seed_num=None, export_for_xpub=True)
+
+        def mock_start(self):
+            self.verified_index.set_value(0)
+            self.verified_index_is_change.set_value(0)
+
+        view.addr_verification_thread.start = mock_start.__get__(view.addr_verification_thread, type(view.addr_verification_thread))
+        view.run_screen = Mock(return_value=RET_CODE__BACK_BUTTON)
+        destination = view.run()
+        assert destination.View_cls == seed_views.SeedExportXpubVerificationSuccessView
 
 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -957,7 +957,8 @@ class TestSatochipLoadDescriptor(BaseTest):
         view.run_screen = Mock(return_value=0)
         destination = view.run()
 
+        assert view.run_screen.call_count == 2
         assert isinstance(controller.multisig_wallet_descriptor, Descriptor)
-        assert destination.View_cls == tools_views.ToolsAddressExplorerAddressTypeView
+        assert destination.View_cls == tools_views.MainMenuView
 
 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -893,3 +893,71 @@ class TestSatochipDescriptorVerification(BaseTest):
         assert destination.View_cls == seed_views.SeedExportXpubVerificationSuccessView
 
 
+class TestExportXpubSuccess(BaseTest):
+    def test_success_clears_descriptor(self):
+        from embit.bip32 import HDKey
+        from embit.descriptor import Descriptor
+        from embit import bip39, networks
+        from seedsigner.views import seed_views
+        from seedsigner.controller import Controller
+
+        seed_bytes = bip39.mnemonic_to_seed(
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+        )
+        root = HDKey.from_seed(seed_bytes, version=networks.NETWORKS["main"]["xprv"])
+        xpub = root.derive("m/84h/0h/0h").to_public().to_string()
+        descriptor = Descriptor.from_string(f"wpkh({xpub}/{{0,1}}/*)")
+
+        controller = Controller.get_instance()
+        controller.multisig_wallet_descriptor = descriptor
+
+        view = seed_views.SeedExportXpubVerificationSuccessView()
+        view.run_screen = Mock(return_value=0)
+        view.run()
+
+        assert controller.multisig_wallet_descriptor is None
+
+
+class TestSatochipLoadDescriptor(BaseTest):
+    def test_load_descriptor_sets_descriptor(self, monkeypatch):
+        from embit.bip32 import HDKey
+        from embit.descriptor import Descriptor
+        from embit import bip39, networks
+        from seedsigner.views import tools_views
+        from seedsigner.controller import Controller
+        from seedsigner.models.settings_definition import SettingsConstants
+        from seedsigner.helpers import seedkeeper_utils
+
+        seed_bytes = bip39.mnemonic_to_seed(
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+        )
+        root = HDKey.from_seed(seed_bytes, version=networks.NETWORKS["main"]["xprv"])
+        derived_xpub = root.derive("m/84h/0h/0h").to_public().to_string()
+        master_xpub = root.to_public().to_string()
+
+        class MockConnector:
+            def card_bip32_get_xpub(self, path, xtype, is_mainnet):
+                if path == "":
+                    return master_xpub
+                elif path == "m/84'/0'/0'":
+                    return derived_xpub
+                raise ValueError("unexpected path")
+
+        def mock_init_satochip(parent, init_card_filter=None):
+            return MockConnector()
+
+        monkeypatch.setattr(seedkeeper_utils, "init_satochip", mock_init_satochip)
+
+        controller = Controller.get_instance()
+        controller.multisig_wallet_descriptor = None
+
+        view = tools_views.SatochipLoadDescriptorDetailsView(
+            script_type=SettingsConstants.NATIVE_SEGWIT, custom_derivation=""
+        )
+        view.run_screen = Mock(return_value=0)
+        destination = view.run()
+
+        assert isinstance(controller.multisig_wallet_descriptor, Descriptor)
+        assert destination.View_cls == tools_views.ToolsAddressExplorerAddressTypeView
+
+

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -958,6 +958,9 @@ class TestSatochipLoadDescriptor(BaseTest):
         destination = view.run()
 
         assert view.run_screen.call_count == 2
+        assert (
+            view.run_screen.call_args_list[0].kwargs["button_label"] == "Confirm"
+        )
         assert isinstance(controller.multisig_wallet_descriptor, Descriptor)
         assert destination.View_cls == tools_views.MainMenuView
 


### PR DESCRIPTION
## Summary
- add Satochip xpub export flow with script type and coordinator selection
- build descriptor from Satochip xpub and show QR for wallet export
- allow address verification using descriptors without a seed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688eb8ba4ba48322a1d17d08c007a6c4