### PR TITLE
feat: enable Satochip card transaction signing

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -133,6 +133,7 @@ class Controller(Singleton):
     psbt: PSBT = None
     psbt_seed: Seed = None
     psbt_parser: PSBTParser = None
+    psbt_sign_with_satochip: bool = False
 
     unverified_address = None
 
@@ -214,6 +215,7 @@ class Controller(Singleton):
         # Store one working psbt in memory
         controller.psbt = None
         controller.psbt_parser = None
+        controller.psbt_sign_with_satochip = False
 
         # Configure the Renderer
         Renderer.configure_instance()
@@ -347,6 +349,7 @@ class Controller(Singleton):
                     self.psbt = None
                     self.psbt_parser = None
                     self.psbt_seed = None
+                    self.psbt_sign_with_satochip = False
 
                     # Clear the whole Smartcard session if caching PIN is disabled (Same as removing the card)
                     if Settings.get_instance().get_value(SettingsConstants.SETTING__CACHE_SCARD_PIN) != "E":
@@ -498,6 +501,7 @@ class Controller(Singleton):
         self.psbt = None
         self.psbt_parser = None
         self.psbt_seed = None
+        self.psbt_sign_with_satochip = False
         self.multisig_wallet_descriptor = None
         self.unverified_address = None
         self.address_explorer_data = None

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from embit.psbt import PSBT
+from embit.bip32 import HARDENED
+from embit.util import secp256k1
+
+
+def _format_path(derivation: list[int]) -> str:
+    """Convert a list of BIP32 indices to string path"""
+    path = "m"
+    for index in derivation:
+        hardened = index & HARDENED
+        index &= ~HARDENED
+        path += f"/{index}{'\'' if hardened else ''}"
+    return path
+
+
+def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
+    """Sign the given PSBT using a connected Satochip card.
+
+    Returns the number of signatures added.
+    """
+    signed = 0
+    for i, inp in enumerate(psbt.inputs):
+        if len(inp.bip32_derivations) == 0:
+            continue
+        for pubkey, deriv in inp.bip32_derivations.items():
+            path = _format_path(deriv.derivation)
+            try:
+                key, chaincode = connector.card_bip32_get_extendedkey(path)
+                card_pub = key.get_public_key_bytes(compressed=True)
+            except Exception:
+                continue
+            if card_pub != pubkey:
+                continue
+            tx_hash = psbt.sighash(i)
+            sig, sw1, sw2 = connector.card_sign_transaction_hash(0xFF, list(tx_hash), None)
+            if sw1 != 0x90 or sw2 != 0x00:
+                continue
+            sig_der = bytes(sig)
+            # ensure low-S signature
+            sig_obj = secp256k1.ecdsa_signature_parse_der(sig_der)
+            sig_norm = secp256k1.ecdsa_signature_normalize(sig_obj)
+            sig_der = secp256k1.ecdsa_signature_serialize_der(sig_norm)
+            inp.partial_sigs[pubkey] = sig_der + b"\x01"
+            signed += 1
+            break
+    return signed

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -11,7 +11,8 @@ def _format_path(derivation: list[int]) -> str:
     for index in derivation:
         hardened = index & HARDENED
         index &= ~HARDENED
-        path += f"/{index}{"'" if hardened else ''}"
+        suffix = "'" if hardened else ""
+        path += f"/{index}{suffix}"
     return path
 
 

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from embit.ec import PublicKey
 from embit.psbt import PSBT
 from embit.util import secp256k1
 
@@ -34,7 +35,9 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
             path = _format_path(deriv.derivation)
             try:
                 key, chaincode = connector.card_bip32_get_extendedkey(path)
-                card_pub = key.get_public_key_bytes(compressed=True)
+                card_pub = PublicKey.parse(
+                    key.get_public_key_bytes(compressed=True)
+                )
             except Exception:
                 continue
             if card_pub != pubkey:

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -11,7 +11,7 @@ def _format_path(derivation: list[int]) -> str:
     for index in derivation:
         hardened = index & HARDENED
         index &= ~HARDENED
-        path += f"/{index}{'\'' if hardened else ''}"
+        path += f"/{index}{"'" if hardened else ''}"
     return path
 
 

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from embit.psbt import PSBT
-from embit.bip32 import HARDENED
+from embit.bip32 import HARDENED_INDEX
 from embit.util import secp256k1
 
 
@@ -9,8 +9,8 @@ def _format_path(derivation: list[int]) -> str:
     """Convert a list of BIP32 indices to string path"""
     path = "m"
     for index in derivation:
-        hardened = index & HARDENED
-        index &= ~HARDENED
+        hardened = bool(index & HARDENED_INDEX)
+        index &= ~HARDENED_INDEX
         suffix = "'" if hardened else ""
         path += f"/{index}{suffix}"
     return path

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 from embit.psbt import PSBT
-from embit.bip32 import HARDENED_INDEX
 from embit.util import secp256k1
+
+try:
+    # Constant introduced in newer embit versions
+    from embit.bip32 import HARDENED_INDEX  # type: ignore
+except ImportError:  # pragma: no cover - support older embit releases
+    HARDENED_INDEX = 0x80000000
 
 
 def _format_path(derivation: list[int]) -> str:

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -10,6 +10,7 @@ from seedsigner.views.view import BackStackView, MainMenuView, NotYetImplemented
 
 class PSBTSelectSeedView(View):
     SCAN_SEED = ButtonOption("Scan a seed", SeedSignerIconConstants.QRCODE)
+    SATOCHIP = ButtonOption("Use Satochip card", SeedSignerIconConstants.FINGERPRINT)
     TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=12)
     TYPE_15WORD = ButtonOption("Enter 15-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=15)
     TYPE_18WORD = ButtonOption("Enter 18-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=18)
@@ -43,6 +44,7 @@ class PSBTSelectSeedView(View):
 
             button_data.append(ButtonOption(button_str, SeedSignerIconConstants.FINGERPRINT))
 
+        button_data.append(self.SATOCHIP)
         button_data.append(self.SCAN_SEED)
         seed_lengths = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
         options = {
@@ -78,6 +80,15 @@ class PSBTSelectSeedView(View):
         if button_data[selected_menu_num] == self.SCAN_SEED:
             from seedsigner.views.scan_views import ScanSeedQRView
             return Destination(ScanSeedQRView)
+
+        elif button_data[selected_menu_num] == self.SATOCHIP:
+            from seedsigner.helpers import seedkeeper_utils
+            connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
+            if not connector:
+                return Destination(BackStackView)
+            self.controller.psbt_seed = None
+            self.controller.psbt_sign_with_satochip = True
+            return Destination(PSBTFinalizeView)
 
         elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_15WORD, self.TYPE_18WORD, self.TYPE_21WORD, self.TYPE_24WORD]:
             from seedsigner.views.seed_views import SeedMnemonicEntryView
@@ -532,8 +543,11 @@ class PSBTFinalizeView(View):
         psbt_parser: PSBTParser = self.controller.psbt_parser
         psbt: PSBT = self.controller.psbt
 
-        if not psbt_parser:
+        if psbt is None:
             # Should not be able to get here
+            return Destination(MainMenuView)
+
+        if not self.controller.psbt_sign_with_satochip and psbt_parser is None:
             return Destination(MainMenuView)
         
         selected_menu_num = self.run_screen(
@@ -545,20 +559,22 @@ class PSBTFinalizeView(View):
             return Destination(BackStackView)
 
         else:
-            # Sign PSBT
             sig_cnt = PSBTParser.sig_count(psbt)
-            psbt.sign_with(psbt_parser.root)
+            if self.controller.psbt_sign_with_satochip:
+                from seedsigner.helpers.satochip_signer import sign_psbt_with_satochip
+                if not self.controller.Satochip_Connector:
+                    return Destination(PSBTSigningErrorView)
+                sign_psbt_with_satochip(psbt, self.controller.Satochip_Connector)
+            else:
+                psbt.sign_with(psbt_parser.root)
             trimmed_psbt = PSBTParser.trim(psbt)
 
             if sig_cnt == PSBTParser.sig_count(trimmed_psbt):
-                # Signing failed / didn't do anything
-                # TODO: Reserved for Nick. Are there different failure scenarios that we can detect?
-                # Would be nice to alter the message on the next screen w/more detail.
                 return Destination(PSBTSigningErrorView)
-            
-            else:
-                self.controller.psbt = trimmed_psbt
-                return Destination(PSBTSignedQRDisplayView)
+
+            self.controller.psbt = trimmed_psbt
+            self.controller.psbt_sign_with_satochip = False
+            return Destination(PSBTSignedQRDisplayView)
 
 
 


### PR DESCRIPTION
## Summary
- allow selecting a Satochip card as a signer
- add helper to produce Satochip signatures for PSBT inputs
- track Satochip signing state in controller

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ec3f4a8ac8322b820f518f0d536b6