### PR TITLE
Allow multisig xpub export for Satochip

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2545,16 +2545,27 @@ class SatochipExportXpubDetailsView(View):
 
         network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
         is_mainnet = network == SettingsConstants.MAINNET
-        if self.script_type == SettingsConstants.NATIVE_SEGWIT:
-            xtype = "p2wpkh"
-        elif self.script_type == SettingsConstants.NESTED_SEGWIT:
-            xtype = "p2wpkh-p2sh"
-        elif self.script_type == SettingsConstants.LEGACY_P2PKH:
-            xtype = "standard"
-        elif self.script_type == SettingsConstants.TAPROOT:
-            xtype = "standard"
+
+        if self.sig_type == SettingsConstants.MULTISIG:
+            if self.script_type == SettingsConstants.NATIVE_SEGWIT:
+                xtype = "p2wsh"
+            elif self.script_type == SettingsConstants.NESTED_SEGWIT:
+                xtype = "p2wsh-p2sh"
+            elif self.script_type == SettingsConstants.LEGACY_P2PKH:
+                xtype = "standard"
+            else:
+                xtype = "p2wsh"
         else:
-            xtype = "p2wpkh"
+            if self.script_type == SettingsConstants.NATIVE_SEGWIT:
+                xtype = "p2wpkh"
+            elif self.script_type == SettingsConstants.NESTED_SEGWIT:
+                xtype = "p2wpkh-p2sh"
+            elif self.script_type == SettingsConstants.LEGACY_P2PKH:
+                xtype = "standard"
+            elif self.script_type == SettingsConstants.TAPROOT:
+                xtype = "standard"
+            else:
+                xtype = "p2wpkh"
 
         try:
             xpub_base58 = Satochip_Connector.card_bip32_get_xpub(derivation_path, xtype, is_mainnet)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2204,7 +2204,7 @@ class ToolsSatochipView(View):
             return Destination(ToolsSatochipEnable2FAView)
 
         elif button_data[selected_menu_num] == self.EXPORT_XPUB:
-            return Destination(SatochipExportXpubScriptTypeView)
+            return Destination(SatochipExportXpubSigTypeView)
 
         elif button_data[selected_menu_num] == self.LOAD_DESCRIPTOR:
             return Destination(SatochipLoadDescriptorScriptTypeView)
@@ -2357,9 +2357,40 @@ class ToolsSatochipEnable2FAView(View):
         return Destination(MainMenuView)
 
 
+class SatochipExportXpubSigTypeView(View):
+    SINGLE_SIG = ButtonOption(_("Single Sig"), return_data=SettingsConstants.SINGLE_SIG)
+    MULTISIG = ButtonOption(_("Multisig"), return_data=SettingsConstants.MULTISIG)
+
+    def run(self):
+        sig_types = self.settings.get_value(SettingsConstants.SETTING__SIG_TYPES)
+        if len(sig_types) == 1:
+            return Destination(
+                SatochipExportXpubScriptTypeView,
+                view_args=dict(sig_type=sig_types[0]),
+                skip_current_view=True,
+            )
+
+        button_data = [self.SINGLE_SIG, self.MULTISIG]
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title=_("Export Xpub"),
+            button_data=button_data,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        return Destination(
+            SatochipExportXpubScriptTypeView,
+            view_args=dict(sig_type=button_data[selected_menu_num].return_data),
+        )
+
+
 class SatochipExportXpubScriptTypeView(View):
-    def __init__(self, script_type: str = None):
+    def __init__(self, sig_type: str, script_type: str = None):
         super().__init__()
+        self.sig_type = sig_type
         self.script_type = script_type
 
     def run(self):
@@ -2381,13 +2412,20 @@ class SatochipExportXpubScriptTypeView(View):
 
         script_type = button_data[selected_menu_num].return_data
         if script_type == SettingsConstants.CUSTOM_DERIVATION:
-            return Destination(SatochipExportXpubCustomDerivationView, view_args=dict(script_type=script_type))
-        return Destination(SatochipExportXpubCoordinatorView, view_args=dict(script_type=script_type))
+            return Destination(
+                SatochipExportXpubCustomDerivationView,
+                view_args=dict(sig_type=self.sig_type, script_type=script_type),
+            )
+        return Destination(
+            SatochipExportXpubCoordinatorView,
+            view_args=dict(sig_type=self.sig_type, script_type=script_type),
+        )
 
 
 class SatochipExportXpubCustomDerivationView(View):
-    def __init__(self, script_type: str):
+    def __init__(self, sig_type: str, script_type: str):
         super().__init__()
+        self.sig_type = sig_type
         self.script_type = script_type
         self.custom_derivation_path = "m/"
 
@@ -2402,13 +2440,14 @@ class SatochipExportXpubCustomDerivationView(View):
 
         return Destination(
             SatochipExportXpubCoordinatorView,
-            view_args=dict(script_type=self.script_type, custom_derivation=ret),
+            view_args=dict(sig_type=self.sig_type, script_type=self.script_type, custom_derivation=ret),
         )
 
 
 class SatochipExportXpubCoordinatorView(View):
-    def __init__(self, script_type: str, custom_derivation: str = ""):
+    def __init__(self, sig_type: str, script_type: str, custom_derivation: str = ""):
         super().__init__()
+        self.sig_type = sig_type
         self.script_type = script_type
         self.custom_derivation = custom_derivation
 
@@ -2434,6 +2473,7 @@ class SatochipExportXpubCoordinatorView(View):
         return Destination(
             SatochipExportXpubWarningView,
             view_args=dict(
+                sig_type=self.sig_type,
                 script_type=self.script_type,
                 coordinator=coordinator,
                 custom_derivation=self.custom_derivation,
@@ -2443,8 +2483,9 @@ class SatochipExportXpubCoordinatorView(View):
 
 
 class SatochipExportXpubWarningView(View):
-    def __init__(self, script_type: str, coordinator: str, custom_derivation: str, coordinator_label: str):
+    def __init__(self, sig_type: str, script_type: str, coordinator: str, custom_derivation: str, coordinator_label: str):
         super().__init__()
+        self.sig_type = sig_type
         self.script_type = script_type
         self.coordinator = coordinator
         self.custom_derivation = custom_derivation
@@ -2454,6 +2495,7 @@ class SatochipExportXpubWarningView(View):
         destination = Destination(
             SatochipExportXpubDetailsView,
             view_args=dict(
+                sig_type=self.sig_type,
                 script_type=self.script_type,
                 coordinator=self.coordinator,
                 custom_derivation=self.custom_derivation,
@@ -2479,8 +2521,9 @@ class SatochipExportXpubWarningView(View):
 
 
 class SatochipExportXpubDetailsView(View):
-    def __init__(self, script_type: str, coordinator: str, custom_derivation: str, coordinator_label: str):
+    def __init__(self, sig_type: str, script_type: str, coordinator: str, custom_derivation: str, coordinator_label: str):
         super().__init__()
+        self.sig_type = sig_type
         self.script_type = script_type
         self.coordinator = coordinator
         self.custom_derivation = custom_derivation
@@ -2496,7 +2539,7 @@ class SatochipExportXpubDetailsView(View):
         else:
             derivation_path = embit_utils.get_standard_derivation_path(
                 network=self.settings.get_value(SettingsConstants.SETTING__NETWORK),
-                wallet_type=SettingsConstants.SINGLE_SIG,
+                wallet_type=self.sig_type,
                 script_type=self.script_type,
             )
 
@@ -2528,19 +2571,20 @@ class SatochipExportXpubDetailsView(View):
         fingerprint = HDKey.from_string(master_xpub).my_fingerprint
         fingerprint_hex = hexlify(fingerprint).decode("utf-8")
 
-        # Build descriptor and store for address explorer
-        if self.script_type == SettingsConstants.NATIVE_SEGWIT:
-            desc_str = f"wpkh({xpub_base58}/{{0,1}}/*)"
-        elif self.script_type == SettingsConstants.NESTED_SEGWIT:
-            desc_str = f"sh(wpkh({xpub_base58}/{{0,1}}/*))"
-        elif self.script_type == SettingsConstants.LEGACY_P2PKH:
-            desc_str = f"pkh({xpub_base58}/{{0,1}}/*)"
-        elif self.script_type == SettingsConstants.TAPROOT:
-            desc_str = f"tr({xpub_base58}/{{0,1}}/*)"
-        else:
-            desc_str = f"wpkh({xpub_base58}/{{0,1}}/*)"
+        if self.sig_type == SettingsConstants.SINGLE_SIG:
+            # Build descriptor and store for address explorer
+            if self.script_type == SettingsConstants.NATIVE_SEGWIT:
+                desc_str = f"wpkh({xpub_base58}/{{0,1}}/*)"
+            elif self.script_type == SettingsConstants.NESTED_SEGWIT:
+                desc_str = f"sh(wpkh({xpub_base58}/{{0,1}}/*))"
+            elif self.script_type == SettingsConstants.LEGACY_P2PKH:
+                desc_str = f"pkh({xpub_base58}/{{0,1}}/*)"
+            elif self.script_type == SettingsConstants.TAPROOT:
+                desc_str = f"tr({xpub_base58}/{{0,1}}/*)"
+            else:
+                desc_str = f"wpkh({xpub_base58}/{{0,1}}/*)"
 
-        self.controller.multisig_wallet_descriptor = Descriptor.from_string(desc_str)
+            self.controller.multisig_wallet_descriptor = Descriptor.from_string(desc_str)
 
         selected_menu_num = self.run_screen(
             seed_screens.SeedExportXpubDetailsScreen,
@@ -2562,6 +2606,7 @@ class SatochipExportXpubDetailsView(View):
                 coordinator=self.coordinator,
                 coordinator_label=self.coordinator_label,
                 fingerprint=fingerprint_hex,
+                sig_type=self.sig_type,
             ),
         )
 
@@ -2575,6 +2620,7 @@ class SatochipExportXpubQRDisplayView(View):
         coordinator: str,
         coordinator_label: str = "",
         fingerprint: str = "",
+        sig_type: str = SettingsConstants.SINGLE_SIG,
     ):
         super().__init__()
         self.xpub = xpub
@@ -2583,6 +2629,7 @@ class SatochipExportXpubQRDisplayView(View):
         self.coordinator = coordinator
         self.coordinator_label = coordinator_label
         self.fingerprint = fingerprint
+        self.sig_type = sig_type
 
     class _SpecterEncoder:
         def __init__(self, xpubstring: str, qr_density: str):
@@ -2646,17 +2693,20 @@ class SatochipExportXpubQRDisplayView(View):
             qr_encoder=encoder,
         )
 
-        return Destination(
-            SeedExportXpubVerifyAddressView,
-            view_args=dict(
-                seed_num=None,
-                derivation_path=self.derivation_path,
-                script_type=self.script_type,
-                sig_type=SettingsConstants.SINGLE_SIG,
-                coordinator_label=self.coordinator_label,
-            ),
-            skip_current_view=True,
-        )
+        if self.sig_type == SettingsConstants.SINGLE_SIG:
+            return Destination(
+                SeedExportXpubVerifyAddressView,
+                view_args=dict(
+                    seed_num=None,
+                    derivation_path=self.derivation_path,
+                    script_type=self.script_type,
+                    sig_type=self.sig_type,
+                    coordinator_label=self.coordinator_label,
+                ),
+                skip_current_view=True,
+            )
+
+        return Destination(MainMenuView)
 
 
 class SatochipLoadDescriptorScriptTypeView(View):

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -1002,3 +1002,39 @@ class TestSatochipExportXpubQRDisplayView(BaseTest):
         destination = view.run()
         assert destination.View_cls == seed_views.SeedExportXpubVerifyAddressView
 
+
+class TestSatochipExportXpubDetailsView(BaseTest):
+    def test_multisig_uses_slip132_headers(self):
+        from seedsigner.views import tools_views
+        from seedsigner.models.settings_definition import SettingsConstants
+        from unittest.mock import Mock, patch
+
+        mock_connector = Mock()
+
+        def fake_get_xpub(path, xtype, is_mainnet):
+            assert xtype == "p2wsh"
+            return "ZpubExample"
+
+        mock_connector.card_bip32_get_xpub.side_effect = fake_get_xpub
+
+        with patch(
+            "seedsigner.helpers.seedkeeper_utils.init_satochip",
+            return_value=mock_connector,
+        ):
+            with patch("seedsigner.views.tools_views.HDKey") as MockHDKey:
+                hdkey = Mock()
+                hdkey.my_fingerprint = b"\x00\x00\x00\x00"
+                MockHDKey.from_string.return_value = hdkey
+
+                view = tools_views.SatochipExportXpubDetailsView(
+                    sig_type=SettingsConstants.MULTISIG,
+                    script_type=SettingsConstants.NATIVE_SEGWIT,
+                    coordinator=SettingsConstants.COORDINATOR__SPECTER_DESKTOP,
+                    custom_derivation="",
+                    coordinator_label="Specter",
+                )
+                view.run_screen = Mock(return_value=0)
+                view.run()
+
+                assert view.run_screen.call_args.kwargs["xpub"].startswith("Zpub")
+

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -965,3 +965,40 @@ class TestSatochipLoadDescriptor(BaseTest):
         assert destination.View_cls == tools_views.MainMenuView
 
 
+class TestSatochipExportXpubQRDisplayView(BaseTest):
+    def test_multisig_skips_verification(self):
+        from seedsigner.views import tools_views, seed_views
+        from seedsigner.models.settings_definition import SettingsConstants
+        from unittest.mock import Mock
+
+        view = tools_views.SatochipExportXpubQRDisplayView(
+            xpub="xpub",
+            derivation_path="m/48'/0'/0'/2'",
+            script_type=SettingsConstants.NATIVE_SEGWIT,
+            coordinator=SettingsConstants.COORDINATOR__SPECTER_DESKTOP,
+            coordinator_label="Specter",
+            fingerprint="f" * 8,
+            sig_type=SettingsConstants.MULTISIG,
+        )
+        view.run_screen = Mock(return_value=0)
+        destination = view.run()
+        assert destination.View_cls == tools_views.MainMenuView
+
+    def test_single_sig_requires_verification(self):
+        from seedsigner.views import tools_views, seed_views
+        from seedsigner.models.settings_definition import SettingsConstants
+        from unittest.mock import Mock
+
+        view = tools_views.SatochipExportXpubQRDisplayView(
+            xpub="xpub",
+            derivation_path="m/84'/0'/0'",
+            script_type=SettingsConstants.NATIVE_SEGWIT,
+            coordinator=SettingsConstants.COORDINATOR__SPECTER_DESKTOP,
+            coordinator_label="Specter",
+            fingerprint="f" * 8,
+            sig_type=SettingsConstants.SINGLE_SIG,
+        )
+        view.run_screen = Mock(return_value=0)
+        destination = view.run()
+        assert destination.View_cls == seed_views.SeedExportXpubVerifyAddressView
+


### PR DESCRIPTION
## Summary
- Add Satochip export xpub flow to handle multisig wallets
- Skip address verification when exporting multisig xpub
- Test Satochip multisig xpub export path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f6c7e459c83228537e066a75a0018