### PR TITLE
Add Satochip option to Address Explorer

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -638,6 +638,7 @@ class ToolsAddressExplorerSelectSourceView(View):
     TYPE_21WORD = ButtonOption("Enter 21-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=21)
     TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=24)
     LOADED_DESCRIPTOR = ButtonOption("Loaded Multisig Descriptor")
+    SATOCHIP = ButtonOption("Load from Satochip", SeedSignerIconConstants.FINGERPRINT)
     TYPE_ELECTRUM = ButtonOption("Electrum Seed", FontAwesomeIconConstants.KEYBOARD)
 
     def run(self):
@@ -660,7 +661,11 @@ class ToolsAddressExplorerSelectSourceView(View):
             21: self.TYPE_21WORD,
             24: self.TYPE_24WORD,
         }
-        button_data = button_data + [self.SCAN_SEED, self.SCAN_DESCRIPTOR] + [options[l] for l in seed_lengths]
+        button_data = (
+            button_data
+            + [self.SCAN_SEED, self.SCAN_DESCRIPTOR, self.SATOCHIP]
+            + [options[l] for l in seed_lengths]
+        )
         if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_ELECTRUM)
 
@@ -701,6 +706,9 @@ class ToolsAddressExplorerSelectSourceView(View):
         elif button_data[selected_menu_num] == self.SCAN_DESCRIPTOR:
             from seedsigner.views.scan_views import ScanWalletDescriptorView
             return Destination(ScanWalletDescriptorView)
+
+        elif button_data[selected_menu_num] == self.SATOCHIP:
+            return Destination(SatochipLoadDescriptorScriptTypeView)
 
         elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_15WORD, self.TYPE_18WORD, self.TYPE_21WORD, self.TYPE_24WORD]:
             from seedsigner.views.seed_views import SeedMnemonicEntryView
@@ -2782,6 +2790,10 @@ class SatochipLoadDescriptorDetailsView(View):
             return Destination(BackStackView)
 
         self.controller.multisig_wallet_descriptor = descriptor
+        from seedsigner.controller import Controller
+        if self.controller.resume_main_flow == Controller.FLOW__ADDRESS_EXPLORER:
+            from seedsigner.views.seed_views import MultisigWalletDescriptorView
+            return Destination(MultisigWalletDescriptorView, skip_current_view=True)
 
         self.run_screen(
             LargeIconStatusScreen,

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2763,17 +2763,21 @@ class SatochipLoadDescriptorDetailsView(View):
 
         fingerprint = HDKey.from_string(master_xpub).my_fingerprint
         fingerprint_hex = hexlify(fingerprint).decode("utf-8")
+        if derivation_path.startswith("m/"):
+            origin_path = derivation_path[2:]
+        else:
+            origin_path = derivation_path
 
         if self.script_type == SettingsConstants.NATIVE_SEGWIT:
-            desc_str = f"wpkh({xpub_base58}/{{0,1}}/*)"
+            desc_str = f"wpkh([{fingerprint_hex}/{origin_path}]{xpub_base58}/{{0,1}}/*)"
         elif self.script_type == SettingsConstants.NESTED_SEGWIT:
-            desc_str = f"sh(wpkh({xpub_base58}/{{0,1}}/*))"
+            desc_str = f"sh(wpkh([{fingerprint_hex}/{origin_path}]{xpub_base58}/{{0,1}}/*))"
         elif self.script_type == SettingsConstants.LEGACY_P2PKH:
-            desc_str = f"pkh({xpub_base58}/{{0,1}}/*)"
+            desc_str = f"pkh([{fingerprint_hex}/{origin_path}]{xpub_base58}/{{0,1}}/*)"
         elif self.script_type == SettingsConstants.TAPROOT:
-            desc_str = f"tr({xpub_base58}/{{0,1}}/*)"
+            desc_str = f"tr([{fingerprint_hex}/{origin_path}]{xpub_base58}/{{0,1}}/*)"
         else:
-            desc_str = f"wpkh({xpub_base58}/{{0,1}}/*)"
+            desc_str = f"wpkh([{fingerprint_hex}/{origin_path}]{xpub_base58}/{{0,1}}/*)"
 
         descriptor = Descriptor.from_string(desc_str)
 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -13,6 +13,7 @@ from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.seed import ElectrumSeed, Seed
 from seedsigner.views.view import MainMenuView, OptionDisabledView, View, NetworkMismatchErrorView
 from seedsigner.views import seed_views, scan_views, settings_views
+from binascii import hexlify
 
 
 def load_seed_into_decoder(view: scan_views.ScanView):
@@ -934,6 +935,7 @@ class TestSatochipLoadDescriptor(BaseTest):
         root = HDKey.from_seed(seed_bytes, version=networks.NETWORKS["main"]["xprv"])
         derived_xpub = root.derive("m/84h/0h/0h").to_public().to_string()
         master_xpub = root.to_public().to_string()
+        master_fingerprint = hexlify(root.my_fingerprint).decode()
 
         class MockConnector:
             def card_bip32_get_xpub(self, path, xtype, is_mainnet):
@@ -963,5 +965,9 @@ class TestSatochipLoadDescriptor(BaseTest):
         )
         assert isinstance(controller.multisig_wallet_descriptor, Descriptor)
         assert destination.View_cls == tools_views.MainMenuView
+        assert (
+            hexlify(controller.multisig_wallet_descriptor.keys[0].fingerprint).decode()
+            == master_fingerprint
+        )
 
 

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -10,6 +10,7 @@ from seedsigner.views import scan_views, seed_views, tools_views
 from embit.bip32 import HDKey
 from embit import bip39, networks
 from seedsigner.helpers import seedkeeper_utils
+from binascii import hexlify
 
 
 
@@ -226,6 +227,7 @@ class TestToolsFlows(FlowTest):
         root = HDKey.from_seed(seed_bytes, version=networks.NETWORKS["main"]["xprv"])
         derived_xpub = root.derive("m/84h/0h/0h").to_public().to_string()
         master_xpub = root.to_public().to_string()
+        master_fingerprint = hexlify(root.my_fingerprint).decode()
 
         class MockConnector:
             def card_bip32_get_xpub(self, path, xtype, is_mainnet):
@@ -256,6 +258,9 @@ class TestToolsFlows(FlowTest):
             FlowStep(tools_views.ToolsAddressExplorerAddressTypeView, button_data_selection=tools_views.ToolsAddressExplorerAddressTypeView.RECEIVE),
             FlowStep(tools_views.ToolsAddressExplorerAddressListView),
         ])
+
+        descriptor = controller.multisig_wallet_descriptor
+        assert hexlify(descriptor.keys[0].fingerprint).decode() == master_fingerprint
 
 
     def test__verify_address__legacy_multisig_p2sh__flow(self):

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -7,6 +7,9 @@ from seedsigner.models.seed import Seed
 from seedsigner.models.settings_definition import SettingsConstants, SettingsDefinition
 from seedsigner.views.view import ErrorView, MainMenuView
 from seedsigner.views import scan_views, seed_views, tools_views
+from embit.bip32 import HDKey
+from embit import bip39, networks
+from seedsigner.helpers import seedkeeper_utils
 
 
 
@@ -211,6 +214,46 @@ class TestToolsFlows(FlowTest):
             FlowStep(tools_views.ToolsAddressExplorerAddressListView, screen_return_value=10),  # ret NEXT page of addrs
             FlowStep(tools_views.ToolsAddressExplorerAddressListView, screen_return_value=4),  # ret a specific addr from the list
             FlowStep(tools_views.ToolsAddressExplorerAddressView),  # runs until dismissed; no ret value
+            FlowStep(tools_views.ToolsAddressExplorerAddressListView),
+        ])
+
+
+    def test__address_explorer__satochip_descriptor__flow(self, monkeypatch):
+        """Address Explorer should be able to load a descriptor from a Satochip card."""
+        seed_bytes = bip39.mnemonic_to_seed(
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+        )
+        root = HDKey.from_seed(seed_bytes, version=networks.NETWORKS["main"]["xprv"])
+        derived_xpub = root.derive("m/84h/0h/0h").to_public().to_string()
+        master_xpub = root.to_public().to_string()
+
+        class MockConnector:
+            def card_bip32_get_xpub(self, path, xtype, is_mainnet):
+                if path == "":
+                    return master_xpub
+                elif path == "m/84'/0'/0'":
+                    return derived_xpub
+                raise ValueError("unexpected path")
+
+        monkeypatch.setattr(seedkeeper_utils, "init_satochip", lambda *args, **kwargs: MockConnector())
+
+        controller = Controller.get_instance()
+        controller.multisig_wallet_descriptor = None
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.ADDRESS_EXPLORER),
+            FlowStep(tools_views.ToolsAddressExplorerSelectSourceView, button_data_selection=tools_views.ToolsAddressExplorerSelectSourceView.SATOCHIP),
+            FlowStep(
+                tools_views.SatochipLoadDescriptorScriptTypeView,
+                button_data_selection=ButtonOption(
+                    SettingsDefinition.get_settings_entry(SettingsConstants.SETTING__SCRIPT_TYPES).get_selection_option_display_name_by_value(SettingsConstants.NATIVE_SEGWIT),
+                    return_data=SettingsConstants.NATIVE_SEGWIT,
+                ),
+            ),
+            FlowStep(tools_views.SatochipLoadDescriptorDetailsView, screen_return_value=0),
+            FlowStep(seed_views.MultisigWalletDescriptorView, button_data_selection=seed_views.MultisigWalletDescriptorView.ADDRESS_EXPLORER),
+            FlowStep(tools_views.ToolsAddressExplorerAddressTypeView, button_data_selection=tools_views.ToolsAddressExplorerAddressTypeView.RECEIVE),
             FlowStep(tools_views.ToolsAddressExplorerAddressListView),
         ])
 


### PR DESCRIPTION
## Summary
- add "Load from Satochip" option in Address Explorer
- redirect Satochip descriptor load back into Address Explorer
- test loading a descriptor from Satochip card

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f6c95efc0832286f721e84969d344