### PR TITLE
feat: enable psbt verification for satochip

### DIFF
--- a/src/seedsigner/helpers/seedkeeper_utils.py
+++ b/src/seedsigner/helpers/seedkeeper_utils.py
@@ -187,7 +187,7 @@ def init_satochip(parentObject, init_card_filter=None, require_pin=True):
             except Exception as e:
                 parentObject.loading_screen.stop()
                 time.sleep(0.1)  # Sleep for 100ms
-                print("Pin Check General Exception:" + str(e))
+                logger.exception("Pin check failed")
 
                 parentObject.run_screen(
                     WarningScreen,
@@ -378,6 +378,7 @@ def run_globalplatform(
         ):
             failureText = "Unable to complete secure connection... (App or reader may need restart)"
 
+        logger.error(failureText)
         parentObject.run_screen(
             WarningScreen,
             title="Failed",
@@ -395,11 +396,13 @@ def run_globalplatform(
                 successtext="Mis-Installed Applet Uninstalled",
             )
             if data is None:
+                msg = "Mis-Installed Applet Uninstalled, try uninstalling it again..."
+                logger.error(msg)
                 parentObject.run_screen(
                     WarningScreen,
                     title="Failed",
                     status_headline=None,
-                    text="Mis-Installed Applet Uninstalled, try uninstalling it again...",
+                    text=msg,
                     show_back_button=False,
                 )
         return None

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from binascii import hexlify
 from embit import psbt, script, ec, bip32
@@ -19,10 +21,23 @@ class OPCODES:
 
 
 class PSBTParser():
-    def __init__(self, p: PSBT, seed: Seed, network: str = SettingsConstants.MAINNET):
+    def __init__(
+        self,
+        p: PSBT,
+        seed: Seed | None = None,
+        *,
+        root: bip32.HDKey | None = None,
+        root_path: list[int] | None = None,
+        master_fingerprint: bytes | None = None,
+        network: str = SettingsConstants.MAINNET,
+    ):
         self.psbt: PSBT = p
         self.seed = seed
         self.network = network
+        self.root = root
+        self.root_path = root_path or []
+        self.root_path_str = bip32.path_to_str(self.root_path) if self.root_path else "m"
+        self.master_fingerprint = master_fingerprint
 
         self.policy = None
         self.spend_amount = 0
@@ -35,9 +50,7 @@ class PSBTParser():
         self.destination_amounts = []
         self.op_return_data: bytes = None
 
-        self.root = None
-
-        if self.seed is not None:
+        if self.seed is not None or self.root is not None:
             self.parse()
 
 
@@ -66,7 +79,13 @@ class PSBTParser():
 
 
     def _set_root(self):
-        self.root = bip32.HDKey.from_seed(self.seed.seed_bytes, version=NETWORKS[SettingsConstants.map_network_to_embit(self.network)]["xprv"])
+        if self.seed is not None:
+            self.root = bip32.HDKey.from_seed(
+                self.seed.seed_bytes,
+                version=NETWORKS[SettingsConstants.map_network_to_embit(self.network)]["xprv"],
+            )
+        elif self.root is None:
+            raise RuntimeError("No seed or root key available")
 
 
     def parse(self):
@@ -74,11 +93,8 @@ class PSBTParser():
             logger.info(f"self.psbt is None!!")
             return False
 
-        if not self.seed:
-            logger.info("self.seed is None!")
-            return False
-
-        self._set_root()
+        if self.root is None:
+            self._set_root()
 
         rt = self._parse_inputs()
         if rt == False:
@@ -118,7 +134,6 @@ class PSBTParser():
         self.destination_amounts = []
         for i, out in enumerate(self.psbt.outputs):
             out_policy = PSBTParser._get_policy(out, self.psbt.tx.vout[i].script_pubkey, self.psbt.xpubs)
-            print(out_policy)
             is_change = False
 
             # if policy is the same - probably change
@@ -154,6 +169,7 @@ class PSBTParser():
                     # should be one or zero for single-key addresses
                     if len(out.bip32_derivations.values()) > 0:
                         der = list(out.bip32_derivations.values())[0].derivation
+                        der = der[len(self.root_path):]
                         my_pubkey = self.root.derive(der)
 
                     if self.policy["type"] == "p2pkh" and my_pubkey is not None:
@@ -176,7 +192,7 @@ class PSBTParser():
                     if len(out.taproot_bip32_derivations.values()) > 0:
                         # TODO: Support keys in taptree leaves
                         leaf_hashes, derivation = list(out.taproot_bip32_derivations.values())[0]
-                        der = derivation.derivation
+                        der = derivation.derivation[len(self.root_path):]
                         my_pubkey = self.root.derive(der)
                         sc = script.p2tr(my_pubkey)
 
@@ -369,12 +385,24 @@ class PSBTParser():
 
 
     @staticmethod
-    def has_matching_input_fingerprint(psbt: PSBT, seed: Seed, network: str = SettingsConstants.MAINNET):
+    def has_matching_input_fingerprint(
+        psbt: PSBT,
+        seed: Seed | None = None,
+        *,
+        root: bip32.HDKey | None = None,
+        network: str = SettingsConstants.MAINNET,
+    ):
         """
             Extracts the fingerprint from each psbt input utxo. Returns True if any match
-            the current seed.
+            the current seed or root xpub.
         """
-        seed_fingerprint = seed.get_fingerprint(network)
+        if seed is not None:
+            seed_fingerprint = seed.get_fingerprint(network)
+        elif root is not None:
+            seed_fingerprint = hexlify(root.child(0).fingerprint).decode()
+        else:
+            return False
+
         for input in psbt.inputs:
             for pub, derivation_path in input.bip32_derivations.items():
                 if seed_fingerprint == hexlify(derivation_path.fingerprint).decode():

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -196,8 +196,8 @@ class PSBTOverviewView(View):
         num_change_outputs = 0
         num_self_transfer_outputs = 0
         for change_output in change_data:
-            # print(f"""{change_output["derivation_path"][0]}""")
-            if change_output["derivation_path"][0].split("/")[-2] == "1":
+            path_ints = bip32.parse_path(change_output["derivation_path"][0])
+            if len(path_ints) >= 2 and (path_ints[-2] & 0x7FFFFFFF) == 1:
                 num_change_outputs += 1
             else:
                 num_self_transfer_outputs += 1
@@ -417,8 +417,9 @@ class PSBTChangeDetailsView(View):
         derivation_path = change_data.get("derivation_path")[i]
 
         # 'm/84h/1h/0h/1/0' would be a change addr while 'm/84h/1h/0h/0/0' is a self-receive
-        is_change_derivation_path = int(derivation_path.split("/")[-2]) == 1
-        derivation_path_addr_index = int(derivation_path.split("/")[-1])
+        path_ints = bip32.parse_path(derivation_path)
+        is_change_derivation_path = len(path_ints) >= 2 and (path_ints[-2] & 0x7FFFFFFF) == 1
+        derivation_path_addr_index = path_ints[-1] & 0x7FFFFFFF if path_ints else 0
 
         if is_change_derivation_path:
             # TRANSLATOR_NOTE: The amount you're receiving back from the transaction
@@ -461,8 +462,9 @@ class PSBTChangeDetailsView(View):
                 script_type = pubkey.script_type()
                 
                 # extract derivation path to get wallet and change derivation
-                change_path = '/'.join(derivation_path.split("/")[-2:])
-                wallet_path = '/'.join(derivation_path.split("/")[:-2])
+                change_path = bip32.path_to_str(path_ints[-2:])[2:] if len(path_ints) >= 2 else ""
+                wallet_path_list = path_ints[:-2]
+                wallet_path = bip32.path_to_str(wallet_path_list)
                 
                 if self.controller.psbt_seed:
                     xpub = self.controller.psbt_seed.get_xpub(
@@ -471,13 +473,17 @@ class PSBTChangeDetailsView(View):
                     )
                     xpub_key = xpub.derive(change_path).key
                 else:
-                    rel_wallet_path = wallet_path.replace(
-                        psbt_parser.root_path_str + "/", "", 1
+                    rel_wallet_path_list = wallet_path_list[len(psbt_parser.root_path):]
+                    rel_wallet_path = (
+                        bip32.path_to_str(rel_wallet_path_list)[2:]
+                        if rel_wallet_path_list
+                        else ""
                     )
-                    if rel_wallet_path:
-                        xpub = psbt_parser.root.derive(rel_wallet_path)
-                    else:
-                        xpub = psbt_parser.root
+                    xpub = (
+                        psbt_parser.root.derive(rel_wallet_path)
+                        if rel_wallet_path
+                        else psbt_parser.root
+                    )
                     xpub_key = xpub.derive(change_path).key
 
                 network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -1,5 +1,8 @@
 from gettext import gettext as _
 
+from binascii import hexlify
+from embit import bip32
+
 from seedsigner.models.psbt_parser import PSBTParser
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
@@ -83,12 +86,43 @@ class PSBTSelectSeedView(View):
 
         elif button_data[selected_menu_num] == self.SATOCHIP:
             from seedsigner.helpers import seedkeeper_utils
+            from embit.bip32 import HDKey
+
             connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
             if not connector:
                 return Destination(BackStackView)
+
+            network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+            is_mainnet = network == SettingsConstants.MAINNET
+            first_der = next(iter(self.controller.psbt.inputs[0].bip32_derivations.values())).derivation
+            account_path = []
+            HARDENED_INDEX = 0x80000000
+            for idx in first_der:
+                if idx & HARDENED_INDEX:
+                    account_path.append(idx)
+                else:
+                    break
+            account_path_str = bip32.path_to_str(account_path)
+            account_xpub = connector.card_bip32_get_xpub(account_path_str, "xpub", is_mainnet)
+            root_key = HDKey.from_base58(account_xpub)
+            master_xpub = connector.card_bip32_get_xpub("", "xpub", is_mainnet)
+            master_fp = HDKey.from_base58(master_xpub).child(0).fingerprint
+
+            try:
+                self.controller.psbt_parser = PSBTParser(
+                    self.controller.psbt,
+                    seed=None,
+                    root=root_key,
+                    root_path=account_path,
+                    master_fingerprint=master_fp,
+                    network=network,
+                )
+            except Exception:
+                return Destination(BackStackView)
+
             self.controller.psbt_seed = None
             self.controller.psbt_sign_with_satochip = True
-            return Destination(PSBTFinalizeView)
+            return Destination(PSBTOverviewView)
 
         elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_15WORD, self.TYPE_18WORD, self.TYPE_21WORD, self.TYPE_24WORD]:
             from seedsigner.views.seed_views import SeedMnemonicEntryView
@@ -349,7 +383,12 @@ class PSBTChangeDetailsView(View):
 
         # Single-sig verification is easy. We expect to find a single fingerprint
         # and derivation path.
-        seed_fingerprint = self.controller.psbt_seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
+        if self.controller.psbt_seed:
+            seed_fingerprint = self.controller.psbt_seed.get_fingerprint(
+                self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+            )
+        else:
+            seed_fingerprint = hexlify(psbt_parser.master_fingerprint).decode()
 
         if seed_fingerprint not in change_data.get("fingerprint"):
             # TODO: Something is wrong with this psbt(?). Reroute to warning?
@@ -406,13 +445,22 @@ class PSBTChangeDetailsView(View):
                 change_path = '/'.join(derivation_path.split("/")[-2:])
                 wallet_path = '/'.join(derivation_path.split("/")[:-2])
                 
-                xpub = self.controller.psbt_seed.get_xpub(
-                    wallet_path=wallet_path,
-                    network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)
-                )
-                
-                # take script type and call script method to generate address from seed / derivation
-                xpub_key = xpub.derive(change_path).key
+                if self.controller.psbt_seed:
+                    xpub = self.controller.psbt_seed.get_xpub(
+                        wallet_path=wallet_path,
+                        network=self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+                    )
+                    xpub_key = xpub.derive(change_path).key
+                else:
+                    rel_wallet_path = wallet_path.replace(
+                        psbt_parser.root_path_str + "/", "", 1
+                    )
+                    if rel_wallet_path:
+                        xpub = psbt_parser.root.derive(rel_wallet_path)
+                    else:
+                        xpub = psbt_parser.root
+                    xpub_key = xpub.derive(change_path).key
+
                 network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
                 scriptcall = getattr(script, script_type)
                 if script_type == "p2sh":

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -103,10 +103,29 @@ class PSBTSelectSeedView(View):
                 else:
                     break
             account_path_str = bip32.path_to_str(account_path)
-            account_xpub = connector.card_bip32_get_xpub(account_path_str, "xpub", is_mainnet)
+
+            purpose = account_path[0] & 0x7FFFFFFF if account_path else 0
+            xtype = {
+                44: "standard",
+                49: "p2wpkh-p2sh",
+                84: "p2wpkh",
+                48: "p2wsh-p2sh" if len(account_path) > 3 and (account_path[3] & 0x7FFFFFFF) == 1 else "p2wsh",
+            }.get(purpose, "standard")
+
+            try:
+                account_xpub = connector.card_bip32_get_xpub(account_path_str, xtype, is_mainnet)
+                master_xpub = connector.card_bip32_get_xpub("", xtype, is_mainnet)
+            except Exception as e:
+                self.run_screen(
+                    WarningScreen,
+                    title="Failed",
+                    status_headline=None,
+                    text=str(e),
+                )
+                return Destination(BackStackView)
+
             root_key = HDKey.from_base58(account_xpub)
-            master_xpub = connector.card_bip32_get_xpub("", "xpub", is_mainnet)
-            master_fp = HDKey.from_base58(master_xpub).child(0).fingerprint
+            master_fp = HDKey.from_base58(master_xpub).my_fingerprint
 
             try:
                 self.controller.psbt_parser = PSBTParser(

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -109,7 +109,9 @@ class PSBTSelectSeedView(View):
             account_path_str = "m"
             for i in account_path:
                 hardened = bool(i & HARDENED_INDEX)
-                account_path_str += f"/{i & 0x7FFFFFFF}{"'" if hardened else ''}"
+                index = i & 0x7FFFFFFF
+                suffix = "'" if hardened else ""
+                account_path_str += f"/{index}{suffix}"
 
             purpose = account_path[0] & 0x7FFFFFFF if account_path else 0
             xtype = {

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -2,12 +2,15 @@ from gettext import gettext as _
 
 from binascii import hexlify
 from embit import bip32
+import logging
 
 from seedsigner.models.psbt_parser import PSBTParser
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
 from seedsigner.gui.screens.screen import (RET_CODE__BACK_BUTTON, ButtonListScreen, ButtonOption, WarningScreen, DireWarningScreen, QRDisplayScreen)
 from seedsigner.views.view import BackStackView, MainMenuView, NotYetImplementedView, View, Destination
+
+logger = logging.getLogger(__name__)
 
 
 
@@ -102,7 +105,11 @@ class PSBTSelectSeedView(View):
                     account_path.append(idx)
                 else:
                     break
-            account_path_str = bip32.path_to_str(account_path)
+
+            account_path_str = "m"
+            for i in account_path:
+                hardened = bool(i & HARDENED_INDEX)
+                account_path_str += f"/{i & 0x7FFFFFFF}{"'" if hardened else ''}"
 
             purpose = account_path[0] & 0x7FFFFFFF if account_path else 0
             xtype = {
@@ -116,6 +123,7 @@ class PSBTSelectSeedView(View):
                 account_xpub = connector.card_bip32_get_xpub(account_path_str, xtype, is_mainnet)
                 master_xpub = connector.card_bip32_get_xpub("", xtype, is_mainnet)
             except Exception as e:
+                logger.exception("Failed to export xpub from Satochip card")
                 self.run_screen(
                     WarningScreen,
                     title="Failed",
@@ -136,7 +144,14 @@ class PSBTSelectSeedView(View):
                     master_fingerprint=master_fp,
                     network=network,
                 )
-            except Exception:
+            except Exception as e:
+                logger.exception("Failed to parse PSBT with Satochip data")
+                self.run_screen(
+                    WarningScreen,
+                    title="Failed",
+                    status_headline=None,
+                    text=str(e),
+                )
                 return Destination(BackStackView)
 
             self.controller.psbt_seed = None


### PR DESCRIPTION
## Summary
- allow `PSBTParser` to parse using account-level xpubs and master fingerprints
- load Satochip xpubs to verify PSBT details before signing
- support verifying change paths and fingerprints when signing with Satochip

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f6c448a248322ba41db27bf77881d