### PR TITLE
Enable Satochip card message signing

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -134,6 +134,7 @@ class Controller(Singleton):
     psbt_seed: Seed = None
     psbt_parser: PSBTParser = None
     psbt_sign_with_satochip: bool = False
+    sign_message_with_satochip: bool = False
 
     unverified_address = None
 
@@ -216,6 +217,7 @@ class Controller(Singleton):
         controller.psbt = None
         controller.psbt_parser = None
         controller.psbt_sign_with_satochip = False
+        controller.sign_message_with_satochip = False
 
         # Configure the Renderer
         Renderer.configure_instance()
@@ -350,6 +352,7 @@ class Controller(Singleton):
                     self.psbt_parser = None
                     self.psbt_seed = None
                     self.psbt_sign_with_satochip = False
+                    self.sign_message_with_satochip = False
 
                     # Clear the whole Smartcard session if caching PIN is disabled (Same as removing the card)
                     if Settings.get_instance().get_value(SettingsConstants.SETTING__CACHE_SCARD_PIN) != "E":
@@ -502,6 +505,7 @@ class Controller(Singleton):
         self.psbt_parser = None
         self.psbt_seed = None
         self.psbt_sign_with_satochip = False
+        self.sign_message_with_satochip = False
         self.multisig_wallet_descriptor = None
         self.unverified_address = None
         self.address_explorer_data = None

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -24,6 +24,26 @@ def _format_path(derivation: list[int]) -> str:
     return path
 
 
+def format_path_string(path: str) -> str:
+    """Normalize a BIP32 path string for Satochip expectations.
+
+    Satochip's ``CardConnector`` only accepts hardened markers as an
+    apostrophe (``'``) and requires a leading ``m/``. SeedSigner uses
+    ``h`` to denote hardened indices and may omit the master prefix, so
+    we convert here.
+    """
+
+    if path is None:
+        return "m"
+    path = path.strip()
+    if path.startswith("m/"):
+        path = path[2:]
+    path = path.replace("H", "'").replace("h", "'")
+    if path == "" or path == "m":
+        return "m"
+    return "m/" + path
+
+
 def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
     """Sign the given PSBT using a connected Satochip card.
 
@@ -71,7 +91,8 @@ def sign_message_with_satochip(derivation_path: str, message: str, connector) ->
         Base64 encoded compact signature string.
     """
 
-    key, _chaincode = connector.card_bip32_get_extendedkey(derivation_path)
+    path = format_path_string(derivation_path)
+    key, _chaincode = connector.card_bip32_get_extendedkey(path)
     _resp, sw1, sw2, compsig = connector.card_sign_message(0xFF, key, message)
     if sw1 != 0x90 or sw2 != 0x00 or not compsig:
         raise Exception("Failed to sign message with Satochip")

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from binascii import b2a_base64
+
 from embit.ec import PublicKey
 from embit.psbt import PSBT
 from embit.util import secp256k1
@@ -55,3 +57,22 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
             signed += 1
             break
     return signed
+
+
+def sign_message_with_satochip(derivation_path: str, message: str, connector) -> str:
+    """Sign an arbitrary message using a connected Satochip card.
+
+    Args:
+        derivation_path: BIP32 derivation path for the signing key ("m/84'/0'/0'/0/0").
+        message: Message to be signed.
+        connector: Active Satochip ``CardConnector`` instance.
+
+    Returns:
+        Base64 encoded compact signature string.
+    """
+
+    key, _chaincode = connector.card_bip32_get_extendedkey(derivation_path)
+    _resp, sw1, sw2, compsig = connector.card_sign_message(0xFF, key, message)
+    if sw1 != 0x90 or sw2 != 0x00 or not compsig:
+        raise Exception("Failed to sign message with Satochip")
+    return b2a_base64(compsig).strip().decode()

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -84,6 +84,7 @@ class SeedSelectSeedView(View):
                 verify single sig addr or sign message).
     """
     SCAN_SEED = ButtonOption("Scan a seed", SeedSignerIconConstants.QRCODE)
+    SATOCHIP = ButtonOption("Use Satochip card", SeedSignerIconConstants.FINGERPRINT)
     TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=12)
     TYPE_15WORD = ButtonOption("Enter 15-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=15)
     TYPE_18WORD = ButtonOption("Enter 18-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=18)
@@ -121,7 +122,9 @@ class SeedSelectSeedView(View):
         for seed in seeds:
             button_str = seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
             button_data.append(ButtonOption(button_str, SeedSignerIconConstants.FINGERPRINT, icon_color="blue"))
-        
+        if self.flow == Controller.FLOW__SIGN_MESSAGE:
+            button_data.append(self.SATOCHIP)
+
         button_data.append(self.SCAN_SEED)
         seed_lengths = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
         options = {
@@ -161,6 +164,14 @@ class SeedSelectSeedView(View):
                 return Destination(SeedSignMessageConfirmMessageView)
 
         self.controller.resume_main_flow = self.flow
+
+        if self.flow == Controller.FLOW__SIGN_MESSAGE and button_data[selected_menu_num] == self.SATOCHIP:
+            connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
+            if not connector:
+                return Destination(BackStackView)
+            self.controller.sign_message_with_satochip = True
+            self.controller.sign_message_data["seed_num"] = None
+            return Destination(SeedSignMessageConfirmMessageView)
 
         if button_data[selected_menu_num] == self.SCAN_SEED:
             from seedsigner.views.scan_views import ScanView
@@ -3647,26 +3658,22 @@ class SeedSignMessageConfirmMessageView(View):
 
 class SeedSignMessageConfirmAddressView(View):
     def __init__(self):
+        from embit import bip32
         from seedsigner.helpers import embit_utils
+
         super().__init__()
         data = self.controller.sign_message_data
-        seed_num = data.get("seed_num")
+        self.seed_num = data.get("seed_num")
         self.derivation_path = data.get("derivation_path")
 
-        if seed_num is None or not self.derivation_path:
+        if not self.derivation_path:
             raise Exception("Routing error: sign_message_data hasn't been set")
 
-        seed = self.controller.storage.seeds[seed_num]
-        addr_format = data.get("addr_format")
-
-        # calculate the actual receive address
-        seed = self.controller.storage.seeds[seed_num]
         addr_format = embit_utils.parse_derivation_path(self.derivation_path)
         if not addr_format["clean_match"] or addr_format["script_type"] == SettingsConstants.CUSTOM_DERIVATION:
             raise Exception(_("Signing messages for custom derivation paths not supported"))
 
         if addr_format["network"] != SettingsConstants.MAINNET:
-            # We're in either Testnet or Regtest or...?
             if self.settings.get_value(SettingsConstants.SETTING__NETWORK) in [SettingsConstants.TESTNET, SettingsConstants.REGTEST]:
                 addr_format["network"] = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
             else:
@@ -3679,9 +3686,36 @@ class SeedSignMessageConfirmAddressView(View):
                 self.controller.sign_message_data = None
                 return
 
-        xpub = seed.get_xpub(wallet_path=addr_format["wallet_derivation_path"], network=addr_format["network"])
+        if self.controller.sign_message_with_satochip:
+            connector = self.controller.Satochip_Connector
+            script_type = addr_format["script_type"]
+            if script_type == SettingsConstants.NATIVE_SEGWIT:
+                xtype = "p2wpkh"
+            elif script_type == SettingsConstants.NESTED_SEGWIT:
+                xtype = "p2wpkh-p2sh"
+            elif script_type == SettingsConstants.LEGACY_P2PKH:
+                xtype = "standard"
+            elif script_type == SettingsConstants.TAPROOT:
+                xtype = "standard"
+            else:
+                xtype = "p2wpkh"
+            is_mainnet = addr_format["network"] == SettingsConstants.MAINNET
+            xpub_base58 = connector.card_bip32_get_xpub(addr_format["wallet_derivation_path"], xtype, is_mainnet)
+            xpub = bip32.HDKey.from_base58(xpub_base58)
+        else:
+            if self.seed_num is None:
+                raise Exception("Routing error: sign_message_data hasn't been set")
+            seed = self.controller.get_seed(self.seed_num)
+            xpub = seed.get_xpub(wallet_path=addr_format["wallet_derivation_path"], network=addr_format["network"])
+
         embit_network = embit_utils.get_embit_network_name(addr_format["network"])
-        self.address = embit_utils.get_single_sig_address(xpub=xpub, script_type=addr_format["script_type"], index=addr_format["index"], is_change=addr_format["is_change"], embit_network=embit_network)
+        self.address = embit_utils.get_single_sig_address(
+            xpub=xpub,
+            script_type=addr_format["script_type"],
+            index=addr_format["index"],
+            is_change=addr_format["is_change"],
+            embit_network=embit_network,
+        )
 
 
     def run(self):
@@ -3709,12 +3743,23 @@ class SeedSignMessageSignedMessageQRView(View):
         super().__init__()
         data = self.controller.sign_message_data
 
-        self.seed_num = data["seed_num"]
-        seed = self.controller.get_seed(self.seed_num)
         derivation_path = data["derivation_path"]
         message: str = data["message"]
 
-        self.signed_message = embit_utils.sign_message(seed_bytes=seed.seed_bytes, derivation=derivation_path, msg=message.encode())
+        if self.controller.sign_message_with_satochip:
+            from seedsigner.helpers.satochip_signer import sign_message_with_satochip
+
+            self.signed_message = sign_message_with_satochip(
+                derivation_path, message, self.controller.Satochip_Connector
+            )
+        else:
+            self.seed_num = data["seed_num"]
+            seed = self.controller.get_seed(self.seed_num)
+            self.signed_message = embit_utils.sign_message(
+                seed_bytes=seed.seed_bytes,
+                derivation=derivation_path,
+                msg=message.encode(),
+            )
 
 
     def run(self):
@@ -3725,10 +3770,11 @@ class SeedSignMessageSignedMessageQRView(View):
             QRDisplayScreen,
             qr_encoder=qr_encoder,
         )
-    
+
         # cleanup
         self.controller.resume_main_flow = None
         self.controller.sign_message_data = None
+        self.controller.sign_message_with_satochip = False
 
         # Exiting/Canceling the QR display screen always returns Home
         return Destination(MainMenuView, skip_current_view=True)

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -3700,7 +3700,9 @@ class SeedSignMessageConfirmAddressView(View):
             else:
                 xtype = "p2wpkh"
             is_mainnet = addr_format["network"] == SettingsConstants.MAINNET
-            xpub_base58 = connector.card_bip32_get_xpub(addr_format["wallet_derivation_path"], xtype, is_mainnet)
+            from seedsigner.helpers.satochip_signer import format_path_string
+            wallet_path = format_path_string(addr_format["wallet_derivation_path"])
+            xpub_base58 = connector.card_bip32_get_xpub(wallet_path, xtype, is_mainnet)
             xpub = bip32.HDKey.from_base58(xpub_base58)
         else:
             if self.seed_num is None:

--- a/tests/test_satochip_sign_message.py
+++ b/tests/test_satochip_sign_message.py
@@ -1,0 +1,24 @@
+from binascii import b2a_base64
+
+from seedsigner.helpers.satochip_signer import sign_message_with_satochip
+
+
+class DummyKey:
+    def get_public_key_bytes(self, compressed=True):
+        return b"\x02" + b"\x00" * 32
+
+
+class DummyConnector:
+    def card_bip32_get_extendedkey(self, path):
+        return DummyKey(), b""
+
+    def card_sign_message(self, keynbr, pubkey, message, hmac=None):
+        compsig = b"\x01" * 65
+        return None, 0x90, 0x00, compsig
+
+
+def test_sign_message_with_satochip_returns_base64_signature():
+    connector = DummyConnector()
+    sig = sign_message_with_satochip("m/84'/0'/0'/0/0", "hello", connector)
+    assert sig == b2a_base64(b"\x01" * 65).strip().decode()
+

--- a/tests/test_satochip_sign_message.py
+++ b/tests/test_satochip_sign_message.py
@@ -22,3 +22,9 @@ def test_sign_message_with_satochip_returns_base64_signature():
     sig = sign_message_with_satochip("m/84'/0'/0'/0/0", "hello", connector)
     assert sig == b2a_base64(b"\x01" * 65).strip().decode()
 
+
+def test_sign_message_with_satochip_accepts_hardened_notation_without_m_prefix():
+    connector = DummyConnector()
+    sig = sign_message_with_satochip("84h/0h/0h/0/0", "hello", connector)
+    assert sig == b2a_base64(b"\x01" * 65).strip().decode()
+


### PR DESCRIPTION
## Summary
- allow Satochip smartcards to sign arbitrary messages
- integrate card-based signing into message-signing workflow
- test Satochip message signing helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f6cdb672483229136b32078a41383