### PR TITLE
Fix Satochip seed import flow when initializing blank card

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2219,10 +2219,6 @@ class ToolsSatochipImportSeedView(View):
 
     def run(self):
         from seedsigner.gui.screens.screen import LoadingScreenThread
-        Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
-
-        if not Satochip_Connector:
-            return Destination(BackStackView)
 
         seeds = self.controller.storage.seeds
         button_data = []
@@ -2258,6 +2254,12 @@ class ToolsSatochipImportSeedView(View):
 
         if len(seeds) > 0 and selected_menu_num < len(seeds):
             # User selected one of the n seeds
+
+            Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
+
+            if not Satochip_Connector:
+                return Destination(BackStackView)
+
             try:
                 self.loading_screen = LoadingScreenThread(text="Importing Secret\n\n\n\n\n\n")
                 self.loading_screen.start()
@@ -2276,7 +2278,7 @@ class ToolsSatochipImportSeedView(View):
                 )
             except Exception as e:
                 self.loading_screen.stop()
-                logger.info("Satochip Import Failed:",str(e))
+                logger.info("Satochip Import Failed:", str(e))
                 self.run_screen(
                     WarningScreen,
                     title="Failed",

--- a/tests/test_tools_satochip_import.py
+++ b/tests/test_tools_satochip_import.py
@@ -1,0 +1,50 @@
+from base import BaseTest
+
+
+class TestSatochipImportSeed(BaseTest):
+
+    def test_init_after_seed_selection(self, monkeypatch):
+        from seedsigner.views import tools_views
+        from seedsigner.helpers import seedkeeper_utils
+        from seedsigner.models.seed import Seed
+        from seedsigner.gui.screens.screen import (
+            ButtonListScreen,
+            LargeIconStatusScreen,
+            WarningScreen,
+        )
+
+        seed = Seed(
+            mnemonic="abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split()
+        )
+        self.controller.storage.seeds = [seed]
+
+        call_sequence = []
+
+        def fake_run_screen(self, Screen_cls, **kwargs):
+            call_sequence.append(Screen_cls)
+            if Screen_cls == ButtonListScreen:
+                return 0
+            elif Screen_cls in [LargeIconStatusScreen, WarningScreen]:
+                return 0
+            return 0
+
+        view = tools_views.ToolsSatochipImportSeedView()
+        view.run_screen = fake_run_screen.__get__(view, tools_views.ToolsSatochipImportSeedView)
+
+        def fake_init_satochip(parent, init_card_filter=None):
+            # Ensure seed selection screen was shown before connecting to the card
+            assert call_sequence == [ButtonListScreen]
+
+            class MockConnector:
+                def card_bip32_import_seed(self, seed_bytes):
+                    pass
+
+            return MockConnector()
+
+        monkeypatch.setattr(seedkeeper_utils, "init_satochip", fake_init_satochip)
+
+        destination = view.run()
+
+        assert destination.View_cls == tools_views.MainMenuView
+        # init_satochip should have been called after the seed selection screen
+        assert call_sequence[0] == ButtonListScreen


### PR DESCRIPTION
## Summary
- Only connect to the Satochip card after the user chooses which seed to import
- Add regression test ensuring Satochip initialization happens after seed selection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f6d35dff08322960f554bc3093aa3