### PR TITLE
Add WIF key import and signing

### DIFF
--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -5,7 +5,7 @@ import re
 
 from binascii import a2b_base64, b2a_base64
 from enum import IntEnum
-from embit import psbt, bip39
+from embit import psbt, bip39, ec
 from pyzbar import pyzbar
 from pyzbar.pyzbar import ZBarSymbol
 from urtypes.crypto import PSBT as UR_PSBT
@@ -120,6 +120,9 @@ class DecodeQR:
 
             elif self.qr_type == QRType.ENCRYPTION_KEY:
                 self.decoder = EncryptionKeyQrDecoder()
+
+            elif self.qr_type == QRType.WIF:
+                self.decoder = WifQrDecoder()
 
             elif self.qr_type == QRType.TEXT:
                 self.decoder = TextQrDecoder()
@@ -244,6 +247,10 @@ class DecodeQR:
         if self.is_encryptionkey:
             return self.decoder.get_encryption_key()
 
+    def get_wif(self):
+        if self.is_wif:
+            return self.decoder.get_wif()
+
 
     def get_public_data(self):
         if self.is_encrypted_seedqr:
@@ -352,6 +359,10 @@ class DecodeQR:
     @property
     def is_sign_message(self):
         return self.qr_type == QRType.SIGN_MESSAGE
+
+    @property
+    def is_wif(self):
+        return self.qr_type == QRType.WIF
         
 
     @property
@@ -481,6 +492,13 @@ class DecodeQR:
 
             elif DecodeQR.is_base43_psbt(s):
                 return QRType.PSBT__BASE43
+
+            # WIF private key
+            try:
+                ec.PrivateKey.from_wif(s.strip())
+                return QRType.WIF
+            except Exception:
+                pass
 
         except UnicodeDecodeError:
             # Probably this isn't meant to be string data; check if it's valid byte data
@@ -1279,6 +1297,29 @@ class EncryptionKeyQrDecoder(BaseSingleFrameQrDecoder):
 
     def get_encryption_key(self):
         return self.encryption_key
+
+
+class WifQrDecoder(BaseSingleFrameQrDecoder):
+    """Decodes single frame representing a WIF-encoded private key."""
+
+    def __init__(self):
+        super().__init__()
+        self.wif = None
+
+    def add(self, segment, qr_type=QRType.WIF):
+        if qr_type == QRType.WIF:
+            try:
+                ec.PrivateKey.from_wif(segment)
+                self.wif = segment
+                self.complete = True
+                self.collected_segments = 1
+                return DecodeQRStatus.COMPLETE
+            except Exception as e:
+                logger.exception(repr(e))
+        return DecodeQRStatus.INVALID
+
+    def get_wif(self):
+        return self.wif
 
 
 

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -8,6 +8,7 @@ from io import BytesIO
 from typing import List
 
 from seedsigner.models.seed import Seed
+from seedsigner.models.wif import WIFKey
 from seedsigner.models.settings import SettingsConstants
 
 logger = logging.getLogger(__name__)
@@ -19,7 +20,7 @@ class OPCODES:
 
 
 class PSBTParser():
-    def __init__(self, p: PSBT, seed: Seed, network: str = SettingsConstants.MAINNET):
+    def __init__(self, p: PSBT, seed: Seed | WIFKey, network: str = SettingsConstants.MAINNET):
         self.psbt: PSBT = p
         self.seed = seed
         self.network = network
@@ -66,7 +67,14 @@ class PSBTParser():
 
 
     def _set_root(self):
-        self.root = bip32.HDKey.from_seed(self.seed.seed_bytes, version=NETWORKS[SettingsConstants.map_network_to_embit(self.network)]["xprv"])
+        if isinstance(self.seed, WIFKey):
+            # root is a simple private key
+            self.root = self.seed.privkey
+        else:
+            self.root = bip32.HDKey.from_seed(
+                self.seed.seed_bytes,
+                version=NETWORKS[SettingsConstants.map_network_to_embit(self.network)]["xprv"],
+            )
 
 
     def parse(self):
@@ -152,7 +160,7 @@ class PSBTParser():
                     my_pubkey = None
 
                     # should be one or zero for single-key addresses
-                    if len(out.bip32_derivations.values()) > 0:
+                    if hasattr(self.root, "derive") and len(out.bip32_derivations.values()) > 0:
                         der = list(out.bip32_derivations.values())[0].derivation
                         my_pubkey = self.root.derive(der)
 
@@ -173,7 +181,7 @@ class PSBTParser():
                 elif "p2tr" in self.policy["type"]:
                     my_pubkey = None
                     # should have one or zero derivations for single-key addresses
-                    if len(out.taproot_bip32_derivations.values()) > 0:
+                    if hasattr(self.root, "derive") and len(out.taproot_bip32_derivations.values()) > 0:
                         # TODO: Support keys in taptree leaves
                         leaf_hashes, derivation = list(out.taproot_bip32_derivations.values())[0]
                         der = derivation.derivation

--- a/src/seedsigner/models/qr_type.py
+++ b/src/seedsigner/models/qr_type.py
@@ -27,6 +27,8 @@ class QRType:
 
     PASSPHRASE = "passphrase"
 
+    WIF = "wif"
+
     ENCRYPTION_KEY = "encryption_key"
 
     TEXT = "text"

--- a/src/seedsigner/models/wif.py
+++ b/src/seedsigner/models/wif.py
@@ -1,0 +1,24 @@
+import binascii
+from binascii import hexlify
+
+from embit import ec, hashes
+
+from seedsigner.models.seed import InvalidSeedException
+from seedsigner.models.settings import SettingsConstants
+
+
+class WIFKey:
+    """Container for a single WIF-encoded private key."""
+
+    def __init__(self, wif: str):
+        try:
+            self.privkey = ec.PrivateKey.from_wif(wif)
+        except Exception as e:
+            raise InvalidSeedException("Invalid WIF") from e
+        self.wif = wif
+
+    def get_fingerprint(self, network: str = SettingsConstants.MAINNET) -> str:
+        """Return BIP32-style fingerprint for the key's public key."""
+        pub = self.privkey.get_public_key()
+        fp = hashes.hash160(pub.sec())[:4]
+        return hexlify(fp).decode()

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -582,6 +582,8 @@ class PSBTFinalizeView(View):
     def run(self):
         from embit.psbt import PSBT
         from seedsigner.gui.screens.psbt_screens import PSBTFinalizeScreen
+        from seedsigner.models.wif import WIFKey
+        from embit.finalizer import finalize_psbt
 
         psbt_parser: PSBTParser = self.controller.psbt_parser
         psbt: PSBT = self.controller.psbt
@@ -610,6 +612,12 @@ class PSBTFinalizeView(View):
                 sign_psbt_with_satochip(psbt, self.controller.Satochip_Connector)
             else:
                 psbt.sign_with(psbt_parser.root)
+            if isinstance(self.controller.psbt_seed, WIFKey):
+                tx = finalize_psbt(psbt)
+                self.controller.signed_tx_hex = tx.serialize().hex() if tx else None
+            else:
+                self.controller.signed_tx_hex = None
+
             trimmed_psbt = PSBTParser.trim(psbt)
 
             if sig_cnt == PSBTParser.sig_count(trimmed_psbt):
@@ -623,12 +631,17 @@ class PSBTFinalizeView(View):
 
 class PSBTSignedQRDisplayView(View):
     def run(self):
-        from seedsigner.models.encode_qr import UrPsbtQrEncoder
+        from seedsigner.models.encode_qr import UrPsbtQrEncoder, GenericStringEncoder
+        from seedsigner.models.wif import WIFKey
 
-        qr_encoder = UrPsbtQrEncoder(
-            psbt=self.controller.psbt,
-            qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
-        )
+        if isinstance(self.controller.psbt_seed, WIFKey) and getattr(self.controller, "signed_tx_hex", None):
+            qr_encoder = GenericStringEncoder(self.controller.signed_tx_hex)
+        else:
+            qr_encoder = UrPsbtQrEncoder(
+                psbt=self.controller.psbt,
+                qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
+            )
+
         self.run_screen(QRDisplayScreen, qr_encoder=qr_encoder)
 
         # We're done with this PSBT. Route back to MainMenuView which always

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -17,6 +17,8 @@ class PSBTSelectSeedView(View):
     TYPE_21WORD = ButtonOption("Enter 21-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=21)
     TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=24)
     TYPE_ELECTRUM = ButtonOption("Enter Electrum seed", FontAwesomeIconConstants.KEYBOARD)
+    TYPE_WIF = ButtonOption("Enter WIF", FontAwesomeIconConstants.KEYBOARD)
+    SCAN_WIF = ButtonOption("Scan WIF", SeedSignerIconConstants.QRCODE)
 
 
     def run(self):
@@ -46,6 +48,7 @@ class PSBTSelectSeedView(View):
 
         button_data.append(self.SATOCHIP)
         button_data.append(self.SCAN_SEED)
+        button_data.append(self.SCAN_WIF)
         seed_lengths = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
         options = {
             12: self.TYPE_12WORD,
@@ -58,6 +61,7 @@ class PSBTSelectSeedView(View):
             button_data.append(options[l])
         if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_ELECTRUM)
+        button_data.append(self.TYPE_WIF)
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,
@@ -81,6 +85,10 @@ class PSBTSelectSeedView(View):
             from seedsigner.views.scan_views import ScanSeedQRView
             return Destination(ScanSeedQRView)
 
+        elif button_data[selected_menu_num] == self.SCAN_WIF:
+            from seedsigner.views.scan_views import ScanWIFQRView
+            return Destination(ScanWIFQRView)
+
         elif button_data[selected_menu_num] == self.SATOCHIP:
             from seedsigner.helpers import seedkeeper_utils
             connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
@@ -99,7 +107,42 @@ class PSBTSelectSeedView(View):
             from seedsigner.views.seed_views import SeedElectrumMnemonicStartView
             return Destination(SeedElectrumMnemonicStartView)
 
+        elif button_data[selected_menu_num] == self.TYPE_WIF:
+            return Destination(PSBTWIFEntryView)
 
+
+
+class PSBTWIFEntryView(View):
+    def run(self):
+        from seedsigner.gui.screens import seed_screens
+
+        ret = self.run_screen(
+            seed_screens.SeedAddPassphraseScreen,
+            title=_("Private Key (WIF)"),
+            passphrase="",
+        )
+
+        if "is_back_button" in ret:
+            return Destination(BackStackView)
+
+        wif = ret["passphrase"]
+        from seedsigner.models.wif import WIFKey
+        from seedsigner.models.seed import InvalidSeedException
+
+        try:
+            key = WIFKey(wif)
+        except InvalidSeedException:
+            self.run_screen(
+                DireWarningScreen,
+                status_headline=_("Invalid WIF!"),
+                text=_("Not a valid WIF-encoded private key."),
+                button_data=[ButtonOption("OK")],
+                show_back_button=False,
+            )
+            return Destination(PSBTSelectSeedView)
+
+        self.controller.psbt_seed = key
+        return Destination(PSBTOverviewView)
 
 class PSBTOverviewView(View):
     def __init__(self):

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -172,7 +172,15 @@ class ScanView(View):
                         message=qr_data["message"],
                     )
                 )
-            
+
+            elif self.decoder.is_wif:
+                from seedsigner.models.wif import WIFKey
+                from seedsigner.views.psbt_views import PSBTOverviewView
+
+                wif = self.decoder.get_wif()
+                self.controller.psbt_seed = WIFKey(wif)
+                return Destination(PSBTOverviewView, skip_current_view=True)
+
             elif self.decoder.is_encrypted_seedqr:
                 DECRYPT = ButtonOption("Decrypt")
                 CANCEL = ButtonOption("Cancel")
@@ -274,6 +282,15 @@ class ScanSlip39ShareQRView(ScanView):
             return Destination(ScanInvalidQRTypeView)
 
         return Destination(BackStackView)
+
+
+class ScanWIFQRView(ScanView):
+    instructions_text = _mft("Scan WIF")
+    invalid_qr_type_message = _mft("Expected a WIF private key")
+
+    @property
+    def is_valid_qr_type(self):
+        return self.decoder.is_wif
 
 
 

--- a/tests/test_flows_psbt.py
+++ b/tests/test_flows_psbt.py
@@ -169,3 +169,31 @@ class TestPSBTFlows(FlowTest):
             FlowStep(psbt_views.PSBTSignedQRDisplayView),
             FlowStep(MainMenuView)
         ])
+
+    def test_scan_psbt_then_scan_wif_flow(self):
+        from embit import ec, script, psbt
+        from embit.transaction import Transaction, TransactionInput, TransactionOutput
+        import os, base64
+
+        priv = ec.PrivateKey(os.urandom(32))
+        wif = priv.wif()
+        pub = priv.get_public_key()
+        spk = script.p2wpkh(pub)
+        tx = Transaction(1, [TransactionInput(b"\x00" * 32, 0)], [TransactionOutput(900, spk)], 0)
+        p = psbt.PSBT(tx)
+        p.inputs[0].witness_utxo = TransactionOutput(1000, spk)
+        psbt_b64 = base64.b64encode(p.serialize()).decode()
+
+        def load_psbt_into_decoder(view: scan_views.ScanView):
+            view.decoder.add_data(psbt_b64)
+
+        def load_wif_into_decoder(view: scan_views.ScanView):
+            view.decoder.add_data(wif)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_psbt_into_decoder),
+            FlowStep(psbt_views.PSBTSelectSeedView, button_data_selection=psbt_views.PSBTSelectSeedView.SCAN_WIF),
+            FlowStep(scan_views.ScanWIFQRView, before_run=load_wif_into_decoder),
+            FlowStep(psbt_views.PSBTOverviewView),
+        ])

--- a/tests/test_wif.py
+++ b/tests/test_wif.py
@@ -6,6 +6,7 @@ from seedsigner.models.wif import WIFKey
 from seedsigner.models.psbt_parser import PSBTParser
 from seedsigner.models.settings_definition import SettingsConstants
 from seedsigner.models.decode_qr import DecodeQR
+from base import BaseTest
 
 def test_wif_signs_psbt():
     priv = ec.PrivateKey(os.urandom(32))
@@ -30,3 +31,49 @@ def test_decode_qr_wif():
     assert decoder.is_complete
     assert decoder.is_wif
     assert decoder.get_wif() == wif
+
+
+class TestWIF(BaseTest):
+    def test_wif_signed_tx_qr_is_raw_hex(self):
+        from seedsigner.views.psbt_views import PSBTFinalizeView, PSBTSignedQRDisplayView
+        from seedsigner.models.encode_qr import GenericStringEncoder
+        from embit.finalizer import finalize_psbt
+        from seedsigner.controller import Controller
+
+        priv = ec.PrivateKey(os.urandom(32))
+        wif = priv.wif()
+        key = WIFKey(wif)
+        pub = priv.get_public_key()
+        spk = script.p2wpkh(pub)
+        tx = Transaction(1, [TransactionInput(b"\x00" * 32, 0)], [TransactionOutput(900, spk)], 0)
+        p = psbt.PSBT(tx)
+        p.inputs[0].witness_utxo = TransactionOutput(1000, spk)
+
+        # compute expected finalized tx
+        p_expected = psbt.PSBT.parse(p.serialize())
+        p_expected.sign_with(priv)
+        expected_hex = finalize_psbt(p_expected).serialize().hex()
+
+        # setup controller state
+        ctrl = Controller.get_instance()
+        ctrl.psbt = p
+        ctrl.psbt_seed = key
+        ctrl.psbt_parser = PSBTParser(p, seed=key, network=SettingsConstants.MAINNET)
+
+        finalize_view = PSBTFinalizeView()
+        finalize_view.run_screen = lambda *a, **k: 0
+        finalize_view.run()
+
+        captured = {}
+        display_view = PSBTSignedQRDisplayView()
+
+        def fake_run_screen(screen_cls, **kwargs):
+            captured["encoder"] = kwargs["qr_encoder"]
+            return 0
+
+        display_view.run_screen = fake_run_screen
+        display_view.run()
+
+        encoder = captured["encoder"]
+        assert isinstance(encoder, GenericStringEncoder)
+        assert encoder.next_part() == expected_hex

--- a/tests/test_wif.py
+++ b/tests/test_wif.py
@@ -1,0 +1,32 @@
+import os
+from embit import ec, script, psbt
+from embit.transaction import Transaction, TransactionInput, TransactionOutput
+
+from seedsigner.models.wif import WIFKey
+from seedsigner.models.psbt_parser import PSBTParser
+from seedsigner.models.settings_definition import SettingsConstants
+from seedsigner.models.decode_qr import DecodeQR
+
+def test_wif_signs_psbt():
+    priv = ec.PrivateKey(os.urandom(32))
+    wif = priv.wif()
+    key = WIFKey(wif)
+    pub = priv.get_public_key()
+    spk = script.p2wpkh(pub)
+    tx = Transaction(1, [TransactionInput(b"\x00" * 32, 0)], [TransactionOutput(900, spk)], 0)
+    p = psbt.PSBT(tx)
+    p.inputs[0].witness_utxo = TransactionOutput(1000, spk)
+    parser = PSBTParser(p, seed=key, network=SettingsConstants.MAINNET)
+    assert isinstance(parser.root, ec.PrivateKey)
+    p.sign_with(parser.root)
+    assert PSBTParser.sig_count(p) == 1
+
+
+def test_decode_qr_wif():
+    priv = ec.PrivateKey(os.urandom(32))
+    wif = priv.wif()
+    decoder = DecodeQR()
+    decoder.add_data(wif)
+    assert decoder.is_complete
+    assert decoder.is_wif
+    assert decoder.get_wif() == wif


### PR DESCRIPTION
## Summary
- allow selecting a WIF private key for PSBT signing
- support WIF keys in PSBT parser and signing logic
- test WIF signing capability
- allow scanning WIF keys via QR codes for PSBT signing

## Testing
- `pytest tests/test_wif.py`
- `pytest tests/test_flows_psbt.py::TestPSBTFlows::test_scan_psbt_then_scan_wif_flow`
- `pytest tests/test_psbt_parser.py::test_p2tr_change_detection`


------
https://chatgpt.com/codex/tasks/task_e_688f6de422ac83229d56beb2a83ba0de