### PR TITLE
Return to signer selection after Satochip failure

### DIFF
--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -93,7 +93,7 @@ class PSBTSelectSeedView(View):
 
             connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
             if not connector:
-                return Destination(BackStackView)
+                return Destination(PSBTSelectSeedView, clear_history=True)
 
             network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
             is_mainnet = network == SettingsConstants.MAINNET
@@ -132,7 +132,7 @@ class PSBTSelectSeedView(View):
                     status_headline=None,
                     text=str(e),
                 )
-                return Destination(BackStackView)
+                return Destination(PSBTSelectSeedView, clear_history=True)
 
             root_key = HDKey.from_base58(account_xpub)
             master_fp = HDKey.from_base58(master_xpub).my_fingerprint
@@ -154,7 +154,7 @@ class PSBTSelectSeedView(View):
                     status_headline=None,
                     text=str(e),
                 )
-                return Destination(BackStackView)
+                return Destination(PSBTSelectSeedView, clear_history=True)
 
             self.controller.psbt_seed = None
             self.controller.psbt_sign_with_satochip = True

--- a/tests/test_flows_psbt.py
+++ b/tests/test_flows_psbt.py
@@ -169,3 +169,30 @@ class TestPSBTFlows(FlowTest):
             FlowStep(psbt_views.PSBTSignedQRDisplayView),
             FlowStep(MainMenuView)
         ])
+
+
+class TestPSBTSatochip(FlowTest):
+
+    def test_satochip_connect_failure_returns_to_select_menu(self, monkeypatch):
+        """Satochip connection failure should return to the signer selection menu."""
+        from seedsigner.views import scan_views, psbt_views
+        from seedsigner.views.view import MainMenuView
+        from seedsigner.helpers import seedkeeper_utils
+
+        def load_psbt_into_decoder(view: scan_views.ScanView):
+            # Single sig PSBT for tests
+            view.decoder.add_data(
+                "cHNidP8BAHECAAAAAX9/d6VyI7nvVTyhLBfqu05za2AJ2Z0dKMC0cUX+S2U7AQAAAAD9////AgeHAAAAAAAAFgAUOnNPuZMD1sQudt3+7LvHBUvGhyd//gAAAAAAABYAFGO9QLvu4V9/hz6ZjbIGMrqsEiIYAjQTAAABAR+ghgEAAAAAABYAFKawrgcT62jmIVQwyHPCV0thmJWbAQDBAQAAAAABAYeHL9UQlz/jEKUuNNY3LTeQRjudjBinsP2L0ppvgRt0AAAAAAD/////AnbP3rsPAAAAIlEgtgmCioGjfKwp6f8rOoI4OPb+ZV8db581J9IizZPskl2ghgEAAAAAABYAFKawrgcT62jmIVQwyHPCV0thmJWbAUDCBlMh9VjZN2NdU9Wabi0o3Ct1q9YHTsJRLAkLfUuIHB+BE+ucR4bdGAJG5nBhCWOmCXbpRwKP1INRYvkuQ2fHAAAAACIGA2+PEYHyVy6nhYwAx5SJKBIWXjsWgjhhf/2FEWqXgxnoEKNOC3gAAACAAAAAAAAAAAAAACICA0SBeeHxfHdny6rUnQJuteAnQ7shSydexjJCkSJarn3mEKNOC3gAAACAAQAAAAEAAAAA"
+            )
+
+        def mock_init_satochip(parent, init_card_filter=None, require_pin=True):
+            return None
+
+        monkeypatch.setattr(seedkeeper_utils, "init_satochip", mock_init_satochip)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_psbt_into_decoder),
+            FlowStep(psbt_views.PSBTSelectSeedView, button_data_selection=psbt_views.PSBTSelectSeedView.SATOCHIP),
+            FlowStep(psbt_views.PSBTSelectSeedView),
+        ])


### PR DESCRIPTION
## Summary
- Redirect Satochip connection or parsing failures back to the PSBT signer selection menu
- Add regression test ensuring Satochip failures return to the selection screen

## Testing
- `pytest tests/test_flows_psbt.py::TestPSBTSatochip::test_satochip_connect_failure_returns_to_select_menu -q`
- `pytest tests/test_flows_psbt.py::TestPSBTFlows::test_scan_psbt_first_then_correct_seedqr_flow -q`


------
https://chatgpt.com/codex/tasks/task_e_688ff3bb571083228e03a5694294eff6