### PR TITLE
Add loading screens for PSBT operations

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: seedsigner 0.8.6\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-08-02 16:56+0000\n"
+"POT-Creation-Date: 2025-08-04 00:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -150,7 +150,7 @@ msgstr ""
 
 #: src/seedsigner/gui/screens/psbt_screens.py
 #: src/seedsigner/models/settings_definition.py
-#: src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
 msgid "Multisig"
 msgstr ""
 
@@ -230,6 +230,7 @@ msgid "Caution"
 msgstr ""
 
 #: src/seedsigner/gui/screens/screen.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/tools_views.py
 msgid "Privacy Leak!"
 msgstr ""
 
@@ -318,11 +319,6 @@ msgid "Derivation Path"
 msgstr ""
 
 #: src/seedsigner/gui/screens/seed_screens.py
-#: src/seedsigner/views/seed_views.py
-msgid "Export Xpub"
-msgstr ""
-
-#: src/seedsigner/gui/screens/seed_screens.py
 msgid "Xpub Details"
 msgstr ""
 
@@ -381,6 +377,7 @@ msgstr ""
 
 #. Refers to the SeedQR type: Standard or Compact or encrypted
 #: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
 msgid "Encrypted"
 msgstr ""
 
@@ -766,7 +763,7 @@ msgid "30 minutes"
 msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
-#: src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
 msgid "Single Sig"
 msgstr ""
 
@@ -816,7 +813,11 @@ msgid "Denomination display"
 msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
-msgid "Wipe timer"
+msgid "Smartcard PIN Attempts"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
 msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
@@ -840,6 +841,10 @@ msgid "Script types"
 msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
 msgid "Show xpub details"
 msgstr ""
 
@@ -860,6 +865,14 @@ msgid "BIP-85 child seeds"
 msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
 msgid "Electrum seeds"
 msgstr ""
 
@@ -869,6 +882,10 @@ msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Message signing"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
 msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
@@ -908,8 +925,27 @@ msgid "Scan a seed"
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
 #: src/seedsigner/views/tools_views.py
 msgid "Enter 12-word seed"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
@@ -1031,6 +1067,14 @@ msgid "Approve PSBT"
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
 msgid "Select Diff Seed"
 msgstr ""
 
@@ -1110,6 +1154,11 @@ msgstr ""
 msgid "Expected an address QR"
 msgstr ""
 
+#: src/seedsigner/views/scan_views.py
+#, python-brace-format
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr ""
+
 #: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
 msgid "Type encryption key"
 msgstr ""
@@ -1162,10 +1211,6 @@ msgstr ""
 
 #: src/seedsigner/views/seed_views.py
 msgid "In-Memory Seeds"
-msgstr ""
-
-#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
-msgid "Enter 18-word seed"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
@@ -1350,6 +1395,10 @@ msgstr ""
 msgid "Verify Addr"
 msgstr ""
 
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Export Xpub"
+msgstr ""
+
 #: src/seedsigner/views/seed_views.py
 msgid "BIP-85 Child Seed"
 msgstr ""
@@ -1378,12 +1427,21 @@ msgstr ""
 msgid "Regenerate Shares"
 msgstr ""
 
-#: src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
 msgid "Xpub can be used to view all future transactions."
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
 msgid "Generating xpub..."
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/view.py
+msgid "Scan"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
@@ -1476,30 +1534,6 @@ msgstr ""
 
 #: src/seedsigner/views/seed_views.py
 msgid "All mnemonic backup words were successfully verified!"
-msgstr ""
-
-#: src/seedsigner/views/seed_views.py
-msgid "Standard: 25x25"
-msgstr ""
-
-#: src/seedsigner/views/seed_views.py
-msgid "Compact: 21x21"
-msgstr ""
-
-#: src/seedsigner/views/seed_views.py
-msgid "Encrypted: 29x29"
-msgstr ""
-
-#: src/seedsigner/views/seed_views.py
-msgid "Standard: 29x29"
-msgstr ""
-
-#: src/seedsigner/views/seed_views.py
-msgid "Compact: 25x25"
-msgstr ""
-
-#: src/seedsigner/views/seed_views.py
-msgid "Encrypted: 33x33"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
@@ -1628,7 +1662,25 @@ msgid "Skip 10"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-msgid "Can't validate a single sig addr without specifying a seed"
+msgid "Wallet Export"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Address format doesn't match exported script type. Wallet export "
+"unsuccessful."
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
@@ -1740,6 +1792,18 @@ msgid "12 words"
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
 msgid "24 words"
 msgstr ""
 
@@ -1811,6 +1875,10 @@ msgstr ""
 
 #: src/seedsigner/views/tools_views.py
 msgid "Loaded Multisig Descriptor"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py
@@ -1937,6 +2005,10 @@ msgid "Enable 2FA"
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py
+msgid "Load as Descriptor"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
 msgid "Build Applets"
 msgstr ""
 
@@ -2048,10 +2120,6 @@ msgstr ""
 
 #: src/seedsigner/views/tools_views.py
 msgid "Decoded Text"
-msgstr ""
-
-#: src/seedsigner/views/view.py
-msgid "Scan"
 msgstr ""
 
 #: src/seedsigner/views/view.py

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -93,7 +93,7 @@ class PSBTSelectSeedView(View):
 
             connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
             if not connector:
-                return Destination(BackStackView)
+                return Destination(PSBTSelectSeedView, clear_history=True)
 
             network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
             is_mainnet = network == SettingsConstants.MAINNET
@@ -136,7 +136,7 @@ class PSBTSelectSeedView(View):
                         status_headline=None,
                         text=str(e),
                     )
-                    return Destination(BackStackView)
+                    return Destination(PSBTSelectSeedView, clear_history=True)
 
                 root_key = HDKey.from_base58(account_xpub)
                 master_fp = HDKey.from_base58(master_xpub).my_fingerprint
@@ -158,7 +158,7 @@ class PSBTSelectSeedView(View):
                         status_headline=None,
                         text=str(e),
                     )
-                    return Destination(BackStackView)
+                    return Destination(PSBTSelectSeedView, clear_history=True)
             finally:
                 loading.stop()
 

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -121,43 +121,44 @@ class PSBTSelectSeedView(View):
                 48: "p2wsh-p2sh" if len(account_path) > 3 and (account_path[3] & 0x7FFFFFFF) == 1 else "p2wsh",
             }.get(purpose, "standard")
 
-            try:
-                account_xpub = connector.card_bip32_get_xpub(account_path_str, xtype, is_mainnet)
-                master_xpub = connector.card_bip32_get_xpub("", xtype, is_mainnet)
-            except Exception as e:
-                logger.exception("Failed to export xpub from Satochip card")
-                self.run_screen(
-                    WarningScreen,
-                    title="Failed",
-                    status_headline=None,
-                    text=str(e),
-                )
-                return Destination(BackStackView)
-
-            root_key = HDKey.from_base58(account_xpub)
-            master_fp = HDKey.from_base58(master_xpub).my_fingerprint
-
             from seedsigner.gui.screens.screen import LoadingScreenThread
             loading = LoadingScreenThread(text=_("Parsing PSBT..."))
             loading.start()
             try:
-                self.controller.psbt_parser = PSBTParser(
-                    self.controller.psbt,
-                    seed=None,
-                    root=root_key,
-                    root_path=account_path,
-                    master_fingerprint=master_fp,
-                    network=network,
-                )
-            except Exception as e:
-                logger.exception("Failed to parse PSBT with Satochip data")
-                self.run_screen(
-                    WarningScreen,
-                    title="Failed",
-                    status_headline=None,
-                    text=str(e),
-                )
-                return Destination(BackStackView)
+                try:
+                    account_xpub = connector.card_bip32_get_xpub(account_path_str, xtype, is_mainnet)
+                    master_xpub = connector.card_bip32_get_xpub("", xtype, is_mainnet)
+                except Exception as e:
+                    logger.exception("Failed to export xpub from Satochip card")
+                    self.run_screen(
+                        WarningScreen,
+                        title="Failed",
+                        status_headline=None,
+                        text=str(e),
+                    )
+                    return Destination(BackStackView)
+
+                root_key = HDKey.from_base58(account_xpub)
+                master_fp = HDKey.from_base58(master_xpub).my_fingerprint
+
+                try:
+                    self.controller.psbt_parser = PSBTParser(
+                        self.controller.psbt,
+                        seed=None,
+                        root=root_key,
+                        root_path=account_path,
+                        master_fingerprint=master_fp,
+                        network=network,
+                    )
+                except Exception as e:
+                    logger.exception("Failed to parse PSBT with Satochip data")
+                    self.run_screen(
+                        WarningScreen,
+                        title="Failed",
+                        status_headline=None,
+                        text=str(e),
+                    )
+                    return Destination(BackStackView)
             finally:
                 loading.stop()
 

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -137,6 +137,9 @@ class PSBTSelectSeedView(View):
             root_key = HDKey.from_base58(account_xpub)
             master_fp = HDKey.from_base58(master_xpub).my_fingerprint
 
+            from seedsigner.gui.screens.screen import LoadingScreenThread
+            loading = LoadingScreenThread(text=_("Parsing PSBT..."))
+            loading.start()
             try:
                 self.controller.psbt_parser = PSBTParser(
                     self.controller.psbt,
@@ -155,6 +158,8 @@ class PSBTSelectSeedView(View):
                     text=str(e),
                 )
                 return Destination(BackStackView)
+            finally:
+                loading.stop()
 
             self.controller.psbt_seed = None
             self.controller.psbt_sign_with_satochip = True
@@ -639,7 +644,7 @@ class PSBTFinalizeView(View):
 
         if not self.controller.psbt_sign_with_satochip and psbt_parser is None:
             return Destination(MainMenuView)
-        
+
         selected_menu_num = self.run_screen(
             PSBTFinalizeScreen,
             button_data=[self.APPROVE_PSBT]
@@ -648,7 +653,10 @@ class PSBTFinalizeView(View):
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        else:
+        from seedsigner.gui.screens.screen import LoadingScreenThread
+        loading = LoadingScreenThread(text=_("Signing PSBT..."))
+        loading.start()
+        try:
             sig_cnt = PSBTParser.sig_count(psbt)
             if self.controller.psbt_sign_with_satochip:
                 from seedsigner.helpers.satochip_signer import sign_psbt_with_satochip
@@ -658,24 +666,33 @@ class PSBTFinalizeView(View):
             else:
                 psbt.sign_with(psbt_parser.root)
             trimmed_psbt = PSBTParser.trim(psbt)
+        finally:
+            loading.stop()
 
-            if sig_cnt == PSBTParser.sig_count(trimmed_psbt):
-                return Destination(PSBTSigningErrorView)
+        if sig_cnt == PSBTParser.sig_count(trimmed_psbt):
+            return Destination(PSBTSigningErrorView)
 
-            self.controller.psbt = trimmed_psbt
-            self.controller.psbt_sign_with_satochip = False
-            return Destination(PSBTSignedQRDisplayView)
+        self.controller.psbt = trimmed_psbt
+        self.controller.psbt_sign_with_satochip = False
+        return Destination(PSBTSignedQRDisplayView)
 
 
 
 class PSBTSignedQRDisplayView(View):
     def run(self):
         from seedsigner.models.encode_qr import UrPsbtQrEncoder
+        from seedsigner.gui.screens.screen import LoadingScreenThread
 
-        qr_encoder = UrPsbtQrEncoder(
-            psbt=self.controller.psbt,
-            qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
-        )
+        loading = LoadingScreenThread(text=_("Encoding PSBT..."))
+        loading.start()
+        try:
+            qr_encoder = UrPsbtQrEncoder(
+                psbt=self.controller.psbt,
+                qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
+            )
+        finally:
+            loading.stop()
+
         self.run_screen(QRDisplayScreen, qr_encoder=qr_encoder)
 
         # We're done with this PSBT. Route back to MainMenuView which always

--- a/tests/test_flows_psbt.py
+++ b/tests/test_flows_psbt.py
@@ -169,3 +169,30 @@ class TestPSBTFlows(FlowTest):
             FlowStep(psbt_views.PSBTSignedQRDisplayView),
             FlowStep(MainMenuView)
         ])
+
+
+class TestPSBTSatochip(FlowTest):
+
+    def test_satochip_connect_failure_returns_to_select_menu(self, monkeypatch):
+        """Satochip connection failure should return to the signer selection menu."""
+        from seedsigner.views import scan_views, psbt_views
+        from seedsigner.views.view import MainMenuView
+        from seedsigner.helpers import seedkeeper_utils
+
+        def load_psbt_into_decoder(view: scan_views.ScanView):
+            # Single sig PSBT for tests
+            view.decoder.add_data(
+                "cHNidP8BAHECAAAAAX9/d6VyI7nvVTyhLBfqu05za2AJ2Z0dKMC0cUX+S2U7AQAAAAD9////AgeHAAAAAAAAFgAUOnNPuZMD1sQudt3+7LvHBUvGhyd//gAAAAAAABYAFGO9QLvu4V9/hz6ZjbIGMrqsEiIYAjQTAAABAR+ghgEAAAAAABYAFKawrgcT62jmIVQwyHPCV0thmJWbAQDBAQAAAAABAYeHL9UQlz/jEKUuNNY3LTeQRjudjBinsP2L0ppvgRt0AAAAAAD/////AnbP3rsPAAAAIlEgtgmCioGjfKwp6f8rOoI4OPb+ZV8db581J9IizZPskl2ghgEAAAAAABYAFKawrgcT62jmIVQwyHPCV0thmJWbAUDCBlMh9VjZN2NdU9Wabi0o3Ct1q9YHTsJRLAkLfUuIHB+BE+ucR4bdGAJG5nBhCWOmCXbpRwKP1INRYvkuQ2fHAAAAACIGA2+PEYHyVy6nhYwAx5SJKBIWXjsWgjhhf/2FEWqXgxnoEKNOC3gAAACAAAAAAAAAAAAAACICA0SBeeHxfHdny6rUnQJuteAnQ7shSydexjJCkSJarn3mEKNOC3gAAACAAQAAAAEAAAAA"
+            )
+
+        def mock_init_satochip(parent, init_card_filter=None, require_pin=True):
+            return None
+
+        monkeypatch.setattr(seedkeeper_utils, "init_satochip", mock_init_satochip)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_psbt_into_decoder),
+            FlowStep(psbt_views.PSBTSelectSeedView, button_data_selection=psbt_views.PSBTSelectSeedView.SATOCHIP),
+            FlowStep(psbt_views.PSBTSelectSeedView),
+        ])


### PR DESCRIPTION
## Summary
- show loading indicator when parsing PSBT after Satochip PIN verification
- display loading while signing PSBT and encoding QR

## Testing
- `pre-commit run --files src/seedsigner/views/psbt_views.py l10n/messages.pot` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest tests/test_flows_psbt.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688ff70b6f588322880d9b734726b3c9