### PR TITLE
Add WIF and BIP38 key import functionality

### DIFF
--- a/src/seedsigner/models/bip38.py
+++ b/src/seedsigner/models/bip38.py
@@ -1,0 +1,67 @@
+import hashlib
+
+from Cryptodome.Cipher import AES
+from embit import base58, ec, hashes
+
+from seedsigner.models.seed import InvalidSeedException
+from seedsigner.models.settings import SettingsConstants
+from seedsigner.models.wif import WIFKey
+
+
+class BIP38Key:
+    """Container for a BIP38 encrypted private key."""
+
+    def __init__(self, encrypted: str):
+        self.encrypted = encrypted
+        try:
+            data = base58.decode_check(encrypted)
+        except Exception as e:
+            raise InvalidSeedException("Invalid BIP38") from e
+
+        if len(data) != 39 or data[0] != 0x01 or data[1] != 0x42:
+            raise InvalidSeedException("Invalid BIP38")
+
+        flagbyte = data[2]
+        self.compressed = bool(flagbyte & 0x20)
+        self.address_hash = data[3:7]
+        self.encrypted_half1 = data[7:23]
+        self.encrypted_half2 = data[23:39]
+
+    def decrypt(self, passphrase: str, network: str = SettingsConstants.MAINNET) -> WIFKey:
+        """Decrypt the BIP38 key using the given passphrase."""
+
+        derived = hashlib.scrypt(
+            passphrase.encode("utf-8"),
+            salt=self.address_hash,
+            n=16384,
+            r=8,
+            p=8,
+            dklen=64,
+        )
+        derivedhalf1 = derived[:32]
+        derivedhalf2 = derived[32:]
+
+        aes = AES.new(derivedhalf2, AES.MODE_ECB)
+        decrypted_half1 = aes.decrypt(self.encrypted_half1)
+        decrypted_half2 = aes.decrypt(self.encrypted_half2)
+
+        priv = bytearray(32)
+        for i in range(16):
+            priv[i] = decrypted_half1[i] ^ derivedhalf1[i]
+            priv[i + 16] = decrypted_half2[i] ^ derivedhalf1[i + 16]
+        priv = bytes(priv)
+
+        pub = ec.PrivateKey(priv).get_public_key()
+        if not self.compressed:
+            pub.compressed = False
+        prefix = b"\x00" if network == SettingsConstants.MAINNET else b"\x6f"
+        h160 = hashes.hash160(pub.sec())
+        addr = base58.encode_check(prefix + h160)
+        if hashes.double_sha256(addr.encode("ascii"))[:4] != self.address_hash:
+            raise InvalidSeedException("Invalid passphrase")
+
+        wif_prefix = b"\x80" if network == SettingsConstants.MAINNET else b"\xef"
+        wif_bytes = wif_prefix + priv + (b"\x01" if self.compressed else b"")
+        wif = base58.encode_check(wif_bytes)
+        return WIFKey(wif)
+

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -5,7 +5,7 @@ import re
 
 from binascii import a2b_base64, b2a_base64
 from enum import IntEnum
-from embit import psbt, bip39
+from embit import psbt, bip39, ec
 from pyzbar import pyzbar
 from pyzbar.pyzbar import ZBarSymbol
 from urtypes.crypto import PSBT as UR_PSBT
@@ -120,6 +120,12 @@ class DecodeQR:
 
             elif self.qr_type == QRType.ENCRYPTION_KEY:
                 self.decoder = EncryptionKeyQrDecoder()
+
+            elif self.qr_type == QRType.WIF:
+                self.decoder = WifQrDecoder()
+
+            elif self.qr_type == QRType.BIP38:
+                self.decoder = Bip38QrDecoder()
 
             elif self.qr_type == QRType.TEXT:
                 self.decoder = TextQrDecoder()
@@ -244,6 +250,14 @@ class DecodeQR:
         if self.is_encryptionkey:
             return self.decoder.get_encryption_key()
 
+    def get_wif(self):
+        if self.is_wif:
+            return self.decoder.get_wif()
+
+    def get_bip38(self):
+        if self.is_bip38:
+            return self.decoder.get_bip38()
+
 
     def get_public_data(self):
         if self.is_encrypted_seedqr:
@@ -352,6 +366,14 @@ class DecodeQR:
     @property
     def is_sign_message(self):
         return self.qr_type == QRType.SIGN_MESSAGE
+
+    @property
+    def is_wif(self):
+        return self.qr_type == QRType.WIF
+
+    @property
+    def is_bip38(self):
+        return self.qr_type == QRType.BIP38
         
 
     @property
@@ -481,6 +503,21 @@ class DecodeQR:
 
             elif DecodeQR.is_base43_psbt(s):
                 return QRType.PSBT__BASE43
+
+            # WIF private key
+            try:
+                ec.PrivateKey.from_wif(s.strip())
+                return QRType.WIF
+            except Exception:
+                pass
+
+            # BIP38 encrypted key
+            try:
+                from seedsigner.models.bip38 import BIP38Key
+                BIP38Key(s.strip())
+                return QRType.BIP38
+            except Exception:
+                pass
 
         except UnicodeDecodeError:
             # Probably this isn't meant to be string data; check if it's valid byte data
@@ -1279,6 +1316,53 @@ class EncryptionKeyQrDecoder(BaseSingleFrameQrDecoder):
 
     def get_encryption_key(self):
         return self.encryption_key
+
+
+class WifQrDecoder(BaseSingleFrameQrDecoder):
+    """Decodes single frame representing a WIF-encoded private key."""
+
+    def __init__(self):
+        super().__init__()
+        self.wif = None
+
+    def add(self, segment, qr_type=QRType.WIF):
+        if qr_type == QRType.WIF:
+            try:
+                ec.PrivateKey.from_wif(segment)
+                self.wif = segment
+                self.complete = True
+                self.collected_segments = 1
+                return DecodeQRStatus.COMPLETE
+            except Exception as e:
+                logger.exception(repr(e))
+        return DecodeQRStatus.INVALID
+
+    def get_wif(self):
+        return self.wif
+
+
+class Bip38QrDecoder(BaseSingleFrameQrDecoder):
+    """Decodes single frame representing a BIP38-encrypted private key."""
+
+    def __init__(self):
+        super().__init__()
+        self.bip38 = None
+
+    def add(self, segment, qr_type=QRType.BIP38):
+        if qr_type == QRType.BIP38:
+            try:
+                from seedsigner.models.bip38 import BIP38Key
+                BIP38Key(segment)
+                self.bip38 = segment
+                self.complete = True
+                self.collected_segments = 1
+                return DecodeQRStatus.COMPLETE
+            except Exception as e:
+                logger.exception(repr(e))
+        return DecodeQRStatus.INVALID
+
+    def get_bip38(self):
+        return self.bip38
 
 
 

--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -10,6 +10,7 @@ from io import BytesIO
 from typing import List
 
 from seedsigner.models.seed import Seed
+from seedsigner.models.wif import WIFKey
 from seedsigner.models.settings import SettingsConstants
 
 logger = logging.getLogger(__name__)
@@ -24,7 +25,7 @@ class PSBTParser():
     def __init__(
         self,
         p: PSBT,
-        seed: Seed | None = None,
+        seed: Seed | WIFKey | None = None,
         *,
         root: bip32.HDKey | None = None,
         root_path: list[int] | None = None,
@@ -80,10 +81,14 @@ class PSBTParser():
 
     def _set_root(self):
         if self.seed is not None:
-            self.root = bip32.HDKey.from_seed(
-                self.seed.seed_bytes,
-                version=NETWORKS[SettingsConstants.map_network_to_embit(self.network)]["xprv"],
-            )
+            if isinstance(self.seed, WIFKey):
+                # root is a simple private key
+                self.root = self.seed.privkey
+            else:
+                self.root = bip32.HDKey.from_seed(
+                    self.seed.seed_bytes,
+                    version=NETWORKS[SettingsConstants.map_network_to_embit(self.network)]["xprv"],
+                )
         elif self.root is None:
             raise RuntimeError("No seed or root key available")
 
@@ -167,7 +172,7 @@ class PSBTParser():
                     my_pubkey = None
 
                     # should be one or zero for single-key addresses
-                    if len(out.bip32_derivations.values()) > 0:
+                    if hasattr(self.root, "derive") and len(out.bip32_derivations.values()) > 0:
                         der = list(out.bip32_derivations.values())[0].derivation
                         der = der[len(self.root_path):]
                         my_pubkey = self.root.derive(der)
@@ -189,7 +194,7 @@ class PSBTParser():
                 elif "p2tr" in self.policy["type"]:
                     my_pubkey = None
                     # should have one or zero derivations for single-key addresses
-                    if len(out.taproot_bip32_derivations.values()) > 0:
+                    if hasattr(self.root, "derive") and len(out.taproot_bip32_derivations.values()) > 0:
                         # TODO: Support keys in taptree leaves
                         leaf_hashes, derivation = list(out.taproot_bip32_derivations.values())[0]
                         der = derivation.derivation[len(self.root_path):]

--- a/src/seedsigner/models/qr_type.py
+++ b/src/seedsigner/models/qr_type.py
@@ -27,6 +27,9 @@ class QRType:
 
     PASSPHRASE = "passphrase"
 
+    WIF = "wif"
+    BIP38 = "bip38"
+
     ENCRYPTION_KEY = "encryption_key"
 
     TEXT = "text"

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -383,7 +383,9 @@ class SettingsConstants:
     SETTING__ENCRYPTED_QR = "encrypted_qr"
     SETTING__ENCRYPTION_MODE = "version"
     SETTING__ENCRYPTION_ITER = "pbkdf2_iterations"
-    
+    SETTING__WIF_KEYS = "wif_keys"
+    SETTING__BIP38_KEYS = "bip38_keys"
+
     SETTING__DEBUG = "debug"
 
 
@@ -779,6 +781,18 @@ class SettingsDefinition:
                       type=SettingsConstants.TYPE__FREE_ENTRY,
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.ENCRYPTION_ITERATIONS),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__WIF_KEYS,
+                      display_name="WIF keys",
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      default_value=SettingsConstants.OPTION__ENABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__BIP38_KEYS,
+                      display_name="BIP38 keys",
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      default_value=SettingsConstants.OPTION__ENABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__BIP85_CHILD_SEEDS,

--- a/src/seedsigner/models/wif.py
+++ b/src/seedsigner/models/wif.py
@@ -1,0 +1,24 @@
+import binascii
+from binascii import hexlify
+
+from embit import ec, hashes
+
+from seedsigner.models.seed import InvalidSeedException
+from seedsigner.models.settings import SettingsConstants
+
+
+class WIFKey:
+    """Container for a single WIF-encoded private key."""
+
+    def __init__(self, wif: str):
+        try:
+            self.privkey = ec.PrivateKey.from_wif(wif)
+        except Exception as e:
+            raise InvalidSeedException("Invalid WIF") from e
+        self.wif = wif
+
+    def get_fingerprint(self, network: str = SettingsConstants.MAINNET) -> str:
+        """Return BIP32-style fingerprint for the key's public key."""
+        pub = self.privkey.get_public_key()
+        fp = hashes.hash160(pub.sec())[:4]
+        return hexlify(fp).decode()

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -23,6 +23,10 @@ class PSBTSelectSeedView(View):
     TYPE_21WORD = ButtonOption("Enter 21-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=21)
     TYPE_24WORD = ButtonOption("Enter 24-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=24)
     TYPE_ELECTRUM = ButtonOption("Enter Electrum seed", FontAwesomeIconConstants.KEYBOARD)
+    TYPE_WIF = ButtonOption("Enter WIF", FontAwesomeIconConstants.KEYBOARD)
+    SCAN_WIF = ButtonOption("Scan WIF", SeedSignerIconConstants.QRCODE)
+    TYPE_BIP38 = ButtonOption("Enter BIP38", FontAwesomeIconConstants.KEYBOARD)
+    SCAN_BIP38 = ButtonOption("Scan BIP38", SeedSignerIconConstants.QRCODE)
 
 
     def run(self):
@@ -52,6 +56,10 @@ class PSBTSelectSeedView(View):
 
         button_data.append(self.SATOCHIP)
         button_data.append(self.SCAN_SEED)
+        if self.settings.get_value(SettingsConstants.SETTING__WIF_KEYS) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.SCAN_WIF)
+        if self.settings.get_value(SettingsConstants.SETTING__BIP38_KEYS) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.SCAN_BIP38)
         seed_lengths = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
         options = {
             12: self.TYPE_12WORD,
@@ -64,6 +72,10 @@ class PSBTSelectSeedView(View):
             button_data.append(options[l])
         if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_ELECTRUM)
+        if self.settings.get_value(SettingsConstants.SETTING__WIF_KEYS) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.TYPE_WIF)
+        if self.settings.get_value(SettingsConstants.SETTING__BIP38_KEYS) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.TYPE_BIP38)
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,
@@ -86,6 +98,14 @@ class PSBTSelectSeedView(View):
         if button_data[selected_menu_num] == self.SCAN_SEED:
             from seedsigner.views.scan_views import ScanSeedQRView
             return Destination(ScanSeedQRView)
+
+        elif button_data[selected_menu_num] == self.SCAN_WIF:
+            from seedsigner.views.scan_views import ScanWIFQRView
+            return Destination(ScanWIFQRView)
+
+        elif button_data[selected_menu_num] == self.SCAN_BIP38:
+            from seedsigner.views.scan_views import ScanBIP38QRView
+            return Destination(ScanBIP38QRView)
 
         elif button_data[selected_menu_num] == self.SATOCHIP:
             from seedsigner.helpers import seedkeeper_utils
@@ -175,7 +195,98 @@ class PSBTSelectSeedView(View):
             from seedsigner.views.seed_views import SeedElectrumMnemonicStartView
             return Destination(SeedElectrumMnemonicStartView)
 
+        elif button_data[selected_menu_num] == self.TYPE_WIF:
+            return Destination(PSBTWIFEntryView)
 
+        elif button_data[selected_menu_num] == self.TYPE_BIP38:
+            return Destination(PSBTBIP38EntryView)
+
+
+
+class PSBTWIFEntryView(View):
+    def run(self):
+        from seedsigner.gui.screens import seed_screens
+
+        ret = self.run_screen(
+            seed_screens.SeedAddPassphraseScreen,
+            title=_("Private Key (WIF)"),
+            passphrase="",
+        )
+
+        if "is_back_button" in ret:
+            return Destination(BackStackView)
+
+        wif = ret["passphrase"]
+        from seedsigner.models.wif import WIFKey
+        from seedsigner.models.seed import InvalidSeedException
+
+        try:
+            key = WIFKey(wif)
+        except InvalidSeedException:
+            self.run_screen(
+                DireWarningScreen,
+                status_headline=_("Invalid WIF!"),
+                text=_("Not a valid WIF-encoded private key."),
+                button_data=[ButtonOption("OK")],
+                show_back_button=False,
+            )
+            return Destination(PSBTSelectSeedView)
+
+        self.controller.psbt_seed = key
+        return Destination(PSBTOverviewView)
+
+
+class PSBTBIP38EntryView(View):
+    def run(self):
+        from seedsigner.gui.screens import seed_screens
+
+        ret = self.run_screen(
+            seed_screens.SeedAddPassphraseScreen,
+            title=_("BIP38 Key"),
+            passphrase="",
+        )
+
+        if "is_back_button" in ret:
+            return Destination(BackStackView)
+
+        bip38 = ret["passphrase"]
+        return Destination(PSBTBIP38PassphraseView, view_args=dict(encrypted=bip38))
+
+
+class PSBTBIP38PassphraseView(View):
+    def __init__(self, encrypted: str):
+        super().__init__()
+        self.encrypted = encrypted
+
+    def run(self):
+        from seedsigner.gui.screens import seed_screens
+        from seedsigner.models.bip38 import BIP38Key
+        from seedsigner.models.seed import InvalidSeedException
+
+        ret = self.run_screen(
+            seed_screens.SeedAddPassphraseScreen,
+            title=_("BIP38 Passphrase"),
+            passphrase="",
+        )
+
+        if "is_back_button" in ret:
+            return Destination(BackStackView)
+
+        passphrase = ret["passphrase"]
+        try:
+            key = BIP38Key(self.encrypted).decrypt(passphrase, self.settings.get_value(SettingsConstants.SETTING__NETWORK))
+        except InvalidSeedException:
+            self.run_screen(
+                DireWarningScreen,
+                status_headline=_("Invalid BIP38!"),
+                text=_("Could not decrypt BIP38 key."),
+                button_data=[ButtonOption("OK")],
+                show_back_button=False,
+            )
+            return Destination(PSBTSelectSeedView)
+
+        self.controller.psbt_seed = key
+        return Destination(PSBTOverviewView)
 
 class PSBTOverviewView(View):
     def __init__(self):
@@ -635,6 +746,8 @@ class PSBTFinalizeView(View):
     def run(self):
         from embit.psbt import PSBT
         from seedsigner.gui.screens.psbt_screens import PSBTFinalizeScreen
+        from seedsigner.models.wif import WIFKey
+        from embit.finalizer import finalize_psbt
 
         psbt_parser: PSBTParser = self.controller.psbt_parser
         psbt: PSBT = self.controller.psbt
@@ -666,6 +779,12 @@ class PSBTFinalizeView(View):
                 sign_psbt_with_satochip(psbt, self.controller.Satochip_Connector)
             else:
                 psbt.sign_with(psbt_parser.root)
+            if isinstance(self.controller.psbt_seed, WIFKey):
+                tx = finalize_psbt(psbt)
+                self.controller.signed_tx_hex = tx.serialize().hex() if tx else None
+            else:
+                self.controller.signed_tx_hex = None
+
             trimmed_psbt = PSBTParser.trim(psbt)
         finally:
             loading.stop()
@@ -681,18 +800,22 @@ class PSBTFinalizeView(View):
 
 class PSBTSignedQRDisplayView(View):
     def run(self):
-        from seedsigner.models.encode_qr import UrPsbtQrEncoder
+        from seedsigner.models.encode_qr import UrPsbtQrEncoder, GenericStringEncoder
+        from seedsigner.models.wif import WIFKey
         from seedsigner.gui.screens.screen import LoadingScreenThread
 
-        loading = LoadingScreenThread(text=_("Encoding PSBT..."))
-        loading.start()
-        try:
-            qr_encoder = UrPsbtQrEncoder(
-                psbt=self.controller.psbt,
-                qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
-            )
-        finally:
-            loading.stop()
+        if isinstance(self.controller.psbt_seed, WIFKey) and getattr(self.controller, "signed_tx_hex", None):
+            qr_encoder = GenericStringEncoder(self.controller.signed_tx_hex)
+        else:
+            loading = LoadingScreenThread(text=_("Encoding PSBT..."))
+            loading.start()
+            try:
+                qr_encoder = UrPsbtQrEncoder(
+                    psbt=self.controller.psbt,
+                    qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
+                )
+            finally:
+                loading.stop()
 
         self.run_screen(QRDisplayScreen, qr_encoder=qr_encoder)
 

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -172,7 +172,27 @@ class ScanView(View):
                         message=qr_data["message"],
                     )
                 )
-            
+
+            elif self.decoder.is_bip38:
+                if self.settings.get_value(SettingsConstants.SETTING__BIP38_KEYS) == SettingsConstants.OPTION__ENABLED:
+                    from seedsigner.views.psbt_views import PSBTBIP38PassphraseView
+
+                    bip38 = self.decoder.get_bip38()
+                    return Destination(PSBTBIP38PassphraseView, view_args=dict(encrypted=bip38), skip_current_view=True)
+                else:
+                    return Destination(ScanInvalidQRTypeView)
+
+            elif self.decoder.is_wif:
+                if self.settings.get_value(SettingsConstants.SETTING__WIF_KEYS) == SettingsConstants.OPTION__ENABLED:
+                    from seedsigner.models.wif import WIFKey
+                    from seedsigner.views.psbt_views import PSBTOverviewView
+
+                    wif = self.decoder.get_wif()
+                    self.controller.psbt_seed = WIFKey(wif)
+                    return Destination(PSBTOverviewView, skip_current_view=True)
+                else:
+                    return Destination(ScanInvalidQRTypeView)
+
             elif self.decoder.is_encrypted_seedqr:
                 DECRYPT = ButtonOption("Decrypt")
                 CANCEL = ButtonOption("Cancel")
@@ -274,6 +294,30 @@ class ScanSlip39ShareQRView(ScanView):
             return Destination(ScanInvalidQRTypeView)
 
         return Destination(BackStackView)
+
+
+class ScanWIFQRView(ScanView):
+    instructions_text = _mft("Scan WIF")
+    invalid_qr_type_message = _mft("Expected a WIF private key")
+
+    @property
+    def is_valid_qr_type(self):
+        return (
+            self.settings.get_value(SettingsConstants.SETTING__WIF_KEYS) == SettingsConstants.OPTION__ENABLED
+            and self.decoder.is_wif
+        )
+
+
+class ScanBIP38QRView(ScanView):
+    instructions_text = _mft("Scan BIP38")
+    invalid_qr_type_message = _mft("Expected a BIP38 private key")
+
+    @property
+    def is_valid_qr_type(self):
+        return (
+            self.settings.get_value(SettingsConstants.SETTING__BIP38_KEYS) == SettingsConstants.OPTION__ENABLED
+            and self.decoder.is_bip38
+        )
 
 
 

--- a/tests/test_bip38.py
+++ b/tests/test_bip38.py
@@ -1,0 +1,85 @@
+from embit import ec, script, psbt
+from embit.transaction import Transaction, TransactionInput, TransactionOutput
+
+from seedsigner.models.bip38 import BIP38Key
+from seedsigner.models.psbt_parser import PSBTParser
+from seedsigner.models.settings_definition import SettingsConstants
+from seedsigner.models.decode_qr import DecodeQR
+from base import BaseTest
+
+
+def test_bip38_signs_psbt():
+    enc = "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg"
+    bip38 = BIP38Key(enc)
+    key = bip38.decrypt("TestingOneTwoThree")
+
+    priv = key.privkey
+    pub = priv.get_public_key()
+    spk = script.p2wpkh(pub)
+    tx = Transaction(1, [TransactionInput(b"\x00" * 32, 0)], [TransactionOutput(900, spk)], 0)
+    p = psbt.PSBT(tx)
+    p.inputs[0].witness_utxo = TransactionOutput(1000, spk)
+    parser = PSBTParser(p, seed=key, network=SettingsConstants.MAINNET)
+    assert isinstance(parser.root, ec.PrivateKey)
+    p.sign_with(parser.root)
+    assert PSBTParser.sig_count(p) == 1
+
+
+def test_decode_qr_bip38():
+    enc = "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg"
+    decoder = DecodeQR()
+    decoder.add_data(enc)
+    assert decoder.is_complete
+    assert decoder.is_bip38
+    assert decoder.get_bip38() == enc
+
+
+class TestBIP38Settings(BaseTest):
+    def test_bip38_setting_disables_options(self):
+        from seedsigner.views import psbt_views
+        from embit import ec, script, psbt
+        from embit.transaction import Transaction, TransactionInput, TransactionOutput
+        import os
+
+        self.settings.set_value(SettingsConstants.SETTING__BIP38_KEYS, SettingsConstants.OPTION__DISABLED)
+
+        priv = ec.PrivateKey(os.urandom(32))
+        pub = priv.get_public_key()
+        spk = script.p2wpkh(pub)
+        tx = Transaction(1, [TransactionInput(b"\x00" * 32, 0)], [TransactionOutput(900, spk)], 0)
+        p = psbt.PSBT(tx)
+        p.inputs[0].witness_utxo = TransactionOutput(1000, spk)
+        self.controller.psbt = p
+        self.controller._storage = type("s", (), {})()
+        self.controller._storage.seeds = []
+
+        # Build button list as PSBTSelectSeedView would
+        buttons = [
+            psbt_views.PSBTSelectSeedView.SATOCHIP,
+            psbt_views.PSBTSelectSeedView.SCAN_SEED,
+        ]
+        if self.settings.get_value(SettingsConstants.SETTING__WIF_KEYS) == SettingsConstants.OPTION__ENABLED:
+            buttons.append(psbt_views.PSBTSelectSeedView.SCAN_WIF)
+        if self.settings.get_value(SettingsConstants.SETTING__BIP38_KEYS) == SettingsConstants.OPTION__ENABLED:
+            buttons.append(psbt_views.PSBTSelectSeedView.SCAN_BIP38)
+
+        seed_lengths = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
+        options = {
+            12: psbt_views.PSBTSelectSeedView.TYPE_12WORD,
+            15: psbt_views.PSBTSelectSeedView.TYPE_15WORD,
+            18: psbt_views.PSBTSelectSeedView.TYPE_18WORD,
+            21: psbt_views.PSBTSelectSeedView.TYPE_21WORD,
+            24: psbt_views.PSBTSelectSeedView.TYPE_24WORD,
+        }
+        for l in seed_lengths:
+            buttons.append(options[l])
+        if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
+            buttons.append(psbt_views.PSBTSelectSeedView.TYPE_ELECTRUM)
+        if self.settings.get_value(SettingsConstants.SETTING__WIF_KEYS) == SettingsConstants.OPTION__ENABLED:
+            buttons.append(psbt_views.PSBTSelectSeedView.TYPE_WIF)
+        if self.settings.get_value(SettingsConstants.SETTING__BIP38_KEYS) == SettingsConstants.OPTION__ENABLED:
+            buttons.append(psbt_views.PSBTSelectSeedView.TYPE_BIP38)
+
+        assert psbt_views.PSBTSelectSeedView.SCAN_BIP38 not in buttons
+        assert psbt_views.PSBTSelectSeedView.TYPE_BIP38 not in buttons
+

--- a/tests/test_flows_psbt.py
+++ b/tests/test_flows_psbt.py
@@ -171,6 +171,66 @@ class TestPSBTFlows(FlowTest):
         ])
 
 
+    def test_scan_psbt_then_scan_wif_flow(self):
+        from embit import ec, script, psbt
+        from embit.transaction import Transaction, TransactionInput, TransactionOutput
+        import os, base64
+
+        priv = ec.PrivateKey(os.urandom(32))
+        wif = priv.wif()
+        pub = priv.get_public_key()
+        spk = script.p2wpkh(pub)
+        tx = Transaction(1, [TransactionInput(b"\x00" * 32, 0)], [TransactionOutput(900, spk)], 0)
+        p = psbt.PSBT(tx)
+        p.inputs[0].witness_utxo = TransactionOutput(1000, spk)
+        psbt_b64 = base64.b64encode(p.serialize()).decode()
+
+        def load_psbt_into_decoder(view: scan_views.ScanView):
+            view.decoder.add_data(psbt_b64)
+
+        def load_wif_into_decoder(view: scan_views.ScanView):
+            view.decoder.add_data(wif)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_psbt_into_decoder),
+            FlowStep(psbt_views.PSBTSelectSeedView, button_data_selection=psbt_views.PSBTSelectSeedView.SCAN_WIF),
+            FlowStep(scan_views.ScanWIFQRView, before_run=load_wif_into_decoder),
+            FlowStep(psbt_views.PSBTOverviewView),
+        ])
+
+    def test_scan_psbt_then_scan_bip38_flow(self):
+        from embit import ec, script, psbt
+        from embit.transaction import Transaction, TransactionInput, TransactionOutput
+        import base64
+        from seedsigner.models.bip38 import BIP38Key
+
+        enc = "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg"
+        passphrase = "TestingOneTwoThree"
+        priv = BIP38Key(enc).decrypt(passphrase).privkey
+        pub = priv.get_public_key()
+        spk = script.p2wpkh(pub)
+        tx = Transaction(1, [TransactionInput(b"\x00" * 32, 0)], [TransactionOutput(900, spk)], 0)
+        p = psbt.PSBT(tx)
+        p.inputs[0].witness_utxo = TransactionOutput(1000, spk)
+        psbt_b64 = base64.b64encode(p.serialize()).decode()
+
+        def load_psbt_into_decoder(view: scan_views.ScanView):
+            view.decoder.add_data(psbt_b64)
+
+        def load_bip38_into_decoder(view: scan_views.ScanView):
+            view.decoder.add_data(enc)
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_psbt_into_decoder),
+            FlowStep(psbt_views.PSBTSelectSeedView, button_data_selection=psbt_views.PSBTSelectSeedView.SCAN_BIP38),
+            FlowStep(scan_views.ScanBIP38QRView, before_run=load_bip38_into_decoder),
+            FlowStep(psbt_views.PSBTBIP38PassphraseView, screen_return_value=dict(passphrase=passphrase)),
+            FlowStep(psbt_views.PSBTOverviewView),
+        ])
+
+
 class TestPSBTSatochip(FlowTest):
 
     def test_satochip_connect_failure_returns_to_select_menu(self, monkeypatch):

--- a/tests/test_wif.py
+++ b/tests/test_wif.py
@@ -1,0 +1,127 @@
+import os
+from embit import ec, script, psbt
+from embit.transaction import Transaction, TransactionInput, TransactionOutput
+
+from seedsigner.models.wif import WIFKey
+from seedsigner.models.psbt_parser import PSBTParser
+from seedsigner.models.settings_definition import SettingsConstants
+from seedsigner.models.decode_qr import DecodeQR
+from base import BaseTest
+
+def test_wif_signs_psbt():
+    priv = ec.PrivateKey(os.urandom(32))
+    wif = priv.wif()
+    key = WIFKey(wif)
+    pub = priv.get_public_key()
+    spk = script.p2wpkh(pub)
+    tx = Transaction(1, [TransactionInput(b"\x00" * 32, 0)], [TransactionOutput(900, spk)], 0)
+    p = psbt.PSBT(tx)
+    p.inputs[0].witness_utxo = TransactionOutput(1000, spk)
+    parser = PSBTParser(p, seed=key, network=SettingsConstants.MAINNET)
+    assert isinstance(parser.root, ec.PrivateKey)
+    p.sign_with(parser.root)
+    assert PSBTParser.sig_count(p) == 1
+
+
+def test_decode_qr_wif():
+    priv = ec.PrivateKey(os.urandom(32))
+    wif = priv.wif()
+    decoder = DecodeQR()
+    decoder.add_data(wif)
+    assert decoder.is_complete
+    assert decoder.is_wif
+    assert decoder.get_wif() == wif
+
+
+class TestWIF(BaseTest):
+    def test_wif_signed_tx_qr_is_raw_hex(self):
+        from seedsigner.views.psbt_views import PSBTFinalizeView, PSBTSignedQRDisplayView
+        from seedsigner.models.encode_qr import GenericStringEncoder
+        from embit.finalizer import finalize_psbt
+        from seedsigner.controller import Controller
+
+        priv = ec.PrivateKey(os.urandom(32))
+        wif = priv.wif()
+        key = WIFKey(wif)
+        pub = priv.get_public_key()
+        spk = script.p2wpkh(pub)
+        tx = Transaction(1, [TransactionInput(b"\x00" * 32, 0)], [TransactionOutput(900, spk)], 0)
+        p = psbt.PSBT(tx)
+        p.inputs[0].witness_utxo = TransactionOutput(1000, spk)
+
+        # compute expected finalized tx
+        p_expected = psbt.PSBT.parse(p.serialize())
+        p_expected.sign_with(priv)
+        expected_hex = finalize_psbt(p_expected).serialize().hex()
+
+        # setup controller state
+        ctrl = Controller.get_instance()
+        ctrl.psbt = p
+        ctrl.psbt_seed = key
+        ctrl.psbt_parser = PSBTParser(p, seed=key, network=SettingsConstants.MAINNET)
+
+        finalize_view = PSBTFinalizeView()
+        finalize_view.run_screen = lambda *a, **k: 0
+        finalize_view.run()
+
+        captured = {}
+        display_view = PSBTSignedQRDisplayView()
+
+        def fake_run_screen(screen_cls, **kwargs):
+            captured["encoder"] = kwargs["qr_encoder"]
+            return 0
+
+        display_view.run_screen = fake_run_screen
+        display_view.run()
+
+        encoder = captured["encoder"]
+        assert isinstance(encoder, GenericStringEncoder)
+        assert encoder.next_part() == expected_hex
+
+    def test_wif_setting_disables_options(self):
+        from seedsigner.views import psbt_views
+        from embit import ec, script, psbt
+        from embit.transaction import Transaction, TransactionInput, TransactionOutput
+        import os
+
+        self.settings.set_value(SettingsConstants.SETTING__WIF_KEYS, SettingsConstants.OPTION__DISABLED)
+
+        priv = ec.PrivateKey(os.urandom(32))
+        pub = priv.get_public_key()
+        spk = script.p2wpkh(pub)
+        tx = Transaction(1, [TransactionInput(b"\x00" * 32, 0)], [TransactionOutput(900, spk)], 0)
+        p = psbt.PSBT(tx)
+        p.inputs[0].witness_utxo = TransactionOutput(1000, spk)
+        self.controller.psbt = p
+        self.controller._storage = type("s", (), {})()
+        self.controller._storage.seeds = []
+
+        # Build button list as PSBTSelectSeedView would
+        buttons = [
+            psbt_views.PSBTSelectSeedView.SATOCHIP,
+            psbt_views.PSBTSelectSeedView.SCAN_SEED,
+        ]
+        if self.settings.get_value(SettingsConstants.SETTING__WIF_KEYS) == SettingsConstants.OPTION__ENABLED:
+            buttons.append(psbt_views.PSBTSelectSeedView.SCAN_WIF)
+        if self.settings.get_value(SettingsConstants.SETTING__BIP38_KEYS) == SettingsConstants.OPTION__ENABLED:
+            buttons.append(psbt_views.PSBTSelectSeedView.SCAN_BIP38)
+
+        seed_lengths = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
+        options = {
+            12: psbt_views.PSBTSelectSeedView.TYPE_12WORD,
+            15: psbt_views.PSBTSelectSeedView.TYPE_15WORD,
+            18: psbt_views.PSBTSelectSeedView.TYPE_18WORD,
+            21: psbt_views.PSBTSelectSeedView.TYPE_21WORD,
+            24: psbt_views.PSBTSelectSeedView.TYPE_24WORD,
+        }
+        for l in seed_lengths:
+            buttons.append(options[l])
+        if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
+            buttons.append(psbt_views.PSBTSelectSeedView.TYPE_ELECTRUM)
+        if self.settings.get_value(SettingsConstants.SETTING__WIF_KEYS) == SettingsConstants.OPTION__ENABLED:
+            buttons.append(psbt_views.PSBTSelectSeedView.TYPE_WIF)
+        if self.settings.get_value(SettingsConstants.SETTING__BIP38_KEYS) == SettingsConstants.OPTION__ENABLED:
+            buttons.append(psbt_views.PSBTSelectSeedView.TYPE_BIP38)
+
+        assert psbt_views.PSBTSelectSeedView.SCAN_WIF not in buttons
+        assert psbt_views.PSBTSelectSeedView.TYPE_WIF not in buttons


### PR DESCRIPTION
## Summary
- add WIF and BIP38 key model classes and settings toggles
- extend PSBT seed selection to scan or enter WIF/BIP38 keys
- encode signed transactions as raw hex when signing with WIF

## Testing
- `pytest tests/test_bip38.py tests/test_wif.py tests/test_flows_psbt.py`

------
https://chatgpt.com/codex/tasks/task_e_68900f0f451083229bb664c7cf957046