### PR TITLE
Add loading screens for Satochip xpub and message signing

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -3701,9 +3701,15 @@ class SeedSignMessageConfirmAddressView(View):
                 xtype = "p2wpkh"
             is_mainnet = addr_format["network"] == SettingsConstants.MAINNET
             from seedsigner.helpers.satochip_signer import format_path_string
+            from seedsigner.gui.screens.screen import LoadingScreenThread
             wallet_path = format_path_string(addr_format["wallet_derivation_path"])
-            xpub_base58 = connector.card_bip32_get_xpub(wallet_path, xtype, is_mainnet)
-            xpub = bip32.HDKey.from_base58(xpub_base58)
+            loading = LoadingScreenThread(text=_("Exporting xpub..."))
+            loading.start()
+            try:
+                xpub_base58 = connector.card_bip32_get_xpub(wallet_path, xtype, is_mainnet)
+                xpub = bip32.HDKey.from_base58(xpub_base58)
+            finally:
+                loading.stop()
         else:
             if self.seed_num is None:
                 raise Exception("Routing error: sign_message_data hasn't been set")
@@ -3750,10 +3756,16 @@ class SeedSignMessageSignedMessageQRView(View):
 
         if self.controller.sign_message_with_satochip:
             from seedsigner.helpers.satochip_signer import sign_message_with_satochip
+            from seedsigner.gui.screens.screen import LoadingScreenThread
 
-            self.signed_message = sign_message_with_satochip(
-                derivation_path, message, self.controller.Satochip_Connector
-            )
+            loading = LoadingScreenThread(text=_("Signing message..."))
+            loading.start()
+            try:
+                self.signed_message = sign_message_with_satochip(
+                    derivation_path, message, self.controller.Satochip_Connector
+                )
+            finally:
+                loading.stop()
         else:
             self.seed_num = data["seed_num"]
             seed = self.controller.get_seed(self.seed_num)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2574,11 +2574,14 @@ class SatochipExportXpubDetailsView(View):
                 xtype = "standard"
             else:
                 xtype = "p2wpkh"
-
+        from seedsigner.gui.screens.screen import LoadingScreenThread
+        loading = LoadingScreenThread(text=_("Exporting xpub..."))
+        loading.start()
         try:
             xpub_base58 = Satochip_Connector.card_bip32_get_xpub(derivation_path, xtype, is_mainnet)
             master_xpub = Satochip_Connector.card_bip32_get_xpub("", xtype, is_mainnet)
         except Exception as e:
+            loading.stop()
             self.run_screen(
                 WarningScreen,
                 title="Failed",
@@ -2586,6 +2589,8 @@ class SatochipExportXpubDetailsView(View):
                 text=str(e),
             )
             return Destination(BackStackView)
+        finally:
+            loading.stop()
 
         fingerprint = HDKey.from_string(master_xpub).my_fingerprint
         fingerprint_hex = hexlify(fingerprint).decode("utf-8")
@@ -2809,11 +2814,14 @@ class SatochipLoadDescriptorDetailsView(View):
             xtype = "standard"
         else:
             xtype = "p2wpkh"
-
+        from seedsigner.gui.screens.screen import LoadingScreenThread
+        loading = LoadingScreenThread(text=_("Exporting xpub..."))
+        loading.start()
         try:
             xpub_base58 = Satochip_Connector.card_bip32_get_xpub(derivation_path, xtype, is_mainnet)
             master_xpub = Satochip_Connector.card_bip32_get_xpub("", xtype, is_mainnet)
         except Exception as e:
+            loading.stop()
             self.run_screen(
                 WarningScreen,
                 title="Failed",
@@ -2821,6 +2829,8 @@ class SatochipLoadDescriptorDetailsView(View):
                 text=str(e),
             )
             return Destination(BackStackView)
+        finally:
+            loading.stop()
 
         fingerprint = HDKey.from_string(master_xpub).my_fingerprint
         fingerprint_hex = hexlify(fingerprint).decode("utf-8")


### PR DESCRIPTION
## Summary
- show loading indicator when exporting xpub or signing messages with Satochip
- add xpub loading spinner for Satochip descriptor exporting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68921dabed7483228f8a0a2933804856