### PR TITLE
Prevent reseeding already-initialized Satochip cards

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2232,6 +2232,21 @@ class ToolsSatochipImportSeedView(View):
         if not Satochip_Connector:
             return Destination(BackStackView)
 
+        # Prevent reseeding an already-initialized card. Attempting to import a new
+        # seed into a seeded Satochip results in a generic failure. Instead, check
+        # the card's status up front and inform the user so they can take
+        # appropriate action (like resetting the card) before proceeding.
+        _resp, _sw1, _sw2, status = Satochip_Connector.card_get_status()
+        if status.get("is_seeded"):
+            self.run_screen(
+                WarningScreen,
+                title=_("Already Seeded"),
+                status_headline=None,
+                text=_("Satochip card already contains a seed."),
+                show_back_button=False,
+            )
+            return Destination(MainMenuView)
+
         seeds = self.controller.storage.seeds
         button_data = []
         for seed in seeds:

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -1044,3 +1044,28 @@ class TestSatochipExportXpubDetailsView(BaseTest):
 
                 assert view.run_screen.call_args.kwargs["xpub"].startswith("Zpub")
 
+
+class TestSatochipImportSeedView(BaseTest):
+    def test_already_seeded_card_shows_warning(self, monkeypatch):
+        from seedsigner.views import tools_views
+        from seedsigner.helpers import seedkeeper_utils
+        from unittest.mock import Mock
+
+        class MockConnector:
+            def card_get_status(self):
+                return (None, 0x90, 0x00, {"is_seeded": True})
+
+        monkeypatch.setattr(
+            seedkeeper_utils, "init_satochip", lambda *a, **k: MockConnector()
+        )
+
+        view = tools_views.ToolsSatochipImportSeedView()
+        view.run_screen = Mock(return_value=0)
+        destination = view.run()
+
+        # Should warn user and return to main menu without attempting import
+        assert view.run_screen.call_count == 1
+        assert view.run_screen.call_args.args[0] is tools_views.WarningScreen
+        assert "already" in view.run_screen.call_args.kwargs["text"].lower()
+        assert destination.View_cls == tools_views.MainMenuView
+


### PR DESCRIPTION
## Summary
- avoid re-seeding a Satochip card that's already initialized
- notify the user that the card already contains a seed
- add regression test for Satochip import workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c086bfef8832292dbca4690a0fe4a