### PR TITLE
Improve NFC policy error handling

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -1107,13 +1107,21 @@ class ToolsSatochipChangeNFCView(View):
             return Destination(MainMenuView)
     
         else:
-            if (sw1 == 0x9C and sw2 == 0x48):
-                failed_string = "Cannot set the NFC policy through the NFC interface, use contact interface instead"
-            elif (sw1 == 0x9C and sw2 == 0x49):
-                failed_string = "Cannot set the NFC policy: NFC interface is BLOCKED, a factory reset is required to reenable NFC!"
-            else:
-                failed_string = "Failed to set NFC policy with error code: {hex(256*sw1+sw2)}"
-            logger.info("Failure: NFC Change Failed")
+            error_messages = {
+                0x9C48: "Cannot set the NFC policy through the NFC interface, use contact interface instead",
+                0x9C49: "Cannot set the NFC policy: NFC interface is BLOCKED, a factory reset is required to reenable NFC!",
+            }
+
+            status_word = (sw1 << 8) | sw2
+            failed_string = error_messages.get(
+                status_word,
+                f"Failed to set NFC policy with error code: {status_word:#06x}",
+            )
+
+            logger.info(
+                "Failure: NFC Change Failed with status word %s",
+                hex(status_word),
+            )
             self.run_screen(
                 WarningScreen,
                 title="Failed",

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -1108,6 +1108,7 @@ class ToolsSatochipChangeNFCView(View):
     
         else:
             error_messages = {
+                0x6D00: "This card's firmware does not support setting the NFC policy",
                 0x9C48: "Cannot set the NFC policy through the NFC interface, use contact interface instead",
                 0x9C49: "Cannot set the NFC policy: NFC interface is BLOCKED, a factory reset is required to reenable NFC!",
             }


### PR DESCRIPTION
## Summary
- show card status word in NFC policy failure message
- centralize known error codes for easier expansion

## Testing
- `pytest tests/test_bip38.py -q`
- `pytest tests/test_encodepsbtqr.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c0900e9c083228ba6a80c62635f47