### PR TITLE
Centralize ISO7816 status code handling

### DIFF
--- a/src/seedsigner/helpers/iso7816.py
+++ b/src/seedsigner/helpers/iso7816.py
@@ -25,7 +25,10 @@ ISO7816_STATUS_WORDS: Dict[int, str] = {
     0x6A86: "Incorrect parameters P1 P2",
     0x6A88: "Referenced data not found",
     0x6B00: "Wrong parameters P1 P2",
-    0x6D00: "Instruction code not supported or invalid",
+    # Commonly returned when a command isn't implemented by the card's
+    # firmware. Keep the wording simple so users understand the feature
+    # isn't available on their card/app.
+    0x6D00: "Feature not supported for this applet",
     0x6E00: "Class not supported",
     0x6F00: "Unknown error, no precise diagnosis",
     0x9000: "Success",

--- a/src/seedsigner/helpers/iso7816.py
+++ b/src/seedsigner/helpers/iso7816.py
@@ -1,0 +1,49 @@
+"""Common ISO/IEC 7816-4 status word helpers.
+
+This module centralizes known ISO/IEC 7816-4 status words so that
+smartcard-related components can provide more helpful error messages.
+The dictionary can easily be extended as additional codes are
+encountered.
+"""
+from __future__ import annotations
+
+from typing import Dict
+
+# Mapping of status word integers to human-friendly descriptions.
+# Only a subset of the full ISO/IEC 7816-4 table is included here; add to this
+# list as new codes are encountered in the wild.
+ISO7816_STATUS_WORDS: Dict[int, str] = {
+    0x6300: "State of non-volatile memory unchanged",
+    0x6400: "State of non-volatile memory change is expected",
+    0x6700: "Wrong length",
+    0x6982: "Security status not satisfied",
+    0x6985: "Conditions of use not satisfied",
+    0x6A80: "Incorrect parameters in the data field",
+    0x6A82: "File not found",
+    0x6A83: "Record not found",
+    0x6A84: "Not enough memory space",
+    0x6A86: "Incorrect parameters P1 P2",
+    0x6A88: "Referenced data not found",
+    0x6B00: "Wrong parameters P1 P2",
+    0x6D00: "Instruction code not supported or invalid",
+    0x6E00: "Class not supported",
+    0x6F00: "Unknown error, no precise diagnosis",
+    0x9000: "Success",
+}
+
+def format_sw_error(sw1: int, sw2: int) -> str:
+    """Return a human friendly description of an ISO7816 status word.
+
+    Args:
+        sw1: First status byte.
+        sw2: Second status byte.
+
+    Returns:
+        Description string that includes the hexadecimal status word. For
+        unknown codes, a generic "unknown" message is returned.
+    """
+    status_word = (sw1 << 8) | sw2
+    description = ISO7816_STATUS_WORDS.get(status_word)
+    if description:
+        return f"{description} ({status_word:#06x})"
+    return f"Unknown status word: {status_word:#06x}"

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from binascii import b2a_base64
+import logging
 
 from embit.ec import PublicKey
 from embit.psbt import PSBT
 from embit.util import secp256k1
+from seedsigner.helpers.iso7816 import format_sw_error
 
 try:
     # Constant introduced in newer embit versions
@@ -12,6 +14,7 @@ try:
 except ImportError:  # pragma: no cover - support older embit releases
     HARDENED_INDEX = 0x80000000
 
+logger = logging.getLogger(__name__)
 
 def _format_path(derivation: list[int]) -> str:
     """Convert a list of BIP32 indices to string path"""
@@ -67,6 +70,7 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
             tx_hash = psbt.sighash(i)
             sig, sw1, sw2 = connector.card_sign_transaction_hash(0xFF, list(tx_hash), None)
             if sw1 != 0x90 or sw2 != 0x00:
+                logger.warning("Satochip signing failed: %s", format_sw_error(sw1, sw2))
                 continue
             sig_der = bytes(sig)
             # ensure low-S signature
@@ -95,5 +99,7 @@ def sign_message_with_satochip(derivation_path: str, message: str, connector) ->
     key, _chaincode = connector.card_bip32_get_extendedkey(path)
     _resp, sw1, sw2, compsig = connector.card_sign_message(0xFF, key, message)
     if sw1 != 0x90 or sw2 != 0x00 or not compsig:
-        raise Exception("Failed to sign message with Satochip")
+        raise Exception(
+            f"Failed to sign message with Satochip: {format_sw_error(sw1, sw2)}"
+        )
     return b2a_base64(compsig).strip().decode()

--- a/src/seedsigner/helpers/seedkeeper_utils.py
+++ b/src/seedsigner/helpers/seedkeeper_utils.py
@@ -15,6 +15,7 @@ from seedsigner.gui.screens import (
     KeyboardScreen,
 )
 from seedsigner.gui.screens.screen import LoadingScreenThread
+from seedsigner.helpers.iso7816 import format_sw_error
 
 
 import os
@@ -185,7 +186,7 @@ def init_satochip(parentObject, init_card_filter=None, require_pin=True):
                         WarningScreen,
                         title="Failure",
                         status_headline=None,
-                        text=f"Failed, Code:" + str(sw1) + " " + str(sw2),
+                        text=format_sw_error(sw1, sw2),
                         show_back_button=True,
                     )
                     return None
@@ -264,7 +265,7 @@ def init_satochip(parentObject, init_card_filter=None, require_pin=True):
                 WarningScreen,
                 title="Invalid PIN",
                 status_headline=None,
-                text=f"Invalid PIN entered, select another and try again.",
+                text=format_sw_error(sw1, sw2),
                 show_back_button=True,
             )
             return None

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -28,6 +28,7 @@ from seedsigner.gui.screens.tools_screens import (ToolsCalcFinalWordDoneScreen, 
     ToolsTextQRTranscribeModePromptScreen, ToolsTranscribeTextQRWholeQRScreen, ToolsTranscribeTextQRZoomedInScreen,
     ToolsTranscribeTextQRConfirmQRPromptScreen)
 from seedsigner.helpers import embit_utils, mnemonic_generation
+from seedsigner.helpers.iso7816 import format_sw_error
 from seedsigner.models.decode_qr import DecodeQR
 from seedsigner.models.encode_qr import GenericStaticQrEncoder
 from seedsigner.gui.screens import RET_CODE__BACK_BUTTON, ButtonListScreen
@@ -1107,13 +1108,18 @@ class ToolsSatochipChangeNFCView(View):
             return Destination(MainMenuView)
     
         else:
-            if (sw1 == 0x9C and sw2 == 0x48):
-                failed_string = "Cannot set the NFC policy through the NFC interface, use contact interface instead"
-            elif (sw1 == 0x9C and sw2 == 0x49):
-                failed_string = "Cannot set the NFC policy: NFC interface is BLOCKED, a factory reset is required to reenable NFC!"
-            else:
-                failed_string = "Failed to set NFC policy with error code: {hex(256*sw1+sw2)}"
-            logger.info("Failure: NFC Change Failed")
+            error_messages = {
+                0x9C48: "Cannot set the NFC policy through the NFC interface, use contact interface instead",
+                0x9C49: "Cannot set the NFC policy: NFC interface is BLOCKED, a factory reset is required to reenable NFC!",
+            }
+
+            status_word = (sw1 << 8) | sw2
+            failed_string = error_messages.get(status_word, format_sw_error(sw1, sw2))
+
+            logger.info(
+                "Failure: NFC Change Failed with status word %s",
+                hex(status_word),
+            )
             self.run_screen(
                 WarningScreen,
                 title="Failed",


### PR DESCRIPTION
## Summary
- add reusable dictionary for common ISO/IEC 7816-4 status words
- refactor NFC policy and Seedkeeper helpers to use shared status word helper
- surface descriptive smartcard errors in Satochip signer

## Testing
- `pytest tests/test_bip38.py -q`
- `pytest tests/test_encodepsbtqr.py -q`
- `pytest tests/test_embit_utils.py -q`
- `pytest tests/test_flows_tools.py::TestToolsFlows::test__address_explorer__flow -q`


------
https://chatgpt.com/codex/tasks/task_e_689c0900e9c083228ba6a80c62635f47