### PR TITLE
Add BIP32 account prompt for single-sig workflows

### DIFF
--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -589,6 +589,22 @@ class SeedWordsBackupTestPromptScreen(ButtonListScreen):
 
 
 @dataclass
+class SeedExportXpubAccountNumberScreen(KeyboardScreen):
+    def __post_init__(self):
+        self.title = _("Account Number")
+        self.user_input = "0"
+
+        # Specify the keys in the keyboard
+        self.rows = 3
+        self.cols = 5
+        self.keys_charset = "0123456789"
+        self.show_save_button = True
+
+        super().__post_init__()
+
+
+
+@dataclass
 class SeedExportXpubCustomDerivationScreen(KeyboardScreen):
     def __post_init__(self):
         self.title = _("Derivation Path")

--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -20,7 +20,7 @@ from seedsigner.models.settings_definition import SettingsConstants
 
 
 # TODO: Refactor `wallet_type` to conform to our `sig_type` naming convention
-def get_standard_derivation_path(network: str = SettingsConstants.MAINNET, wallet_type: str = SettingsConstants.SINGLE_SIG, script_type: str = SettingsConstants.NATIVE_SEGWIT) -> str:
+def get_standard_derivation_path(network: str = SettingsConstants.MAINNET, wallet_type: str = SettingsConstants.SINGLE_SIG, script_type: str = SettingsConstants.NATIVE_SEGWIT, account: int = 0) -> str:
     if network == SettingsConstants.MAINNET:
         network_path = "0'"
     elif network == SettingsConstants.TESTNET:
@@ -32,13 +32,13 @@ def get_standard_derivation_path(network: str = SettingsConstants.MAINNET, walle
 
     if wallet_type == SettingsConstants.SINGLE_SIG:
         if script_type == SettingsConstants.LEGACY_P2PKH:
-            return f"m/44'/{network_path}/0'"
+            return f"m/44'/{network_path}/{account}'"
         elif script_type == SettingsConstants.NESTED_SEGWIT:
-            return f"m/49'/{network_path}/0'"
+            return f"m/49'/{network_path}/{account}'"
         elif script_type == SettingsConstants.NATIVE_SEGWIT:
-            return f"m/84'/{network_path}/0'"
+            return f"m/84'/{network_path}/{account}'"
         elif script_type == SettingsConstants.TAPROOT:
-            return f"m/86'/{network_path}/0'"
+            return f"m/86'/{network_path}/{account}'"
         else:
             raise Exception("Unexpected script type")
 
@@ -46,9 +46,9 @@ def get_standard_derivation_path(network: str = SettingsConstants.MAINNET, walle
         if script_type == SettingsConstants.LEGACY_P2PKH:
             return f"m/45'" #BIP45
         elif script_type == SettingsConstants.NESTED_SEGWIT:
-            return f"m/48'/{network_path}/0'/1'"
+            return f"m/48'/{network_path}/{account}'/1'"
         elif script_type == SettingsConstants.NATIVE_SEGWIT:
-            return f"m/48'/{network_path}/0'/2'"
+            return f"m/48'/{network_path}/{account}'/2'"
         elif script_type == SettingsConstants.TAPROOT:
             raise Exception("Taproot multisig not yet supported")
         else:

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -382,6 +382,7 @@ class SettingsConstants:
     SETTING__XPUB_EXPORT = "xpub_export"
     SETTING__SIG_TYPES = "sig_types"
     SETTING__SCRIPT_TYPES = "script_types"
+    SETTING__ACCOUNT_PROMPT = "account_prompt"
     SETTING__SEED_WORD_LENGTHS = "seed_word_lengths"
     SETTING__XPUB_DETAILS = "xpub_details"
     SETTING__PASSPHRASE = "passphrase"
@@ -761,6 +762,12 @@ class SettingsDefinition:
                       display_name=_mft("Show xpub details"),
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__ENABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__ACCOUNT_PROMPT,
+                      display_name=_mft("BIP32 account prompt"),
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      default_value=SettingsConstants.OPTION__DISABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__PASSPHRASE,

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1454,8 +1454,8 @@ class SeedExportXpubScriptTypeView(View):
                 return Destination(SeedExportXpubCustomDerivationView, view_args=args, skip_current_view=True)
 
             if (
-                self.sig_type == SettingsConstants.SINGLE_SIG
-                and self.settings.get_value(SettingsConstants.SETTING__ACCOUNT_PROMPT) == SettingsConstants.OPTION__ENABLED
+                self.settings.get_value(SettingsConstants.SETTING__ACCOUNT_PROMPT)
+                == SettingsConstants.OPTION__ENABLED
             ):
                 if self.controller.resume_main_flow == Controller.FLOW__ADDRESS_EXPLORER:
                     del args["sig_type"]
@@ -1499,8 +1499,8 @@ class SeedExportXpubScriptTypeView(View):
                 return Destination(SeedExportXpubCustomDerivationView, view_args=args)
 
             if (
-                self.sig_type == SettingsConstants.SINGLE_SIG
-                and self.settings.get_value(SettingsConstants.SETTING__ACCOUNT_PROMPT) == SettingsConstants.OPTION__ENABLED
+                self.settings.get_value(SettingsConstants.SETTING__ACCOUNT_PROMPT)
+                == SettingsConstants.OPTION__ENABLED
             ):
                 if self.controller.resume_main_flow == Controller.FLOW__ADDRESS_EXPLORER:
                     del args["sig_type"]

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1450,11 +1450,24 @@ class SeedExportXpubScriptTypeView(View):
             # Nothing to select; skip this screen
             args["script_type"] = script_types[0]
 
-            if self.controller.resume_main_flow == Controller.FLOW__ADDRESS_EXPLORER:
-                del args["sig_type"]
-                return Destination(ToolsAddressExplorerAddressTypeView, view_args=args, skip_current_view=True)
+            if args["script_type"] == SettingsConstants.CUSTOM_DERIVATION:
+                return Destination(SeedExportXpubCustomDerivationView, view_args=args, skip_current_view=True)
+
+            if (
+                self.sig_type == SettingsConstants.SINGLE_SIG
+                and self.settings.get_value(SettingsConstants.SETTING__ACCOUNT_PROMPT) == SettingsConstants.OPTION__ENABLED
+            ):
+                if self.controller.resume_main_flow == Controller.FLOW__ADDRESS_EXPLORER:
+                    del args["sig_type"]
+                    return Destination(AccountNumberView, view_args=dict(next_view_cls=ToolsAddressExplorerAddressTypeView, next_view_args=args), skip_current_view=True)
+                else:
+                    return Destination(AccountNumberView, view_args=dict(next_view_cls=SeedExportXpubCoordinatorView, next_view_args=args), skip_current_view=True)
             else:
-                return Destination(SeedExportXpubCoordinatorView, view_args=args, skip_current_view=True)
+                if self.controller.resume_main_flow == Controller.FLOW__ADDRESS_EXPLORER:
+                    del args["sig_type"]
+                    return Destination(ToolsAddressExplorerAddressTypeView, view_args=args, skip_current_view=True)
+                else:
+                    return Destination(SeedExportXpubCoordinatorView, view_args=args, skip_current_view=True)
         
         title = _("Export Xpub")
         if self.controller.resume_main_flow == Controller.FLOW__ADDRESS_EXPLORER:
@@ -1485,11 +1498,21 @@ class SeedExportXpubScriptTypeView(View):
             if args["script_type"] == SettingsConstants.CUSTOM_DERIVATION:
                 return Destination(SeedExportXpubCustomDerivationView, view_args=args)
 
-            if self.controller.resume_main_flow == Controller.FLOW__ADDRESS_EXPLORER:
-                del args["sig_type"]
-                return Destination(ToolsAddressExplorerAddressTypeView, view_args=args)
+            if (
+                self.sig_type == SettingsConstants.SINGLE_SIG
+                and self.settings.get_value(SettingsConstants.SETTING__ACCOUNT_PROMPT) == SettingsConstants.OPTION__ENABLED
+            ):
+                if self.controller.resume_main_flow == Controller.FLOW__ADDRESS_EXPLORER:
+                    del args["sig_type"]
+                    return Destination(AccountNumberView, view_args=dict(next_view_cls=ToolsAddressExplorerAddressTypeView, next_view_args=args))
+                else:
+                    return Destination(AccountNumberView, view_args=dict(next_view_cls=SeedExportXpubCoordinatorView, next_view_args=args))
             else:
-                return Destination(SeedExportXpubCoordinatorView, view_args=args)
+                if self.controller.resume_main_flow == Controller.FLOW__ADDRESS_EXPLORER:
+                    del args["sig_type"]
+                    return Destination(ToolsAddressExplorerAddressTypeView, view_args=args)
+                else:
+                    return Destination(SeedExportXpubCoordinatorView, view_args=args)
 
 
 
@@ -1531,13 +1554,34 @@ class SeedExportXpubCustomDerivationView(View):
 
 
 
+class AccountNumberView(View):
+    def __init__(self, next_view_cls, next_view_args: dict):
+        super().__init__()
+        self.next_view_cls = next_view_cls
+        self.next_view_args = next_view_args
+
+    def run(self):
+        ret = self.run_screen(
+            seed_screens.SeedExportXpubAccountNumberScreen,
+            initial_value="0",
+        )
+
+        if ret == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        self.next_view_args["account"] = int(ret)
+        return Destination(self.next_view_cls, view_args=self.next_view_args)
+
+
+
 class SeedExportXpubCoordinatorView(View):
-    def __init__(self, seed_num: int, sig_type: str, script_type: str, custom_derivation: str = None):
+    def __init__(self, seed_num: int, sig_type: str, script_type: str, custom_derivation: str = None, account: int = 0):
         super().__init__()
         self.seed_num = seed_num
         self.sig_type = sig_type
         self.script_type = script_type
         self.custom_derivation = custom_derivation
+        self.account = account
 
 
     def run(self):
@@ -1546,6 +1590,7 @@ class SeedExportXpubCoordinatorView(View):
             "sig_type": self.sig_type,
             "script_type": self.script_type,
             "custom_derivation": self.custom_derivation,
+            "account": self.account,
         }
         if len(self.settings.get_value(SettingsConstants.SETTING__COORDINATORS)) == 1:
             # Nothing to select; skip this screen
@@ -1579,7 +1624,7 @@ class SeedExportXpubCoordinatorView(View):
 
 
 class SeedExportXpubWarningView(View):
-    def __init__(self, seed_num: int, sig_type: str, script_type: str, coordinator: str, custom_derivation: str, coordinator_label: str):
+    def __init__(self, seed_num: int, sig_type: str, script_type: str, coordinator: str, custom_derivation: str, coordinator_label: str, account: int = 0):
         super().__init__()
         self.seed_num = seed_num
         self.sig_type = sig_type
@@ -1587,6 +1632,7 @@ class SeedExportXpubWarningView(View):
         self.coordinator = coordinator
         self.custom_derivation = custom_derivation
         self.coordinator_label = coordinator_label
+        self.account = account
 
 
     def run(self):
@@ -1599,6 +1645,7 @@ class SeedExportXpubWarningView(View):
                 "coordinator": self.coordinator,
                 "custom_derivation": self.custom_derivation,
                 "coordinator_label": self.coordinator_label,
+                "account": self.account,
             },
             skip_current_view=True,  # Prevent going BACK to WarningViews
         )
@@ -1627,14 +1674,15 @@ class SeedExportXpubDetailsView(View):
         Collects the user input from all the previous screens leading up to this and
         finally calculates the xpub and displays the summary view to the user.
     """
-    def __init__(self, seed_num: int, sig_type: str, script_type: str, coordinator: str, custom_derivation: str, coordinator_label: str):
+    def __init__(self, seed_num: int, sig_type: str, script_type: str, coordinator: str, custom_derivation: str, coordinator_label: str, account: int = 0):
         super().__init__()
         self.sig_type = sig_type
         self.script_type = script_type
         self.coordinator = coordinator
         self.custom_derivation = custom_derivation
         self.coordinator_label = coordinator_label
-        
+        self.account = account
+
         self.seed_num = seed_num
         self.seed = self.controller.get_seed(self.seed_num)
 
@@ -1650,7 +1698,8 @@ class SeedExportXpubDetailsView(View):
             derivation_path = embit_utils.get_standard_derivation_path(
                 network=self.settings.get_value(SettingsConstants.SETTING__NETWORK),
                 wallet_type=self.sig_type,
-                script_type=self.script_type
+                script_type=self.script_type,
+                account=self.account,
             )
 
         if self.settings.get_value(SettingsConstants.SETTING__XPUB_DETAILS) == SettingsConstants.OPTION__DISABLED:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -46,6 +46,7 @@ from seedsigner.views.seed_views import (
     LoadSeedView,
     SeedSlip39CreateFromBytesView,
     SeedSlip39RegenerateSharesView,
+    AccountNumberView,
 )
 
 from .view import View, Destination, BackStackView, MainMenuView
@@ -731,7 +732,7 @@ class ToolsAddressExplorerAddressTypeView(View):
     CHANGE = ButtonOption("Change Addresses")
 
 
-    def __init__(self, seed_num: int = None, script_type: str = None, custom_derivation: str = None):
+    def __init__(self, seed_num: int = None, script_type: str = None, custom_derivation: str = None, account: int = 0):
         """
             If the explorer source is a seed, `seed_num` and `script_type` must be
             specified. `custom_derivation` can be specified as needed.
@@ -743,6 +744,7 @@ class ToolsAddressExplorerAddressTypeView(View):
         self.seed_num = seed_num
         self.script_type = script_type
         self.custom_derivation = custom_derivation
+        self.account = account
     
         network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
 
@@ -753,6 +755,7 @@ class ToolsAddressExplorerAddressTypeView(View):
             network=self.settings.get_value(SettingsConstants.SETTING__NETWORK),
             embit_network=SettingsConstants.map_network_to_embit(network),
             script_type=script_type,
+            account=account,
         )
         if self.seed_num is not None:
             self.seed = self.controller.storage.seeds[seed_num]
@@ -769,6 +772,7 @@ class ToolsAddressExplorerAddressTypeView(View):
                     network=self.settings.get_value(SettingsConstants.SETTING__NETWORK),
                     wallet_type=SettingsConstants.SINGLE_SIG,
                     script_type=self.script_type,
+                    account=self.account,
                 )
 
             data["derivation_path"] = derivation_path
@@ -2439,6 +2443,14 @@ class SatochipExportXpubScriptTypeView(View):
                 SatochipExportXpubCustomDerivationView,
                 view_args=dict(sig_type=self.sig_type, script_type=script_type),
             )
+        if (
+            self.sig_type == SettingsConstants.SINGLE_SIG
+            and self.settings.get_value(SettingsConstants.SETTING__ACCOUNT_PROMPT) == SettingsConstants.OPTION__ENABLED
+        ):
+            return Destination(
+                AccountNumberView,
+                view_args=dict(next_view_cls=SatochipExportXpubCoordinatorView, next_view_args=dict(sig_type=self.sig_type, script_type=script_type)),
+            )
         return Destination(
             SatochipExportXpubCoordinatorView,
             view_args=dict(sig_type=self.sig_type, script_type=script_type),
@@ -2468,11 +2480,12 @@ class SatochipExportXpubCustomDerivationView(View):
 
 
 class SatochipExportXpubCoordinatorView(View):
-    def __init__(self, sig_type: str, script_type: str, custom_derivation: str = ""):
+    def __init__(self, sig_type: str, script_type: str, custom_derivation: str = "", account: int = 0):
         super().__init__()
         self.sig_type = sig_type
         self.script_type = script_type
         self.custom_derivation = custom_derivation
+        self.account = account
 
     def run(self):
         button_data = []
@@ -2501,18 +2514,20 @@ class SatochipExportXpubCoordinatorView(View):
                 coordinator=coordinator,
                 custom_derivation=self.custom_derivation,
                 coordinator_label=coordinator_label,
+                account=self.account,
             ),
         )
 
 
 class SatochipExportXpubWarningView(View):
-    def __init__(self, sig_type: str, script_type: str, coordinator: str, custom_derivation: str, coordinator_label: str):
+    def __init__(self, sig_type: str, script_type: str, coordinator: str, custom_derivation: str, coordinator_label: str, account: int = 0):
         super().__init__()
         self.sig_type = sig_type
         self.script_type = script_type
         self.coordinator = coordinator
         self.custom_derivation = custom_derivation
         self.coordinator_label = coordinator_label
+        self.account = account
 
     def run(self):
         destination = Destination(
@@ -2523,6 +2538,7 @@ class SatochipExportXpubWarningView(View):
                 coordinator=self.coordinator,
                 custom_derivation=self.custom_derivation,
                 coordinator_label=self.coordinator_label,
+                account=self.account,
             ),
             skip_current_view=True,
         )
@@ -2544,13 +2560,14 @@ class SatochipExportXpubWarningView(View):
 
 
 class SatochipExportXpubDetailsView(View):
-    def __init__(self, sig_type: str, script_type: str, coordinator: str, custom_derivation: str, coordinator_label: str):
+    def __init__(self, sig_type: str, script_type: str, coordinator: str, custom_derivation: str, coordinator_label: str, account: int = 0):
         super().__init__()
         self.sig_type = sig_type
         self.script_type = script_type
         self.coordinator = coordinator
         self.custom_derivation = custom_derivation
         self.coordinator_label = coordinator_label
+        self.account = account
 
     def run(self):
         Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
@@ -2564,6 +2581,7 @@ class SatochipExportXpubDetailsView(View):
                 network=self.settings.get_value(SettingsConstants.SETTING__NETWORK),
                 wallet_type=self.sig_type,
                 script_type=self.script_type,
+                account=self.account,
             )
 
         network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
@@ -2773,6 +2791,8 @@ class SatochipLoadDescriptorScriptTypeView(View):
         script_type = button_data[selected_menu_num].return_data
         if script_type == SettingsConstants.CUSTOM_DERIVATION:
             return Destination(SatochipLoadDescriptorCustomDerivationView, view_args=dict(script_type=script_type))
+        if self.settings.get_value(SettingsConstants.SETTING__ACCOUNT_PROMPT) == SettingsConstants.OPTION__ENABLED:
+            return Destination(AccountNumberView, view_args=dict(next_view_cls=SatochipLoadDescriptorDetailsView, next_view_args=dict(script_type=script_type)))
         return Destination(SatochipLoadDescriptorDetailsView, view_args=dict(script_type=script_type))
 
 
@@ -2798,10 +2818,11 @@ class SatochipLoadDescriptorCustomDerivationView(View):
 
 
 class SatochipLoadDescriptorDetailsView(View):
-    def __init__(self, script_type: str, custom_derivation: str = ""):
+    def __init__(self, script_type: str, custom_derivation: str = "", account: int = 0):
         super().__init__()
         self.script_type = script_type
         self.custom_derivation = custom_derivation
+        self.account = account
 
     def run(self):
         Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
@@ -2815,6 +2836,7 @@ class SatochipLoadDescriptorDetailsView(View):
                 network=self.settings.get_value(SettingsConstants.SETTING__NETWORK),
                 wallet_type=SettingsConstants.SINGLE_SIG,
                 script_type=self.script_type,
+                account=self.account,
             )
 
         network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2444,8 +2444,8 @@ class SatochipExportXpubScriptTypeView(View):
                 view_args=dict(sig_type=self.sig_type, script_type=script_type),
             )
         if (
-            self.sig_type == SettingsConstants.SINGLE_SIG
-            and self.settings.get_value(SettingsConstants.SETTING__ACCOUNT_PROMPT) == SettingsConstants.OPTION__ENABLED
+            self.settings.get_value(SettingsConstants.SETTING__ACCOUNT_PROMPT)
+            == SettingsConstants.OPTION__ENABLED
         ):
             return Destination(
                 AccountNumberView,

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -316,6 +316,31 @@ def test_account_changes_xpub_and_address():
     assert addr1 == "bc1qku0qh0mc00y8tk0n65x2tqw4trlspak0fnjmfz"
 
 
+def test_multisig_account_changes_xpub():
+    """Verify different accounts generate unique multisig xpubs"""
+
+    from embit import bip39
+
+    seed = bip39.mnemonic_to_seed("abandon " * 11 + "about")
+
+    path0 = embit_utils.get_standard_derivation_path(
+        SC.MAINNET, SC.MULTISIG, SC.NATIVE_SEGWIT, account=0
+    )
+    path1 = embit_utils.get_standard_derivation_path(
+        SC.MAINNET, SC.MULTISIG, SC.NATIVE_SEGWIT, account=1
+    )
+
+    xpub0 = embit_utils.get_xpub(seed, path0)
+    xpub1 = embit_utils.get_xpub(seed, path1)
+
+    assert str(xpub0) == (
+        "xpub6DkFAXWQ2dHxq2vatrt9qyA3bXYU4ToWQwCHbf5XB2mSTexcHZCeKS1VZYcPoBd5X8yVcbXFHJR9R8UCVpt82VX1VhR28mCyxUFL4r6KFrf"
+    )
+    assert str(xpub1) == (
+        "xpub6DzhyrnFFYQ1HimDiM388xHnDiRPNdZJFBmmxge3Y1WWcHLtMJLfRuhRHqnQCPbTj3fGKTuKFLHzzwpJkp5Dtc3UtLKZKaVZe1yqMBXd6Vk"
+    )
+    assert str(xpub0) != str(xpub1)
+
 def test_get_multisig_address():
     """
     tests seedsigner.helpers.embit_utils.get_multisig_address()

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -40,6 +40,9 @@ def test_get_standard_derivation_path():
         (SC.TESTNET, SC.MULTISIG, SC.NATIVE_SEGWIT): "m/48'/1'/0'/2'",
         (SC.REGTEST, SC.MULTISIG, SC.NATIVE_SEGWIT): "m/48'/1'/0'/2'",
 
+        (SC.MAINNET, SC.MULTISIG, SC.NATIVE_SEGWIT, 3): "m/48'/0'/3'/2'",
+        (SC.TESTNET, SC.MULTISIG, SC.NESTED_SEGWIT, 1): "m/48'/1'/1'/1'",
+
         (SC.MAINNET, SC.MULTISIG, SC.NESTED_SEGWIT): "m/48'/0'/0'/1'",
         (SC.TESTNET, SC.MULTISIG, SC.NESTED_SEGWIT): "m/48'/1'/0'/1'",
         (SC.REGTEST, SC.MULTISIG, SC.NESTED_SEGWIT): "m/48'/1'/0'/1'",
@@ -279,6 +282,38 @@ def test_get_single_sig_address():
         # call with named params
         print(f'  {func.__name__}(xpub=HDKey.from_string("{args[0]}"), script_type="{args[1]}", index={args[2]}, is_change={args[3]}, embit_network="{args[4]}") == "{expected}"')
         assert str(func(xpub=args[0], script_type=args[1], index=args[2], is_change=args[3], embit_network=args[4])) == expected
+
+
+def test_account_changes_xpub_and_address():
+    """Verify different accounts generate unique xpubs and addresses"""
+
+    from embit import bip39
+
+    seed = bip39.mnemonic_to_seed("abandon " * 11 + "about")
+
+    path0 = embit_utils.get_standard_derivation_path(
+        SC.MAINNET, SC.SINGLE_SIG, SC.NATIVE_SEGWIT, account=0
+    )
+    path1 = embit_utils.get_standard_derivation_path(
+        SC.MAINNET, SC.SINGLE_SIG, SC.NATIVE_SEGWIT, account=1
+    )
+
+    xpub0 = embit_utils.get_xpub(seed, path0)
+    xpub1 = embit_utils.get_xpub(seed, path1)
+
+    assert str(xpub0) == (
+        "xpub6CatWdiZiodmUeTDp8LT5or8nmbKNcuyvz7WyksVFkKB4RHwCD3XyuvPEbvqAQY3rAPshWcMLoP2fMFMKHPJ4ZeZXYVUhLv1VMrjPC7PW6V"
+    )
+    assert str(xpub1) == (
+        "xpub6CatWdiZiodmYVtWLtEQsAg1H9ooS1bmsJUBwQ83FE1Fyk386FWcyicJgEZv3quZSJKA5dh5Lo2PbubMGxCfZtRthV6ST2qquL9w3HSzcUn"
+    )
+    assert str(xpub0) != str(xpub1)
+
+    addr0 = embit_utils.get_single_sig_address(xpub0, SC.NATIVE_SEGWIT, 0, False, "main")
+    addr1 = embit_utils.get_single_sig_address(xpub1, SC.NATIVE_SEGWIT, 0, False, "main")
+
+    assert addr0 == "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
+    assert addr1 == "bc1qku0qh0mc00y8tk0n65x2tqw4trlspak0fnjmfz"
 
 
 def test_get_multisig_address():

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -27,6 +27,9 @@ def test_get_standard_derivation_path():
         (SC.TESTNET, SC.SINGLE_SIG, SC.TAPROOT): "m/86'/1'/0'",
         (SC.REGTEST, SC.SINGLE_SIG, SC.TAPROOT): "m/86'/1'/0'",
 
+        (SC.MAINNET, SC.SINGLE_SIG, SC.NATIVE_SEGWIT, 1): "m/84'/0'/1'",
+        (SC.TESTNET, SC.SINGLE_SIG, SC.NESTED_SEGWIT, 2): "m/49'/1'/2'",
+
         (SC.MAINNET, SC.SINGLE_SIG, SC.LEGACY_P2PKH): "m/44'/0'/0'",
         (SC.TESTNET, SC.SINGLE_SIG, SC.LEGACY_P2PKH): "m/44'/1'/0'",
         (SC.REGTEST, SC.SINGLE_SIG, SC.LEGACY_P2PKH): "m/44'/1'/0'",
@@ -76,6 +79,7 @@ def test_get_standard_derivation_path():
             if len(args) == 1: a_dict = {'network': args[0]}
             elif len(args) == 2: a_dict = {'network': args[0], 'wallet_type': args[1]}
             elif len(args) == 3: a_dict = {'network': args[0], 'wallet_type': args[1], 'script_type': args[2]}
+            elif len(args) == 4: a_dict = {'network': args[0], 'wallet_type': args[1], 'script_type': args[2], 'account': args[3]}
             print(f"asserting {func.__name__}(**{a_dict}) == {repr(expected)}")
             assert func(**a_dict) == expected
 
@@ -91,6 +95,7 @@ def test_get_standard_derivation_path():
             if len(args) == 1: a_dict = {'network': args[0]}
             elif len(args) == 2: a_dict = {'network': args[0], 'wallet_type': args[1]}
             elif len(args) == 3: a_dict = {'network': args[0], 'wallet_type': args[1], 'script_type': args[2]}
+            elif len(args) == 4: a_dict = {'network': args[0], 'wallet_type': args[1], 'script_type': args[2], 'account': args[3]}
             print(f"asserting {func.__name__}(**{a_dict}) raises Exception")
             with pytest.raises(expected):
                 func(**a_dict)


### PR DESCRIPTION
## Summary
- add optional setting to enable BIP32 account prompting
- allow entering account number for single-sig xpub export and address explorer
- extend standard derivation path helper to accept account index

## Testing
- `pytest tests/test_embit_utils.py -q`
- `pytest` *(fails: KeyboardInterrupt after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f581de2883229f538ca3e68af93b