### PR TITLE
Retry Satochip genuine check when UID mismatch

### DIFF
--- a/src/seedsigner/helpers/seedkeeper_utils.py
+++ b/src/seedsigner/helpers/seedkeeper_utils.py
@@ -197,6 +197,13 @@ def init_satochip(parentObject, init_card_filter=None, require_pin=True):
                 time.sleep(0.1)  # Sleep for 100ms
                 logger.exception("Pin check failed")
 
+                # clear any cached PIN as it's obviously wrong and was mistakenly cached somewhere...
+                # (This can happen when the card UID is incorrectly read which happens sometimes)
+                try:
+                    parentObject.controller.Satochip_PIN = None
+                except:
+                    pass
+
                 parentObject.run_screen(
                     WarningScreen,
                     title="Failed",

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -1096,30 +1096,22 @@ class ToolsSmartcardGenuineCheckView(View):
             is_genuine, _, _, _, txt_error = Satochip_Connector.card_verify_authenticity()
 
             # Workaround for occasional incorrect UID calculation in pysatochip
+            # basically just try to connect again, using the PIN entered on the first attempt
             if not is_genuine or txt_error:
+                print("Initial genuine check failed, retrying...")
+                temp_pin = self.controller.Satochip_PIN
                 try:
-                    # Freshly query the card; this may update the UID
-                    Satochip_Connector.card_get_status()
-                    if (
-                        self.controller.Satochip_Last_UID_SHA1 is not None
-                        and Satochip_Connector.UID_SHA1
-                        != self.controller.Satochip_Last_UID_SHA1
-                    ):
-                        # Cached UID doesn't match, clear and recreate connector
-                        try:
-                            self.controller.Satochip_Connector.card_disconnect()
-                        except Exception:
-                            pass
-                        self.controller.Satochip_Connector = None
-                        self.controller.Satochip_Last_UID_SHA1 = None
-                        Satochip_Connector = seedkeeper_utils.init_satochip(
-                            self,
-                            init_card_filter=["satochip", "seedkeeper", "satodime"],
+
+                    Satochip_Connector = seedkeeper_utils.init_satochip(
+                        self,
+                        init_card_filter=["satochip", "seedkeeper", "satodime"],
+                        require_pin=False,
+                    )
+                    Satochip_Connector.set_pin(0, temp_pin)
+                    if Satochip_Connector:
+                        is_genuine, _, _, _, txt_error = (
+                            Satochip_Connector.card_verify_authenticity()
                         )
-                        if Satochip_Connector:
-                            is_genuine, _, _, _, txt_error = (
-                                Satochip_Connector.card_verify_authenticity()
-                            )
                 except Exception:
                     pass
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -1094,6 +1094,35 @@ class ToolsSmartcardGenuineCheckView(View):
 
         try:
             is_genuine, _, _, _, txt_error = Satochip_Connector.card_verify_authenticity()
+
+            # Workaround for occasional incorrect UID calculation in pysatochip
+            if not is_genuine or txt_error:
+                try:
+                    # Freshly query the card; this may update the UID
+                    Satochip_Connector.card_get_status()
+                    if (
+                        self.controller.Satochip_Last_UID_SHA1 is not None
+                        and Satochip_Connector.UID_SHA1
+                        != self.controller.Satochip_Last_UID_SHA1
+                    ):
+                        # Cached UID doesn't match, clear and recreate connector
+                        try:
+                            self.controller.Satochip_Connector.card_disconnect()
+                        except Exception:
+                            pass
+                        self.controller.Satochip_Connector = None
+                        self.controller.Satochip_Last_UID_SHA1 = None
+                        Satochip_Connector = seedkeeper_utils.init_satochip(
+                            self,
+                            init_card_filter=["satochip", "seedkeeper", "satodime"],
+                        )
+                        if Satochip_Connector:
+                            is_genuine, _, _, _, txt_error = (
+                                Satochip_Connector.card_verify_authenticity()
+                            )
+                except Exception:
+                    pass
+
             if txt_error:
                 self.run_screen(
                     ErrorScreen,


### PR DESCRIPTION
## Summary
- Re-query card UID and rebuild connector if authenticity check fails
- Retry genuine check using previously verified PIN

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1588d0e208322bf9c423f3ce7988d