### PR TITLE
Display smartcard UID in card info view

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -1049,6 +1049,14 @@ class ToolsSmartcardInfoView(View):
         card_type = getattr(Satochip_Connector, "card_type", "Unknown")
         info_lines.append(f"Type: {card_type}")
 
+        uid = getattr(Satochip_Connector, "UID_SHA1", None)
+        if not uid:
+            uid_raw = getattr(Satochip_Connector, "UID", None)
+            if uid_raw:
+                uid = bytes(uid_raw).hex()
+        if uid:
+            info_lines.append(f"UID: {uid}")
+
         version = f"{status.get('protocol_major_version', 0)}.{status.get('protocol_minor_version', 0)}-" \
                   f"{status.get('applet_major_version', 0)}.{status.get('applet_minor_version', 0)}"
         info_lines.append(f"Version: {version}")


### PR DESCRIPTION
## Summary
- show the smartcard's UID on the Common card info screen

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1f454d2f083229c9f2fc5023613d4