### PR TITLE
Fix persistent smartcard settings boot hang

### DIFF
--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -186,6 +186,14 @@ class Settings(Singleton):
                     if type(new_settings[entry.attr_name]) == str:
                         # Break comma-separated SettingsQR input into List
                         new_settings[entry.attr_name] = new_settings[entry.attr_name].split(",")
+                    elif (
+                        type(new_settings[entry.attr_name]) == list
+                        and len(new_settings[entry.attr_name]) > 0
+                        and type(new_settings[entry.attr_name][0]) in [list, tuple]
+                    ):
+                        # Handle legacy format where selection options were stored
+                        # as [value, label] pairs.
+                        new_settings[entry.attr_name] = [v[0] for v in new_settings[entry.attr_name]]
 
         for key, value in new_settings.items():
             # Defer writing to disk until all values have been applied to avoid

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -681,7 +681,7 @@ class SettingsDefinition:
                     type=SettingsConstants.TYPE__MULTISELECT,
                     visibility=SettingsConstants.VISIBILITY__HARDWARE,
                     selection_options=SettingsConstants.ALL_SMARTCARD_INTERFACES,
-                    default_value=SettingsConstants.ALL_SMARTCARD_INTERFACES),
+                    default_value=[opt[0] for opt in SettingsConstants.ALL_SMARTCARD_INTERFACES]),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__SYSTEM,
                     attr_name=SettingsConstants.SETTING__CACHE_SCARD_PIN,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,6 +2,7 @@ import pytest
 from base import BaseTest
 from seedsigner.models.settings import InvalidSettingsQRData, Settings
 from seedsigner.models.settings_definition import SettingsConstants
+from unittest.mock import patch
 
 
 
@@ -110,3 +111,15 @@ class TestSettings(BaseTest):
 
         # Accepts update with no Exceptions
         self.settings.update(new_settings=settings_update_dict)
+
+    def test_update_handles_legacy_multiselect_format(self):
+        """Updating from old list-of-lists format should normalize to list of values"""
+        legacy = [[opt[0], opt[1]] for opt in SettingsConstants.ALL_SMARTCARD_INTERFACES]
+
+        with patch("os.system"), patch("time.sleep"):
+            self.settings.update({
+                SettingsConstants.SETTING__SMARTCARD_INTERFACES: legacy
+            })
+
+        expected = [opt[0] for opt in SettingsConstants.ALL_SMARTCARD_INTERFACES]
+        assert self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_INTERFACES) == expected


### PR DESCRIPTION
## Summary
- ensure smartcard interface defaults store only interface values
- normalize multiselect settings from legacy format
- test legacy multiselect settings normalization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2580d23708322b8a6dcc711415bd7