### PR TITLE
Avoid microSD save during settings load

### DIFF
--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -54,10 +54,13 @@ class Settings(Singleton):
 
             settings._data = SettingsDefinition.get_defaults()
 
-            # Read persistent settings file, if it exists
+            # Read persistent settings file, if it exists. Loading should not
+            # immediately write back to disk which can dramatically slow boot
+            # if the microSD card is present. ``persist=False`` ensures we only
+            # populate the in-memory data without triggering ``save()``.
             if os.path.exists(Settings.SETTINGS_FILENAME):
                 with open(Settings.SETTINGS_FILENAME) as settings_file:
-                    settings.update(json.load(settings_file))
+                    settings.update(json.load(settings_file), persist=False)
 
             # Setup multilanguage support
             path = os.path.join(
@@ -159,7 +162,7 @@ class Settings(Singleton):
                 os.fsync(settings_file.fileno())
 
 
-    def update(self, new_settings: dict):
+    def update(self, new_settings: dict, persist: bool = True):
         print("Updating Settings")
         print("Existing Settings:", self._data) 
         print()
@@ -201,8 +204,9 @@ class Settings(Singleton):
             # bulk updates.
             self.set_value(key, value, save=False)
 
-        # Persist once after all settings have been updated.
-        self.save()
+        # Persist once after all settings have been updated, if requested.
+        if persist:
+            self.save()
 
 
 
@@ -559,15 +563,14 @@ class Settings(Singleton):
                 entry.selection_options = SettingsConstants.OPTIONS__ENABLED_DISABLED
                 entry.help_text = SettingsConstants.PERSISTENT_SETTINGS__SD_INSERTED__HELP_TEXT
 
-                # TODO: Perhaps prompt the user if the current settings (not including persistent
-                # settings) should overwrite the settings on disk, if they differ:
-                # - Overwrite settings on the SD?
-                # - Load settings from SD?
-                # if Settings file exists (meaning persistent settings was previously enabled), write out current settings to disk
+                # If a settings file exists, load it without persisting again. This
+                # avoids unnecessary disk writes during boot and when cards are
+                # re-inserted.
                 if os.path.exists(Settings.SETTINGS_FILENAME):
-                    # enable persistent settings first, then save
-                    Settings.get_instance()._data[SettingsConstants.SETTING__PERSISTENT_SETTINGS] = SettingsConstants.OPTION__ENABLED
-                    Settings.get_instance().save()
+                    settings = Settings.get_instance()
+                    if settings.get_value(SettingsConstants.SETTING__PERSISTENT_SETTINGS) != SettingsConstants.OPTION__ENABLED:
+                        with open(Settings.SETTINGS_FILENAME) as settings_file:
+                            settings.update(json.load(settings_file), persist=False)
 
             elif action == MicroSD.ACTION__REMOVED:
                 # SD card was just removed.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from base import BaseTest
 from seedsigner.models.settings import InvalidSettingsQRData, Settings
@@ -123,3 +124,26 @@ class TestSettings(BaseTest):
 
         expected = [opt[0] for opt in SettingsConstants.ALL_SMARTCARD_INTERFACES]
         assert self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_INTERFACES) == expected
+
+    def test_update_can_skip_persist(self):
+        """Updating with persist=False should not trigger a save to disk"""
+        from unittest.mock import patch
+        with patch.object(Settings, "save") as mock_save:
+            self.settings.update(
+                {SettingsConstants.SETTING__BTC_DENOMINATION: SettingsConstants.BTC_DENOMINATION__THRESHOLD},
+                persist=False,
+            )
+            mock_save.assert_not_called()
+
+    def test_get_instance_loads_without_saving(self):
+        """Loading settings from disk should not immediately write them back"""
+        from unittest.mock import patch
+        BaseTest.reset_settings()
+        data = {SettingsConstants.SETTING__PERSISTENT_SETTINGS: SettingsConstants.OPTION__ENABLED}
+        with open(Settings.SETTINGS_FILENAME, "w") as f:
+            json.dump(data, f)
+
+        with patch.object(Settings, "save") as mock_save:
+            settings = Settings.get_instance()
+            mock_save.assert_not_called()
+            assert settings.get_value(SettingsConstants.SETTING__PERSISTENT_SETTINGS) == SettingsConstants.OPTION__ENABLED


### PR DESCRIPTION
## Summary
- prevent boot hangs by skipping microSD writes when loading persistent settings
- allow Settings.update() to opt-out of saving
- load settings from SD card without persisting on insert
- test that settings load/update skip saving when requested

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a28df570508322b26b50e2d65443ed