### PR TITLE
fix: reset invalid desktop display config on hardware

### DIFF
--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -75,6 +75,22 @@ class Settings(Singleton):
             # Load default/persistent locale setting
             settings.load_locale()
 
+            # Ensure persisted display configuration is compatible with the
+            # current platform.  Desktop display options rely on optional
+            # modules (e.g. pygame) that are not installed on SeedSignerOS.
+            # If such an option was saved while running on a desktop and is
+            # now loaded on a Pi, fall back to the default hardware display
+            # to avoid import errors during startup.
+            if not USING_MOCK_GPIO:
+                valid_configs = [opt[0] for opt in SettingsConstants.ALL_DISPLAY_CONFIGURATIONS]
+                if (
+                    settings._data.get(SettingsConstants.SETTING__DISPLAY_CONFIGURATION)
+                    not in valid_configs
+                ):
+                    settings._data[
+                        SettingsConstants.SETTING__DISPLAY_CONFIGURATION
+                    ] = SettingsConstants.DISPLAY_CONFIGURATION__ST7789__240x240
+
             if USING_MOCK_GPIO:
                 settings._data[SettingsConstants.SETTING__DISPLAY_CONFIGURATION] = (
                     SettingsConstants.DISPLAY_CONFIGURATION__DESKTOP__240x240

--- a/tests/test_display_config_fallback.py
+++ b/tests/test_display_config_fallback.py
@@ -1,0 +1,38 @@
+import json
+
+from seedsigner.models import settings as settings_module
+from seedsigner.models.settings import Settings
+from seedsigner.models.settings_definition import SettingsConstants
+
+
+def test_invalid_display_config_falls_back(tmp_path, monkeypatch):
+    # Simulate running on real hardware without desktop display support
+    monkeypatch.setattr(settings_module, "USING_MOCK_GPIO", False)
+    monkeypatch.setattr(
+        SettingsConstants,
+        "ALL_DISPLAY_CONFIGURATIONS",
+        [
+            (SettingsConstants.DISPLAY_CONFIGURATION__ST7789__240x240, "st7789 240x240"),
+            (SettingsConstants.DISPLAY_CONFIGURATION__ST7789__320x240, "st7789 320x240"),
+            (SettingsConstants.DISPLAY_CONFIGURATION__ILI9341__320x240, "ili9341 320x240 (beta)"),
+        ],
+        raising=False,
+    )
+
+    # Create a settings file with an incompatible desktop display configuration
+    settings_file = tmp_path / "settings.json"
+    settings_data = {
+        SettingsConstants.SETTING__DISPLAY_CONFIGURATION: SettingsConstants.DISPLAY_CONFIGURATION__DESKTOP__240x240,
+    }
+    settings_file.write_text(json.dumps(settings_data))
+
+    monkeypatch.setattr(Settings, "SETTINGS_FILENAME", str(settings_file))
+
+    # Reset singleton and load settings
+    Settings._instance = None
+    loaded = Settings.get_instance()
+
+    assert (
+        loaded.get_value(SettingsConstants.SETTING__DISPLAY_CONFIGURATION)
+        == SettingsConstants.DISPLAY_CONFIGURATION__ST7789__240x240
+    )


### PR DESCRIPTION
## Summary
- ensure persisted desktop display settings fall back to hardware default on SeedSignerOS
- add regression test for desktop display fallback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3ff2bcf188322a99abbe3e82b3568