### PR TITLE
Avoid crash on missing settings entry

### DIFF
--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -221,7 +221,13 @@ class Settings(Singleton):
             print(f"Setting {attr_name} not recognized. Ignoring.")
             return
 
-        if SettingsDefinition.get_settings_entry(attr_name).type == SettingsConstants.TYPE__MULTISELECT:
+        settings_entry = SettingsDefinition.get_settings_entry(attr_name)
+        if not settings_entry:
+            # Settings entry may be unavailable on this platform
+            print(f"Setting {attr_name} not found. Ignoring.")
+            return
+
+        if settings_entry.type == SettingsConstants.TYPE__MULTISELECT:
             if type(value) != list:
                 raise Exception(f"value must be a List for {attr_name}")
         

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -147,3 +147,18 @@ class TestSettings(BaseTest):
             settings = Settings.get_instance()
             mock_save.assert_not_called()
             assert settings.get_value(SettingsConstants.SETTING__PERSISTENT_SETTINGS) == SettingsConstants.OPTION__ENABLED
+
+    def test_set_value_ignores_missing_settings_entry(self):
+        """set_value should not raise if the settings entry cannot be found"""
+        from seedsigner.models import settings_definition
+
+        # Force SettingsDefinition.get_settings_entry to return None for camera device
+        orig = settings_definition.USING_MOCK_GPIO
+        settings_definition.USING_MOCK_GPIO = False
+        try:
+            current = self.settings.get_value(SettingsConstants.SETTING__CAMERA_DEVICE)
+            # Should silently ignore without raising
+            self.settings.set_value(SettingsConstants.SETTING__CAMERA_DEVICE, current)
+            assert self.settings.get_value(SettingsConstants.SETTING__CAMERA_DEVICE) == current
+        finally:
+            settings_definition.USING_MOCK_GPIO = orig


### PR DESCRIPTION
## Summary
- Guard against missing SettingsDefinition entries to avoid crashes when certain settings are unavailable
- Add regression test ensuring `set_value` ignores missing settings entries

## Testing
- `pytest tests/test_settings.py::TestSettings::test_set_value_ignores_missing_settings_entry -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a769dae08883229872891db8692665