### PR TITLE
Avoid unnecessary pcscd restart when settings unchanged

### DIFF
--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -230,6 +230,18 @@ class Settings(Singleton):
         if settings_entry.type == SettingsConstants.TYPE__MULTISELECT:
             if type(value) != list:
                 raise Exception(f"value must be a List for {attr_name}")
+
+        # Skip processing if the incoming value is identical to the current
+        # value. This prevents unnecessary side-effects (like restarting
+        # services) when loading persistent settings that match defaults.
+        if attr_name in self._data:
+            current_value = self._data[attr_name]
+            if settings_entry.type == SettingsConstants.TYPE__MULTISELECT:
+                if sorted(current_value) == sorted(value):
+                    return
+            else:
+                if current_value == value:
+                    return
         
         # Special handling for toggling persistence
         if attr_name == SettingsConstants.SETTING__PERSISTENT_SETTINGS and value == SettingsConstants.OPTION__DISABLED:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -125,6 +125,16 @@ class TestSettings(BaseTest):
         expected = [opt[0] for opt in SettingsConstants.ALL_SMARTCARD_INTERFACES]
         assert self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_INTERFACES) == expected
 
+    def test_update_skips_unchanged_smartcard_interfaces(self):
+        """Updating with identical smartcard interfaces should not restart pcscd"""
+        current = self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_INTERFACES)
+        with patch("os.system") as mock_system, patch("time.sleep"):
+            self.settings.update({
+                SettingsConstants.SETTING__SMARTCARD_INTERFACES: current
+            })
+
+        mock_system.assert_not_called()
+
     def test_update_can_skip_persist(self):
         """Updating with persist=False should not trigger a save to disk"""
         from unittest.mock import patch


### PR DESCRIPTION
## Summary
- Skip processing in `Settings.set_value` if the incoming value matches the current value
- Add regression test ensuring smartcard interface updates do not restart `pcscd` when unchanged

## Testing
- `pytest tests/test_settings.py`

------
https://chatgpt.com/codex/tasks/task_e_68a7e6c6b7ec8322a672242f5a74d861