### PR TITLE
Disable WIF and BIP38 signing by default

### DIFF
--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -823,13 +823,13 @@ class SettingsDefinition:
                       attr_name=SettingsConstants.SETTING__WIF_KEYS,
                       display_name="WIF keys",
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
-                      default_value=SettingsConstants.OPTION__ENABLED),
+                      default_value=SettingsConstants.OPTION__DISABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__BIP38_KEYS,
                       display_name="BIP38 keys",
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
-                      default_value=SettingsConstants.OPTION__ENABLED),
+                      default_value=SettingsConstants.OPTION__DISABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__BIP85_CHILD_SEEDS,

--- a/tests/test_flows_psbt.py
+++ b/tests/test_flows_psbt.py
@@ -176,6 +176,9 @@ class TestPSBTFlows(FlowTest):
         from embit.transaction import Transaction, TransactionInput, TransactionOutput
         import os, base64
 
+        # Enable WIF signing for this test
+        self.settings.set_value(SettingsConstants.SETTING__WIF_KEYS, SettingsConstants.OPTION__ENABLED)
+
         priv = ec.PrivateKey(os.urandom(32))
         wif = priv.wif()
         pub = priv.get_public_key()
@@ -204,6 +207,9 @@ class TestPSBTFlows(FlowTest):
         from embit.transaction import Transaction, TransactionInput, TransactionOutput
         import base64
         from seedsigner.models.bip38 import BIP38Key
+
+        # Enable BIP38 signing for this test
+        self.settings.set_value(SettingsConstants.SETTING__BIP38_KEYS, SettingsConstants.OPTION__ENABLED)
 
         enc = "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg"
         passphrase = "TestingOneTwoThree"


### PR DESCRIPTION
## Summary
- disable WIF and BIP38 signing in default settings
- adjust tests to enable these features explicitly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9e71de7548322a4a196471ee39875