### PR TITLE
Restrict Satochip script types to card capabilities

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2634,9 +2634,20 @@ class SatochipExportXpubScriptTypeView(View):
         self.script_type = script_type
 
     def run(self):
+        Satochip_Connector = seedkeeper_utils.init_satochip(
+            self, init_card_filter=["satochip"], require_pin=False
+        )
+        if not Satochip_Connector:
+            return Destination(BackStackView)
+
+        status = Satochip_Connector.card_get_status()[3]
+        schnorr_supported = status.get("feature_schnorr_policy") == 0
+
         button_data = []
         for script_type, display_name in SettingsConstants.ALL_SCRIPT_TYPES:
             if script_type in self.settings.get_value(SettingsConstants.SETTING__SCRIPT_TYPES):
+                if script_type == SettingsConstants.TAPROOT and not schnorr_supported:
+                    continue
                 button_data.append(ButtonOption(display_name, return_data=script_type))
 
         selected_menu_num = self.run_screen(
@@ -2985,9 +2996,20 @@ class SatochipLoadDescriptorScriptTypeView(View):
         self.script_type = script_type
 
     def run(self):
+        Satochip_Connector = seedkeeper_utils.init_satochip(
+            self, init_card_filter=["satochip"], require_pin=False
+        )
+        if not Satochip_Connector:
+            return Destination(BackStackView)
+
+        status = Satochip_Connector.card_get_status()[3]
+        schnorr_supported = status.get("feature_schnorr_policy") == 0
+
         button_data = []
         for script_type, display_name in SettingsConstants.ALL_SCRIPT_TYPES:
             if script_type in self.settings.get_value(SettingsConstants.SETTING__SCRIPT_TYPES):
+                if script_type == SettingsConstants.TAPROOT and not schnorr_supported:
+                    continue
                 button_data.append(ButtonOption(display_name, return_data=script_type))
 
         selected_menu_num = self.run_screen(

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -1045,6 +1045,91 @@ class TestSatochipExportXpubDetailsView(BaseTest):
                 assert view.run_screen.call_args.kwargs["xpub"].startswith("Zpub")
 
 
+class TestSatochipScriptTypeFiltering(BaseTest):
+    def test_export_xpub_hides_taproot_when_unsupported(self, monkeypatch):
+        from seedsigner.views import tools_views
+        from seedsigner.models.settings_definition import SettingsConstants
+        from seedsigner.helpers import seedkeeper_utils
+        from seedsigner.controller import Controller
+        from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
+        from seedsigner.views.view import BackStackView
+
+        class MockConnector:
+            def card_get_status(self):
+                return None, 0x90, 0x00, {"feature_schnorr_policy": 1}
+
+        monkeypatch.setattr(seedkeeper_utils, "init_satochip", lambda *a, **k: MockConnector())
+
+        controller = Controller.get_instance()
+        controller.settings.set_value(
+            SettingsConstants.SETTING__SCRIPT_TYPES,
+            [
+                SettingsConstants.NATIVE_SEGWIT,
+                SettingsConstants.NESTED_SEGWIT,
+                SettingsConstants.TAPROOT,
+            ],
+        )
+
+        view = tools_views.SatochipExportXpubScriptTypeView(sig_type=SettingsConstants.SINGLE_SIG)
+
+        captured = {}
+
+        def fake_run_screen(screen_cls, **kwargs):
+            captured["button_data"] = kwargs.get("button_data")
+            return RET_CODE__BACK_BUTTON
+
+        monkeypatch.setattr(view, "run_screen", fake_run_screen)
+
+        destination = view.run()
+
+        assert destination.View_cls == BackStackView
+        assert all(
+            option.return_data != SettingsConstants.TAPROOT
+            for option in captured["button_data"]
+        )
+
+    def test_load_descriptor_hides_taproot_when_unsupported(self, monkeypatch):
+        from seedsigner.views import tools_views
+        from seedsigner.models.settings_definition import SettingsConstants
+        from seedsigner.helpers import seedkeeper_utils
+        from seedsigner.controller import Controller
+        from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
+        from seedsigner.views.view import BackStackView
+
+        class MockConnector:
+            def card_get_status(self):
+                return None, 0x90, 0x00, {"feature_schnorr_policy": 2}
+
+        monkeypatch.setattr(seedkeeper_utils, "init_satochip", lambda *a, **k: MockConnector())
+
+        controller = Controller.get_instance()
+        controller.settings.set_value(
+            SettingsConstants.SETTING__SCRIPT_TYPES,
+            [
+                SettingsConstants.NATIVE_SEGWIT,
+                SettingsConstants.NESTED_SEGWIT,
+                SettingsConstants.TAPROOT,
+            ],
+        )
+
+        view = tools_views.SatochipLoadDescriptorScriptTypeView()
+
+        captured = {}
+
+        def fake_run_screen(screen_cls, **kwargs):
+            captured["button_data"] = kwargs.get("button_data")
+            return RET_CODE__BACK_BUTTON
+
+        monkeypatch.setattr(view, "run_screen", fake_run_screen)
+
+        destination = view.run()
+
+        assert destination.View_cls == BackStackView
+        assert all(
+            option.return_data != SettingsConstants.TAPROOT
+            for option in captured["button_data"]
+        )
+
 class TestSatochipImportSeedView(BaseTest):
     def test_already_seeded_card_shows_warning(self, monkeypatch):
         from seedsigner.views import tools_views

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -237,6 +237,9 @@ class TestToolsFlows(FlowTest):
                     return derived_xpub
                 raise ValueError("unexpected path")
 
+            def card_get_status(self):
+                return None, 0x90, 0x00, {"feature_schnorr_policy": 0}
+
         monkeypatch.setattr(seedkeeper_utils, "init_satochip", lambda *args, **kwargs: MockConnector())
 
         controller = Controller.get_instance()


### PR DESCRIPTION
## Summary
- hide Satochip Taproot options when the card doesn't advertise Schnorr support
- add regression tests covering script-type filtering for Satochip xpub export and descriptor loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9eccc5cf48322b7a17d43db44bb53