### PR TITLE
Add Jupyter notebook for desktop simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,3 +435,5 @@ See the [SeedSigner OS repo](https://github.com/SeedSigner/seedsigner-os/) for i
 Raspberry Pi OS is commonly used for development. See the [Raspberry Pi OS Build Instructions](docs/raspberry_pi_os_build_instructions.md)
 
 To experiment on a regular PC, a pygame‑based simulator is available. See the [Desktop Simulation guide](docs/desktop_simulation.md) for installation and usage instructions.
+
+For a browser‑based workflow, a [Jupyter notebook](notebooks/desktop_simulation.ipynb) is provided to install dependencies and launch the simulator directly from a notebook environment.

--- a/notebooks/desktop_simulation.ipynb
+++ b/notebooks/desktop_simulation.ipynb
@@ -1,0 +1,50 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SeedSigner Desktop Simulation in Jupyter\n",
+    "This notebook installs dependencies and launches the SeedSigner desktop simulator.\n",
+    "It is intended for development and testing only."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --no-deps -r ../requirements.txt -r ../requirements-desktop.txt\n",
+    "# For headless environments you may need a virtual display:\n",
+    "# !pip install pyvirtualdisplay\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If using a virtual display, start it before launching SeedSigner:\n",
+    "# from pyvirtualdisplay import Display\n",
+    "# display = Display(visible=0, size=(800, 600))\n",
+    "# display.start()\n",
+    "\n",
+    "!python ../src/main.py\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Provide a notebook for running the SeedSigner desktop simulator from a browser-based Jupyter environment.
- Document the notebook in the developer build instructions.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa2d64217c8322a4bfe8e92b2fceed