### PR TITLE
Warn when running on developer SeedSignerOS

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -299,9 +299,13 @@ class Controller(Singleton):
         from seedsigner.views.screensaver import OpeningSplashView
         from seedsigner.models.settings_definition import SettingsConstants
         from seedsigner.views.desktop_warning import DesktopWarningView
+        from seedsigner.views.developer_os_warning import DeveloperOSWarningView
+        from seedsigner.helpers.seedsigner_os import is_seedsigner_os_dev_build
         from seedsigner.gui.toast import RemoveSDCardToastManagerThread
 
         OpeningSplashView().run()
+        if is_seedsigner_os_dev_build():
+            DeveloperOSWarningView().run()
         if self.settings.get_value(SettingsConstants.SETTING__DISPLAY_CONFIGURATION).startswith("desktop"):
             DesktopWarningView().run()
 

--- a/src/seedsigner/helpers/seedsigner_os.py
+++ b/src/seedsigner/helpers/seedsigner_os.py
@@ -1,0 +1,13 @@
+import os
+
+
+def is_seedsigner_os_dev_build() -> bool:
+    """Return True if running on a developer SeedSignerOS image.
+
+    Developer OS images include additional utilities such as
+    ``/usr/bin/microsd_notice.py`` used during boot to load sources
+    from an external microSD card. The presence of this file marks a
+    development build that is not intended for production use.
+    """
+    return os.path.exists("/usr/bin/microsd_notice.py")
+

--- a/src/seedsigner/views/developer_os_warning.py
+++ b/src/seedsigner/views/developer_os_warning.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+
+from seedsigner.views.view import View, Destination
+from seedsigner.gui.screens.screen import WarningScreen, ButtonOption
+from seedsigner.helpers.l10n import mark_for_translation as _mft
+
+
+@dataclass
+class DeveloperOSWarningView(View):
+    """Warn users that a developer SeedSignerOS image is running."""
+
+    def run(self) -> Destination:
+        self.run_screen(
+            WarningScreen,
+            title=_mft("Development Build"),
+            status_headline=_mft("Not secure!"),
+            text=_mft(
+                "This SeedSignerOS development build is for testing only.\nDo NOT use with real seeds or private keys."
+            ),
+            button_data=[ButtonOption(_mft("I Understand"))],
+        )
+        return Destination(None)
+

--- a/tests/test_seedsigner_os.py
+++ b/tests/test_seedsigner_os.py
@@ -1,0 +1,14 @@
+import os
+
+from seedsigner.helpers.seedsigner_os import is_seedsigner_os_dev_build
+
+
+def test_is_seedsigner_os_dev_build(monkeypatch):
+    # Simulate developer OS by faking the presence of the indicator file.
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/usr/bin/microsd_notice.py")
+    assert is_seedsigner_os_dev_build()
+
+    # Simulate non-developer OS where the file is absent.
+    monkeypatch.setattr(os.path, "exists", lambda p: False)
+    assert not is_seedsigner_os_dev_build()
+


### PR DESCRIPTION
## Summary
- Detect developer SeedSignerOS builds via `/usr/bin/microsd_notice.py`
- Show a startup warning for dev OS images
- Add tests for dev OS detection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab3c6a04548322add46d02d384a67f