### PR TITLE
Add device filter to common smartcard tasks

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -152,6 +152,7 @@ class Controller(Singleton):
     Satochip_Connector = None
     Satochip_PIN = None
     Satochip_Last_UID_SHA1 = None
+    tools_common_card_filter: list[str] = None
 
     # Destination placeholder for when we need to jump out to a side flow but intend to
     # return navigation to the main flow (e.g. PSBT flow, load multisig descriptor,

--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -3,18 +3,30 @@ import time
 
 from dataclasses import dataclass
 from gettext import gettext as _
-from typing import Any
+from typing import Any, List
 from PIL import Image, ImageDraw
 from seedsigner.helpers import mnemonic_generation
 from seedsigner.gui.renderer import Renderer
 from seedsigner.hardware.camera import Camera
 from seedsigner.helpers.qr import QR
-from seedsigner.gui.components import FontAwesomeIconConstants, Fonts, GUIConstants, IconTextLine, SeedSignerIconConstants, TextArea, Button, IconButton
+from seedsigner.gui.components import FontAwesomeIconConstants, Fonts, GUIConstants, IconTextLine, SeedSignerIconConstants, TextArea, Button, IconButton, CheckboxButton
 from seedsigner.gui.keyboard import Keyboard, TextEntryDisplay
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, BaseScreen, BaseTopNavScreen, ButtonListScreen, KeyboardScreen, WarningEdgesMixin, ButtonOption
 from seedsigner.hardware.buttons import HardwareButtonsConstants
 from seedsigner.models.settings_definition import SettingsConstants, SettingsDefinition
 
+
+
+@dataclass
+class ToolsCommonFilterScreen(ButtonListScreen):
+    checked_buttons: List[int] = None
+
+    def __post_init__(self):
+        self.title = _("Device Filter")
+        self.is_bottom_list = True
+        self.is_button_text_centered = False
+        self.Button_cls = CheckboxButton
+        super().__post_init__()
 
 
 @dataclass

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -26,7 +26,7 @@ from seedsigner.gui.screens.tools_screens import (ToolsCalcFinalWordDoneScreen, 
     ToolsCalcFinalWordScreen, ToolsCoinFlipEntryScreen, ToolsDiceEntropyEntryScreen, ToolsImageEntropyFinalImageScreen,
     ToolsImageEntropyLivePreviewScreen, ToolsAddressExplorerAddressTypeScreen, ToolsTextQRTextEntryScreen, ToolsTextQRReviewTextScreen,
     ToolsTextQRTranscribeModePromptScreen, ToolsTranscribeTextQRWholeQRScreen, ToolsTranscribeTextQRZoomedInScreen,
-    ToolsTranscribeTextQRConfirmQRPromptScreen)
+    ToolsTranscribeTextQRConfirmQRPromptScreen, ToolsCommonFilterScreen)
 from seedsigner.helpers import embit_utils, mnemonic_generation
 from seedsigner.helpers.iso7816 import format_sw_error
 from seedsigner.models.decode_qr import DecodeQR
@@ -1009,6 +1009,7 @@ class ToolsSmartcardMenuView(View):
             return Destination(ToolsSatochipDIYView)
 
 class ToolsCommonView(View):
+    FILTER = ButtonOption("Device Filter")
     INFO = ButtonOption("Card Info")
     GENUINE = ButtonOption("Genuine Check")
     CHANGE_PIN = ButtonOption("Change PIN")
@@ -1018,7 +1019,15 @@ class ToolsCommonView(View):
 
     def run(self):
 
-        button_data = [self.INFO, self.GENUINE, self.CHANGE_PIN, self.CHANGE_LABEL, self.CHANGE_NFC, self.FACTORY_RESET]
+        button_data = [
+            self.FILTER,
+            self.INFO,
+            self.GENUINE,
+            self.CHANGE_PIN,
+            self.CHANGE_LABEL,
+            self.CHANGE_NFC,
+            self.FACTORY_RESET,
+        ]
 
         selected_menu_num = self.run_screen(
                 ButtonListScreen,
@@ -1029,6 +1038,9 @@ class ToolsCommonView(View):
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
+
+        elif button_data[selected_menu_num] == self.FILTER:
+            return Destination(ToolsCommonFilterView)
 
         elif button_data[selected_menu_num] == self.INFO:
             return Destination(ToolsSmartcardInfoView)
@@ -1048,11 +1060,49 @@ class ToolsCommonView(View):
         elif button_data[selected_menu_num] == self.FACTORY_RESET:
             return Destination(ToolsSatochipFactoryResetView)
 
+
+class ToolsCommonFilterView(View):
+    def run(self):
+        devices = [
+            ("satochip", "Satochip"),
+            ("seedkeeper", "Seedkeeper"),
+            ("satodime", "Satodime"),
+        ]
+
+        selected = self.controller.tools_common_card_filter or [d[0] for d in devices]
+
+        while True:
+            button_data = [ButtonOption(name) for _, name in devices]
+            checked = [i for i, (code, _) in enumerate(devices) if code in selected]
+
+            ret = self.run_screen(
+                ToolsCommonFilterScreen,
+                button_data=button_data,
+                checked_buttons=checked,
+            )
+
+            if ret == RET_CODE__BACK_BUTTON:
+                if len(selected) == len(devices):
+                    self.controller.tools_common_card_filter = None
+                else:
+                    self.controller.tools_common_card_filter = list(selected)
+                return Destination(BackStackView)
+
+            code = devices[ret][0]
+            if code in selected:
+                selected.remove(code)
+            else:
+                selected.append(code)
+
 class ToolsSmartcardInfoView(View):
     def run(self):
 
+        allowed = ["satochip", "seedkeeper", "satodime"]
+        card_filter = self.controller.tools_common_card_filter or allowed
+        card_filter = [c for c in card_filter if c in allowed]
+
         Satochip_Connector = seedkeeper_utils.init_satochip(
-            self, init_card_filter=["satochip", "seedkeeper", "satodime"], require_pin=False
+            self, init_card_filter=card_filter, require_pin=False
         )
 
         if not Satochip_Connector:
@@ -1109,8 +1159,12 @@ class ToolsSmartcardInfoView(View):
 class ToolsSmartcardGenuineCheckView(View):
     def run(self):
 
+        allowed = ["satochip", "seedkeeper", "satodime"]
+        card_filter = self.controller.tools_common_card_filter or allowed
+        card_filter = [c for c in card_filter if c in allowed]
+
         Satochip_Connector = seedkeeper_utils.init_satochip(
-            self, init_card_filter=["satochip", "seedkeeper", "satodime"]
+            self, init_card_filter=card_filter
         )
 
         if not Satochip_Connector:
@@ -1128,7 +1182,7 @@ class ToolsSmartcardGenuineCheckView(View):
 
                     Satochip_Connector = seedkeeper_utils.init_satochip(
                         self,
-                        init_card_filter=["satochip", "seedkeeper", "satodime"],
+                        init_card_filter=card_filter,
                         require_pin=False,
                     )
                     Satochip_Connector.set_pin(0, temp_pin)
@@ -1172,8 +1226,12 @@ class ToolsSmartcardGenuineCheckView(View):
 
 class ToolsSatochipChangePinView(View):
     def run(self):
-        
-        Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip", "seedkeeper"])
+
+        allowed = ["satochip", "seedkeeper"]
+        card_filter = self.controller.tools_common_card_filter or ["satochip", "seedkeeper", "satodime"]
+        card_filter = [c for c in card_filter if c in allowed]
+
+        Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=card_filter)
 
         if not Satochip_Connector:
             return Destination(BackStackView)
@@ -1211,8 +1269,12 @@ class ToolsSatochipChangePinView(View):
     
 class ToolsSatochipChangeNFCView(View):
     def run(self):
-        
-        Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip", "seedkeeper"])
+
+        allowed = ["satochip", "seedkeeper"]
+        card_filter = self.controller.tools_common_card_filter or ["satochip", "seedkeeper", "satodime"]
+        card_filter = [c for c in card_filter if c in allowed]
+
+        Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=card_filter)
 
         if not Satochip_Connector:
             return Destination(BackStackView)
@@ -1302,7 +1364,11 @@ class ToolsSatochipFactoryResetView(View):
         
         new version currently only implemented on SeedKeeper v0.2 and higher
         """
-        Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip", "seedkeeper"], require_pin = False)
+        allowed = ["satochip", "seedkeeper"]
+        card_filter = self.controller.tools_common_card_filter or ["satochip", "seedkeeper", "satodime"]
+        card_filter = [c for c in card_filter if c in allowed]
+
+        Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=card_filter, require_pin = False)
 
         if not Satochip_Connector:
             return Destination(BackStackView)
@@ -1676,8 +1742,12 @@ class ToolsSatochipFactoryResetView(View):
 
 class ToolsSatochipChangeLabelView(View):
     def run(self):
-        
-        Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip", "seedkeeper"])
+
+        allowed = ["satochip", "seedkeeper"]
+        card_filter = self.controller.tools_common_card_filter or ["satochip", "seedkeeper", "satodime"]
+        card_filter = [c for c in card_filter if c in allowed]
+
+        Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=card_filter)
 
         if not Satochip_Connector:
             return Destination(BackStackView)

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -196,6 +196,7 @@ class MainMenuView(View):
 
         controller = Controller.get_instance()
         controller.storage.discard_pending_slip39_shares()
+        controller.tools_common_card_filter = None
         if controller.auto_wiped:
             controller.auto_wiped = False
             controller.activate_toast(InfoToast(label_text=_("Data wiped after inactivity")))


### PR DESCRIPTION
## Summary
- add Device Filter option to common smartcard tools
- allow users to choose Satochip, Seedkeeper, and Satodime devices for common tasks
- clear filter on returning to the home menu

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b08131d9f08322be51f3954fa37a2e