### PR TITLE
Add BIP85 GPG key loading option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 Entries marked "(SeedSigner official)" originate from the upstream project, while "(smartcard fork)" indicates releases and changes unique to this repository.
 
 ## Unreleased - SS0.8.6+Satochip+Earthdiver-B4 (smartcard fork)
-- Deterministic BIP85 GPG key derivation with configurable name, email, and expiration (defaulting to 10 years from creation); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
+- Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to 10 years from creation), and key type (RSA 4096, RSA 2048, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
 
 ## 2025-08-04 - SS0.8.6+Satochip+Earthdiver-B3 (smartcard fork)
 - Satochip card transaction signing and PSBT verification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Entries marked "(SeedSigner official)" originate from the upstream project, whil
 
 ## Unreleased - SS0.8.6+Satochip+Earthdiver-B4 (smartcard fork)
 - Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to 10 years from creation), and key type (RSA 4096, RSA 2048, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
+- MicroSD and GPG tools now display seed-loaded warnings only when opening file pickers
 
 ## 2025-08-04 - SS0.8.6+Satochip+Earthdiver-B3 (smartcard fork)
 - Satochip card transaction signing and PSBT verification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Entries marked "(SeedSigner official)" originate from the upstream project, whil
 - SeedKeeper Electrum seed support and splitted passphrase/encryption key QR codes
 - Enhanced entropy monitoring with hardware RNG, quality indicators and optional 30-minute wipe timer
 - Desktop simulation mode with system camera support
+- Deterministic BIP85 GPG key derivation with configurable name, email, and expiration (defaulting to 2035-12-31); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
 
 ## 2025-08-04 - SS0.8.6+Satochip+Earthdiver-B2-A1 (smartcard fork)
 - Pre-release build for SS0.8.6 smartcard fork; see GitHub release notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented in this file.
 
 Entries marked "(SeedSigner official)" originate from the upstream project, while "(smartcard fork)" indicates releases and changes unique to this repository.
 
+## Unreleased - SS0.8.6+Satochip+Earthdiver-B4 (smartcard fork)
+- Deterministic BIP85 GPG key derivation with configurable name, email, and expiration (defaulting to 10 years from creation); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
+
 ## 2025-08-04 - SS0.8.6+Satochip+Earthdiver-B3 (smartcard fork)
 - Satochip card transaction signing and PSBT verification
 - Satochip Message signing and xpub export (single and multisig) with address explorer integration
@@ -15,7 +18,6 @@ Entries marked "(SeedSigner official)" originate from the upstream project, whil
 - SeedKeeper Electrum seed support and splitted passphrase/encryption key QR codes
 - Enhanced entropy monitoring with hardware RNG, quality indicators and optional 30-minute wipe timer
 - Desktop simulation mode with system camera support
-- Deterministic BIP85 GPG key derivation with configurable name, email, and expiration (defaulting to 2035-12-31); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
 
 ## 2025-08-04 - SS0.8.6+Satochip+Earthdiver-B2-A1 (smartcard fork)
 - Pre-release build for SS0.8.6 smartcard fork; see GitHub release notes

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Support and discussion relating to this fork can happen via this [Telegram Group
    - Secure Wipe (Both with zeros and random data)
 * GPG Tools
    - GPG Signature verification & Sha256 Manifest check (Includes pubkey bundle the from Sparrow to verify Seedsigner, Sparrow, Electrum, plus many more)
+   - Load BIP85-derived RSA keys into gpg with prompts for name, email, and expiration (defaulting to 2035-12-31); metadata such as name, email, expiration, and deprecation/end-of-use dates can be modified later ([docs](./docs/gpg_tools.md))
 * Tested and working with the following hardware
    - Raspberry Pi Zero 1.3
    - Raspberry Pi Zero W

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Support and discussion relating to this fork can happen via this [Telegram Group
    - Secure Wipe (Both with zeros and random data)
 * GPG Tools
    - GPG Signature verification & Sha256 Manifest check (Includes pubkey bundle the from Sparrow to verify Seedsigner, Sparrow, Electrum, plus many more)
-   - Load BIP85-derived RSA keys into gpg with prompts for name, email, and expiration (defaulting to 2035-12-31); metadata such as name, email, expiration, and deprecation/end-of-use dates can be modified later ([docs](./docs/gpg_tools.md))
+   - Load BIP85-derived GPG keys (RSA 4096, RSA 2048, or secp256k1) with prompts for key type, name, email, and expiration (defaulting to 10 years in the future); metadata such as name, email, expiration, and deprecation/end-of-use dates can be modified later ([docs](./docs/gpg_tools.md))
 * Tested and working with the following hardware
    - Raspberry Pi Zero 1.3
    - Raspberry Pi Zero W

--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -1,8 +1,8 @@
 # GPG Tools
 
-SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives an RSA keypair from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG.
+SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives a keypair (RSA 4096, RSA 2048, or secp256k1) from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG.
 
-During import, SeedSigner prompts for the key's user name, email address, and expiration date. The expiration defaults to **2035-12-31** (the last day of 2035) in line with NIST guidelines. 
+During import, SeedSigner prompts for the key type, user name, email address, and expiration date. The expiration defaults to **10 years in the future**.
 
 After the key is imported, all metadata can be changed within GPG. You may edit the name, email address, and adjust the expiration, including setting future deprecation or end-of-use dates, using standard commands such as `gpg --edit-key`.
 

--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -2,7 +2,9 @@
 
 SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives a keypair (RSA 4096, RSA 2048, or secp256k1) from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG.
 
-During import, SeedSigner prompts for the key type, user name, email address, and expiration date. The expiration defaults to **10 years in the future**.
+For SeedSignerOS, everything is stateless. If running on desktop or some other normal system, you will be interacting with your system GPG2 install...
 
-After the key is imported, all metadata can be changed within GPG. You may edit the name, email address, and adjust the expiration, including setting future deprecation or end-of-use dates, using standard commands such as `gpg --edit-key`.
+During import, SeedSigner prompts for the key type, user name, email address, and expiration date. The expiration defaults to **10 years in the future**. (Noting that NIST guidelines have RSA2048 deprecated in 2030 and non-quantum safe keys, both RSA4096 and ECC keys, being discontinued for government applications after 2035)
+
+Note: The key derivation with BIP85 is deterministic, meaning the key and fingerprint will always be the same, but metadata like the username, email address and expiration date can be changed. (And are not saved on-device, but can be exported to a Smartcard, etc)
 

--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -1,0 +1,8 @@
+# GPG Tools
+
+SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives an RSA keypair from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG.
+
+During import, SeedSigner prompts for the key's user name, email address, and expiration date. The expiration defaults to **2035-12-31** (the last day of 2035) in line with NIST guidelines. 
+
+After the key is imported, all metadata can be changed within GPG. You may edit the name, email address, and adjust the expiration, including setting future deprecation or end-of-use dates, using standard commands such as `gpg --edit-key`.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,8 @@ colorama==0.4.6 ; platform_system == "Windows" \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
 urtypes @ https://github.com/selfcustody/urtypes/archive/7fb280eab3b3563dfc57d2733b0bf5cbc0a96a6a.zip#sha256=a44046378f6f1bca21cee40ce941d7509e1ec1e8677b5b3b146a918fa6fd475d
 pycryptodomex==3.23.0 --hash=sha256:71909758f010c82bc99b0abf4ea12012c98962fbf0583c2164f8b84533c2e4da
+pgpy==0.6.0 --hash=sha256:279c2e353f4c3a319f00bd9bd582456e420f8a3ac6de2b4e9731444746828383
+pyasn1==0.6.1 --hash=sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629
 pysatochip==0.17.0 --hash=sha256:2e7085c6d64dd89d2b5ccdab5319735ef837d708f8d2bf084ea8ba5c2c18fe41
 pyscard==2.2.2 --hash=sha256:c77481fb86f4a17bc441d7b36551c1d36a9d3a48c4bb30ab8118886e6f275081
 ecdsa==0.19.1 --hash=sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -120,7 +120,7 @@ class Controller(Singleton):
         rather than at the top in order avoid circular imports.
     """
     
-    VERSION = "0.8.6+Satochip+ERT-B3"
+    VERSION = "0.8.6+Satochip+Earthdiver-B4"
 
     # Declare class member vars with type hints to enable richer IDE support throughout
     # the code.

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4154,12 +4154,35 @@ class ToolsGPGImportPubkeyView(View):
         return Destination(MainMenuView)
 
 
+def bip85_rsa_from_root(root, bits: int, index: int, sub_index: int | None = None):
+    from hashlib import shake_256
+    from embit import bip85
+    from Cryptodome.PublicKey import RSA
+
+    path = [bits, index]
+    if sub_index is not None:
+        path.append(sub_index)
+    entropy = bip85.derive_entropy(root, 828365, path)
+    counter = 0
+    buffer = b""
+
+    def randfunc(n: int) -> bytes:
+        nonlocal counter, buffer
+        while len(buffer) < n:
+            ctr = counter.to_bytes(4, "big")
+            buffer += shake_256(entropy + ctr).digest(64)
+            counter += 1
+        result, buffer = buffer[:n], buffer[n:]
+        return result
+
+    return RSA.generate(bits, randfunc=randfunc)
+
+
 class ToolsGPGLoadBIP85KeyView(View):
     def run(self):
-        from hashlib import shake_256
-        from embit import bip32, bip85
-        from Cryptodome.PublicKey import RSA
+        from embit import bip32
         from pgpy import PGPKey, PGPUID
+        from Cryptodome.PublicKey import RSA
         from pgpy.constants import (
             PubKeyAlgorithm,
             KeyFlags,
@@ -4170,7 +4193,7 @@ class ToolsGPGLoadBIP85KeyView(View):
         from pgpy.pgp import PrivKeyV4, PrivSubKeyV4
         from pgpy.packet import fields
         from pgpy.packet.types import MPI
-        from datetime import datetime, timezone
+        from datetime import datetime, timezone, timedelta
         from subprocess import run
         from seedsigner.gui.screens.screen import LoadingScreenThread
         from seedsigner.gui.screens import LargeIconStatusScreen, WarningScreen
@@ -4192,9 +4215,9 @@ class ToolsGPGLoadBIP85KeyView(View):
             return Destination(BackStackView)
         key_index = int(ret)
 
-        def prompt_text(title: str):
+        def prompt_text(title: str, default: str = ""):
             ret_dict = tools_screens.ToolsTextQRTextEntryScreen(
-                textToEncode="", title=title
+                textToEncode=default, title=title
             ).display()
             if "is_back_button" in ret_dict:
                 return None
@@ -4216,13 +4239,21 @@ class ToolsGPGLoadBIP85KeyView(View):
             return Destination(BackStackView)
 
         created = datetime.fromtimestamp(1231006505, tz=timezone.utc)
-        expiration_str = prompt_text("Expiration YYYY-MM-DD")
+        default_expiration = (datetime.now(timezone.utc) + timedelta(days=365 * 10)).date()
+        expiration_str = prompt_text(
+            "Expiration YYYY-MM-DD", default_expiration.isoformat()
+        )
         if expiration_str is None:
             return Destination(BackStackView)
         try:
-            expiration_dt = datetime.strptime(
-                expiration_str, "%Y-%m-%d"
-            ).replace(tzinfo=timezone.utc)
+            if expiration_str == "":
+                expiration_dt = datetime.combine(
+                    default_expiration, datetime.min.time(), tzinfo=timezone.utc
+                )
+            else:
+                expiration_dt = datetime.strptime(
+                    expiration_str, "%Y-%m-%d"
+                ).replace(tzinfo=timezone.utc)
             if expiration_dt <= created:
                 raise ValueError
             expires = expiration_dt - created
@@ -4241,22 +4272,6 @@ class ToolsGPGLoadBIP85KeyView(View):
         root = bip32.HDKey.from_seed(seed.seed_bytes)
         KEY_BITS = 4096
 
-        def bip85_rsa(bits: int, index: int, sub_index: int | None = None):
-            path = [bits, index]
-            if sub_index is not None:
-                path.append(sub_index)
-            entropy = bip85.derive_entropy(root, 828365, path)
-            shake_data = shake_256(entropy).digest(1000000)
-            offset = 0
-
-            def randfunc(n: int) -> bytes:
-                nonlocal offset
-                data = shake_data[offset:offset + n]
-                offset += n
-                return data
-
-            return RSA.generate(bits, randfunc=randfunc)
-
         def rsa_to_privpacket(rsa_key: RSA.RsaKey) -> fields.RSAPriv:
             priv = fields.RSAPriv()
             priv.n = MPI(rsa_key.n)
@@ -4268,7 +4283,7 @@ class ToolsGPGLoadBIP85KeyView(View):
             priv._compute_chksum()
             return priv
 
-        rsa_main = bip85_rsa(KEY_BITS, key_index)
+        rsa_main = bip85_rsa_from_root(root, KEY_BITS, key_index)
         pk = PrivKeyV4()
         pk.pkalg = PubKeyAlgorithm.RSAEncryptOrSign
         pk.keymaterial = rsa_to_privpacket(rsa_main)
@@ -4295,7 +4310,7 @@ class ToolsGPGLoadBIP85KeyView(View):
         ]
 
         for sub_index, usage in subkey_specs:
-            rsa_sub = bip85_rsa(KEY_BITS, key_index, sub_index)
+            rsa_sub = bip85_rsa_from_root(root, KEY_BITS, key_index, sub_index)
             subpkt = PrivSubKeyV4()
             subpkt.pkalg = PubKeyAlgorithm.RSAEncryptOrSign
             subpkt.keymaterial = rsa_to_privpacket(rsa_sub)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4178,6 +4178,42 @@ def bip85_rsa_from_root(root, bits: int, index: int, sub_index: int | None = Non
     return RSA.generate(bits, randfunc=randfunc)
 
 
+def bip85_secp256k1_from_root(
+    root, index: int, sub_index: int | None = None, alg: str = "ECDSA"
+):
+    from embit import bip85
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from pgpy.constants import EllipticCurveOID
+    from pgpy.packet import fields
+
+    path = [256, index]
+    if sub_index is not None:
+        path.append(sub_index)
+    entropy = bip85.derive_entropy(root, 828365, path)
+    order = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+    d = int.from_bytes(entropy[:32], "big") % order
+    if d == 0:
+        d = 1
+    pn = ec.derive_private_key(d, ec.SECP256K1()).public_key().public_numbers()
+    if alg == "ECDH":
+        priv = fields.ECDHPriv()
+        priv.oid = EllipticCurveOID.SECP256K1
+        priv.kdf.halg = priv.oid.kdf_halg
+        priv.kdf.encalg = priv.oid.kek_alg
+    else:
+        priv = fields.ECDSAPriv()
+        priv.oid = EllipticCurveOID.SECP256K1
+    priv.p = fields.ECPoint.from_values(
+        priv.oid.key_size,
+        fields.ECPointFormat.Standard,
+        fields.MPI(pn.x),
+        fields.MPI(pn.y),
+    )
+    priv.s = fields.MPI(d)
+    priv._compute_chksum()
+    return priv
+
+
 class ToolsGPGLoadBIP85KeyView(View):
     def run(self):
         from embit import bip32
@@ -4215,6 +4251,21 @@ class ToolsGPGLoadBIP85KeyView(View):
             return Destination(BackStackView)
         key_index = int(ret)
 
+        keytype_buttons = [
+            ButtonOption("RSA 4096"),
+            ButtonOption("RSA 2048"),
+            ButtonOption("secp256k1"),
+        ]
+        selected_type = self.run_screen(
+            ButtonListScreen,
+            title="Key Type",
+            is_button_text_centered=False,
+            button_data=keytype_buttons,
+        )
+        if selected_type == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+        key_type = ["rsa4096", "rsa2048", "secp256k1"][selected_type]
+
         def prompt_text(title: str, default: str = ""):
             ret_dict = tools_screens.ToolsTextQRTextEntryScreen(
                 textToEncode=default, title=title
@@ -4239,8 +4290,8 @@ class ToolsGPGLoadBIP85KeyView(View):
             return Destination(BackStackView)
 
         created = datetime.fromtimestamp(1231006505, tz=timezone.utc)
-        # Per NIST guidelines, default expiration is set to the last day of 2035.
-        default_expiration = date(2035, 12, 31)
+        from datetime import timedelta
+        default_expiration = (datetime.now(timezone.utc) + timedelta(days=3650)).date()
         expiration_str = prompt_text(
             "Expiration YYYY-MM-DD", default_expiration.isoformat()
         )
@@ -4271,7 +4322,7 @@ class ToolsGPGLoadBIP85KeyView(View):
 
         seed = self.controller.get_seed(0)
         root = bip32.HDKey.from_seed(seed.seed_bytes)
-        KEY_BITS = 4096
+        KEY_BITS = 4096 if key_type == "rsa4096" else 2048
 
         def rsa_to_privpacket(rsa_key: RSA.RsaKey) -> fields.RSAPriv:
             priv = fields.RSAPriv()
@@ -4287,10 +4338,14 @@ class ToolsGPGLoadBIP85KeyView(View):
         self.loading_screen = LoadingScreenThread(text="Generating BIP85 GPG key\n\n\n\n\n\n(This takes a while)")
         self.loading_screen.start()
         try:
-            rsa_main = bip85_rsa_from_root(root, KEY_BITS, key_index)
             pk = PrivKeyV4()
-            pk.pkalg = PubKeyAlgorithm.RSAEncryptOrSign
-            pk.keymaterial = rsa_to_privpacket(rsa_main)
+            if key_type == "secp256k1":
+                pk.pkalg = PubKeyAlgorithm.ECDSA
+                pk.keymaterial = bip85_secp256k1_from_root(root, key_index)
+            else:
+                rsa_main = bip85_rsa_from_root(root, KEY_BITS, key_index)
+                pk.pkalg = PubKeyAlgorithm.RSAEncryptOrSign
+                pk.keymaterial = rsa_to_privpacket(rsa_main)
             pk.created = created
             pk.update_hlen()
 
@@ -4307,17 +4362,28 @@ class ToolsGPGLoadBIP85KeyView(View):
                 expires=expires,
             )
 
-            subkey_specs = [
-                (0, {KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage}),
-                (1, {KeyFlags.Authentication}),
-                (2, {KeyFlags.Sign}),
-            ]
+            if key_type == "secp256k1":
+                subkey_specs = [
+                    (0, PubKeyAlgorithm.ECDH, {KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage}, "ECDH"),
+                    (1, PubKeyAlgorithm.ECDSA, {KeyFlags.Authentication}, "ECDSA"),
+                    (2, PubKeyAlgorithm.ECDSA, {KeyFlags.Sign}, "ECDSA"),
+                ]
+            else:
+                subkey_specs = [
+                    (0, PubKeyAlgorithm.RSAEncryptOrSign, {KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage}),
+                    (1, PubKeyAlgorithm.RSAEncryptOrSign, {KeyFlags.Authentication}),
+                    (2, PubKeyAlgorithm.RSAEncryptOrSign, {KeyFlags.Sign}),
+                ]
 
-            for sub_index, usage in subkey_specs:
-                rsa_sub = bip85_rsa_from_root(root, KEY_BITS, key_index, sub_index)
+            for spec in subkey_specs:
+                sub_index, pkalg, usage, *alg = spec
                 subpkt = PrivSubKeyV4()
-                subpkt.pkalg = PubKeyAlgorithm.RSAEncryptOrSign
-                subpkt.keymaterial = rsa_to_privpacket(rsa_sub)
+                subpkt.pkalg = pkalg
+                if key_type == "secp256k1":
+                    subpkt.keymaterial = bip85_secp256k1_from_root(root, key_index, sub_index, alg[0])
+                else:
+                    rsa_sub = bip85_rsa_from_root(root, KEY_BITS, key_index, sub_index)
+                    subpkt.keymaterial = rsa_to_privpacket(rsa_sub)
                 subpkt.created = created
                 subpkt.update_hlen()
                 subkey = PGPKey()

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -3426,15 +3426,6 @@ class ToolsMicroSDMenuView(View):
     WIPE_RANDOM = ButtonOption("Wipe (Random)")
 
     def run(self):
-        if len(self.controller.storage.seeds) > 0:
-            self.run_screen(
-                WarningScreen,
-                title="WARNING",
-                status_headline=None,
-                text="These tools read from the microSD card and may leak loaded secrets.",
-                show_back_button=False,
-                button_data=[ButtonOption("Continue")]
-            )
         button_data = [self.FLASH_IMAGE, self.VERIFY_IMAGE, self.WIPE_ZERO, self.WIPE_RANDOM]
 
         selected_menu_num = self.run_screen(
@@ -3463,6 +3454,18 @@ class ToolsMicroSDFlashView(View):
     def run(self):
         from subprocess import run
         from seedsigner.gui.screens.screen import LoadingScreenThread
+
+        if len(self.controller.storage.seeds) > 0:
+            ret = self.run_screen(
+                WarningScreen,
+                title="WARNING",
+                status_headline=None,
+                text="These tools read from the microSD card and may leak loaded secrets.",
+                show_back_button=True,
+                button_data=[ButtonOption("Continue")]
+            )
+            if ret == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
 
         microsd_dev = find_sd_card_device()
 
@@ -3891,16 +3894,6 @@ class ToolsGPGMenuView(View):
                 run(["gpg", "--import", *key_files])
             self.loading_screen.stop()
             self.controller.gpg_keys_imported = True
-
-        if len(self.controller.storage.seeds) > 0:
-            self.run_screen(
-                WarningScreen,
-                title="WARNING",
-                status_headline=None,
-                text="These tools load data from the microSD card and may expose loaded secrets.",
-                show_back_button=False,
-                button_data=[ButtonOption("Continue")]
-            )
         button_data = [self.VERIFY_FILE, self.IMPORT_PUBKEY, self.LOAD_BIP85_KEY]
 
         selected_menu_num = self.run_screen(
@@ -3926,6 +3919,18 @@ class ToolsGPGVerifyFileView(View):
     def run(self):
         from subprocess import run
         from seedsigner.gui.screens.screen import LoadingScreenThread
+
+        if len(self.controller.storage.seeds) > 0:
+            ret = self.run_screen(
+                WarningScreen,
+                title="WARNING",
+                status_headline=None,
+                text="These tools load data from the microSD card and may expose loaded secrets.",
+                show_back_button=True,
+                button_data=[ButtonOption("Continue")]
+            )
+            if ret == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
 
         if platform.uname()[1] == "seedsigner-os":
             file_list_path = '/mnt/microsd/microsd-images/'
@@ -4100,6 +4105,18 @@ class ToolsGPGImportPubkeyView(View):
     def run(self):
         from subprocess import run
         from seedsigner.gui.screens.screen import LoadingScreenThread
+
+        if len(self.controller.storage.seeds) > 0:
+            ret = self.run_screen(
+                WarningScreen,
+                title="WARNING",
+                status_headline=None,
+                text="These tools load data from the microSD card and may expose loaded secrets.",
+                show_back_button=True,
+                button_data=[ButtonOption("Continue")]
+            )
+            if ret == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
 
         if platform.uname()[1] == "seedsigner-os":
             file_list_path = '/mnt/microsd/microsd-images/'

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4193,7 +4193,7 @@ class ToolsGPGLoadBIP85KeyView(View):
         from pgpy.pgp import PrivKeyV4, PrivSubKeyV4
         from pgpy.packet import fields
         from pgpy.packet.types import MPI
-        from datetime import datetime, timezone, timedelta
+        from datetime import datetime, timezone, date
         from subprocess import run
         from seedsigner.gui.screens.screen import LoadingScreenThread
         from seedsigner.gui.screens import LargeIconStatusScreen, WarningScreen
@@ -4239,7 +4239,8 @@ class ToolsGPGLoadBIP85KeyView(View):
             return Destination(BackStackView)
 
         created = datetime.fromtimestamp(1231006505, tz=timezone.utc)
-        default_expiration = (datetime.now(timezone.utc) + timedelta(days=365 * 10)).date()
+        # Per NIST guidelines, default expiration is set to the last day of 2035.
+        default_expiration = date(2035, 12, 31)
         expiration_str = prompt_text(
             "Expiration YYYY-MM-DD", default_expiration.isoformat()
         )

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -31,9 +31,7 @@ from seedsigner.helpers import embit_utils, mnemonic_generation
 from seedsigner.helpers.iso7816 import format_sw_error
 from seedsigner.models.decode_qr import DecodeQR
 from seedsigner.models.encode_qr import GenericStaticQrEncoder
-from seedsigner.gui.screens import RET_CODE__BACK_BUTTON, ButtonListScreen
 from seedsigner.gui.screens.screen import ButtonOption
-from seedsigner.helpers import mnemonic_generation
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings_definition import SettingsConstants
 from seedsigner.views.seed_views import (
@@ -56,8 +54,7 @@ from seedsigner.views.seed_views import (
 from .view import View, Destination, BackStackView, MainMenuView
 
 from seedsigner.helpers import seedkeeper_utils
-from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
-    WarningScreen, DireWarningScreen, seed_screens, LargeIconStatusScreen)
+from seedsigner.gui.screens import seed_screens
 logger = logging.getLogger(__name__)
 
 from pysatochip.JCconstants import SEEDKEEPER_DIC_TYPE, SEEDKEEPER_DIC_ORIGIN, SEEDKEEPER_DIC_EXPORT_RIGHTS, BIP39_WORDLIST_DIC
@@ -87,7 +84,15 @@ class ToolsMenuView(View):
         if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.SMARTCARD)
         
-        button_data.extend([self.KEYBOARD, self.ADDRESS_EXPLORER, self.VERIFY_ADDRESS, self.TEXTQRCODE, self.SMARTCARD, self.MICROSD, self.GPG, self.CLEAR_DESCRIPTOR])
+        button_data.extend([
+            self.KEYBOARD,
+            self.ADDRESS_EXPLORER,
+            self.VERIFY_ADDRESS,
+            self.TEXTQRCODE,
+            self.MICROSD,
+            self.GPG,
+            self.CLEAR_DESCRIPTOR,
+        ])
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -3870,6 +3870,7 @@ class ToolsMicroSDWipeRandomView(View):
 class ToolsGPGMenuView(View):
     VERIFY_FILE = ButtonOption("Verify File Sig")
     IMPORT_PUBKEY = ButtonOption("Import Pubkey")
+    LOAD_BIP85_KEY = ButtonOption("Load BIP85 Key")
 
     def run(self):
         from subprocess import run
@@ -3895,7 +3896,7 @@ class ToolsGPGMenuView(View):
                 show_back_button=False,
                 button_data=[ButtonOption("Continue")]
             )
-        button_data = [self.VERIFY_FILE, self.IMPORT_PUBKEY]
+        button_data = [self.VERIFY_FILE, self.IMPORT_PUBKEY, self.LOAD_BIP85_KEY]
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,
@@ -3912,6 +3913,8 @@ class ToolsGPGMenuView(View):
         
         elif button_data[selected_menu_num] == self.IMPORT_PUBKEY:
             return Destination(ToolsGPGImportPubkeyView)
+        elif button_data[selected_menu_num] == self.LOAD_BIP85_KEY:
+            return Destination(ToolsGPGLoadBIP85KeyView)
 
 class ToolsGPGVerifyFileView(View):
     CHECK_SHA256 = ButtonOption("Check SHA256Sum")
@@ -4142,7 +4145,194 @@ class ToolsGPGImportPubkeyView(View):
                 show_back_button=False,
                 button_data=[ButtonOption("Continue")]
             )
-        
+
+        return Destination(MainMenuView)
+
+
+class ToolsGPGLoadBIP85KeyView(View):
+    def run(self):
+        from hashlib import shake_256
+        from embit import bip32, bip85
+        from Cryptodome.PublicKey import RSA
+        from pgpy import PGPKey, PGPUID
+        from pgpy.constants import (
+            PubKeyAlgorithm,
+            KeyFlags,
+            HashAlgorithm,
+            SymmetricKeyAlgorithm,
+            CompressionAlgorithm,
+        )
+        from pgpy.pgp import PrivKeyV4, PrivSubKeyV4
+        from pgpy.packet import fields
+        from pgpy.packet.types import MPI
+        from datetime import datetime, timezone
+        from subprocess import run
+        from seedsigner.gui.screens.screen import LoadingScreenThread
+        from seedsigner.gui.screens import LargeIconStatusScreen, WarningScreen
+        from seedsigner.gui.screens import seed_screens, tools_screens
+
+        if len(self.controller.storage.seeds) == 0:
+            self.run_screen(
+                WarningScreen,
+                title="WARNING",
+                status_headline=None,
+                text="Load a seed before using\nBIP85 GPG tools.",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        ret = seed_screens.SeedBIP85SelectChildIndexScreen(title="Key Index").display()
+        if ret == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+        key_index = int(ret)
+
+        def prompt_text(title: str):
+            ret_dict = tools_screens.ToolsTextQRTextEntryScreen(
+                textToEncode="", title=title
+            ).display()
+            if "is_back_button" in ret_dict:
+                return None
+            try:
+                import re
+                return bytes(
+                    re.sub(r"\\(?!u)", r"\\\\", ret_dict["textToEncode"]),
+                    encoding="raw_unicode_escape",
+                ).decode("unicode_escape")
+            except UnicodeDecodeError:
+                return ret_dict["textToEncode"]
+
+        name = prompt_text("Name")
+        if name is None:
+            return Destination(BackStackView)
+
+        email = prompt_text("Email")
+        if email is None:
+            return Destination(BackStackView)
+
+        created = datetime.fromtimestamp(1231006505, tz=timezone.utc)
+        expiration_str = prompt_text("Expiration YYYY-MM-DD")
+        if expiration_str is None:
+            return Destination(BackStackView)
+        try:
+            expiration_dt = datetime.strptime(
+                expiration_str, "%Y-%m-%d"
+            ).replace(tzinfo=timezone.utc)
+            if expiration_dt <= created:
+                raise ValueError
+            expires = expiration_dt - created
+        except ValueError:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Invalid expiration date",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        seed = self.controller.get_seed(0)
+        root = bip32.HDKey.from_seed(seed.seed_bytes)
+        KEY_BITS = 4096
+
+        def bip85_rsa(bits: int, index: int, sub_index: int | None = None):
+            path = [bits, index]
+            if sub_index is not None:
+                path.append(sub_index)
+            entropy = bip85.derive_entropy(root, 828365, path)
+            shake_data = shake_256(entropy).digest(1000000)
+            offset = 0
+
+            def randfunc(n: int) -> bytes:
+                nonlocal offset
+                data = shake_data[offset:offset + n]
+                offset += n
+                return data
+
+            return RSA.generate(bits, randfunc=randfunc)
+
+        def rsa_to_privpacket(rsa_key: RSA.RsaKey) -> fields.RSAPriv:
+            priv = fields.RSAPriv()
+            priv.n = MPI(rsa_key.n)
+            priv.e = MPI(rsa_key.e)
+            priv.d = MPI(rsa_key.d)
+            priv.p = MPI(rsa_key.p)
+            priv.q = MPI(rsa_key.q)
+            priv.u = MPI(pow(rsa_key.p, -1, rsa_key.q))
+            priv._compute_chksum()
+            return priv
+
+        rsa_main = bip85_rsa(KEY_BITS, key_index)
+        pk = PrivKeyV4()
+        pk.pkalg = PubKeyAlgorithm.RSAEncryptOrSign
+        pk.keymaterial = rsa_to_privpacket(rsa_main)
+        pk.created = created
+        pk.update_hlen()
+
+        pgp_key = PGPKey()
+        pgp_key._key = pk
+
+        uid = PGPUID.new(name, email=email)
+        pgp_key.add_uid(
+            uid,
+            usage={KeyFlags.Certify, KeyFlags.Sign},
+            hashes=[HashAlgorithm.SHA256],
+            ciphers=[SymmetricKeyAlgorithm.AES256],
+            compression=[CompressionAlgorithm.ZLIB],
+            expires=expires,
+        )
+
+        subkey_specs = [
+            (0, {KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage}),
+            (1, {KeyFlags.Authentication}),
+            (2, {KeyFlags.Sign}),
+        ]
+
+        for sub_index, usage in subkey_specs:
+            rsa_sub = bip85_rsa(KEY_BITS, key_index, sub_index)
+            subpkt = PrivSubKeyV4()
+            subpkt.pkalg = PubKeyAlgorithm.RSAEncryptOrSign
+            subpkt.keymaterial = rsa_to_privpacket(rsa_sub)
+            subpkt.created = created
+            subpkt.update_hlen()
+            subkey = PGPKey()
+            subkey._key = subpkt
+            pgp_key.add_subkey(
+                subkey,
+                usage=usage,
+                hashes=[HashAlgorithm.SHA256],
+                ciphers=[SymmetricKeyAlgorithm.AES256],
+                compression=[CompressionAlgorithm.ZLIB],
+                expires=expires,
+            )
+
+        armored = str(pgp_key)
+
+        self.loading_screen = LoadingScreenThread(text="Importing BIP85 GPG key\n\n\n\n\n\n(May take a while)")
+        self.loading_screen.start()
+        result = run(["gpg", "--batch", "--import"], input=armored.encode(), capture_output=True)
+        self.loading_screen.stop()
+
+        if result.returncode == 0:
+            self.run_screen(
+                LargeIconStatusScreen,
+                title="Success",
+                status_headline=None,
+                text="BIP85 GPG key imported",
+                show_back_button=False,
+                button_data=[ButtonOption("Done")],
+            )
+        else:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to import key",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+
         return Destination(MainMenuView)
 
 class ToolsTextQRTextEntryView(View):

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4283,56 +4283,58 @@ class ToolsGPGLoadBIP85KeyView(View):
             priv._compute_chksum()
             return priv
 
-        rsa_main = bip85_rsa_from_root(root, KEY_BITS, key_index)
-        pk = PrivKeyV4()
-        pk.pkalg = PubKeyAlgorithm.RSAEncryptOrSign
-        pk.keymaterial = rsa_to_privpacket(rsa_main)
-        pk.created = created
-        pk.update_hlen()
+        self.loading_screen = LoadingScreenThread(text="Generating BIP85 GPG key\n\n\n\n\n\n(This takes a while)")
+        self.loading_screen.start()
+        try:
+            rsa_main = bip85_rsa_from_root(root, KEY_BITS, key_index)
+            pk = PrivKeyV4()
+            pk.pkalg = PubKeyAlgorithm.RSAEncryptOrSign
+            pk.keymaterial = rsa_to_privpacket(rsa_main)
+            pk.created = created
+            pk.update_hlen()
 
-        pgp_key = PGPKey()
-        pgp_key._key = pk
+            pgp_key = PGPKey()
+            pgp_key._key = pk
 
-        uid = PGPUID.new(name, email=email)
-        pgp_key.add_uid(
-            uid,
-            usage={KeyFlags.Certify, KeyFlags.Sign},
-            hashes=[HashAlgorithm.SHA256],
-            ciphers=[SymmetricKeyAlgorithm.AES256],
-            compression=[CompressionAlgorithm.ZLIB],
-            expires=expires,
-        )
-
-        subkey_specs = [
-            (0, {KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage}),
-            (1, {KeyFlags.Authentication}),
-            (2, {KeyFlags.Sign}),
-        ]
-
-        for sub_index, usage in subkey_specs:
-            rsa_sub = bip85_rsa_from_root(root, KEY_BITS, key_index, sub_index)
-            subpkt = PrivSubKeyV4()
-            subpkt.pkalg = PubKeyAlgorithm.RSAEncryptOrSign
-            subpkt.keymaterial = rsa_to_privpacket(rsa_sub)
-            subpkt.created = created
-            subpkt.update_hlen()
-            subkey = PGPKey()
-            subkey._key = subpkt
-            pgp_key.add_subkey(
-                subkey,
-                usage=usage,
+            uid = PGPUID.new(name, email=email)
+            pgp_key.add_uid(
+                uid,
+                usage={KeyFlags.Certify, KeyFlags.Sign},
                 hashes=[HashAlgorithm.SHA256],
                 ciphers=[SymmetricKeyAlgorithm.AES256],
                 compression=[CompressionAlgorithm.ZLIB],
                 expires=expires,
             )
 
-        armored = str(pgp_key)
+            subkey_specs = [
+                (0, {KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage}),
+                (1, {KeyFlags.Authentication}),
+                (2, {KeyFlags.Sign}),
+            ]
 
-        self.loading_screen = LoadingScreenThread(text="Importing BIP85 GPG key\n\n\n\n\n\n(May take a while)")
-        self.loading_screen.start()
-        result = run(["gpg", "--batch", "--import"], input=armored.encode(), capture_output=True)
-        self.loading_screen.stop()
+            for sub_index, usage in subkey_specs:
+                rsa_sub = bip85_rsa_from_root(root, KEY_BITS, key_index, sub_index)
+                subpkt = PrivSubKeyV4()
+                subpkt.pkalg = PubKeyAlgorithm.RSAEncryptOrSign
+                subpkt.keymaterial = rsa_to_privpacket(rsa_sub)
+                subpkt.created = created
+                subpkt.update_hlen()
+                subkey = PGPKey()
+                subkey._key = subpkt
+                pgp_key.add_subkey(
+                    subkey,
+                    usage=usage,
+                    hashes=[HashAlgorithm.SHA256],
+                    ciphers=[SymmetricKeyAlgorithm.AES256],
+                    compression=[CompressionAlgorithm.ZLIB],
+                    expires=expires,
+                )
+
+            armored = str(pgp_key)
+
+            result = run(["gpg", "--batch", "--import"], input=armored.encode(), capture_output=True)
+        finally:
+            self.loading_screen.stop()
 
         if result.returncode == 0:
             self.run_screen(

--- a/tests/test_bip85_gpg.py
+++ b/tests/test_bip85_gpg.py
@@ -1,0 +1,23 @@
+from embit import bip32
+from seedsigner.models.seed import Seed
+from seedsigner.views.tools_views import bip85_rsa_from_root
+
+MNEMONIC = "resource timber firm banner horror pupil frozen main pear direct pioneer broken grid core insane begin sister pony end debate task silk empty curious".split()
+
+
+def test_bip85_rsa_deterministic():
+    seed = Seed(mnemonic=MNEMONIC)
+    root = bip32.HDKey.from_seed(seed.seed_bytes)
+    key = bip85_rsa_from_root(root, 1024, 0)
+    assert key.size_in_bits() == 1024
+    assert key.n == int(
+        "d5ddf7786d30bf996b024d1a70aff00354c658ed60479c732343abcaa6b86749c28ee25200f923b1e56b89ba7cb3b4187360781d95651a221880f161c366bab91122762386b6895b38d7b46ed860ac00f12f782a138e92154388927721d0e8a05921ec35d042d64ebd0beaafe819a4af10cb6cc1225fbad35e06c906ffaecd6d",
+        16,
+    )
+
+
+def test_bip85_rsa_large_key():
+    seed = Seed(mnemonic=MNEMONIC)
+    root = bip32.HDKey.from_seed(seed.seed_bytes)
+    key = bip85_rsa_from_root(root, 4096, 0)
+    assert key.size_in_bits() == 4096

--- a/tests/test_bip85_gpg.py
+++ b/tests/test_bip85_gpg.py
@@ -1,6 +1,6 @@
 from embit import bip32
 from seedsigner.models.seed import Seed
-from seedsigner.views.tools_views import bip85_rsa_from_root
+from seedsigner.views.tools_views import bip85_rsa_from_root, bip85_secp256k1_from_root
 
 MNEMONIC = "resource timber firm banner horror pupil frozen main pear direct pioneer broken grid core insane begin sister pony end debate task silk empty curious".split()
 
@@ -21,3 +21,12 @@ def test_bip85_rsa_large_key():
     root = bip32.HDKey.from_seed(seed.seed_bytes)
     key = bip85_rsa_from_root(root, 4096, 0)
     assert key.size_in_bits() == 4096
+
+
+def test_bip85_secp256k1_deterministic():
+    seed = Seed(mnemonic=MNEMONIC)
+    root = bip32.HDKey.from_seed(seed.seed_bytes)
+    key = bip85_secp256k1_from_root(root, 0)
+    assert int(key.s) == int(
+        "cefbb3197f44cbcd28ca548e7d6c22e2b67f497caeebb71fa91d1cc6ab78e502", 16
+    )


### PR DESCRIPTION
## Summary
- add "Load BIP85 Key" item to GPG tools menu
- implement BIP85 deterministic RSA key generation and import into gpg
- depend on pgpy and pyasn1 for PGP key construction
- prompt for name, email and expiration when loading BIP85 key

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b375e6c7e48322a651c1bfa9176418