### PR TITLE
Remove duplicate Smartcard Tools menu item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ src/seedsigner/models/settings_definition.json
 *.po
 *.mo
 jcardsim.jar
+settings.json

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -87,7 +87,15 @@ class ToolsMenuView(View):
         if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.SMARTCARD)
         
-        button_data.extend([self.KEYBOARD, self.ADDRESS_EXPLORER, self.VERIFY_ADDRESS, self.TEXTQRCODE, self.SMARTCARD, self.MICROSD, self.GPG, self.CLEAR_DESCRIPTOR])
+        button_data.extend([
+            self.KEYBOARD,
+            self.ADDRESS_EXPLORER,
+            self.VERIFY_ADDRESS,
+            self.TEXTQRCODE,
+            self.MICROSD,
+            self.GPG,
+            self.CLEAR_DESCRIPTOR,
+        ])
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,


### PR DESCRIPTION
## Summary
- remove duplicate Smartcard Tools entry in Tools menu

## Testing
- `pytest` *(fails: KeyboardInterrupt after 74 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a1e749b0832286a1a3f9d43c2fa8