### PR TITLE
Add BIP85 P-256 GPG key type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 Entries marked "(SeedSigner official)" originate from the upstream project, while "(smartcard fork)" indicates releases and changes unique to this repository.
 
 ## Unreleased - SS0.8.6+Satochip+Earthdiver-B4 (smartcard fork)
-- Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to 10 years from creation), and key type (Brainpool P-256, ECC P-256, RSA 2048, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
+- Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to 10 years from creation), and key type (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
 - MicroSD and GPG tools now display seed-loaded warnings only when opening file pickers
 
 ## 2025-08-04 - SS0.8.6+Satochip+Earthdiver-B3 (smartcard fork)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 Entries marked "(SeedSigner official)" originate from the upstream project, while "(smartcard fork)" indicates releases and changes unique to this repository.
 
 ## Unreleased - SS0.8.6+Satochip+Earthdiver-B4 (smartcard fork)
-- Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to 10 years from creation), and key type (RSA 4096, RSA 2048, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
+- Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to 10 years from creation), and key type (ECC P-256, RSA 2048, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
 - MicroSD and GPG tools now display seed-loaded warnings only when opening file pickers
 
 ## 2025-08-04 - SS0.8.6+Satochip+Earthdiver-B3 (smartcard fork)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 Entries marked "(SeedSigner official)" originate from the upstream project, while "(smartcard fork)" indicates releases and changes unique to this repository.
 
 ## Unreleased - SS0.8.6+Satochip+Earthdiver-B4 (smartcard fork)
-- Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to 10 years from creation), and key type (ECC P-256, RSA 2048, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
+- Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to 10 years from creation), and key type (Brainpool P-256, ECC P-256, RSA 2048, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
 - MicroSD and GPG tools now display seed-loaded warnings only when opening file pickers
 
 ## 2025-08-04 - SS0.8.6+Satochip+Earthdiver-B3 (smartcard fork)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Support and discussion relating to this fork can happen via this [Telegram Group
    - Secure Wipe (Both with zeros and random data)
 * GPG Tools
    - GPG Signature verification & Sha256 Manifest check (Includes pubkey bundle the from Sparrow to verify Seedsigner, Sparrow, Electrum, plus many more)
-  - Load BIP85-derived GPG keys (Brainpool P-256 [default], ECC P-256, RSA 2048, or secp256k1) with prompts for key type, name, email, and expiration (defaulting to 10 years in the future); metadata such as name, email, expiration, and deprecation/end-of-use dates can be modified later ([docs](./docs/gpg_tools.md))
+  - Load BIP85-derived GPG keys (NIST P-256 [default], Brainpool P-256, RSA 2048, RSA 3072, or secp256k1) with prompts for key type, name, email, and expiration (defaulting to 10 years in the future); metadata such as name, email, expiration, and deprecation/end-of-use dates can be modified later ([docs](./docs/gpg_tools.md))
 * Tested and working with the following hardware
    - Raspberry Pi Zero 1.3
    - Raspberry Pi Zero W

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Support and discussion relating to this fork can happen via this [Telegram Group
    - Secure Wipe (Both with zeros and random data)
 * GPG Tools
    - GPG Signature verification & Sha256 Manifest check (Includes pubkey bundle the from Sparrow to verify Seedsigner, Sparrow, Electrum, plus many more)
-   - Load BIP85-derived GPG keys (RSA 4096, RSA 2048, or secp256k1) with prompts for key type, name, email, and expiration (defaulting to 10 years in the future); metadata such as name, email, expiration, and deprecation/end-of-use dates can be modified later ([docs](./docs/gpg_tools.md))
+  - Load BIP85-derived GPG keys (ECC P-256, RSA 2048, or secp256k1) with prompts for key type, name, email, and expiration (defaulting to 10 years in the future); metadata such as name, email, expiration, and deprecation/end-of-use dates can be modified later ([docs](./docs/gpg_tools.md))
 * Tested and working with the following hardware
    - Raspberry Pi Zero 1.3
    - Raspberry Pi Zero W

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Support and discussion relating to this fork can happen via this [Telegram Group
    - Secure Wipe (Both with zeros and random data)
 * GPG Tools
    - GPG Signature verification & Sha256 Manifest check (Includes pubkey bundle the from Sparrow to verify Seedsigner, Sparrow, Electrum, plus many more)
-  - Load BIP85-derived GPG keys (ECC P-256, RSA 2048, or secp256k1) with prompts for key type, name, email, and expiration (defaulting to 10 years in the future); metadata such as name, email, expiration, and deprecation/end-of-use dates can be modified later ([docs](./docs/gpg_tools.md))
+  - Load BIP85-derived GPG keys (Brainpool P-256 [default], ECC P-256, RSA 2048, or secp256k1) with prompts for key type, name, email, and expiration (defaulting to 10 years in the future); metadata such as name, email, expiration, and deprecation/end-of-use dates can be modified later ([docs](./docs/gpg_tools.md))
 * Tested and working with the following hardware
    - Raspberry Pi Zero 1.3
    - Raspberry Pi Zero W

--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -1,6 +1,6 @@
 # GPG Tools
 
-SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives a keypair (Brainpool P-256, ECC P-256, RSA 2048, or secp256k1) from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG.
+SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives a keypair (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, or secp256k1) from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG.
 
 For SeedSignerOS, everything is stateless. If running on desktop or some other normal system, you will be interacting with your system GPG2 install...
 

--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -1,6 +1,6 @@
 # GPG Tools
 
-SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives a keypair (ECC P-256, RSA 2048, or secp256k1) from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG.
+SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives a keypair (Brainpool P-256, ECC P-256, RSA 2048, or secp256k1) from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG.
 
 For SeedSignerOS, everything is stateless. If running on desktop or some other normal system, you will be interacting with your system GPG2 install...
 

--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -1,10 +1,10 @@
 # GPG Tools
 
-SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives a keypair (RSA 4096, RSA 2048, or secp256k1) from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG.
+SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives a keypair (ECC P-256, RSA 2048, or secp256k1) from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG.
 
 For SeedSignerOS, everything is stateless. If running on desktop or some other normal system, you will be interacting with your system GPG2 install...
 
-During import, SeedSigner prompts for the key type, user name, email address, and expiration date. The expiration defaults to **10 years in the future**. (Noting that NIST guidelines have RSA2048 deprecated in 2030 and non-quantum safe keys, both RSA4096 and ECC keys, being discontinued for government applications after 2035)
+During import, SeedSigner prompts for the key type, user name, email address, and expiration date. The expiration defaults to **10 years in the future**. (Noting that NIST guidelines have RSA2048 deprecated in 2030 and non-quantum safe keys, including ECC keys, being discontinued for government applications after 2035)
 
 Note: The key derivation with BIP85 is deterministic, meaning the key and fingerprint will always be the same, but metadata like the username, email address and expiration date can be changed. (And are not saved on-device, but can be exported to a Smartcard, etc)
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4231,6 +4231,42 @@ def bip85_secp256k1_from_root(
     return priv
 
 
+def bip85_p256_from_root(
+    root, index: int, sub_index: int | None = None, alg: str = "ECDSA"
+):
+    from embit import bip85
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from pgpy.constants import EllipticCurveOID
+    from pgpy.packet import fields
+
+    path = [257, index]
+    if sub_index is not None:
+        path.append(sub_index)
+    entropy = bip85.derive_entropy(root, 828365, path)
+    order = ec.SECP256R1().group_order
+    d = int.from_bytes(entropy[:32], "big") % order
+    if d == 0:
+        d = 1
+    pn = ec.derive_private_key(d, ec.SECP256R1()).public_key().public_numbers()
+    if alg == "ECDH":
+        priv = fields.ECDHPriv()
+        priv.oid = EllipticCurveOID.NIST_P256
+        priv.kdf.halg = priv.oid.kdf_halg
+        priv.kdf.encalg = priv.oid.kek_alg
+    else:
+        priv = fields.ECDSAPriv()
+        priv.oid = EllipticCurveOID.NIST_P256
+    priv.p = fields.ECPoint.from_values(
+        priv.oid.key_size,
+        fields.ECPointFormat.Standard,
+        fields.MPI(pn.x),
+        fields.MPI(pn.y),
+    )
+    priv.s = fields.MPI(d)
+    priv._compute_chksum()
+    return priv
+
+
 class ToolsGPGLoadBIP85KeyView(View):
     def run(self):
         from embit import bip32
@@ -4269,7 +4305,7 @@ class ToolsGPGLoadBIP85KeyView(View):
         key_index = int(ret)
 
         keytype_buttons = [
-            ButtonOption("RSA 4096"),
+            ButtonOption("ECC P-256"),
             ButtonOption("RSA 2048"),
             ButtonOption("secp256k1"),
         ]
@@ -4281,7 +4317,7 @@ class ToolsGPGLoadBIP85KeyView(View):
         )
         if selected_type == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
-        key_type = ["rsa4096", "rsa2048", "secp256k1"][selected_type]
+        key_type = ["p256", "rsa2048", "secp256k1"][selected_type]
 
         def prompt_text(title: str, default: str = ""):
             ret_dict = tools_screens.ToolsTextQRTextEntryScreen(
@@ -4339,7 +4375,7 @@ class ToolsGPGLoadBIP85KeyView(View):
 
         seed = self.controller.get_seed(0)
         root = bip32.HDKey.from_seed(seed.seed_bytes)
-        KEY_BITS = 4096 if key_type == "rsa4096" else 2048
+        KEY_BITS = 2048 if key_type == "rsa2048" else None
 
         def rsa_to_privpacket(rsa_key: RSA.RsaKey) -> fields.RSAPriv:
             priv = fields.RSAPriv()
@@ -4359,6 +4395,9 @@ class ToolsGPGLoadBIP85KeyView(View):
             if key_type == "secp256k1":
                 pk.pkalg = PubKeyAlgorithm.ECDSA
                 pk.keymaterial = bip85_secp256k1_from_root(root, key_index)
+            elif key_type == "p256":
+                pk.pkalg = PubKeyAlgorithm.ECDSA
+                pk.keymaterial = bip85_p256_from_root(root, key_index)
             else:
                 rsa_main = bip85_rsa_from_root(root, KEY_BITS, key_index)
                 pk.pkalg = PubKeyAlgorithm.RSAEncryptOrSign
@@ -4379,7 +4418,7 @@ class ToolsGPGLoadBIP85KeyView(View):
                 expires=expires,
             )
 
-            if key_type == "secp256k1":
+            if key_type in ["secp256k1", "p256"]:
                 subkey_specs = [
                     (0, PubKeyAlgorithm.ECDH, {KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage}, "ECDH"),
                     (1, PubKeyAlgorithm.ECDSA, {KeyFlags.Authentication}, "ECDSA"),
@@ -4398,6 +4437,8 @@ class ToolsGPGLoadBIP85KeyView(View):
                 subpkt.pkalg = pkalg
                 if key_type == "secp256k1":
                     subpkt.keymaterial = bip85_secp256k1_from_root(root, key_index, sub_index, alg[0])
+                elif key_type == "p256":
+                    subpkt.keymaterial = bip85_p256_from_root(root, key_index, sub_index, alg[0])
                 else:
                     rsa_sub = bip85_rsa_from_root(root, KEY_BITS, key_index, sub_index)
                     subpkt.keymaterial = rsa_to_privpacket(rsa_sub)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4346,9 +4346,10 @@ class ToolsGPGLoadBIP85KeyView(View):
         key_index = int(ret)
 
         keytype_buttons = [
+            ButtonOption("NIST P-256"),
             ButtonOption("Brainpool P-256"),
-            ButtonOption("ECC P-256"),
             ButtonOption("RSA 2048"),
+            ButtonOption("RSA 3072"),
             ButtonOption("secp256k1"),
         ]
         selected_type = self.run_screen(
@@ -4359,7 +4360,13 @@ class ToolsGPGLoadBIP85KeyView(View):
         )
         if selected_type == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
-        key_type = ["brainpoolp256r1", "p256", "rsa2048", "secp256k1"][selected_type]
+        key_type = [
+            "p256",
+            "brainpoolp256r1",
+            "rsa2048",
+            "rsa3072",
+            "secp256k1",
+        ][selected_type]
 
         def prompt_text(title: str, default: str = ""):
             ret_dict = tools_screens.ToolsTextQRTextEntryScreen(
@@ -4417,7 +4424,9 @@ class ToolsGPGLoadBIP85KeyView(View):
 
         seed = self.controller.get_seed(0)
         root = bip32.HDKey.from_seed(seed.seed_bytes)
-        KEY_BITS = 2048 if key_type == "rsa2048" else None
+        KEY_BITS = (
+            2048 if key_type == "rsa2048" else 3072 if key_type == "rsa3072" else None
+        )
 
         def rsa_to_privpacket(rsa_key: RSA.RsaKey) -> fields.RSAPriv:
             priv = fields.RSAPriv()

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4270,6 +4270,44 @@ def bip85_p256_from_root(
     return priv
 
 
+def bip85_brainpoolp256r1_from_root(
+    root, index: int, sub_index: int | None = None, alg: str = "ECDSA",
+):
+    from embit import bip85
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from pgpy.constants import EllipticCurveOID
+    from pgpy.packet import fields
+
+    path = [258, index]
+    if sub_index is not None:
+        path.append(sub_index)
+    entropy = bip85.derive_entropy(root, 828365, path)
+    # Hardcode BrainpoolP256r1 group order to avoid relying on attributes
+    # that may be missing in some cryptography builds.
+    order = 0xA9FB57DBA1EEA9BC3E660A909D838D718C397AA3B561A6F7901E0E82974856A7
+    d = int.from_bytes(entropy[:32], "big") % order
+    if d == 0:
+        d = 1
+    pn = ec.derive_private_key(d, ec.BrainpoolP256R1()).public_key().public_numbers()
+    if alg == "ECDH":
+        priv = fields.ECDHPriv()
+        priv.oid = EllipticCurveOID.Brainpool_P256
+        priv.kdf.halg = priv.oid.kdf_halg
+        priv.kdf.encalg = priv.oid.kek_alg
+    else:
+        priv = fields.ECDSAPriv()
+        priv.oid = EllipticCurveOID.Brainpool_P256
+    priv.p = fields.ECPoint.from_values(
+        priv.oid.key_size,
+        fields.ECPointFormat.Standard,
+        fields.MPI(pn.x),
+        fields.MPI(pn.y),
+    )
+    priv.s = fields.MPI(d)
+    priv._compute_chksum()
+    return priv
+
+
 class ToolsGPGLoadBIP85KeyView(View):
     def run(self):
         from embit import bip32
@@ -4308,6 +4346,7 @@ class ToolsGPGLoadBIP85KeyView(View):
         key_index = int(ret)
 
         keytype_buttons = [
+            ButtonOption("Brainpool P-256"),
             ButtonOption("ECC P-256"),
             ButtonOption("RSA 2048"),
             ButtonOption("secp256k1"),
@@ -4320,7 +4359,7 @@ class ToolsGPGLoadBIP85KeyView(View):
         )
         if selected_type == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
-        key_type = ["p256", "rsa2048", "secp256k1"][selected_type]
+        key_type = ["brainpoolp256r1", "p256", "rsa2048", "secp256k1"][selected_type]
 
         def prompt_text(title: str, default: str = ""):
             ret_dict = tools_screens.ToolsTextQRTextEntryScreen(
@@ -4401,6 +4440,9 @@ class ToolsGPGLoadBIP85KeyView(View):
             elif key_type == "p256":
                 pk.pkalg = PubKeyAlgorithm.ECDSA
                 pk.keymaterial = bip85_p256_from_root(root, key_index)
+            elif key_type == "brainpoolp256r1":
+                pk.pkalg = PubKeyAlgorithm.ECDSA
+                pk.keymaterial = bip85_brainpoolp256r1_from_root(root, key_index)
             else:
                 rsa_main = bip85_rsa_from_root(root, KEY_BITS, key_index)
                 pk.pkalg = PubKeyAlgorithm.RSAEncryptOrSign
@@ -4421,7 +4463,7 @@ class ToolsGPGLoadBIP85KeyView(View):
                 expires=expires,
             )
 
-            if key_type in ["secp256k1", "p256"]:
+            if key_type in ["secp256k1", "p256", "brainpoolp256r1"]:
                 subkey_specs = [
                     (0, PubKeyAlgorithm.ECDH, {KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage}, "ECDH"),
                     (1, PubKeyAlgorithm.ECDSA, {KeyFlags.Authentication}, "ECDSA"),
@@ -4442,6 +4484,8 @@ class ToolsGPGLoadBIP85KeyView(View):
                     subpkt.keymaterial = bip85_secp256k1_from_root(root, key_index, sub_index, alg[0])
                 elif key_type == "p256":
                     subpkt.keymaterial = bip85_p256_from_root(root, key_index, sub_index, alg[0])
+                elif key_type == "brainpoolp256r1":
+                    subpkt.keymaterial = bip85_brainpoolp256r1_from_root(root, key_index, sub_index, alg[0])
                 else:
                     rsa_sub = bip85_rsa_from_root(root, KEY_BITS, key_index, sub_index)
                     subpkt.keymaterial = rsa_to_privpacket(rsa_sub)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4243,7 +4243,10 @@ def bip85_p256_from_root(
     if sub_index is not None:
         path.append(sub_index)
     entropy = bip85.derive_entropy(root, 828365, path)
-    order = ec.SECP256R1().group_order
+    # Avoid relying on cryptography's ``group_order`` attribute since
+    # some versions (such as those bundled with seedsigner-os) do not
+    # expose it. Instead, use the well-known group order for P-256.
+    order = 0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
     d = int.from_bytes(entropy[:32], "big") % order
     if d == 0:
         d = 1

--- a/tests/test_bip85_gpg.py
+++ b/tests/test_bip85_gpg.py
@@ -28,6 +28,22 @@ def test_bip85_rsa_large_key():
     assert key.size_in_bits() == 4096
 
 
+def test_bip85_rsa_3072_deterministic():
+    seed = Seed(mnemonic=MNEMONIC)
+    root = bip32.HDKey.from_seed(seed.seed_bytes)
+    key = bip85_rsa_from_root(root, 3072, 0)
+    assert key.size_in_bits() == 3072
+    assert key.n == int(
+        "d75e35129fd00e06a4b26894c11d7c420d1b758d18190857ce100e3a7720a1a57fee5820ee5332bf2fe8c7d336acbeb44b6543f01a162c3304c970e20924f495"
+        "09936ee727cbd07b39a091340e5518a72ad6dafe181014109a1b8d8db0bd94cf5bda97ee713dd90ef4acebee6f7f747362dc0deb86fa93ef76ab7ec884381fac"
+        "eda19721939b39f7a6c25ea4ba58f8a430b1d6ba7b2d3dd994c93096f206e1a95ef2a872299a302718510869fb27d6bbfe0d27801d6f05465e8bb8d748aa55db"
+        "235268644ffe5cf16d4d5d6ee8e51a16072bba3e3c1d1075f20061e62562ab7bc267f6be05fb2d56e4e477653c2b22cd88b849ee69cbf4fdcf8d297ce2f804dd"
+        "0545cfc9f533997e5f5df984c9de844597674ba349bf6a8770a6f6e86a9cbaee6134b4349d226acc80101b31f80888cbb0113b138a79e2d5467af2a21991d0a8"
+        "307247fcaa44fb123248e848edfcb1306878e1020fc5832bc2213241caa30b2309d5bc9ea3e0f47275f2a2299fa9bed5faa8256fbf9e0fa253e3a1defa034685",
+        16,
+    )
+
+
 def test_bip85_secp256k1_deterministic():
     seed = Seed(mnemonic=MNEMONIC)
     root = bip32.HDKey.from_seed(seed.seed_bytes)

--- a/tests/test_bip85_gpg.py
+++ b/tests/test_bip85_gpg.py
@@ -1,6 +1,10 @@
 from embit import bip32
 from seedsigner.models.seed import Seed
-from seedsigner.views.tools_views import bip85_rsa_from_root, bip85_secp256k1_from_root
+from seedsigner.views.tools_views import (
+    bip85_p256_from_root,
+    bip85_rsa_from_root,
+    bip85_secp256k1_from_root,
+)
 
 MNEMONIC = "resource timber firm banner horror pupil frozen main pear direct pioneer broken grid core insane begin sister pony end debate task silk empty curious".split()
 
@@ -29,4 +33,13 @@ def test_bip85_secp256k1_deterministic():
     key = bip85_secp256k1_from_root(root, 0)
     assert int(key.s) == int(
         "cefbb3197f44cbcd28ca548e7d6c22e2b67f497caeebb71fa91d1cc6ab78e502", 16
+    )
+
+
+def test_bip85_p256_deterministic():
+    seed = Seed(mnemonic=MNEMONIC)
+    root = bip32.HDKey.from_seed(seed.seed_bytes)
+    key = bip85_p256_from_root(root, 0)
+    assert int(key.s) == int(
+        "ef959a78fb241496d3b56bf1307f142a1c4b141b7bdb6ec95afc11f66eafad2f", 16
     )

--- a/tests/test_bip85_gpg.py
+++ b/tests/test_bip85_gpg.py
@@ -1,6 +1,7 @@
 from embit import bip32
 from seedsigner.models.seed import Seed
 from seedsigner.views.tools_views import (
+    bip85_brainpoolp256r1_from_root,
     bip85_p256_from_root,
     bip85_rsa_from_root,
     bip85_secp256k1_from_root,
@@ -42,4 +43,13 @@ def test_bip85_p256_deterministic():
     key = bip85_p256_from_root(root, 0)
     assert int(key.s) == int(
         "ef959a78fb241496d3b56bf1307f142a1c4b141b7bdb6ec95afc11f66eafad2f", 16
+    )
+
+
+def test_bip85_brainpoolp256r1_deterministic():
+    seed = Seed(mnemonic=MNEMONIC)
+    root = bip32.HDKey.from_seed(seed.seed_bytes)
+    key = bip85_brainpoolp256r1_from_root(root, 0)
+    assert int(key.s) == int(
+        "6f48a0f8172149dd27c6d18e43017e2083e3dcf9ac58144ca054e4e86a7d3a24", 16
     )


### PR DESCRIPTION
## Summary
- Support deterministic P-256 key generation for BIP85 GPG loading
- Offer ECC P-256 option alongside RSA2048 and secp256k1
- Document new key type and update tests

## Testing
- `pytest tests/test_bip85_gpg.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6fffb1a4c8322b7776002340bc41b