### PR TITLE
feat(gpg): export password-protected private key

### DIFF
--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -2,6 +2,8 @@
 
 SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives a keypair (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, or secp256k1) from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG.
 
+Additional menu options can export existing GPG keys. Public keys are written to the microSD card in ASCII armor, while private keys are first exported and then symmetrically encrypted with a user-provided passphrase before being saved.
+
 For SeedSignerOS, everything is stateless. If running on desktop or some other normal system, you will be interacting with your system GPG2 install...
 
 During import, SeedSigner prompts for the key type, user name, email address, and expiration date. The expiration defaults to **10 years in the future**. (Noting that NIST guidelines have RSA2048 deprecated in 2030 and non-quantum safe keys, including ECC keys, being discontinued for government applications after 2035)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -3950,6 +3950,7 @@ class ToolsGPGMenuView(View):
     IMPORT_PUBKEY = ButtonOption("Import Pubkey")
     LOAD_BIP85_KEY = ButtonOption("Load BIP85 Key")
     EXPORT_PUBKEY = ButtonOption("Export Pubkey")
+    EXPORT_PRIVKEY = ButtonOption("Export Privkey")
 
     def run(self):
         from subprocess import run
@@ -3970,6 +3971,7 @@ class ToolsGPGMenuView(View):
             self.IMPORT_PUBKEY,
             self.LOAD_BIP85_KEY,
             self.EXPORT_PUBKEY,
+            self.EXPORT_PRIVKEY,
         ]
 
         selected_menu_num = self.run_screen(
@@ -3991,6 +3993,8 @@ class ToolsGPGMenuView(View):
             return Destination(ToolsGPGLoadBIP85KeyView)
         elif button_data[selected_menu_num] == self.EXPORT_PUBKEY:
             return Destination(ToolsGPGExportPubkeyView)
+        elif button_data[selected_menu_num] == self.EXPORT_PRIVKEY:
+            return Destination(ToolsGPGExportPrivkeyView)
 
 class ToolsGPGVerifyFileView(View):
     CHECK_SHA256 = ButtonOption("Check SHA256Sum")
@@ -4702,6 +4706,155 @@ class ToolsGPGExportPubkeyView(View):
                 title="Error",
                 status_headline=None,
                 text="Failed to export key",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        self.run_screen(
+            LargeIconStatusScreen,
+            title="Success",
+            status_headline=None,
+            text=f"Saved as {filename}",
+            show_back_button=False,
+            button_data=[ButtonOption("Continue")],
+        )
+        return Destination(MainMenuView)
+
+
+class ToolsGPGExportPrivkeyView(View):
+    def run(self):
+        from subprocess import run
+        import os
+        import platform
+        from seedsigner.gui.screens.screen import (
+            ButtonListScreen,
+            LargeIconStatusScreen,
+            WarningScreen,
+        )
+        from seedsigner.gui.screens import tools_screens
+
+        if len(self.controller.storage.seeds) > 0:
+            ret = self.run_screen(
+                WarningScreen,
+                title="WARNING",
+                status_headline=None,
+                text="These tools write data to the microSD card and may expose loaded secrets.",
+                show_back_button=True,
+                button_data=[ButtonOption("Continue")],
+            )
+            if ret == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
+
+        if platform.uname()[1] == "seedsigner-os":
+            file_list_path = "/mnt/microsd/microsd-images/"
+        else:
+            file_list_path = "/boot/microsd-images/"
+
+        result = run(
+            ["gpg", "--list-secret-keys", "--with-colons"],
+            capture_output=True,
+            text=True,
+        )
+        keys = []
+        cur = None
+        for line in result.stdout.splitlines():
+            parts = line.split(":")
+            if parts[0] == "sec":
+                cur = {"fpr": None, "uid": None}
+                keys.append(cur)
+            elif parts[0] == "fpr" and cur is not None:
+                cur["fpr"] = parts[9]
+            elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
+                cur["uid"] = parts[9]
+
+        if not keys:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="No private keys found",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        buttons = []
+        for key in keys:
+            label = key["uid"] if key["uid"] else key["fpr"][-8:]
+            buttons.append(ButtonOption(label))
+
+        selected = self.run_screen(
+            ButtonListScreen,
+            title="Select Key",
+            is_button_text_centered=False,
+            button_data=buttons,
+        )
+
+        if selected == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        key = keys[selected]
+
+        ret_dict = tools_screens.ToolsTextQRTextEntryScreen(
+            textToEncode="", title="Passphrase"
+        ).display()
+        if "is_back_button" in ret_dict:
+            return Destination(BackStackView)
+        try:
+            import re
+
+            passphrase = bytes(
+                re.sub(r"\\(?!u)", r"\\\\", ret_dict["textToEncode"]),
+                encoding="raw_unicode_escape",
+            ).decode("unicode_escape")
+        except UnicodeDecodeError:
+            passphrase = ret_dict["textToEncode"]
+
+        filename = key["fpr"] + "_private.gpg"
+        filepath = os.path.join(file_list_path, filename)
+        exported = run(
+            ["gpg", "--armor", "--export-secret-keys", key["fpr"]],
+            capture_output=True,
+            text=True,
+        )
+        if exported.returncode != 0:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to export key",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        protected = run(
+            [
+                "gpg",
+                "--armor",
+                "--batch",
+                "--yes",
+                "--pinentry-mode",
+                "loopback",
+                "--passphrase",
+                passphrase,
+                "--symmetric",
+                "--cipher-algo",
+                "AES256",
+                "--output",
+                filepath,
+            ],
+            input=exported.stdout,
+            capture_output=True,
+            text=True,
+        )
+        if protected.returncode != 0:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to protect key",
                 show_back_button=False,
                 button_data=[ButtonOption("I Understand")],
             )


### PR DESCRIPTION
## Summary
- add option to export privkey in GPG tools
- encrypt exported private key with user-provided passphrase
- document GPG key export workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7a92c68588322bc5f8d7cb31f8ec2