### PR TITLE
feat: export GPG pubkeys to Seedkeeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Entries marked "(SeedSigner official)" originate from the upstream project, whil
 ## Unreleased - SS0.8.6+Satochip+Earthdiver-B4 (smartcard fork)
 - Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to 10 years from creation), and key type (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
 - MicroSD and GPG tools now display seed-loaded warnings only when opening file pickers
-- GPG public keys can now be exported directly to a connected Seedkeeper card
+- GPG public keys can now be exported directly to a connected Seedkeeper card as ASCII-armored text
 
 ## 2025-08-04 - SS0.8.6+Satochip+Earthdiver-B3 (smartcard fork)
 - Satochip card transaction signing and PSBT verification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Entries marked "(SeedSigner official)" originate from the upstream project, whil
 ## Unreleased - SS0.8.6+Satochip+Earthdiver-B4 (smartcard fork)
 - Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to 10 years from creation), and key type (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
 - MicroSD and GPG tools now display seed-loaded warnings only when opening file pickers
+- GPG public keys can now be exported directly to a connected Seedkeeper card
 
 ## 2025-08-04 - SS0.8.6+Satochip+Earthdiver-B3 (smartcard fork)
 - Satochip card transaction signing and PSBT verification

--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -8,3 +8,5 @@ During import, SeedSigner prompts for the key type, user name, email address, an
 
 Note: The key derivation with BIP85 is deterministic, meaning the key and fingerprint will always be the same, but metadata like the username, email address and expiration date can be changed. (And are not saved on-device, but can be exported to a Smartcard, etc)
 
+Existing GPG keys can also be exported. After selecting a key, SeedSigner offers to save the ASCII-armored public key either to the microSD card or directly to a connected Seedkeeper smartcard.
+

--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -8,5 +8,5 @@ During import, SeedSigner prompts for the key type, user name, email address, an
 
 Note: The key derivation with BIP85 is deterministic, meaning the key and fingerprint will always be the same, but metadata like the username, email address and expiration date can be changed. (And are not saved on-device, but can be exported to a Smartcard, etc)
 
-Existing GPG keys can also be exported. After selecting a key, SeedSigner offers to save the ASCII-armored public key either to the microSD card or directly to a connected Seedkeeper smartcard.
+Existing GPG keys can also be exported. After selecting a key, SeedSigner offers to save the ASCII-armored public key either to the microSD card or directly to a connected Seedkeeper smartcard. On Seedkeeper, the key is saved as ASCII-armored text so it can be copied and pasted easily.
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4626,6 +4626,7 @@ class ToolsGPGExportPubkeyView(View):
             ButtonListScreen,
             LargeIconStatusScreen,
             WarningScreen,
+            LoadingScreenThread,
         )
 
         if len(self.controller.storage.seeds) > 0:
@@ -4689,33 +4690,104 @@ class ToolsGPGExportPubkeyView(View):
             return Destination(BackStackView)
 
         key = keys[selected]
-        filename = key["fpr"] + ".asc"
-        filepath = os.path.join(file_list_path, filename)
-        exported = run(
-            ["gpg", "--armor", "--output", filepath, "--export", key["fpr"]],
-            capture_output=True,
-            text=True,
+        label = key["uid"] if key["uid"] else key["fpr"][-8:]
+
+        dest_buttons = [ButtonOption("microSD"), ButtonOption("Seedkeeper")]
+        dest_selected = self.run_screen(
+            ButtonListScreen,
+            title="Export to",
+            is_button_text_centered=False,
+            button_data=dest_buttons,
         )
-        if exported.returncode != 0:
-            self.run_screen(
-                WarningScreen,
-                title="Error",
-                status_headline=None,
-                text="Failed to export key",
-                show_back_button=False,
-                button_data=[ButtonOption("I Understand")],
-            )
+
+        if dest_selected == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        self.run_screen(
-            LargeIconStatusScreen,
-            title="Success",
-            status_headline=None,
-            text=f"Saved as {filename}",
-            show_back_button=False,
-            button_data=[ButtonOption("Continue")],
-        )
-        return Destination(MainMenuView)
+        if dest_selected == 0:
+            filename = key["fpr"] + ".asc"
+            filepath = os.path.join(file_list_path, filename)
+            exported = run(
+                ["gpg", "--armor", "--output", filepath, "--export", key["fpr"]],
+                capture_output=True,
+                text=True,
+            )
+            if exported.returncode != 0:
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text="Failed to export key",
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
+
+            self.run_screen(
+                LargeIconStatusScreen,
+                title="Success",
+                status_headline=None,
+                text=f"Saved as {filename}",
+                show_back_button=False,
+                button_data=[ButtonOption("Continue")],
+            )
+            return Destination(MainMenuView)
+        else:
+            exported = run(
+                ["gpg", "--armor", "--export", key["fpr"]],
+                capture_output=True,
+                text=True,
+            )
+            if exported.returncode != 0:
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text="Failed to export key",
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
+
+            Satochip_Connector = seedkeeper_utils.init_satochip(
+                self, init_card_filter=["seedkeeper"]
+            )
+            if not Satochip_Connector:
+                return Destination(BackStackView)
+
+            pubkey_bytes = exported.stdout.encode("utf-8")
+            header = Satochip_Connector.make_header(
+                "Public Key", "Plaintext export allowed", label
+            )
+            secret_list = [len(pubkey_bytes)] + list(pubkey_bytes)
+            secret_dic = {"header": header, "secret_list": secret_list}
+
+            try:
+                self.loading_screen = LoadingScreenThread(
+                    text="Saving Secret\n\n\n\n\n\n"
+                )
+                self.loading_screen.start()
+                Satochip_Connector.seedkeeper_import_secret(secret_dic)
+                self.loading_screen.stop()
+                self.run_screen(
+                    LargeIconStatusScreen,
+                    title="Success",
+                    status_headline=None,
+                    text="Pubkey saved to Seedkeeper",
+                    show_back_button=False,
+                    button_data=[ButtonOption("Continue")],
+                )
+                return Destination(MainMenuView)
+            except Exception:
+                self.loading_screen.stop()
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text="Failed to export key",
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
 
 class ToolsTextQRTextEntryView(View):
     def __init__(self, textToEncode: str = ""):

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2010,7 +2010,7 @@ class ToolsSeedkeeperViewSecretsView(View):
                 secret_dict['secret'] = secret_string
 
 
-            elif stype in ('Descriptor', 'Data'):
+            elif stype in ('Descriptor', 'Data', 'Public Key'):
                 secret_dict['secret'] = unhexlify(secret_dict['secret'])[2:].decode()
                 
             else:
@@ -4755,10 +4755,25 @@ class ToolsGPGExportPubkeyView(View):
                 return Destination(BackStackView)
 
             pubkey_bytes = exported.stdout.encode("utf-8")
+            status = Satochip_Connector.card_get_status()[3]
+            if status['protocol_minor_version'] == 1:
+                if len(pubkey_bytes) > 255:
+                    self.run_screen(
+                        WarningScreen,
+                        title="Error",
+                        status_headline=None,
+                        text="Pubkey too large for Seedkeeper v1",
+                        show_back_button=False,
+                        button_data=[ButtonOption("I Understand")],
+                    )
+                    return Destination(BackStackView)
+                secret_list = [len(pubkey_bytes)] + list(pubkey_bytes)
+            else:
+                secret_list = list(len(pubkey_bytes).to_bytes(2, "big")) + list(pubkey_bytes)
+
             header = Satochip_Connector.make_header(
                 "Public Key", "Plaintext export allowed", label
             )
-            secret_list = [len(pubkey_bytes)] + list(pubkey_bytes)
             secret_dic = {"header": header, "secret_list": secret_list}
 
             try:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4772,7 +4772,7 @@ class ToolsGPGExportPubkeyView(View):
                 secret_list = list(len(pubkey_bytes).to_bytes(2, "big")) + list(pubkey_bytes)
 
             header = Satochip_Connector.make_header(
-                "Public Key", "Plaintext export allowed", label
+                "Data", "Plaintext export allowed", label
             )
             secret_dic = {"header": header, "secret_list": secret_list}
 


### PR DESCRIPTION
## Summary
- add option to export GPG public keys to Seedkeeper
- document GPG public key export destinations
- note Seedkeeper export in changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7a566750c832286221437d99b3ed3