### PR TITLE
feat: add random serial number during SmartPGP applet install

### DIFF
--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -14,3 +14,7 @@ Note: The key derivation with BIP85 is deterministic, meaning the key and finger
 
 Existing GPG keys can also be exported. After selecting a key, SeedSigner offers to save the ASCII-armored public key either to the microSD card or directly to a connected Seedkeeper smartcard. On Seedkeeper, the key is saved as ASCII-armored text so it can be copied and pasted easily.
 
+## SmartPGP Applet Installation
+
+SeedSigner can install the [SmartPGP](https://github.com/ANSSI-FR/SmartPGP) applet onto a JavaCard via the **Smartcard Tools → Satochip DIY → Install Applet** menu. When a SmartPGP CAP file is selected, SeedSigner now generates a random 4‑byte serial number and embeds it into the application identifier (AID) during installation, following the [flexsecure applet procedure](https://github.com/DangerousThings/flexsecure-applets/blob/master/docs/applets/1-pgp.md).
+

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -3386,6 +3386,7 @@ class ToolsDIYInstallAppletView(View):
     def run(self):
         from subprocess import run
         import os
+        import secrets
         from seedsigner.gui.screens.screen import LoadingScreenThread
         from seedsigner.hardware.microsd import MicroSD
 
@@ -3409,12 +3410,23 @@ class ToolsDIYInstallAppletView(View):
         applet_file = cap_files[selected_file_num]
         logger.info("Selected:", applet_file)
 
-        installed_applets = seedkeeper_utils.run_globalplatform(
-            self,
-            f"--install {cap_dir}/{applet_file}",
-            "Installing Applet",
-            "Applet Installed",
-        )
+        if "smartpgp" in applet_file.lower():
+            serial_hex = secrets.token_bytes(4).hex().upper()
+            aid = f"D276000124010304C0FE{serial_hex}0000"
+            logger.info("SmartPGP AID: %s", aid)
+            installed_applets = seedkeeper_utils.run_globalplatform(
+                self,
+                f"--install {cap_dir}/{applet_file} --create {aid}",
+                "Installing Applet",
+                f"Applet Installed\nSerial: {serial_hex}",
+            )
+        else:
+            installed_applets = seedkeeper_utils.run_globalplatform(
+                self,
+                f"--install {cap_dir}/{applet_file}",
+                "Installing Applet",
+                "Applet Installed",
+            )
 
         # This process often kills IFD-NFC, so restart it if required
         scinterface = self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_INTERFACES)


### PR DESCRIPTION
## Summary
- generate random 4-byte serial when installing SmartPGP applet
- document SmartPGP installation workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9fae8793c8322a70aebac4d13bb4b