### PR TITLE
Install Seedkeeper applet with 8KB storage

### DIFF
--- a/docs/smartcard_support_installation.md
+++ b/docs/smartcard_support_installation.md
@@ -163,7 +163,8 @@ _The applet management (install/uninstall) in the SeedSigner menu assume that th
 
 The commands that the menu items run are currently hardcoded to be:
 
-    java -jar /home/pi/Satochip-DIY/gp.jar --install /home/pi/Satochip-DIY/build/SeedKeeper-official-3.0.4.cap
+    java -jar /home/pi/Satochip-DIY/gp.jar --install /home/pi/Satochip-DIY/build/SeedKeeper-official-3.0.4.cap --params 2000
+        # reserves 8KB of storage for secrets when the CAP filename includes "SeedKeeper" (case-insensitive)
 
     java -jar /home/pi/Satochip-DIY/gp.jar --uninstall /home/pi/Satochip-DIY/build/SeedKeeper-official-3.0.4.cap
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -3409,9 +3409,11 @@ class ToolsDIYInstallAppletView(View):
         applet_file = cap_files[selected_file_num]
         logger.info("Selected:", applet_file)
 
+        params = " --params 2000" if "seedkeeper" in applet_file.lower() else ""
+
         installed_applets = seedkeeper_utils.run_globalplatform(
             self,
-            f"--install {cap_dir}/{applet_file}",
+            f"--install {cap_dir}/{applet_file}{params}",
             "Installing Applet",
             "Applet Installed",
         )


### PR DESCRIPTION
## Summary
- reserve 8KB for secrets when installing a Seedkeeper applet by passing `--params 2000` only when the CAP filename contains "SeedKeeper"
- document the `gp.jar` command and its conditional storage reservation parameter

## Testing
- `pytest tests/test_flows_tools.py::TestToolsFlows::test__address_explorer__flow -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9fac235648322afcbacfcb4f9c446