### PR TITLE
Install SeedKeeper applet with 8KB storage

### DIFF
--- a/docs/smartcard_support_installation.md
+++ b/docs/smartcard_support_installation.md
@@ -161,9 +161,9 @@ Follow the guide here: https://github.com/3rdIteration/Satochip-DIY
 
 _The applet management (install/uninstall) in the SeedSigner menu assume that the Satochip-DIY repository was cloned into /home/pi/Satochip-DIY and built as per the guide in the repository._
 
-The commands that the menu items run are currently hardcoded to be:
+The commands that the menu items run are currently hardcoded to be (note the `--params 1FFF` which allocates 8KB of storage for the SeedKeeper applet):
 
-    java -jar /home/pi/Satochip-DIY/gp.jar --install /home/pi/Satochip-DIY/build/SeedKeeper-official-3.0.4.cap
+    java -jar /home/pi/Satochip-DIY/gp.jar --install /home/pi/Satochip-DIY/build/SeedKeeper-official-3.0.4.cap --params 1FFF
 
     java -jar /home/pi/Satochip-DIY/gp.jar --uninstall /home/pi/Satochip-DIY/build/SeedKeeper-official-3.0.4.cap
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -3420,6 +3420,13 @@ class ToolsDIYInstallAppletView(View):
                 "Installing Applet",
                 f"Applet Installed\nSerial: {serial_hex}",
             )
+        elif "seedkeeper" in applet_file.lower():
+            installed_applets = seedkeeper_utils.run_globalplatform(
+                self,
+                f"--install {cap_dir}/{applet_file} --params 1FFF",
+                "Installing Applet",
+                "Applet Installed",
+            )
         else:
             installed_applets = seedkeeper_utils.run_globalplatform(
                 self,

--- a/tests/test_seedkeeper_install.py
+++ b/tests/test_seedkeeper_install.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+from seedsigner.views import tools_views
+from seedsigner.hardware import microsd
+from seedsigner.helpers import seedkeeper_utils
+
+def test_seedkeeper_install_adds_params(monkeypatch, tmp_path):
+    view = object.__new__(tools_views.ToolsDIYInstallAppletView)
+    view.settings = SimpleNamespace(get_value=lambda *a, **k: [])
+    view.run_screen = lambda *a, **k: 0
+
+    cap_dir = tmp_path / "javacard-cap"
+    cap_dir.mkdir()
+    (cap_dir / "SeedKeeper-v0.2.cap").touch()
+
+    monkeypatch.setattr(microsd.MicroSD, "get_microsd_dir", lambda: tmp_path)
+
+    captured = {}
+
+    def fake_run_globalplatform(self_obj, command, loadingText, successtext):
+        captured["cmd"] = command
+        return "ok"
+
+    monkeypatch.setattr(seedkeeper_utils, "run_globalplatform", fake_run_globalplatform)
+    monkeypatch.setattr(tools_views, "logger", SimpleNamespace(info=lambda *a, **k: None))
+
+    view.run()
+
+    assert "--params 1FFF" in captured["cmd"]
+


### PR DESCRIPTION
## Summary
- ensure SeedKeeper CAP installation allocates 8KB of storage by passing `--params 1FFF`
- document and test the SeedKeeper install parameters

## Testing
- `pytest tests/test_seedkeeper_install.py -q`
- `pytest tests/test_flows_tools.py::TestToolsFlows::test__address_explorer__flow -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9ffc730448322a4e8f68ca1e4bfb3