### PR TITLE
Add SmartPGP fallback for OpenPGP key import

### DIFF
--- a/src/seedsigner/helpers/smartpgp/commands.py
+++ b/src/seedsigner/helpers/smartpgp/commands.py
@@ -314,6 +314,13 @@ def put_key(connection, pubkey, privkey):
         _raw_send_apdu(connection,"Sending key chunk",apdu)
 
 
+def put_data(connection, tag, value):
+    """Generic helper for ``PUT DATA`` command."""
+    prefix = [0x00, 0xDA, 0x00, tag]
+    apdu = assemble_with_len(prefix, list(value))
+    _raw_send_apdu(connection, f"Put data {tag:02X}", apdu)
+
+
 def put_sm_key(connection, pubkey, privkey):
     """Backward-compatible wrapper for legacy naming."""
     put_key(connection, pubkey, privkey)

--- a/src/seedsigner/helpers/smartpgp/commands.py
+++ b/src/seedsigner/helpers/smartpgp/commands.py
@@ -292,7 +292,7 @@ def unblock_pin(connection, resetting_code, new_user_pin):
     apdu = assemble_with_len([0x00, 0x2C, 0x00, 0x81], data)
     _raw_send_apdu(connection,"Unblock user PIN with resetting code",apdu)
 
-def put_sm_key(connection, pubkey, privkey):
+def put_key(connection, pubkey, privkey):
     ins_p1_p2 = [0xDB, 0x3F, 0xFF]
     cdata = [0x92] + encode_len(privkey) + [0x99] + encode_len(pubkey)
     cdata = [0xA6, 0x00, 0x7F, 0x48] + encode_len(cdata) + cdata
@@ -311,7 +311,12 @@ def put_sm_key(connection, pubkey, privkey):
             data = cdata[i:i+cl]
             i = i + cl
         apdu = assemble_with_len([cla] + ins_p1_p2, data)
-        _raw_send_apdu(connection,"Sending SM key chunk",apdu)
+        _raw_send_apdu(connection,"Sending key chunk",apdu)
+
+
+def put_sm_key(connection, pubkey, privkey):
+    """Backward-compatible wrapper for legacy naming."""
+    put_key(connection, pubkey, privkey)
 
 def put_sign_certificate(connection, cert):
     prefix = [0x00, 0xA5, 0x02, 0x04]

--- a/src/seedsigner/helpers/smartpgp/highlevel.py
+++ b/src/seedsigner/helpers/smartpgp/highlevel.py
@@ -273,7 +273,12 @@ class CardConnectionContext:
         self.connect()
         self.verify_admin_pin()
         switch_crypto(self.connection, curve, 'sm')
-        put_sm_key(self.connection, pubkey, privkey)
+        put_key(self.connection, pubkey, privkey)
+
+    def cmd_put_key(self, pubkey, privkey):
+        self.connect()
+        self.verify_admin_pin()
+        put_key(self.connection, list(pubkey), list(privkey))
 
     def cmd_set_resetting_code(self):
         self.connect()

--- a/src/seedsigner/helpers/smartpgp/highlevel.py
+++ b/src/seedsigner/helpers/smartpgp/highlevel.py
@@ -280,6 +280,11 @@ class CardConnectionContext:
         self.verify_admin_pin()
         put_key(self.connection, list(pubkey), list(privkey))
 
+    def cmd_put_data(self, tag, value):
+        self.connect()
+        self.verify_admin_pin()
+        put_data(self.connection, tag, list(value))
+
     def cmd_set_resetting_code(self):
         self.connect()
         self.verify_admin_pin()

--- a/src/seedsigner/helpers/smartpgp_import.py
+++ b/src/seedsigner/helpers/smartpgp_import.py
@@ -46,7 +46,12 @@ def import_keys_with_smartpgp(fingerprint: str, admin_pin: str) -> bool:
 
     all_keys = [key] + list(key.subkeys.values())
     for k in all_keys:
-        flags = set(k.key_flags)
+        try:
+            flags = set(k.key_flags)  # pgpy <0.6
+        except AttributeError:
+            # pgpy 0.6 dropped the ``key_flags`` attribute; rely on the internal
+            # helper instead so we still detect the proper key usages
+            flags = set(k._get_key_flags())
         role = None
         if KeyFlags.Sign in flags:
             role = 'sig'

--- a/src/seedsigner/helpers/smartpgp_import.py
+++ b/src/seedsigner/helpers/smartpgp_import.py
@@ -1,0 +1,74 @@
+import logging
+from subprocess import run
+
+import pgpy
+from pgpy.constants import KeyFlags
+
+from seedsigner.helpers.smartpgp.highlevel import CardConnectionContext
+
+logger = logging.getLogger(__name__)
+
+_curve_map = {
+    'NIST_P256': 'P-256',
+    'NIST_P384': 'P-384',
+    'NIST_P521': 'P-521',
+    'BRAINPOOLP256R1': 'brainpoolP256r1',
+    'BRAINPOOLP384R1': 'brainpoolP384r1',
+    'BRAINPOOLP512R1': 'brainpoolP512r1',
+}
+
+
+def import_keys_with_smartpgp(fingerprint: str, admin_pin: str) -> bool:
+    """Fallback key import using the bundled SmartPGP module.
+
+    Parameters
+    ----------
+    fingerprint: str
+        Fingerprint of the key to import.
+    admin_pin: str
+        Admin PIN for the OpenPGP card.
+    """
+    try:
+        res = run(['gpg', '--export-secret-key', fingerprint], capture_output=True, check=True)
+        key, _ = pgpy.PGPKey.from_blob(res.stdout)
+    except Exception as e:
+        logger.exception('Failed to export key for SmartPGP import: %s', e)
+        return False
+
+    ctx = CardConnectionContext()
+    ctx.admin_pin = admin_pin
+    try:
+        ctx.connect()
+        ctx.verify_admin_pin()
+    except Exception as e:
+        logger.exception('SmartPGP connection failed: %s', e)
+        return False
+
+    all_keys = [key] + list(key.subkeys.values())
+    for k in all_keys:
+        flags = set(k.key_flags)
+        role = None
+        if KeyFlags.Sign in flags:
+            role = 'sig'
+        elif KeyFlags.EncryptCommunications in flags or KeyFlags.EncryptStorage in flags:
+            role = 'dec'
+        elif KeyFlags.Authentication in flags:
+            role = 'auth'
+        if role is None:
+            continue
+        km = k._key.keymaterial
+        curve_name = _curve_map.get(km.oid.name.upper())
+        if not curve_name:
+            logger.error('Unsupported curve %s', km.oid)
+            return False
+        try:
+            priv = km.s.to_bytes((km.s.bit_length() + 7) // 8, 'big')
+            point = km.p
+            size = (point.x.bit_length() + 7) // 8
+            pub = b'\x04' + point.x.to_bytes(size, 'big') + point.y.to_bytes(size, 'big')
+            ctx.cmd_switch_crypto(curve_name, role)
+            ctx.cmd_put_key(pub, priv)
+        except Exception as e:
+            logger.exception('Failed to import %s key via SmartPGP: %s', role, e)
+            return False
+    return True

--- a/src/seedsigner/helpers/smartpgp_import.py
+++ b/src/seedsigner/helpers/smartpgp_import.py
@@ -45,6 +45,17 @@ def import_keys_with_smartpgp(fingerprint: str, admin_pin: str) -> bool:
         return False
 
     all_keys = [key] + list(key.subkeys.values())
+    fp_tags = {'sig': 0xC7, 'dec': 0xC8, 'auth': 0xC9}
+    ts_tags = {'sig': 0xCD, 'dec': 0xCE, 'auth': 0xCF}
+    size_map = {
+        'P-256': 32,
+        'P-384': 48,
+        'P-521': 66,
+        'brainpoolP256r1': 32,
+        'brainpoolP384r1': 48,
+        'brainpoolP512r1': 64,
+    }
+
     for k in all_keys:
         try:
             flags = set(k.key_flags)  # pgpy <0.6
@@ -66,13 +77,20 @@ def import_keys_with_smartpgp(fingerprint: str, admin_pin: str) -> bool:
         if not curve_name:
             logger.error('Unsupported curve %s', km.oid)
             return False
+        size = size_map.get(curve_name)
+        if not size:
+            logger.error('No size mapping for curve %s', curve_name)
+            return False
         try:
-            priv = km.s.to_bytes((km.s.bit_length() + 7) // 8, 'big')
+            priv = km.s.to_bytes(size, 'big')
             point = km.p
-            size = (point.x.bit_length() + 7) // 8
             pub = b'\x04' + point.x.to_bytes(size, 'big') + point.y.to_bytes(size, 'big')
             ctx.cmd_switch_crypto(curve_name, role)
             ctx.cmd_put_key(pub, priv)
+            fp = bytes.fromhex(str(k.fingerprint).replace(' ', ''))
+            ts = int(k.created.timestamp()).to_bytes(4, 'big')
+            ctx.cmd_put_data(fp_tags[role], fp)
+            ctx.cmd_put_data(ts_tags[role], ts)
         except Exception as e:
             logger.exception('Failed to import %s key via SmartPGP: %s', role, e)
             return False

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -6406,11 +6406,26 @@ class ToolsGPGImportKeyToCardView(View):
         self.loading_screen.stop()
 
         if result.returncode != 0:
+            try:
+                from seedsigner.helpers.smartpgp_import import import_keys_with_smartpgp
+
+                if import_keys_with_smartpgp(self.fingerprint, admin_pin):
+                    self.run_screen(
+                        LargeIconStatusScreen,
+                        title="Success",
+                        status_headline=None,
+                        text="Key imported to card",
+                        show_back_button=False,
+                        button_data=[ButtonOption("Continue")],
+                    )
+                    return Destination(ToolsGPGMenuView)
+            except Exception as e:
+                logger.exception("SmartPGP fallback failed: %s", e)
             self.run_screen(
                 LargeIconStatusScreen,
                 title="Error",
                 status_headline=None,
-                text="Failed to import key", 
+                text="Failed to import key",
                 show_back_button=False,
                 button_data=[ButtonOption("Continue")],
             )


### PR DESCRIPTION
## Summary
- add generic `put_key` helper and expose via `CardConnectionContext`
- implement SmartPGP-based key import fallback that loads signing, encryption and auth keys
- invoke SmartPGP fallback when GPG key-to-card import fails

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba27af4fd483228cfaeb3d0618179e