### PR TITLE
Fix OpenPGP card import sequence

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -6354,7 +6354,9 @@ class ToolsGPGImportKeyToCardView(View):
         cmds = ["toggle\n"]
         used_slots = set()
         if sign_idx is not None:
-            cmds.append(f"key {sign_idx}\nkeytocard\n1\nkey {sign_idx}\n")
+            cmds.append(
+                f"key {sign_idx}\nkeytocard\ny\n1\nkey {sign_idx}\n"
+            )
             used_slots.add("1")
         elif "s" in primary_caps:
             cmds.extend(["keytocard\n", "y\n", "1\n"])
@@ -6371,7 +6373,9 @@ class ToolsGPGImportKeyToCardView(View):
                 None,
             )
             if slot:
-                cmds.append(f"key {idx}\nkeytocard\n{slot}\nkey {idx}\n")
+                cmds.append(
+                    f"key {idx}\nkeytocard\ny\n{slot}\nkey {idx}\n"
+                )
                 used_slots.add(slot)
         cmds.append("quit\ny\n")
         edit_commands = "".join(cmds)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -6409,6 +6409,10 @@ class ToolsGPGImportKeyToCardView(View):
 
         self.loading_screen.stop()
 
+        logger.info("GPG keytocard stdout:\n%s", result.stdout)
+        if result.stderr:
+            logger.warning("GPG keytocard stderr:\n%s", result.stderr)
+
         if result.returncode != 0:
             try:
                 from seedsigner.helpers.smartpgp_import import import_keys_with_smartpgp


### PR DESCRIPTION
## Summary
- ensure OpenPGP card imports confirm `keytocard` operations

## Testing
- `pytest` *(fails: KeyboardInterrupt after 65 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bb30837290832284f353ed03c1e6e3