### PR TITLE
Add RSA4096 GPG key generation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 Entries marked "(SeedSigner official)" originate from the upstream project, while "(smartcard fork)" indicates releases and changes unique to this repository.
 
 ## Unreleased - SS0.8.6+Satochip+Earthdiver-B4 (smartcard fork)
-- Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to 10 years from creation), and key type (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
+- Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to 10 years from creation), and key type (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, RSA 4096, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
 - MicroSD and GPG tools now display seed-loaded warnings only when opening file pickers
 - GPG public keys can now be exported directly to a connected Seedkeeper card as ASCII-armored text
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project are documented in this file.
 Entries marked "(SeedSigner official)" originate from the upstream project, while "(smartcard fork)" indicates releases and changes unique to this repository.
 
 ## Unreleased - SS0.8.6+Satochip+Earthdiver-B4 (smartcard fork)
-- Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to 10 years from creation), and key type (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, RSA 4096, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
+- Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to the end of 2029 for RSA 2048 keys and the end of 2035 for other key types), and key type (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, RSA 4096, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
+- RSA key selections warn that generation on a Pi Zero may take approximately 3 minutes (2048), 15 minutes (3072), or an hour (4096) and recommend NIST or Brainpool keys as faster, smaller alternatives
 - MicroSD and GPG tools now display seed-loaded warnings only when opening file pickers
 - GPG public keys can now be exported directly to a connected Seedkeeper card as ASCII-armored text
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Support and discussion relating to this fork can happen via this [Telegram Group
    - Secure Wipe (Both with zeros and random data)
 * GPG Tools
    - GPG Signature verification & Sha256 Manifest check (Includes pubkey bundle the from Sparrow to verify Seedsigner, Sparrow, Electrum, plus many more)
-    - Load BIP85-derived GPG keys (NIST P-256 [default], Brainpool P-256, RSA 2048, RSA 3072, RSA 4096, or secp256k1) with prompts for key type, name, email, and expiration (defaulting to 10 years in the future); metadata such as name, email, expiration, and deprecation/end-of-use dates can be modified later ([docs](./docs/gpg_tools.md))
+    - Load BIP85-derived GPG keys (NIST P-256 [default], Brainpool P-256, RSA 2048, RSA 3072, RSA 4096, or secp256k1) with prompts for key type, name, email, and expiration (defaulting to the end of 2029 for RSA 2048 keys and the end of 2035 for all other key types); metadata such as name, email, expiration, and deprecation/end-of-use dates can be modified later ([docs](./docs/gpg_tools.md))
 * Tested and working with the following hardware
    - Raspberry Pi Zero 1.3
    - Raspberry Pi Zero W

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Support and discussion relating to this fork can happen via this [Telegram Group
    - Secure Wipe (Both with zeros and random data)
 * GPG Tools
    - GPG Signature verification & Sha256 Manifest check (Includes pubkey bundle the from Sparrow to verify Seedsigner, Sparrow, Electrum, plus many more)
-  - Load BIP85-derived GPG keys (NIST P-256 [default], Brainpool P-256, RSA 2048, RSA 3072, or secp256k1) with prompts for key type, name, email, and expiration (defaulting to 10 years in the future); metadata such as name, email, expiration, and deprecation/end-of-use dates can be modified later ([docs](./docs/gpg_tools.md))
+    - Load BIP85-derived GPG keys (NIST P-256 [default], Brainpool P-256, RSA 2048, RSA 3072, RSA 4096, or secp256k1) with prompts for key type, name, email, and expiration (defaulting to 10 years in the future); metadata such as name, email, expiration, and deprecation/end-of-use dates can be modified later ([docs](./docs/gpg_tools.md))
 * Tested and working with the following hardware
    - Raspberry Pi Zero 1.3
    - Raspberry Pi Zero W

--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -1,6 +1,6 @@
 # GPG Tools
 
-SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives a keypair (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, or secp256k1) from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG.
+SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives a keypair (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, RSA 4096, or secp256k1) from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG.
 
 In addition to verifying detached signatures, files on the microSD card can now be signed. After selecting a file, choose which private key to use from the local GPG keyring and a detached signature (.sig) will be saved alongside the original file on the microSD card.
 

--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -1,6 +1,6 @@
 # GPG Tools
 
-SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives a keypair (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, RSA 4096, or secp256k1) from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG.
+SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives a keypair (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, RSA 4096, or secp256k1) from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG. Selecting RSA 2048, RSA 3072, or RSA 4096 displays a warning that generation on a Pi Zero may take about 3 minutes, 15 minutes, or an hour respectively; NIST or Brainpool keys are faster and smaller.
 
 In addition to verifying detached signatures, files on the microSD card can now be signed. After selecting a file, choose which private key to use from the local GPG keyring and a detached signature (.sig) will be saved alongside the original file on the microSD card.
 
@@ -8,7 +8,7 @@ Additional menu options can export existing GPG keys. Public keys are written to
 
 For SeedSignerOS, everything is stateless. If running on desktop or some other normal system, you will be interacting with your system GPG2 install...
 
-During import, SeedSigner prompts for the key type, user name, email address, and expiration date. The expiration defaults to **10 years in the future**. (Noting that NIST guidelines have RSA2048 deprecated in 2030 and non-quantum safe keys, including ECC keys, being discontinued for government applications after 2035)
+During import, SeedSigner prompts for the key type, user name, email address, and expiration date. The expiration defaults to **the end of 2029 for RSA 2048 keys and the end of 2035 for all other key types**. (Noting that NIST guidelines have RSA2048 deprecated in 2030 and non-quantum safe keys, including ECC keys, being discontinued for government applications after 2035)
 
 Note: The key derivation with BIP85 is deterministic, meaning the key and fingerprint will always be the same, but metadata like the username, email address and expiration date can be changed. (And are not saved on-device, but can be exported to a Smartcard, etc)
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5315,14 +5315,16 @@ class ToolsGPGLoadBIP85KeyView(View):
                 "rsa3072": "Generating an RSA 3072 key can take around 15 minutes on a Pi Zero.\nNIST or Brainpool keys are faster and smaller.",
                 "rsa4096": "Generating an RSA 4096 key can take around an hour on a Pi Zero.\nNIST or Brainpool keys are faster and smaller.",
             }[key_type]
-            self.run_screen(
+            ret = self.run_screen(
                 WarningScreen,
                 title="WARNING",
                 status_headline=None,
                 text=warn_text,
-                show_back_button=False,
+                show_back_button=True,
                 button_data=[ButtonOption("I Understand")],
             )
+            if ret == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
 
         def prompt_text(title: str, default: str = ""):
             ret_dict = tools_screens.ToolsTextQRTextEntryScreen(
@@ -5555,14 +5557,16 @@ class ToolsGPGGenerateKeyView(View):
                 3072: "Generating an RSA 3072 key can take around 15 minutes on a Pi Zero.\nNIST or Brainpool keys are faster and smaller.",
                 4096: "Generating an RSA 4096 key can take around an hour on a Pi Zero.\nNIST or Brainpool keys are faster and smaller.",
             }[param]
-            self.run_screen(
+            ret = self.run_screen(
                 WarningScreen,
                 title="WARNING",
                 status_headline=None,
                 text=warn_text,
-                show_back_button=False,
+                show_back_button=True,
                 button_data=[ButtonOption("I Understand")],
             )
+            if ret == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
 
         def prompt_text(title: str, default: str = ""):
             ret_dict = tools_screens.ToolsTextQRTextEntryScreen(

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5289,6 +5289,7 @@ class ToolsGPGLoadBIP85KeyView(View):
             ButtonOption("Brainpool P-256"),
             ButtonOption("RSA 2048"),
             ButtonOption("RSA 3072"),
+            ButtonOption("RSA 4096"),
             ButtonOption("secp256k1"),
         ]
         selected_type = self.run_screen(
@@ -5304,8 +5305,19 @@ class ToolsGPGLoadBIP85KeyView(View):
             "brainpoolp256r1",
             "rsa2048",
             "rsa3072",
+            "rsa4096",
             "secp256k1",
         ][selected_type]
+
+        if key_type == "rsa4096":
+            self.run_screen(
+                WarningScreen,
+                title="WARNING",
+                status_headline=None,
+                text="Generating an RSA 4096 key can take around an hour on a Pi Zero.",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
 
         def prompt_text(title: str, default: str = ""):
             ret_dict = tools_screens.ToolsTextQRTextEntryScreen(
@@ -5364,7 +5376,13 @@ class ToolsGPGLoadBIP85KeyView(View):
         seed = self.controller.get_seed(0)
         root = bip32.HDKey.from_seed(seed.seed_bytes)
         KEY_BITS = (
-            2048 if key_type == "rsa2048" else 3072 if key_type == "rsa3072" else None
+            2048
+            if key_type == "rsa2048"
+            else 3072
+            if key_type == "rsa3072"
+            else 4096
+            if key_type == "rsa4096"
+            else None
         )
 
         def rsa_to_privpacket(rsa_key: RSA.RsaKey) -> fields.RSAPriv:
@@ -5503,6 +5521,7 @@ class ToolsGPGGenerateKeyView(View):
             ButtonOption("Brainpool P-256"),
             ButtonOption("RSA 2048"),
             ButtonOption("RSA 3072"),
+            ButtonOption("RSA 4096"),
             ButtonOption("secp256k1"),
         ]
         selected_type = self.run_screen(
@@ -5519,8 +5538,19 @@ class ToolsGPGGenerateKeyView(View):
             (PubKeyAlgorithm.ECDSA, EllipticCurveOID.Brainpool_P256),
             (PubKeyAlgorithm.RSAEncryptOrSign, 2048),
             (PubKeyAlgorithm.RSAEncryptOrSign, 3072),
+            (PubKeyAlgorithm.RSAEncryptOrSign, 4096),
             (PubKeyAlgorithm.ECDSA, EllipticCurveOID.SECP256K1),
         ][selected_type]
+
+        if alg == PubKeyAlgorithm.RSAEncryptOrSign and param == 4096:
+            self.run_screen(
+                WarningScreen,
+                title="WARNING",
+                status_headline=None,
+                text="Generating an RSA 4096 key can take around an hour on a Pi Zero.",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
 
         def prompt_text(title: str, default: str = ""):
             ret_dict = tools_screens.ToolsTextQRTextEntryScreen(

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5309,12 +5309,17 @@ class ToolsGPGLoadBIP85KeyView(View):
             "secp256k1",
         ][selected_type]
 
-        if key_type == "rsa4096":
+        if key_type.startswith("rsa"):
+            warn_text = {
+                "rsa2048": "Generating an RSA 2048 key can take around 3 minutes on a Pi Zero.\nNIST or Brainpool keys are faster and smaller.",
+                "rsa3072": "Generating an RSA 3072 key can take around 15 minutes on a Pi Zero.\nNIST or Brainpool keys are faster and smaller.",
+                "rsa4096": "Generating an RSA 4096 key can take around an hour on a Pi Zero.\nNIST or Brainpool keys are faster and smaller.",
+            }[key_type]
             self.run_screen(
                 WarningScreen,
                 title="WARNING",
                 status_headline=None,
-                text="Generating an RSA 4096 key can take around an hour on a Pi Zero.",
+                text=warn_text,
                 show_back_button=False,
                 button_data=[ButtonOption("I Understand")],
             )
@@ -5343,8 +5348,10 @@ class ToolsGPGLoadBIP85KeyView(View):
             return Destination(BackStackView)
 
         created = datetime.fromtimestamp(1231006505, tz=timezone.utc)
-        from datetime import timedelta
-        default_expiration = (datetime.now(timezone.utc) + timedelta(days=3650)).date()
+        if key_type == "rsa2048":
+            default_expiration = date(2029, 12, 31)
+        else:
+            default_expiration = date(2035, 12, 31)
         expiration_str = prompt_text(
             "Expiration YYYY-MM-DD", default_expiration.isoformat()
         )
@@ -5507,7 +5514,7 @@ class ToolsGPGGenerateKeyView(View):
             CompressionAlgorithm,
             EllipticCurveOID,
         )
-        from datetime import datetime, timezone, timedelta
+        from datetime import datetime, timezone, date
         from subprocess import run
         from seedsigner.gui.screens.screen import LoadingScreenThread
         from seedsigner.gui.screens import (
@@ -5542,12 +5549,17 @@ class ToolsGPGGenerateKeyView(View):
             (PubKeyAlgorithm.ECDSA, EllipticCurveOID.SECP256K1),
         ][selected_type]
 
-        if alg == PubKeyAlgorithm.RSAEncryptOrSign and param == 4096:
+        if alg == PubKeyAlgorithm.RSAEncryptOrSign:
+            warn_text = {
+                2048: "Generating an RSA 2048 key can take around 3 minutes on a Pi Zero.\nNIST or Brainpool keys are faster and smaller.",
+                3072: "Generating an RSA 3072 key can take around 15 minutes on a Pi Zero.\nNIST or Brainpool keys are faster and smaller.",
+                4096: "Generating an RSA 4096 key can take around an hour on a Pi Zero.\nNIST or Brainpool keys are faster and smaller.",
+            }[param]
             self.run_screen(
                 WarningScreen,
                 title="WARNING",
                 status_headline=None,
-                text="Generating an RSA 4096 key can take around an hour on a Pi Zero.",
+                text=warn_text,
                 show_back_button=False,
                 button_data=[ButtonOption("I Understand")],
             )
@@ -5577,7 +5589,10 @@ class ToolsGPGGenerateKeyView(View):
             return Destination(BackStackView)
 
         created = datetime.now(timezone.utc)
-        default_expiration = (created + timedelta(days=3650)).date()
+        if alg == PubKeyAlgorithm.RSAEncryptOrSign and param == 2048:
+            default_expiration = date(2029, 12, 31)
+        else:
+            default_expiration = date(2035, 12, 31)
         expiration_str = prompt_text(
             "Expiration YYYY-MM-DD", default_expiration.isoformat()
         )


### PR DESCRIPTION
## Summary
- add RSA 4096 option for BIP85 and new GPG key generation
- show warning that RSA 4096 key generation can take ~1 hour on Pi Zero
- document new RSA 4096 option

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bba2082e9083229ab22a2ded07c885