### PR TITLE
Add animated QR export for GPG public keys

### DIFF
--- a/src/seedsigner/helpers/ur2/cbor_lite.py
+++ b/src/seedsigner/helpers/ur2/cbor_lite.py
@@ -152,7 +152,7 @@ class CBOREncoder:
     def encodeText(self, value):
         str_len = len(value)
         length = self.encodeTagAndValue(Tag_Major_textString, str_len)
-        self.buf.append(bytes(value, 'utf8'))
+        self.buf += value.encode('utf8')
         return length + str_len
 
     def encodeArraySize(self, value):

--- a/src/seedsigner/helpers/ur2/fountain_encoder.py
+++ b/src/seedsigner/helpers/ur2/fountain_encoder.py
@@ -115,6 +115,8 @@ class FountainEncoder:
         fragments = []
         while len(remaining) != 0:
             (fragment, remaining) = split(remaining, fragment_len)
+            # Convert to a mutable sequence so we can append padding bytes
+            fragment = bytearray(fragment)
             padding = fragment_len - len(fragment)
             while padding > 0:
                 fragment.append(0)

--- a/src/seedsigner/models/encode_qr.py
+++ b/src/seedsigner/models/encode_qr.py
@@ -394,6 +394,17 @@ class UrPsbtQrEncoder(BaseFountainQrEncoder):
         qr_ur_bytes = UR("crypto-psbt", UR_PSBT(self.psbt.serialize()).to_cbor())
         self.ur2_encode = UREncoder(ur=qr_ur_bytes, max_fragment_len=self.qr_max_fragment_size)
 
+
+@dataclass
+class UrBytesQrEncoder(BaseFountainQrEncoder):
+    data: bytes = None
+
+    def __post_init__(self):
+        super().__post_init__()
+        qr_ur_bytes = UR("bytes", self.data)
+        self.ur2_encode = UREncoder(ur=qr_ur_bytes, max_fragment_len=self.qr_max_fragment_size)
+
+
 class GenericStringEncoder(BaseStaticQrEncoder):
     def __init__(self, generic_string: str):
         super().__init__()

--- a/src/seedsigner/models/encode_qr.py
+++ b/src/seedsigner/models/encode_qr.py
@@ -11,6 +11,7 @@ from embit.psbt import PSBT
 from seedsigner.helpers.ur2.ur_encoder import UREncoder
 from seedsigner.helpers.ur2.ur import UR
 from seedsigner.helpers.ur2.cbor_lite import CBOREncoder
+from urtypes.bytes import Bytes
 from seedsigner.helpers.qr import QR
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings import SettingsConstants
@@ -402,7 +403,7 @@ class UrBytesQrEncoder(BaseFountainQrEncoder):
 
     def __post_init__(self):
         super().__post_init__()
-        qr_ur_bytes = UR("bytes", self.data)
+        qr_ur_bytes = UR("bytes", Bytes(self.data).to_cbor())
         self.ur2_encode = UREncoder(ur=qr_ur_bytes, max_fragment_len=self.qr_max_fragment_size)
 
 

--- a/src/seedsigner/models/encode_qr.py
+++ b/src/seedsigner/models/encode_qr.py
@@ -10,6 +10,7 @@ from embit.networks import NETWORKS
 from embit.psbt import PSBT
 from seedsigner.helpers.ur2.ur_encoder import UREncoder
 from seedsigner.helpers.ur2.ur import UR
+from seedsigner.helpers.ur2.cbor_lite import CBOREncoder
 from seedsigner.helpers.qr import QR
 from seedsigner.models.seed import Seed
 from seedsigner.models.settings import SettingsConstants
@@ -403,6 +404,18 @@ class UrBytesQrEncoder(BaseFountainQrEncoder):
         super().__post_init__()
         qr_ur_bytes = UR("bytes", self.data)
         self.ur2_encode = UREncoder(ur=qr_ur_bytes, max_fragment_len=self.qr_max_fragment_size)
+
+
+@dataclass
+class UrTextQrEncoder(BaseFountainQrEncoder):
+    text: str = None
+
+    def __post_init__(self):
+        super().__post_init__()
+        cbor_encoder = CBOREncoder()
+        cbor_encoder.encodeText(self.text)
+        qr_ur_text = UR("text", cbor_encoder.get_bytes())
+        self.ur2_encode = UREncoder(ur=qr_ur_text, max_fragment_len=self.qr_max_fragment_size)
 
 
 class GenericStringEncoder(BaseStaticQrEncoder):

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5665,7 +5665,7 @@ class ToolsGPGExportPubkeyView(View):
         from subprocess import run
         import os
         import platform
-        from seedsigner.models.encode_qr import UrBytesQrEncoder
+        from seedsigner.models.encode_qr import UrTextQrEncoder
         from seedsigner.gui.screens.screen import (
             ButtonListScreen,
             LargeIconStatusScreen,
@@ -5799,8 +5799,8 @@ class ToolsGPGExportPubkeyView(View):
             loading = LoadingScreenThread(text="Encoding...")
             loading.start()
             try:
-                qr_encoder = UrBytesQrEncoder(
-                    data=exported.stdout.encode("utf-8"),
+                qr_encoder = UrTextQrEncoder(
+                    text=exported.stdout,
                     qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
                 )
             finally:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5806,6 +5806,18 @@ class ToolsGPGExportPubkeyView(View):
             finally:
                 loading.stop()
 
+            num_codes = qr_encoder.seq_len()
+            ret = self.run_screen(
+                WarningScreen,
+                title="Animated QR",
+                status_headline=None,
+                text=f"This export requires {num_codes} QR code{'s' if num_codes > 1 else ''}.",
+                show_back_button=True,
+                button_data=[ButtonOption("Start")],
+            )
+            if ret == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
+
             self.run_screen(QRDisplayScreen, qr_encoder=qr_encoder)
             return Destination(MainMenuView)
         else:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5783,7 +5783,6 @@ class ToolsGPGExportPubkeyView(View):
             exported = run(
                 ["gpg", "--armor", "--export", key["fpr"]],
                 capture_output=True,
-                text=True,
             )
             if exported.returncode != 0:
                 self.run_screen(
@@ -5800,7 +5799,7 @@ class ToolsGPGExportPubkeyView(View):
             loading.start()
             try:
                 qr_encoder = UrBytesQrEncoder(
-                    data=exported.stdout.encode(),
+                    data=exported.stdout,
                     qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
                 )
             finally:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5665,7 +5665,7 @@ class ToolsGPGExportPubkeyView(View):
         from subprocess import run
         import os
         import platform
-        from seedsigner.models.encode_qr import UrTextQrEncoder
+        from seedsigner.models.encode_qr import UrBytesQrEncoder
         from seedsigner.gui.screens.screen import (
             ButtonListScreen,
             LargeIconStatusScreen,
@@ -5799,8 +5799,8 @@ class ToolsGPGExportPubkeyView(View):
             loading = LoadingScreenThread(text="Encoding...")
             loading.start()
             try:
-                qr_encoder = UrTextQrEncoder(
-                    text=exported.stdout,
+                qr_encoder = UrBytesQrEncoder(
+                    data=exported.stdout.encode(),
                     qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
                 )
             finally:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5665,11 +5665,13 @@ class ToolsGPGExportPubkeyView(View):
         from subprocess import run
         import os
         import platform
+        from seedsigner.models.encode_qr import UrBytesQrEncoder
         from seedsigner.gui.screens.screen import (
             ButtonListScreen,
             LargeIconStatusScreen,
             WarningScreen,
             LoadingScreenThread,
+            QRDisplayScreen,
         )
 
         result = run(
@@ -5720,6 +5722,7 @@ class ToolsGPGExportPubkeyView(View):
 
         dest_buttons = [
             ButtonOption("microSD"),
+            ButtonOption("Animated QR"),
             ButtonOption("Seedkeeper"),
             ButtonOption("OpenGPG Card"),
         ]
@@ -5775,6 +5778,35 @@ class ToolsGPGExportPubkeyView(View):
                 show_back_button=False,
                 button_data=[ButtonOption("Continue")],
             )
+            return Destination(MainMenuView)
+        elif dest_selected == 1:
+            exported = run(
+                ["gpg", "--armor", "--export", key["fpr"]],
+                capture_output=True,
+                text=True,
+            )
+            if exported.returncode != 0:
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text="Failed to export key",
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
+
+            loading = LoadingScreenThread(text="Encoding...")
+            loading.start()
+            try:
+                qr_encoder = UrBytesQrEncoder(
+                    data=exported.stdout.encode("utf-8"),
+                    qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
+                )
+            finally:
+                loading.stop()
+
+            self.run_screen(QRDisplayScreen, qr_encoder=qr_encoder)
             return Destination(MainMenuView)
         else:
             exported = run(

--- a/tests/test_encodepsbtqr.py
+++ b/tests/test_encodepsbtqr.py
@@ -1,6 +1,15 @@
-from seedsigner.models.encode_qr import CompactSeedQrEncoder, SeedQrEncoder, SpecterXPubQrEncoder, StaticXpubQrEncoder, UrPsbtQrEncoder, UrXpubQrEncoder
+from seedsigner.models.encode_qr import (
+    CompactSeedQrEncoder,
+    SeedQrEncoder,
+    SpecterXPubQrEncoder,
+    StaticXpubQrEncoder,
+    UrPsbtQrEncoder,
+    UrXpubQrEncoder,
+    UrBytesQrEncoder,
+)
 from embit import psbt
 from binascii import a2b_base64
+from seedsigner.helpers.ur2.ur_decoder import URDecoder
 
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.models.seed import Seed
@@ -91,3 +100,15 @@ def test_ur_xpub_qr():
     assert e.next_part() == "UR:CRYPTO-ACCOUNT/3-5/LPAXAHCSKECYRTPEDKMOHDCFZTBEAAHDCXVDTPMYRSTDSPZSBZSPGERLGDATUYNLPYBTGYIYYKBDFGWPKE"
     assert e.next_part() == "UR:CRYPTO-ACCOUNT/4-5/LPAAAHCSKECYRTPEDKMOHDCFBTWTAOSWKSVTSGCHBYDKYAVDAHTAADEHOYAOADAMTAADDYOTADGYBKBWFE"
     assert e.next_part() == "UR:CRYPTO-ACCOUNT/5-5/LPAHAHCSKECYRTPEDKMOHDCFLOCSDYYKADYKAEYKAOYKAOCYSSMECPONAXAAAYCYIOREKKJKAETODLFYWP"
+
+
+def test_ur_bytes_qr_roundtrip():
+    data = b"hello world"
+    encoder = UrBytesQrEncoder(data=data, qr_density=SettingsConstants.DENSITY__MEDIUM)
+    part = encoder.next_part()
+    decoder = URDecoder()
+    assert decoder.receive_part(part)
+    assert decoder.is_complete()
+    ur = decoder.result_message()
+    assert ur.type == "bytes"
+    assert ur.cbor == data

--- a/tests/test_encodepsbtqr.py
+++ b/tests/test_encodepsbtqr.py
@@ -6,10 +6,12 @@ from seedsigner.models.encode_qr import (
     UrPsbtQrEncoder,
     UrXpubQrEncoder,
     UrBytesQrEncoder,
+    UrTextQrEncoder,
 )
 from embit import psbt
 from binascii import a2b_base64
 from seedsigner.helpers.ur2.ur_decoder import URDecoder
+from seedsigner.helpers.ur2.cbor_lite import CBORDecoder
 
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.models.seed import Seed
@@ -117,4 +119,23 @@ def test_ur_bytes_qr_roundtrip():
 def test_ur_bytes_qr_seq_len_multiple():
     data = b"a" * 200
     encoder = UrBytesQrEncoder(data=data, qr_density=SettingsConstants.DENSITY__MEDIUM)
+    assert encoder.seq_len() > 1
+
+
+def test_ur_text_qr_roundtrip():
+    text = "hello world"
+    encoder = UrTextQrEncoder(text=text, qr_density=SettingsConstants.DENSITY__MEDIUM)
+    part = encoder.next_part()
+    decoder = URDecoder()
+    assert decoder.receive_part(part)
+    assert decoder.is_complete()
+    ur = decoder.result_message()
+    assert ur.type == "text"
+    decoded, _ = CBORDecoder(ur.cbor).decodeText()
+    assert decoded.decode("utf-8") == text
+
+
+def test_ur_text_qr_seq_len_multiple():
+    text = "a" * 200
+    encoder = UrTextQrEncoder(text=text, qr_density=SettingsConstants.DENSITY__MEDIUM)
     assert encoder.seq_len() > 1

--- a/tests/test_encodepsbtqr.py
+++ b/tests/test_encodepsbtqr.py
@@ -112,3 +112,9 @@ def test_ur_bytes_qr_roundtrip():
     ur = decoder.result_message()
     assert ur.type == "bytes"
     assert ur.cbor == data
+
+
+def test_ur_bytes_qr_seq_len_multiple():
+    data = b"a" * 200
+    encoder = UrBytesQrEncoder(data=data, qr_density=SettingsConstants.DENSITY__MEDIUM)
+    assert encoder.seq_len() > 1

--- a/tests/test_encodepsbtqr.py
+++ b/tests/test_encodepsbtqr.py
@@ -117,6 +117,18 @@ def test_ur_bytes_qr_roundtrip():
     assert Bytes.from_cbor(ur.cbor).data.decode() == text
 
 
+def test_ur_bytes_qr_roundtrip_ascii_armored():
+    armored = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nabc123\n-----END PGP PUBLIC KEY BLOCK-----\n"
+    encoder = UrBytesQrEncoder(data=armored.encode(), qr_density=SettingsConstants.DENSITY__MEDIUM)
+    decoder = URDecoder()
+    while not decoder.is_complete():
+        part = encoder.next_part()
+        assert decoder.receive_part(part)
+    ur = decoder.result_message()
+    assert ur.type == "bytes"
+    assert Bytes.from_cbor(ur.cbor).data.decode() == armored
+
+
 def test_ur_bytes_qr_seq_len_multiple():
     data = b"a" * 200
     encoder = UrBytesQrEncoder(data=data, qr_density=SettingsConstants.DENSITY__MEDIUM)

--- a/tests/test_encodepsbtqr.py
+++ b/tests/test_encodepsbtqr.py
@@ -12,6 +12,7 @@ from embit import psbt
 from binascii import a2b_base64
 from seedsigner.helpers.ur2.ur_decoder import URDecoder
 from seedsigner.helpers.ur2.cbor_lite import CBORDecoder
+from urtypes.bytes import Bytes
 
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.models.seed import Seed
@@ -105,15 +106,15 @@ def test_ur_xpub_qr():
 
 
 def test_ur_bytes_qr_roundtrip():
-    data = b"hello world"
-    encoder = UrBytesQrEncoder(data=data, qr_density=SettingsConstants.DENSITY__MEDIUM)
+    text = "hello world"
+    encoder = UrBytesQrEncoder(data=text.encode(), qr_density=SettingsConstants.DENSITY__MEDIUM)
     part = encoder.next_part()
     decoder = URDecoder()
     assert decoder.receive_part(part)
     assert decoder.is_complete()
     ur = decoder.result_message()
     assert ur.type == "bytes"
-    assert ur.cbor == data
+    assert Bytes.from_cbor(ur.cbor).data.decode() == text
 
 
 def test_ur_bytes_qr_seq_len_multiple():


### PR DESCRIPTION
## Summary
- support UR-encoded animated QRs for arbitrary byte data
- add animated QR option to GPG public key export menu

## Testing
- `pytest tests/test_encodepsbtqr.py -q`
- `pytest tests/test_bip85_gpg.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb896fd6088322baf2a26b745091c3