### PR TITLE
Add SHA256 manifest signing workflow

### DIFF
--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -2,7 +2,9 @@
 
 SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives a keypair (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, or secp256k1) from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG.
 
-In addition to verifying detached signatures, files on the microSD card can now be signed. After selecting a file, choose which private key to use from the local GPG keyring and a detached signature (.sig) will be saved alongside the original file on the microSD card.
+In addition to verifying detached signatures, the **Sign** submenu offers two workflows. Selecting **File** prompts for a file on the microSD card and a private key from the local GPG keyring; a detached signature (`.sig`) is saved alongside the original file.
+
+Choosing **Manifest** generates a SHA256 manifest for every file in the directory and signs it in one step. Both the manifest and its detached signature are written to the same microSD folder.
 
 Additional menu options can export existing GPG keys. Public keys are written to the microSD card in ASCII armor, while private keys are first exported and then symmetrically encrypted with a user-provided passphrase before being saved.
 

--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -4,7 +4,7 @@ SeedSigner includes tools to interact with GPG. When `gpg2` is available on the 
 
 In addition to verifying detached signatures, the **Sign** submenu offers two workflows. Selecting **File** prompts for a file on the microSD card and a private key from the local GPG keyring; a detached signature (`.sig`) is saved alongside the original file.
 
-Choosing **Manifest** creates a `sha256.txt` file listing each file's SHA256 hash and signs it in one step, saving both `sha256.txt` and `sha256.txt.sig` to the same microSD folder. The manifest uses the same format as the `sha256sum` utility so it can be verified with the existing **Verify File Sig** workflow. When the `sha256sum` utility isn't available (such as on Windows), SeedSigner calculates the hashes internally so the workflow still works.
+Choosing **Manifest** creates a `sha256.txt` file listing each file's SHA256 hash and signs it in one step, saving both `sha256.txt` and `sha256.txt.sig` to the same microSD folder. The manifest uses the same format as the `sha256sum` utility so it can be verified with the existing **Verify File Sig** workflow. When the `sha256sum` utility isn't available (such as on Windows), SeedSigner calculates the hashes internally for both manifest creation and verification so the workflow still works.
 
 Additional menu options can export existing GPG keys. Public keys are written to the microSD card in ASCII armor, while private keys are first exported and then symmetrically encrypted with a user-provided passphrase before being saved.
 

--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -4,7 +4,7 @@ SeedSigner includes tools to interact with GPG. When `gpg2` is available on the 
 
 In addition to verifying detached signatures, the **Sign** submenu offers two workflows. Selecting **File** prompts for a file on the microSD card and a private key from the local GPG keyring; a detached signature (`.sig`) is saved alongside the original file.
 
-Choosing **Manifest** generates a SHA256 manifest for every file in the directory and signs it in one step. Both the manifest and its detached signature are written to the same microSD folder. When the `sha256sum` utility isn't available (such as on Windows), SeedSigner calculates the hashes internally so the workflow still works.
+Choosing **Manifest** creates a `sha256.txt` file listing each file's SHA256 hash and signs it in one step, saving both `sha256.txt` and `sha256.txt.sig` to the same microSD folder. The manifest uses the same format as the `sha256sum` utility so it can be verified with the existing **Verify File Sig** workflow. When the `sha256sum` utility isn't available (such as on Windows), SeedSigner calculates the hashes internally so the workflow still works.
 
 Additional menu options can export existing GPG keys. Public keys are written to the microSD card in ASCII armor, while private keys are first exported and then symmetrically encrypted with a user-provided passphrase before being saved.
 

--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -4,7 +4,7 @@ SeedSigner includes tools to interact with GPG. When `gpg2` is available on the 
 
 In addition to verifying detached signatures, the **Sign** submenu offers two workflows. Selecting **File** prompts for a file on the microSD card and a private key from the local GPG keyring; a detached signature (`.sig`) is saved alongside the original file.
 
-Choosing **Manifest** generates a SHA256 manifest for every file in the directory and signs it in one step. Both the manifest and its detached signature are written to the same microSD folder.
+Choosing **Manifest** generates a SHA256 manifest for every file in the directory and signs it in one step. Both the manifest and its detached signature are written to the same microSD folder. When the `sha256sum` utility isn't available (such as on Windows), SeedSigner calculates the hashes internally so the workflow still works.
 
 Additional menu options can export existing GPG keys. Public keys are written to the microSD card in ASCII armor, while private keys are first exported and then symmetrically encrypted with a user-provided passphrase before being saved.
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4730,6 +4730,8 @@ class ToolsGPGSignManifestView(View):
         file_list_path = MicroSD.get_microsd_dir() / "microsd-images"
         os.makedirs(file_list_path, exist_ok=True)
 
+        manifest_name = "sha256.txt"
+
         file_list = [
             f
             for f in os.listdir(file_list_path)
@@ -4738,8 +4740,11 @@ class ToolsGPGSignManifestView(View):
                 and f != '__MACOSX'
                 and os.path.isfile(os.path.join(file_list_path, f))
                 and not f.endswith('.sig')
+                and f != manifest_name
             )
         ]
+
+        file_list.sort()
 
         if not file_list:
             self.run_screen(
@@ -4754,7 +4759,6 @@ class ToolsGPGSignManifestView(View):
 
         self.loading_screen = LoadingScreenThread(text="Generating Manifest\n\n\n\n\n\n(May take a while)")
         self.loading_screen.start()
-        manifest_name = "manifest.sha256.txt"
 
         if shutil.which("sha256sum"):
             result = run(

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4402,13 +4402,16 @@ class ToolsGPGVerifyFileView(View):
         verify_file_name = visible_file_list[selected_file_num]
         logger.info("Selected: %s", verify_file_name)
 
-        cmd = f"cd {file_list_path} ; gpg --verify {verify_file_name}"
-
-        self.loading_screen = LoadingScreenThread(text="Checking Signature\n\n\n\n\n\n(May take a while)")
+        self.loading_screen = LoadingScreenThread(
+            text="Checking Signature\n\n\n\n\n\n(May take a while)"
+        )
         self.loading_screen.start()
-        data = run(cmd, capture_output=True, shell=True, text=True)
-        print(cmd, " ", data)
-
+        data = run(
+            ["gpg", "--verify", verify_file_name],
+            capture_output=True,
+            text=True,
+            cwd=file_list_path,
+        )
         self.loading_screen.stop()
 
         result = data.stderr.split("\n")
@@ -4419,7 +4422,6 @@ class ToolsGPGVerifyFileView(View):
         for line in result:
             if "gpg: assuming signed data in " in line:
                 filechecked = line[30:-1]
-                print(filechecked)
             elif "Primary key fingerprint:" in line:
                 valid_sig_keyid += "\n" + line[-20:]
             elif "Good signature from" in line:
@@ -4460,16 +4462,24 @@ class ToolsGPGVerifyFileView(View):
                 missing_files = []
 
                 if shutil.which("sha256sum"):
-                    if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
-                        cmd = f"cd {file_list_path} ; sha256sum -c {filechecked}"
-                    else:
-                        cmd = f"cd {file_list_path} ; sha256sum --check {filechecked} --ignore-missing"
+                    from seedsigner.models.settings import Settings
 
-                    self.loading_screen = LoadingScreenThread(text="Checking SHA256\n\n\n\n\n\n(This takes a while)")
+                    if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
+                        sha256_cmd = ["sha256sum", "-c", filechecked]
+                    else:
+                        sha256_cmd = ["sha256sum", "--check", filechecked, "--ignore-missing"]
+
+                    self.loading_screen = LoadingScreenThread(
+                        text="Checking SHA256\n\n\n\n\n\n(This takes a while)"
+                    )
                     self.loading_screen.start()
 
-                    data = run(cmd, capture_output=True, shell=True, text=True)
-                    print(cmd, " ", data)
+                    data = run(
+                        sha256_cmd,
+                        capture_output=True,
+                        text=True,
+                        cwd=file_list_path,
+                    )
 
                     self.loading_screen.stop()
 
@@ -4484,10 +4494,6 @@ class ToolsGPGVerifyFileView(View):
                     for line in result_stderr:
                         if "No such file or directory" in line:
                             missing_files.append(line[23:-28])
-
-                    print("Verified:", verified_files)
-                    print("Failed:", failed_files)
-                    print("Missing:", missing_files)
                 else:
                     self.loading_screen = LoadingScreenThread(text="Checking SHA256\n\n\n\n\n\n(This takes a while)")
                     self.loading_screen.start()

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -3577,6 +3577,7 @@ class ToolsMicroSDMenuView(View):
 class ToolsMicroSDFlashView(View):
     def run(self):
         from subprocess import run
+        import hashlib, shutil
         from seedsigner.gui.screens.screen import LoadingScreenThread
         from seedsigner.hardware.microsd import MicroSD
         from seedsigner.hardware.microsd import MicroSD
@@ -3805,6 +3806,7 @@ class ToolsMicroSDWipeZeroView(View):
 
     def run(self):
         from subprocess import run
+        import hashlib, shutil
         from seedsigner.gui.screens.screen import LoadingScreenThread
 
         microsd_dev = find_sd_card_device()
@@ -4341,6 +4343,7 @@ class ToolsGPGVerifyFileView(View):
     CHECK_SHA256 = ButtonOption("Check SHA256Sum")
     def run(self):
         from subprocess import run
+        import hashlib, shutil
         from seedsigner.gui.screens.screen import LoadingScreenThread
 
         if len(self.controller.storage.seeds) > 0:
@@ -4452,38 +4455,65 @@ class ToolsGPGVerifyFileView(View):
                 )
             
             if button_data[ret] == self.CHECK_SHA256:
-                if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
-                    cmd = f"cd {file_list_path} ; sha256sum -c {filechecked}"
-                else:
-                    cmd = f"cd {file_list_path} ; sha256sum --check {filechecked} --ignore-missing"
-
-                self.loading_screen = LoadingScreenThread(text="Checking SHA256\n\n\n\n\n\n(This takes a while)")
-                self.loading_screen.start()
-
-                data = run(cmd, capture_output=True, shell=True, text=True)
-                print(cmd, " ", data)
-
-                self.loading_screen.stop()
-
-                result_stdout = data.stdout.split("\n")
-                result_stderr = data.stderr.split("\n")
-                matched = None
                 verified_files = []
                 failed_files = []
                 missing_files = []
-                for line in result_stdout:
-                    if ": OK" in line:
-                        verified_files.append(line[:-4])
-                    elif ": FAILED" in line:
-                        failed_files.append(line[:-8])
 
-                for line in result_stderr:
-                    if "No such file or directory" in line:
-                        missing_files.append(line[23:-28])
+                if shutil.which("sha256sum"):
+                    if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
+                        cmd = f"cd {file_list_path} ; sha256sum -c {filechecked}"
+                    else:
+                        cmd = f"cd {file_list_path} ; sha256sum --check {filechecked} --ignore-missing"
 
-                print("Verified:", verified_files)
-                print("Failed:", failed_files)
-                print("Missing:", missing_files)
+                    self.loading_screen = LoadingScreenThread(text="Checking SHA256\n\n\n\n\n\n(This takes a while)")
+                    self.loading_screen.start()
+
+                    data = run(cmd, capture_output=True, shell=True, text=True)
+                    print(cmd, " ", data)
+
+                    self.loading_screen.stop()
+
+                    result_stdout = data.stdout.split("\n")
+                    result_stderr = data.stderr.split("\n")
+                    for line in result_stdout:
+                        if ": OK" in line:
+                            verified_files.append(line[:-4])
+                        elif ": FAILED" in line:
+                            failed_files.append(line[:-8])
+
+                    for line in result_stderr:
+                        if "No such file or directory" in line:
+                            missing_files.append(line[23:-28])
+
+                    print("Verified:", verified_files)
+                    print("Failed:", failed_files)
+                    print("Missing:", missing_files)
+                else:
+                    self.loading_screen = LoadingScreenThread(text="Checking SHA256\n\n\n\n\n\n(This takes a while)")
+                    self.loading_screen.start()
+                    manifest_path = file_list_path / filechecked
+                    with open(manifest_path, "r") as mf:
+                        for line in mf:
+                            line = line.strip()
+                            if not line:
+                                continue
+                            parts = line.split()
+                            if len(parts) < 2:
+                                continue
+                            checksum, name = parts[0], parts[-1].lstrip("*")
+                            file_path = file_list_path / name
+                            if file_path.exists():
+                                h = hashlib.sha256()
+                                with open(file_path, "rb") as f:
+                                    for chunk in iter(lambda: f.read(65536), b""):
+                                        h.update(chunk)
+                                if h.hexdigest().lower() == checksum.lower():
+                                    verified_files.append(name)
+                                else:
+                                    failed_files.append(name)
+                            else:
+                                missing_files.append(name)
+                    self.loading_screen.stop()
 
                 for file in missing_files:
                     try:
@@ -4682,6 +4712,7 @@ class ToolsGPGSignFileView(View):
 class ToolsGPGSignManifestView(View):
     def run(self):
         from subprocess import run
+        import hashlib, shutil
         from seedsigner.gui.screens.screen import LoadingScreenThread
 
         if len(self.controller.storage.seeds) > 0:
@@ -4723,14 +4754,27 @@ class ToolsGPGSignManifestView(View):
 
         self.loading_screen = LoadingScreenThread(text="Generating Manifest\n\n\n\n\n\n(May take a while)")
         self.loading_screen.start()
-        result = run(
-            ["sha256sum", *file_list],
-            cwd=file_list_path,
-            capture_output=True,
-            text=True,
-        )
         manifest_name = "manifest.sha256.txt"
-        (file_list_path / manifest_name).write_text(result.stdout)
+
+        if shutil.which("sha256sum"):
+            result = run(
+                ["sha256sum", *file_list],
+                cwd=file_list_path,
+                capture_output=True,
+                text=True,
+            )
+            manifest_content = result.stdout
+        else:
+            lines = []
+            for fname in file_list:
+                h = hashlib.sha256()
+                with open(file_list_path / fname, "rb") as f:
+                    for chunk in iter(lambda: f.read(65536), b""):
+                        h.update(chunk)
+                lines.append(f"{h.hexdigest()}  {fname}")
+            manifest_content = "\n".join(lines) + "\n"
+
+        (file_list_path / manifest_name).write_text(manifest_content)
         self.loading_screen.stop()
 
         key_result = run(

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4401,17 +4401,45 @@ class ToolsGPGVerifyFileView(View):
         # Use the same filtered list to get the selected filename
         verify_file_name = visible_file_list[selected_file_num]
         logger.info("Selected: %s", verify_file_name)
+        filechecked = verify_file_name[:-4] if verify_file_name.endswith(".sig") else verify_file_name
 
         self.loading_screen = LoadingScreenThread(
             text="Checking Signature\n\n\n\n\n\n(May take a while)"
         )
         self.loading_screen.start()
-        data = run(
-            ["gpg", "--verify", verify_file_name],
-            capture_output=True,
-            text=True,
-            cwd=file_list_path,
-        )
+
+        cmd = ["gpg", "--verify"]
+        if verify_file_name.endswith(".sig"):
+            cmd.append(verify_file_name)
+            if (file_list_path / filechecked).exists():
+                cmd.append(filechecked)
+        else:
+            sig_candidate = verify_file_name + ".sig"
+            if (file_list_path / sig_candidate).exists():
+                cmd.extend([sig_candidate, verify_file_name])
+            else:
+                cmd.append(verify_file_name)
+
+        try:
+            data = run(
+                cmd,
+                capture_output=True,
+                text=True,
+                cwd=str(file_list_path),
+            )
+        except FileNotFoundError as exc:
+            self.loading_screen.stop()
+            logger.warning("gpg verify failed: %s", exc)
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="GPG not found",
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(BackStackView)
+
         self.loading_screen.stop()
 
         result = data.stderr.split("\n")

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4004,7 +4004,7 @@ class ToolsMicroSDWipeRandomView(View):
 ****************************************************************************"""
 class ToolsGPGMenuView(View):
     VERIFY_FILE = ButtonOption("Verify File Sig")
-    SIGN_FILE = ButtonOption("Sign File")
+    SIGN = ButtonOption("Sign")
     IMPORT = ButtonOption("Import")
     EXPORT = ButtonOption("Export")
     SMART_GPG = ButtonOption("SmartGPG")
@@ -4026,7 +4026,7 @@ class ToolsGPGMenuView(View):
 
         button_data = [
             self.VERIFY_FILE,
-            self.SIGN_FILE,
+            self.SIGN,
             self.IMPORT,
             self.EXPORT,
             self.SMART_GPG,
@@ -4045,8 +4045,8 @@ class ToolsGPGMenuView(View):
         elif button_data[selected_menu_num] == self.VERIFY_FILE:
             return Destination(ToolsGPGVerifyFileView)
 
-        elif button_data[selected_menu_num] == self.SIGN_FILE:
-            return Destination(ToolsGPGSignFileView)
+        elif button_data[selected_menu_num] == self.SIGN:
+            return Destination(ToolsGPGSignMenuView)
 
         elif button_data[selected_menu_num] == self.IMPORT:
             return Destination(ToolsGPGImportMenuView)
@@ -4054,6 +4054,28 @@ class ToolsGPGMenuView(View):
             return Destination(ToolsGPGExportMenuView)
         elif button_data[selected_menu_num] == self.SMART_GPG:
             return Destination(ToolsGPGSmartMenuView)
+
+
+class ToolsGPGSignMenuView(View):
+    FILE = ButtonOption("File")
+    MANIFEST = ButtonOption("Manifest")
+
+    def run(self):
+        button_data = [self.FILE, self.MANIFEST]
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title="Sign",
+            is_button_text_centered=False,
+            button_data=button_data,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        if button_data[selected_menu_num] == self.FILE:
+            return Destination(ToolsGPGSignFileView)
+        return Destination(ToolsGPGSignManifestView)
 
 
 class ToolsGPGImportMenuView(View):
@@ -4650,6 +4672,149 @@ class ToolsGPGSignFileView(View):
             title="Success",
             status_headline=None,
             text=f"Signature saved as {filename}.sig",
+            show_back_button=False,
+            button_data=[ButtonOption("Done")],
+        )
+
+        return Destination(MainMenuView)
+
+
+class ToolsGPGSignManifestView(View):
+    def run(self):
+        from subprocess import run
+        from seedsigner.gui.screens.screen import LoadingScreenThread
+
+        if len(self.controller.storage.seeds) > 0:
+            ret = self.run_screen(
+                WarningScreen,
+                title="WARNING",
+                status_headline=None,
+                text="These tools load data from the microSD card and may expose loaded secrets.",
+                show_back_button=True,
+                button_data=[ButtonOption("Continue")],
+            )
+            if ret == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
+
+        file_list_path = MicroSD.get_microsd_dir() / "microsd-images"
+        os.makedirs(file_list_path, exist_ok=True)
+
+        file_list = [
+            f
+            for f in os.listdir(file_list_path)
+            if (
+                not f.startswith('.')
+                and f != '__MACOSX'
+                and os.path.isfile(os.path.join(file_list_path, f))
+                and not f.endswith('.sig')
+            )
+        ]
+
+        if not file_list:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="No files found in microsd-images.",
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(BackStackView)
+
+        self.loading_screen = LoadingScreenThread(text="Generating Manifest\n\n\n\n\n\n(May take a while)")
+        self.loading_screen.start()
+        result = run(
+            ["sha256sum", *file_list],
+            cwd=file_list_path,
+            capture_output=True,
+            text=True,
+        )
+        manifest_name = "manifest.sha256.txt"
+        (file_list_path / manifest_name).write_text(result.stdout)
+        self.loading_screen.stop()
+
+        key_result = run(
+            ["gpg", "--list-secret-keys", "--with-colons"],
+            capture_output=True,
+            text=True,
+        )
+        keys = []
+        cur = None
+        for line in key_result.stdout.splitlines():
+            parts = line.split(":")
+            if parts[0] == "sec":
+                cur = {"fpr": None, "uid": None}
+                keys.append(cur)
+            elif parts[0] == "fpr" and cur is not None:
+                cur["fpr"] = parts[9]
+            elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
+                cur["uid"] = parts[9]
+
+        if not keys:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="No private keys found",
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(BackStackView)
+
+        key_buttons = []
+        for key in keys:
+            label = key["uid"] if key["uid"] else key["fpr"][-8:]
+            key_buttons.append(ButtonOption(label))
+
+        selected_key = self.run_screen(
+            ButtonListScreen,
+            title="Select Key",
+            is_button_text_centered=False,
+            button_data=key_buttons,
+        )
+
+        if selected_key == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        key = keys[selected_key]
+
+        self.loading_screen = LoadingScreenThread(text="Signing File\n\n\n\n\n\n(May take a while)")
+        self.loading_screen.start()
+        result = run(
+            [
+                "gpg",
+                "--batch",
+                "--yes",
+                "--local-user",
+                key["fpr"],
+                "--output",
+                f"{manifest_name}.sig",
+                "--armor",
+                "--detach-sign",
+                manifest_name,
+            ],
+            cwd=file_list_path,
+            capture_output=True,
+            text=True,
+        )
+        self.loading_screen.stop()
+
+        if result.returncode != 0:
+            logger.warning("gpg sign failed: %s", result.stderr)
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to sign manifest",
+                show_back_button=False,
+            )
+            return Destination(BackStackView)
+
+        self.run_screen(
+            LargeIconStatusScreen,
+            title="Success",
+            status_headline=None,
+            text=f"Manifest saved as {manifest_name} and {manifest_name}.sig",
             show_back_button=False,
             button_data=[ButtonOption("Done")],
         )


### PR DESCRIPTION
## Summary
- extend GPG Tools menu with **Sign Manifest** option
- generate SHA256 manifest for microSD files and sign with chosen key
- document manifest signing workflow
- group file and manifest signing under a new **Sign** submenu

## Testing
- `pytest tests/test_bip85_gpg.py::test_bip85_rsa_deterministic -q`
- `pytest -q` *(fails: tests/test_flows_seed.py::TestSeedFlows::test_export_xpub_verification_no_match)*

------
https://chatgpt.com/codex/tasks/task_e_68bc44c514d883228e011f70c1a9e737