### PR TITLE
Add helper for PGP message encryption/decryption

### DIFF
--- a/src/seedsigner/helpers/gpg_message.py
+++ b/src/seedsigner/helpers/gpg_message.py
@@ -66,7 +66,7 @@ def decrypt_message(
     ciphertext: str,
     passphrase: Optional[str] = None,
     pubkey_blobs: Optional[Iterable[str]] = None,
-) -> Tuple[str, Optional[str]]:
+) -> Tuple[str, Optional[str], bool]:
     """Decrypt ``ciphertext`` and optionally verify a signature.
 
     Parameters
@@ -82,12 +82,11 @@ def decrypt_message(
 
     Returns
     -------
-    Tuple[str, Optional[str]]
+    Tuple[str, Optional[str], bool]
         A tuple containing the decrypted plaintext message (or the original
-        message if it was not encrypted) and the fingerprint of the signing
-        key if the message included a valid signature. ``None`` is returned
-        for the fingerprint when the message is unsigned or cannot be
-        verified with the provided public keys.
+        message if it was not encrypted), the fingerprint of the signing
+        key if the message included a signature, and a boolean indicating
+        whether the signature was verified with the provided public keys.
     """
 
     message = PGPMessage.from_blob(ciphertext)
@@ -115,14 +114,17 @@ def decrypt_message(
         plaintext = result
 
     signer_fpr: Optional[str] = None
-    if decrypted.is_signed and pubkey_blobs:
-        for blob in pubkey_blobs:
-            try:
-                pub, _ = PGPKey.from_blob(blob)
-                if pub.verify(decrypted):
-                    signer_fpr = decrypted.signatures[0].signer_fingerprint
-                    break
-            except Exception:
-                continue
+    verified = False
+    if decrypted.is_signed:
+        signer_fpr = decrypted.signatures[0].signer_fingerprint
+        if pubkey_blobs:
+            for blob in pubkey_blobs:
+                try:
+                    pub, _ = PGPKey.from_blob(blob)
+                    if pub.verify(decrypted):
+                        verified = True
+                        break
+                except Exception:
+                    continue
 
-    return plaintext, signer_fpr
+    return plaintext, signer_fpr, verified

--- a/src/seedsigner/helpers/gpg_message.py
+++ b/src/seedsigner/helpers/gpg_message.py
@@ -1,0 +1,70 @@
+"""Helper functions for PGP message encryption and decryption.
+
+These utilities wrap the :mod:`pgpy` package so that SeedSigner can encrypt
+and decrypt arbitrary text payloads using PGP public and private keys.  The
+functions are intentionally lightweight and do not rely on the external GPG
+binary, making them suitable for environments where only a minimal Python
+runtime is available.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from pgpy import PGPKey, PGPMessage
+
+
+def encrypt_message(pubkey_blob: str, message: str) -> str:
+    """Encrypt ``message`` with the provided ASCII-armored public key.
+
+    Parameters
+    ----------
+    pubkey_blob: str
+        ASCII-armored public key data.
+    message: str
+        Plaintext message to encrypt.
+
+    Returns
+    -------
+    str
+        ASCII-armored encrypted message suitable for transport or QR
+        encoding.
+    """
+
+    pubkey, _ = PGPKey.from_blob(pubkey_blob)
+    pgp_message = PGPMessage.new(message)
+    encrypted_message = pubkey.encrypt(pgp_message)
+    return str(encrypted_message)
+
+
+def decrypt_message(privkey_blob: str, ciphertext: str, passphrase: Optional[str] = None) -> str:
+    """Decrypt ``ciphertext`` with ``privkey_blob``.
+
+    Parameters
+    ----------
+    privkey_blob: str
+        ASCII-armored private key data.
+    ciphertext: str
+        ASCII-armored encrypted message produced by
+        :func:`encrypt_message`.
+    passphrase: Optional[str]
+        Optional passphrase to unlock the private key.  ``None`` can be
+        provided for unprotected keys.
+
+    Returns
+    -------
+    str
+        The decrypted plaintext message.
+    """
+
+    privkey, _ = PGPKey.from_blob(privkey_blob)
+    message = PGPMessage.from_blob(ciphertext)
+
+    if privkey.is_protected:
+        if passphrase is None:
+            raise ValueError("Passphrase required for encrypted private key")
+        with privkey.unlock(passphrase):
+            decrypted = privkey.decrypt(message)
+    else:
+        decrypted = privkey.decrypt(message)
+
+    return decrypted.message

--- a/src/seedsigner/helpers/gpg_message.py
+++ b/src/seedsigner/helpers/gpg_message.py
@@ -14,17 +14,18 @@ from pgpy import PGPKey, PGPMessage
 
 
 def encrypt_message(
-    pubkey_blob: str,
+    pubkey_blob: Optional[str],
     message: str,
     signkey_blob: Optional[str] = None,
     signkey_passphrase: Optional[str] = None,
 ) -> str:
-    """Encrypt ``message`` with the provided ASCII-armored public key.
+    """Sign and optionally encrypt ``message``.
 
     Parameters
     ----------
-    pubkey_blob: str
-        ASCII-armored public key data.
+    pubkey_blob: Optional[str]
+        ASCII-armored public key data. If ``None`` the message will not be
+        encrypted.
     message: str
         Plaintext message to encrypt.
     signkey_blob: Optional[str]
@@ -37,11 +38,10 @@ def encrypt_message(
     Returns
     -------
     str
-        ASCII-armored encrypted message suitable for transport or QR
-        encoding.
+        The resulting ASCII-armored message which may be signed and/or
+        encrypted.
     """
 
-    pubkey, _ = PGPKey.from_blob(pubkey_blob)
     pgp_message = PGPMessage.new(message)
 
     if signkey_blob:
@@ -54,32 +54,47 @@ def encrypt_message(
         else:
             pgp_message |= signkey.sign(pgp_message)
 
-    encrypted_message = pubkey.encrypt(pgp_message)
-    return str(encrypted_message)
+    if pubkey_blob:
+        pubkey, _ = PGPKey.from_blob(pubkey_blob)
+        pgp_message = pubkey.encrypt(pgp_message)
+
+    return str(pgp_message)
 
 
-def decrypt_message(privkey_blob: str, ciphertext: str, passphrase: Optional[str] = None) -> str:
-    """Decrypt ``ciphertext`` with ``privkey_blob``.
+def decrypt_message(
+    privkey_blob: Optional[str],
+    ciphertext: str,
+    passphrase: Optional[str] = None,
+) -> str:
+    """Decrypt ``ciphertext`` if needed and return the plaintext.
 
     Parameters
     ----------
-    privkey_blob: str
-        ASCII-armored private key data.
+    privkey_blob: Optional[str]
+        ASCII-armored private key data. Required if ``ciphertext`` is
+        encrypted; otherwise ``None`` can be supplied.
     ciphertext: str
-        ASCII-armored encrypted message produced by
-        :func:`encrypt_message`.
+        ASCII-armored message produced by :func:`encrypt_message`.
     passphrase: Optional[str]
-        Optional passphrase to unlock the private key.  ``None`` can be
+        Optional passphrase to unlock the private key. ``None`` can be
         provided for unprotected keys.
 
     Returns
     -------
     str
-        The decrypted plaintext message.
+        The decrypted plaintext message (or the original message if it was
+        not encrypted).
     """
 
-    privkey, _ = PGPKey.from_blob(privkey_blob)
     message = PGPMessage.from_blob(ciphertext)
+
+    if not message.is_encrypted:
+        return message.message
+
+    if privkey_blob is None:
+        raise ValueError("Encrypted message requires a private key")
+
+    privkey, _ = PGPKey.from_blob(privkey_blob)
 
     if privkey.is_protected:
         if passphrase is None:

--- a/src/seedsigner/helpers/gpg_message.py
+++ b/src/seedsigner/helpers/gpg_message.py
@@ -13,7 +13,12 @@ from typing import Optional
 from pgpy import PGPKey, PGPMessage
 
 
-def encrypt_message(pubkey_blob: str, message: str) -> str:
+def encrypt_message(
+    pubkey_blob: str,
+    message: str,
+    signkey_blob: Optional[str] = None,
+    signkey_passphrase: Optional[str] = None,
+) -> str:
     """Encrypt ``message`` with the provided ASCII-armored public key.
 
     Parameters
@@ -22,6 +27,12 @@ def encrypt_message(pubkey_blob: str, message: str) -> str:
         ASCII-armored public key data.
     message: str
         Plaintext message to encrypt.
+    signkey_blob: Optional[str]
+        Optional ASCII-armored private key used to sign the message before
+        encryption.
+    signkey_passphrase: Optional[str]
+        Optional passphrase for the signing key when ``signkey_blob`` is
+        provided.
 
     Returns
     -------
@@ -32,6 +43,17 @@ def encrypt_message(pubkey_blob: str, message: str) -> str:
 
     pubkey, _ = PGPKey.from_blob(pubkey_blob)
     pgp_message = PGPMessage.new(message)
+
+    if signkey_blob:
+        signkey, _ = PGPKey.from_blob(signkey_blob)
+        if signkey.is_protected:
+            if signkey_passphrase is None:
+                raise ValueError("Passphrase required for encrypted signing key")
+            with signkey.unlock(signkey_passphrase):
+                pgp_message |= signkey.sign(pgp_message)
+        else:
+            pgp_message |= signkey.sign(pgp_message)
+
     encrypted_message = pubkey.encrypt(pgp_message)
     return str(encrypted_message)
 

--- a/src/seedsigner/helpers/gpg_message.py
+++ b/src/seedsigner/helpers/gpg_message.py
@@ -89,7 +89,10 @@ def decrypt_message(
     message = PGPMessage.from_blob(ciphertext)
 
     if not message.is_encrypted:
-        return message.message
+        result = message.message
+        if isinstance(result, (bytes, bytearray)):
+            return result.decode("utf-8")
+        return result
 
     if privkey_blob is None:
         raise ValueError("Encrypted message requires a private key")
@@ -104,4 +107,7 @@ def decrypt_message(
     else:
         decrypted = privkey.decrypt(message)
 
-    return decrypted.message
+    result = decrypted.message
+    if isinstance(result, (bytes, bytearray)):
+        return result.decode("utf-8")
+    return result

--- a/src/seedsigner/helpers/gpg_message.py
+++ b/src/seedsigner/helpers/gpg_message.py
@@ -8,7 +8,7 @@ runtime is available.
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import Iterable, Optional, Tuple
 
 from pgpy import PGPKey, PGPMessage
 
@@ -65,8 +65,9 @@ def decrypt_message(
     privkey_blob: Optional[str],
     ciphertext: str,
     passphrase: Optional[str] = None,
-) -> str:
-    """Decrypt ``ciphertext`` if needed and return the plaintext.
+    pubkey_blobs: Optional[Iterable[str]] = None,
+) -> Tuple[str, Optional[str]]:
+    """Decrypt ``ciphertext`` and optionally verify a signature.
 
     Parameters
     ----------
@@ -81,33 +82,47 @@ def decrypt_message(
 
     Returns
     -------
-    str
-        The decrypted plaintext message (or the original message if it was
-        not encrypted).
+    Tuple[str, Optional[str]]
+        A tuple containing the decrypted plaintext message (or the original
+        message if it was not encrypted) and the fingerprint of the signing
+        key if the message included a valid signature. ``None`` is returned
+        for the fingerprint when the message is unsigned or cannot be
+        verified with the provided public keys.
     """
 
     message = PGPMessage.from_blob(ciphertext)
 
     if not message.is_encrypted:
-        result = message.message
-        if isinstance(result, (bytes, bytearray)):
-            return result.decode("utf-8")
-        return result
-
-    if privkey_blob is None:
-        raise ValueError("Encrypted message requires a private key")
-
-    privkey, _ = PGPKey.from_blob(privkey_blob)
-
-    if privkey.is_protected:
-        if passphrase is None:
-            raise ValueError("Passphrase required for encrypted private key")
-        with privkey.unlock(passphrase):
-            decrypted = privkey.decrypt(message)
+        decrypted = message
     else:
-        decrypted = privkey.decrypt(message)
+        if privkey_blob is None:
+            raise ValueError("Encrypted message requires a private key")
+
+        privkey, _ = PGPKey.from_blob(privkey_blob)
+
+        if privkey.is_protected:
+            if passphrase is None:
+                raise ValueError("Passphrase required for encrypted private key")
+            with privkey.unlock(passphrase):
+                decrypted = privkey.decrypt(message)
+        else:
+            decrypted = privkey.decrypt(message)
 
     result = decrypted.message
     if isinstance(result, (bytes, bytearray)):
-        return result.decode("utf-8")
-    return result
+        plaintext = result.decode("utf-8")
+    else:
+        plaintext = result
+
+    signer_fpr: Optional[str] = None
+    if decrypted.is_signed and pubkey_blobs:
+        for blob in pubkey_blobs:
+            try:
+                pub, _ = PGPKey.from_blob(blob)
+                if pub.verify(decrypted):
+                    signer_fpr = decrypted.signatures[0].signer_fingerprint
+                    break
+            except Exception:
+                continue
+
+    return plaintext, signer_fpr

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4396,34 +4396,6 @@ class ToolsGPGDecryptMessageView(View):
             elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
                 cur["uid"] = parts[9]
 
-        if not keys:
-            self.run_screen(
-                WarningScreen,
-                title="Error",
-                status_headline=None,
-                text="No private keys found",
-                show_back_button=False,
-                button_data=[ButtonOption("I Understand")],
-            )
-            return Destination(BackStackView)
-
-        buttons = []
-        for key in keys:
-            label = key["uid"] if key["uid"] else key["fpr"][-8:]
-            buttons.append(ButtonOption(label))
-
-        selected = self.run_screen(
-            ButtonListScreen,
-            title="Select Key",
-            is_button_text_centered=False,
-            button_data=buttons,
-        )
-
-        if selected == RET_CODE__BACK_BUTTON:
-            return Destination(BackStackView)
-
-        key = keys[selected]
-
         decoder = DecodeQR()
         ScanScreen(decoder=decoder, instructions_text="Scan encrypted message").display()
         self.controller.reset_screensaver_timeout()
@@ -4449,23 +4421,6 @@ class ToolsGPGDecryptMessageView(View):
                 title="Error",
                 status_headline=None,
                 text="Unsupported QR format",
-                show_back_button=False,
-                button_data=[ButtonOption("I Understand")],
-            )
-            return Destination(BackStackView)
-
-        exported = run([
-            "gpg",
-            "--armor",
-            "--export-secret-keys",
-            key["fpr"],
-        ], capture_output=True, text=True)
-        if exported.returncode != 0:
-            self.run_screen(
-                WarningScreen,
-                title="Error",
-                status_headline=None,
-                text="Failed to export key",
                 show_back_button=False,
                 button_data=[ButtonOption("I Understand")],
             )
@@ -4499,36 +4454,79 @@ class ToolsGPGDecryptMessageView(View):
             ], capture_output=True, text=True)
             pk["blob"] = exp.stdout
 
+        # try without a private key first in case message is unencrypted
+        dec_key = None
         try:
             plaintext, signer_fpr, verified = decrypt_message(
-                exported.stdout,
+                None,
                 ciphertext,
                 pubkey_blobs=[pk["blob"] for pk in pubkeys],
             )
         except ValueError:
-            ret_dict = ToolsTextQRTextEntryScreen(textToEncode="", title="Passphrase").display()
-            if "is_back_button" in ret_dict:
+            # message is encrypted; try each available private key
+            decrypted = False
+            for key in keys:
+                exported = run([
+                    "gpg",
+                    "--armor",
+                    "--export-secret-keys",
+                    key["fpr"],
+                ], capture_output=True, text=True)
+                if exported.returncode != 0:
+                    continue
+                try:
+                    plaintext, signer_fpr, verified = decrypt_message(
+                        exported.stdout,
+                        ciphertext,
+                        pubkey_blobs=[pk["blob"] for pk in pubkeys],
+                    )
+                    dec_key = key
+                    decrypted = True
+                    break
+                except ValueError as e:
+                    if "Passphrase required" in str(e):
+                        ret_dict = ToolsTextQRTextEntryScreen(
+                            textToEncode="", title="Passphrase"
+                        ).display()
+                        if "is_back_button" in ret_dict:
+                            return Destination(BackStackView)
+                        passphrase = ret_dict["textToEncode"]
+                        try:
+                            plaintext, signer_fpr, verified = decrypt_message(
+                                exported.stdout,
+                                ciphertext,
+                                passphrase=passphrase,
+                                pubkey_blobs=[pk["blob"] for pk in pubkeys],
+                            )
+                            dec_key = key
+                            decrypted = True
+                            break
+                        except Exception:
+                            continue
+                    else:
+                        continue
+                except Exception:
+                    continue
+
+            if not decrypted:
+                err_text = (
+                    "No private keys found" if not keys else "Failed to decrypt message"
+                )
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text=err_text,
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
                 return Destination(BackStackView)
-            passphrase = ret_dict["textToEncode"]
-            plaintext, signer_fpr, verified = decrypt_message(
-                exported.stdout,
-                ciphertext,
-                passphrase=passphrase,
-                pubkey_blobs=[pk["blob"] for pk in pubkeys],
-            )
-        except Exception:
-            self.run_screen(
-                WarningScreen,
-                title="Error",
-                status_headline=None,
-                text="Failed to decrypt message",
-                show_back_button=False,
-                button_data=[ButtonOption("I Understand")],
-            )
-            return Destination(BackStackView)
 
         if isinstance(plaintext, (bytes, bytearray, memoryview)):
             plaintext = plaintext.decode("utf-8")
+
+        # normalize line endings to avoid display issues on carriage returns
+        plaintext = plaintext.replace("\r\n", "\n").replace("\r", "\n")
 
         if signer_fpr:
             label = signer_fpr[-8:]
@@ -4605,8 +4603,9 @@ class ToolsGPGDecryptMessageView(View):
             else:
                 secret_list = list(len(msg_bytes).to_bytes(2, "big")) + list(msg_bytes)
 
+            label = f"GPGMsg:{dec_key['fpr'][-8:]}" if dec_key else "GPGMsg"
             header = Satochip_Connector.make_header(
-                "Data", "Plaintext export allowed", f"GPGMsg:{key['fpr'][-8:]}"
+                "Data", "Plaintext export allowed", label
             )
             secret_dic = {"header": header, "secret_list": secret_list}
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4369,6 +4369,10 @@ class ToolsGPGDecryptMessageView(View):
             QRDisplayScreen,
         )
         from seedsigner.gui.screens.scan_screens import ScanScreen
+        from seedsigner.gui.screens.tools_screens import (
+            ToolsTextQRTextEntryScreen,
+            ToolsTextQRReviewTextScreen,
+        )
         from seedsigner.models.decode_qr import DecodeQR, QRType
         from seedsigner.models.encode_qr import GenericStaticQrEncoder
         from urtypes.bytes import Bytes
@@ -4467,14 +4471,51 @@ class ToolsGPGDecryptMessageView(View):
             )
             return Destination(BackStackView)
 
+        # gather public keys for signature verification
+        pub_result = run([
+            "gpg",
+            "--list-keys",
+            "--with-colons",
+        ], capture_output=True, text=True)
+
+        pubkeys = []
+        cur = None
+        for line in pub_result.stdout.splitlines():
+            parts = line.split(":")
+            if parts[0] == "pub":
+                cur = {"fpr": None, "uid": None}
+                pubkeys.append(cur)
+            elif parts[0] == "fpr" and cur is not None:
+                cur["fpr"] = parts[9]
+            elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
+                cur["uid"] = parts[9]
+
+        for pk in pubkeys:
+            exp = run([
+                "gpg",
+                "--armor",
+                "--export",
+                pk["fpr"],
+            ], capture_output=True, text=True)
+            pk["blob"] = exp.stdout
+
         try:
-            plaintext = decrypt_message(exported.stdout, ciphertext)
+            plaintext, signer_fpr = decrypt_message(
+                exported.stdout,
+                ciphertext,
+                pubkey_blobs=[pk["blob"] for pk in pubkeys],
+            )
         except ValueError:
             ret_dict = ToolsTextQRTextEntryScreen(textToEncode="", title="Passphrase").display()
             if "is_back_button" in ret_dict:
                 return Destination(BackStackView)
             passphrase = ret_dict["textToEncode"]
-            plaintext = decrypt_message(exported.stdout, ciphertext, passphrase=passphrase)
+            plaintext, signer_fpr = decrypt_message(
+                exported.stdout,
+                ciphertext,
+                passphrase=passphrase,
+                pubkey_blobs=[pk["blob"] for pk in pubkeys],
+            )
         except Exception:
             self.run_screen(
                 WarningScreen,
@@ -4489,26 +4530,41 @@ class ToolsGPGDecryptMessageView(View):
         if isinstance(plaintext, (bytes, bytearray, memoryview)):
             plaintext = plaintext.decode("utf-8")
 
+        if signer_fpr:
+            label = signer_fpr[-8:]
+            for pk in pubkeys:
+                if pk["fpr"] == signer_fpr:
+                    label = pk["uid"] if pk["uid"] else pk["fpr"][-8:]
+                    break
+            self.run_screen(
+                LargeIconStatusScreen,
+                title="Success",
+                status_headline=None,
+                text=f"Valid Signature from\n{label}",
+                show_back_button=False,
+                button_data=[ButtonOption("Next")],
+            )
+
+        next_button = ButtonOption("Next")
+        self.run_screen(
+            ToolsTextQRReviewTextScreen,
+            textToEncode=plaintext,
+            title="Decrypted Message",
+            button_data=[next_button],
+            show_back_button=False,
+        )
+
         SAVE = ButtonOption("Save to Seedkeeper")
         SHOW = ButtonOption("Show as QR")
         DONE = ButtonOption("Done")
         button_data = [SAVE, SHOW, DONE]
-
-        if len(plaintext) <= 400:
-            selected_option = self.run_screen(
-                LargeIconStatusScreen,
-                title="Decrypted Message",
-                status_headline=None,
-                text=plaintext,
-                button_data=button_data,
-            )
-        else:
-            selected_option = self.run_screen(
-                ToolsTextQRReviewTextScreen,
-                textToEncode=plaintext,
-                title="Decrypted Message",
-                button_data=button_data,
-            )
+        selected_option = self.run_screen(
+            ButtonListScreen,
+            title="Decrypted Message",
+            is_button_text_centered=False,
+            button_data=button_data,
+            show_back_button=False,
+        )
 
         if selected_option == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4273,7 +4273,7 @@ class ToolsGPGEncryptMessageView(View):
         loading.start()
         try:
             qr_encoder = UrBytesQrEncoder(
-                data=ciphertext,
+                data=ciphertext.encode("utf-8"),
                 qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
             )
         finally:
@@ -4307,8 +4307,9 @@ class ToolsGPGDecryptMessageView(View):
             QRDisplayScreen,
         )
         from seedsigner.gui.screens.scan_screens import ScanScreen
-        from seedsigner.models.decode_qr import DecodeQR
+        from seedsigner.models.decode_qr import DecodeQR, QRType
         from seedsigner.models.encode_qr import GenericStaticQrEncoder
+        from urtypes.bytes import Bytes
         import time
 
         result = run([
@@ -4357,13 +4358,29 @@ class ToolsGPGDecryptMessageView(View):
 
         key = keys[selected]
 
-        decoder = DecodeQR(is_text=True)
+        decoder = DecodeQR()
         ScanScreen(decoder=decoder, instructions_text="Scan encrypted message").display()
         self.controller.reset_screensaver_timeout()
         time.sleep(0.1)
         if not decoder.is_complete:
             return Destination(BackStackView)
-        ciphertext = decoder.get_text()
+
+        if decoder.qr_type == QRType.BYTES__UR:
+            ciphertext = Bytes.from_cbor(
+                decoder.decoder.result_message().cbor
+            ).data.decode("utf-8")
+        elif decoder.qr_type == QRType.TEXT:
+            ciphertext = decoder.get_text()
+        else:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Unsupported QR format",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
 
         exported = run([
             "gpg",

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4104,8 +4104,8 @@ class ToolsGPGEncryptMessageView(View):
             WarningScreen,
             LoadingScreenThread,
             QRDisplayScreen,
-            ScanScreen,
         )
+        from seedsigner.gui.screens.scan_screens import ScanScreen
         from seedsigner.gui.screens.tools_screens import ToolsTextQRTextEntryScreen
         from seedsigner.models.decode_qr import DecodeQR
         from seedsigner.models.encode_qr import UrBytesQrEncoder
@@ -4305,8 +4305,8 @@ class ToolsGPGDecryptMessageView(View):
             LargeIconStatusScreen,
             LoadingScreenThread,
             QRDisplayScreen,
-            ScanScreen,
         )
+        from seedsigner.gui.screens.scan_screens import ScanScreen
         from seedsigner.models.decode_qr import DecodeQR
         from seedsigner.models.encode_qr import GenericStaticQrEncoder
         import time

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4431,9 +4431,13 @@ class ToolsGPGDecryptMessageView(View):
             return Destination(BackStackView)
 
         if decoder.qr_type == QRType.BYTES__UR:
-            ciphertext = Bytes.from_cbor(
+            raw = Bytes.from_cbor(
                 decoder.decoder.result_message().cbor
-            ).data.decode("utf-8")
+            ).data
+            if isinstance(raw, (bytes, bytearray)):
+                ciphertext = raw.decode("utf-8")
+            else:
+                ciphertext = raw
         elif decoder.qr_type == QRType.TEXT:
             ciphertext = decoder.get_text()
         else:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4431,6 +4431,8 @@ class ToolsGPGDecryptMessageView(View):
             raw = Bytes.from_cbor(
                 decoder.decoder.result_message().cbor
             ).data
+            if isinstance(raw, memoryview):
+                raw = raw.tobytes()
             if isinstance(raw, (bytes, bytearray)):
                 ciphertext = raw.decode("utf-8")
             else:
@@ -4483,6 +4485,9 @@ class ToolsGPGDecryptMessageView(View):
                 button_data=[ButtonOption("I Understand")],
             )
             return Destination(BackStackView)
+
+        if isinstance(plaintext, (bytes, bytearray, memoryview)):
+            plaintext = plaintext.decode("utf-8")
 
         SAVE = ButtonOption("Save to Seedkeeper")
         SHOW = ButtonOption("Show as QR")

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4500,7 +4500,7 @@ class ToolsGPGDecryptMessageView(View):
             pk["blob"] = exp.stdout
 
         try:
-            plaintext, signer_fpr = decrypt_message(
+            plaintext, signer_fpr, verified = decrypt_message(
                 exported.stdout,
                 ciphertext,
                 pubkey_blobs=[pk["blob"] for pk in pubkeys],
@@ -4510,7 +4510,7 @@ class ToolsGPGDecryptMessageView(View):
             if "is_back_button" in ret_dict:
                 return Destination(BackStackView)
             passphrase = ret_dict["textToEncode"]
-            plaintext, signer_fpr = decrypt_message(
+            plaintext, signer_fpr, verified = decrypt_message(
                 exported.stdout,
                 ciphertext,
                 passphrase=passphrase,
@@ -4536,14 +4536,26 @@ class ToolsGPGDecryptMessageView(View):
                 if pk["fpr"] == signer_fpr:
                     label = pk["uid"] if pk["uid"] else pk["fpr"][-8:]
                     break
-            self.run_screen(
-                LargeIconStatusScreen,
-                title="Success",
-                status_headline=None,
-                text=f"Valid Signature from\n{label}",
-                show_back_button=False,
-                button_data=[ButtonOption("Next")],
-            )
+            if verified:
+                self.run_screen(
+                    LargeIconStatusScreen,
+                    title="Success",
+                    status_headline=None,
+                    text=f"Valid Signature from\n{label}",
+                    show_back_button=False,
+                    button_data=[ButtonOption("Next")],
+                )
+            else:
+                self.run_screen(
+                    LargeIconStatusScreen,
+                    title="Warning",
+                    status_icon_name=SeedSignerIconConstants.WARNING,
+                    status_color=GUIConstants.WARNING_COLOR,
+                    status_headline=None,
+                    text=f"Unverified Signature from\n{label}",
+                    show_back_button=False,
+                    button_data=[ButtonOption("Next")],
+                )
 
         next_button = ButtonOption("Next")
         self.run_screen(

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4128,18 +4128,8 @@ class ToolsGPGEncryptMessageView(View):
             elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
                 cur["uid"] = parts[9]
 
-        if not keys:
-            self.run_screen(
-                WarningScreen,
-                title="Error",
-                status_headline=None,
-                text="No public keys found",
-                show_back_button=False,
-                button_data=[ButtonOption("I Understand")],
-            )
-            return Destination(BackStackView)
-
-        buttons = []
+        SKIP = ButtonOption("Skip")
+        buttons = [SKIP]
         for key in keys:
             label = key["uid"] if key["uid"] else key["fpr"][-8:]
             buttons.append(ButtonOption(label))
@@ -4154,7 +4144,10 @@ class ToolsGPGEncryptMessageView(View):
         if selected == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        key = keys[selected]
+        if buttons[selected] is SKIP:
+            key = None
+        else:
+            key = keys[selected - 1]
 
         SRC_TYPE = ButtonOption("Type Message")
         SRC_SEEDKEEPER = ButtonOption("Load Seedkeeper")
@@ -4293,32 +4286,36 @@ class ToolsGPGEncryptMessageView(View):
                     return Destination(BackStackView)
                 signkey_blob = exported_sign.stdout
 
-        exported = run([
-            "gpg",
-            "--armor",
-            "--export",
-            key["fpr"],
-        ], capture_output=True, text=True)
-        if exported.returncode != 0:
-            self.run_screen(
-                WarningScreen,
-                title="Error",
-                status_headline=None,
-                text="Failed to export key",
-                show_back_button=False,
-                button_data=[ButtonOption("I Understand")],
-            )
-            return Destination(BackStackView)
+        if key is not None:
+            exported = run([
+                "gpg",
+                "--armor",
+                "--export",
+                key["fpr"],
+            ], capture_output=True, text=True)
+            if exported.returncode != 0:
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text="Failed to export key",
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
+            pub_blob = exported.stdout
+        else:
+            pub_blob = None
 
         try:
-            ciphertext = encrypt_message(exported.stdout, message, signkey_blob=signkey_blob)
+            ciphertext = encrypt_message(pub_blob, message, signkey_blob=signkey_blob)
         except ValueError:
             ret_dict = ToolsTextQRTextEntryScreen(textToEncode="", title="Passphrase").display()
             if "is_back_button" in ret_dict:
                 return Destination(BackStackView)
             passphrase = ret_dict["textToEncode"]
             ciphertext = encrypt_message(
-                exported.stdout,
+                pub_blob,
                 message,
                 signkey_blob=signkey_blob,
                 signkey_passphrase=passphrase,

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4238,6 +4238,60 @@ class ToolsGPGEncryptMessageView(View):
                 length = (secret_list[0] << 8) + secret_list[1]
                 msg_bytes = bytes(secret_list[2:2 + length])
             message = msg_bytes.decode("utf-8")
+        signkey_blob = None
+        result = run([
+            "gpg",
+            "--list-secret-keys",
+            "--with-colons",
+        ], capture_output=True, text=True)
+
+        sign_keys = []
+        cur = None
+        for line in result.stdout.splitlines():
+            parts = line.split(":")
+            if parts[0] == "sec":
+                cur = {"fpr": None, "uid": None}
+                sign_keys.append(cur)
+            elif parts[0] == "fpr" and cur is not None:
+                cur["fpr"] = parts[9]
+            elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
+                cur["uid"] = parts[9]
+
+        if sign_keys:
+            sign_buttons = [ButtonOption("Skip")]
+            for sk in sign_keys:
+                label = sk["uid"] if sk["uid"] else sk["fpr"][-8:]
+                sign_buttons.append(ButtonOption(label))
+
+            selected_sign = self.run_screen(
+                ButtonListScreen,
+                title="Signing Key",
+                is_button_text_centered=False,
+                button_data=sign_buttons,
+            )
+
+            if selected_sign == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
+
+            if selected_sign > 0:
+                sign_key = sign_keys[selected_sign - 1]
+                exported_sign = run([
+                    "gpg",
+                    "--armor",
+                    "--export-secret-keys",
+                    sign_key["fpr"],
+                ], capture_output=True, text=True)
+                if exported_sign.returncode != 0:
+                    self.run_screen(
+                        WarningScreen,
+                        title="Error",
+                        status_headline=None,
+                        text="Failed to export signing key",
+                        show_back_button=False,
+                        button_data=[ButtonOption("I Understand")],
+                    )
+                    return Destination(BackStackView)
+                signkey_blob = exported_sign.stdout
 
         exported = run([
             "gpg",
@@ -4257,7 +4311,18 @@ class ToolsGPGEncryptMessageView(View):
             return Destination(BackStackView)
 
         try:
-            ciphertext = encrypt_message(exported.stdout, message)
+            ciphertext = encrypt_message(exported.stdout, message, signkey_blob=signkey_blob)
+        except ValueError:
+            ret_dict = ToolsTextQRTextEntryScreen(textToEncode="", title="Passphrase").display()
+            if "is_back_button" in ret_dict:
+                return Destination(BackStackView)
+            passphrase = ret_dict["textToEncode"]
+            ciphertext = encrypt_message(
+                exported.stdout,
+                message,
+                signkey_blob=signkey_blob,
+                signkey_passphrase=passphrase,
+            )
         except Exception:
             self.run_screen(
                 WarningScreen,

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4009,6 +4009,7 @@ class ToolsGPGMenuView(View):
     SIGN = ButtonOption("Sign")
     IMPORT = ButtonOption("Import")
     EXPORT = ButtonOption("Export")
+    MESSAGE = ButtonOption("Encrypted Message")
     SMART_GPG = ButtonOption("SmartGPG")
 
     def run(self):
@@ -4018,6 +4019,7 @@ class ToolsGPGMenuView(View):
             self.SIGN,
             self.IMPORT,
             self.EXPORT,
+            self.MESSAGE,
             self.SMART_GPG,
         ]
 
@@ -4041,8 +4043,32 @@ class ToolsGPGMenuView(View):
             return Destination(ToolsGPGImportMenuView)
         elif button_data[selected_menu_num] == self.EXPORT:
             return Destination(ToolsGPGExportMenuView)
+        elif button_data[selected_menu_num] == self.MESSAGE:
+            return Destination(ToolsGPGMessageMenuView)
         elif button_data[selected_menu_num] == self.SMART_GPG:
             return Destination(ToolsGPGSmartMenuView)
+
+
+class ToolsGPGMessageMenuView(View):
+    ENCRYPT = ButtonOption("Encrypt Message")
+    DECRYPT = ButtonOption("Decrypt Message")
+
+    def run(self):
+        button_data = [self.ENCRYPT, self.DECRYPT]
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title="Encrypted Message",
+            is_button_text_centered=False,
+            button_data=button_data,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        if button_data[selected_menu_num] == self.ENCRYPT:
+            return Destination(ToolsGPGEncryptMessageView)
+        return Destination(ToolsGPGDecryptMessageView)
 
 
 class ToolsGPGSignMenuView(View):
@@ -4065,6 +4091,414 @@ class ToolsGPGSignMenuView(View):
         if button_data[selected_menu_num] == self.FILE:
             return Destination(ToolsGPGSignFileView)
         return Destination(ToolsGPGSignManifestView)
+
+
+class ToolsGPGEncryptMessageView(View):
+    def run(self):
+        from subprocess import run
+        import time
+        from seedsigner.helpers import seedkeeper_utils
+        from seedsigner.helpers.gpg_message import encrypt_message
+        from seedsigner.gui.screens.screen import (
+            ButtonListScreen,
+            WarningScreen,
+            LoadingScreenThread,
+            QRDisplayScreen,
+            ScanScreen,
+        )
+        from seedsigner.gui.screens.tools_screens import ToolsTextQRTextEntryScreen
+        from seedsigner.models.decode_qr import DecodeQR
+        from seedsigner.models.encode_qr import UrBytesQrEncoder
+
+        result = run([
+            "gpg",
+            "--list-keys",
+            "--with-colons",
+        ], capture_output=True, text=True)
+
+        keys = []
+        cur = None
+        for line in result.stdout.splitlines():
+            parts = line.split(":")
+            if parts[0] == "pub":
+                cur = {"fpr": None, "uid": None}
+                keys.append(cur)
+            elif parts[0] == "fpr" and cur is not None:
+                cur["fpr"] = parts[9]
+            elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
+                cur["uid"] = parts[9]
+
+        if not keys:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="No public keys found",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        buttons = []
+        for key in keys:
+            label = key["uid"] if key["uid"] else key["fpr"][-8:]
+            buttons.append(ButtonOption(label))
+
+        selected = self.run_screen(
+            ButtonListScreen,
+            title="Select Key",
+            is_button_text_centered=False,
+            button_data=buttons,
+        )
+
+        if selected == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        key = keys[selected]
+
+        SRC_TYPE = ButtonOption("Type Message")
+        SRC_SEEDKEEPER = ButtonOption("Load Seedkeeper")
+        SRC_SCAN = ButtonOption("Scan QR")
+        src_buttons = [SRC_TYPE, SRC_SEEDKEEPER, SRC_SCAN]
+
+        src_selected = self.run_screen(
+            ButtonListScreen,
+            title="Message Source",
+            is_button_text_centered=False,
+            button_data=src_buttons,
+        )
+
+        if src_selected == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        if src_buttons[src_selected] == SRC_TYPE:
+            ret_dict = ToolsTextQRTextEntryScreen(textToEncode="", title="Message").display()
+            if "is_back_button" in ret_dict:
+                return Destination(BackStackView)
+            message = ret_dict["textToEncode"]
+        elif src_buttons[src_selected] == SRC_SCAN:
+            decoder = DecodeQR(is_text=True)
+            ScanScreen(decoder=decoder, instructions_text="Scan message").display()
+            self.controller.reset_screensaver_timeout()
+            time.sleep(0.1)
+            if not decoder.is_complete:
+                return Destination(BackStackView)
+            message = decoder.get_text()
+        else:
+            Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["seedkeeper"])
+            if not Satochip_Connector:
+                return Destination(BackStackView)
+
+            loading = LoadingScreenThread(text="Listing Secrets\n\n\n\n\n\n")
+            loading.start()
+            headers = Satochip_Connector.seedkeeper_list_secret_headers()
+            loading.stop()
+
+            headers_parsed = []
+            buttons = []
+            for header in headers:
+                stype = SEEDKEEPER_DIC_TYPE.get(header["type"], hex(header["type"]))
+                export_rights = SEEDKEEPER_DIC_EXPORT_RIGHTS.get(header["export_rights"], hex(header["export_rights"]))
+                if stype == "Data" and export_rights == "Plaintext export allowed":
+                    label = header["label"] or "Unnamed"
+                    headers_parsed.append((header["id"], label))
+                    buttons.append(ButtonOption(label))
+
+            if not headers_parsed:
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text="No messages found",
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
+
+            selected_msg = self.run_screen(
+                ButtonListScreen,
+                title="Select Message",
+                is_button_text_centered=False,
+                button_data=buttons,
+            )
+            if selected_msg == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
+
+            loading = LoadingScreenThread(text="Loading Secret\n\n\n\n\n\n")
+            loading.start()
+            secret_dict = Satochip_Connector.seedkeeper_export_secret(headers_parsed[selected_msg][0], None)
+            loading.stop()
+
+            secret_list = secret_dict["secret_list"]
+            status = Satochip_Connector.card_get_status()[3]
+            if status["protocol_minor_version"] == 1:
+                length = secret_list[0]
+                msg_bytes = bytes(secret_list[1:1 + length])
+            else:
+                length = (secret_list[0] << 8) + secret_list[1]
+                msg_bytes = bytes(secret_list[2:2 + length])
+            message = msg_bytes.decode("utf-8")
+
+        exported = run([
+            "gpg",
+            "--armor",
+            "--export",
+            key["fpr"],
+        ], capture_output=True, text=True)
+        if exported.returncode != 0:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to export key",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        try:
+            ciphertext = encrypt_message(exported.stdout, message)
+        except Exception:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to encrypt message",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        loading = LoadingScreenThread(text="Encoding...")
+        loading.start()
+        try:
+            qr_encoder = UrBytesQrEncoder(
+                data=ciphertext,
+                qr_density=self.settings.get_value(SettingsConstants.SETTING__QR_DENSITY),
+            )
+        finally:
+            loading.stop()
+
+        num_codes = qr_encoder.seq_len()
+        ret = self.run_screen(
+            WarningScreen,
+            title="Animated QR",
+            status_headline=None,
+            text=f"This export requires {num_codes} QR code{'s' if num_codes > 1 else ''}.",
+            show_back_button=True,
+            button_data=[ButtonOption("Start")],
+        )
+        if ret == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        self.run_screen(QRDisplayScreen, qr_encoder=qr_encoder)
+        return Destination(MainMenuView)
+
+
+class ToolsGPGDecryptMessageView(View):
+    def run(self):
+        from subprocess import run
+        from seedsigner.helpers.gpg_message import decrypt_message
+        from seedsigner.gui.screens.screen import (
+            ButtonListScreen,
+            WarningScreen,
+            LargeIconStatusScreen,
+            LoadingScreenThread,
+            QRDisplayScreen,
+            ScanScreen,
+        )
+        from seedsigner.models.decode_qr import DecodeQR
+        from seedsigner.models.encode_qr import GenericStaticQrEncoder
+        import time
+
+        result = run([
+            "gpg",
+            "--list-secret-keys",
+            "--with-colons",
+        ], capture_output=True, text=True)
+
+        keys = []
+        cur = None
+        for line in result.stdout.splitlines():
+            parts = line.split(":")
+            if parts[0] == "sec":
+                cur = {"fpr": None, "uid": None}
+                keys.append(cur)
+            elif parts[0] == "fpr" and cur is not None:
+                cur["fpr"] = parts[9]
+            elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
+                cur["uid"] = parts[9]
+
+        if not keys:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="No private keys found",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        buttons = []
+        for key in keys:
+            label = key["uid"] if key["uid"] else key["fpr"][-8:]
+            buttons.append(ButtonOption(label))
+
+        selected = self.run_screen(
+            ButtonListScreen,
+            title="Select Key",
+            is_button_text_centered=False,
+            button_data=buttons,
+        )
+
+        if selected == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        key = keys[selected]
+
+        decoder = DecodeQR(is_text=True)
+        ScanScreen(decoder=decoder, instructions_text="Scan encrypted message").display()
+        self.controller.reset_screensaver_timeout()
+        time.sleep(0.1)
+        if not decoder.is_complete:
+            return Destination(BackStackView)
+        ciphertext = decoder.get_text()
+
+        exported = run([
+            "gpg",
+            "--armor",
+            "--export-secret-keys",
+            key["fpr"],
+        ], capture_output=True, text=True)
+        if exported.returncode != 0:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to export key",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        try:
+            plaintext = decrypt_message(exported.stdout, ciphertext)
+        except ValueError:
+            ret_dict = ToolsTextQRTextEntryScreen(textToEncode="", title="Passphrase").display()
+            if "is_back_button" in ret_dict:
+                return Destination(BackStackView)
+            passphrase = ret_dict["textToEncode"]
+            plaintext = decrypt_message(exported.stdout, ciphertext, passphrase=passphrase)
+        except Exception:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to decrypt message",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        SAVE = ButtonOption("Save to Seedkeeper")
+        SHOW = ButtonOption("Show as QR")
+        DONE = ButtonOption("Done")
+        button_data = [SAVE, SHOW, DONE]
+
+        if len(plaintext) <= 400:
+            selected_option = self.run_screen(
+                LargeIconStatusScreen,
+                title="Decrypted Message",
+                status_headline=None,
+                text=plaintext,
+                button_data=button_data,
+            )
+        else:
+            selected_option = self.run_screen(
+                ToolsTextQRReviewTextScreen,
+                textToEncode=plaintext,
+                title="Decrypted Message",
+                button_data=button_data,
+            )
+
+        if selected_option == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        if button_data[selected_option] == SAVE:
+            Satochip_Connector = seedkeeper_utils.init_satochip(
+                self, init_card_filter=["seedkeeper"]
+            )
+            if not Satochip_Connector:
+                return Destination(BackStackView)
+
+            msg_bytes = plaintext.encode("utf-8")
+            status = Satochip_Connector.card_get_status()[3]
+            if status['protocol_minor_version'] == 1:
+                if len(msg_bytes) > 255:
+                    self.run_screen(
+                        WarningScreen,
+                        title="Error",
+                        status_headline=None,
+                        text="Message too large for Seedkeeper v1",
+                        show_back_button=False,
+                        button_data=[ButtonOption("I Understand")],
+                    )
+                    return Destination(BackStackView)
+                secret_list = [len(msg_bytes)] + list(msg_bytes)
+            else:
+                secret_list = list(len(msg_bytes).to_bytes(2, "big")) + list(msg_bytes)
+
+            header = Satochip_Connector.make_header(
+                "Data", "Plaintext export allowed", f"GPGMsg:{key['fpr'][-8:]}"
+            )
+            secret_dic = {"header": header, "secret_list": secret_list}
+
+            try:
+                loading = LoadingScreenThread(text="Saving Secret\n\n\n\n\n\n")
+                loading.start()
+                Satochip_Connector.seedkeeper_import_secret(secret_dic)
+                loading.stop()
+                self.run_screen(
+                    LargeIconStatusScreen,
+                    title="Success",
+                    status_headline=None,
+                    text="Message saved to Seedkeeper",
+                    show_back_button=False,
+                    button_data=[ButtonOption("Continue")],
+                )
+            except UnexpectedSW12Error as e:
+                loading.stop()
+                if e.sw1 == 0x6A and e.sw2 == 0x84:
+                    err_text = "Not enough space on Seedkeeper for message"
+                else:
+                    err_text = format_sw_error(e.sw1, e.sw2)
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text=err_text,
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+            except Exception:
+                loading.stop()
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text="Failed to save message",
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+            return Destination(MainMenuView)
+
+        if button_data[selected_option] == SHOW:
+            encoder = GenericStaticQrEncoder(data=plaintext)
+            self.run_screen(QRDisplayScreen, qr_encoder=encoder)
+            return Destination(MainMenuView)
+
+        return Destination(MainMenuView)
 
 
 class ToolsGPGImportMenuView(View):

--- a/tests/test_gpg_message.py
+++ b/tests/test_gpg_message.py
@@ -16,10 +16,11 @@ def test_encrypt_decrypt_roundtrip():
 
     plaintext = "SeedSigner test message"
     ciphertext = encrypt_message(str(key.pubkey), plaintext)
-    decrypted, signer = decrypt_message(str(key), ciphertext)
+    decrypted, signer, verified = decrypt_message(str(key), ciphertext)
 
     assert decrypted == plaintext
     assert signer is None
+    assert not verified
 
 
 def test_encrypt_qr_roundtrip():
@@ -45,9 +46,10 @@ def test_encrypt_qr_roundtrip():
     else:
         decoded_ciphertext = raw
 
-    decrypted, signer = decrypt_message(str(key), decoded_ciphertext)
+    decrypted, signer, verified = decrypt_message(str(key), decoded_ciphertext)
     assert decrypted == plaintext
     assert signer is None
+    assert not verified
 
 
 def test_sign_encrypt_decrypt_roundtrip():
@@ -65,11 +67,12 @@ def test_sign_encrypt_decrypt_roundtrip():
     )
 
     # decrypt using helper
-    decrypted, signer_fpr = decrypt_message(
+    decrypted, signer_fpr, verified = decrypt_message(
         str(recipient), ciphertext, pubkey_blobs=[str(signer.pubkey)]
     )
     assert decrypted == plaintext
     assert signer_fpr == signer.fingerprint
+    assert verified
 
 
 def test_sign_only_roundtrip():
@@ -81,6 +84,23 @@ def test_sign_only_roundtrip():
     signed_msg = encrypt_message(None, plaintext, signkey_blob=str(signer))
 
     # decrypt_message should return the original message even without a key
-    decrypted, signer_fpr = decrypt_message(None, signed_msg, pubkey_blobs=[str(signer.pubkey)])
+    decrypted, signer_fpr, verified = decrypt_message(
+        None, signed_msg, pubkey_blobs=[str(signer.pubkey)]
+    )
     assert decrypted == plaintext
     assert signer_fpr == signer.fingerprint
+    assert verified
+
+
+def test_unverified_signature():
+    signer = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 1024)
+    signer_uid = PGPUID.new("Signer", email="sign@example.com")
+    signer.add_uid(signer_uid, usage={KeyFlags.Sign})
+
+    plaintext = "SeedSigner unverified sign"
+    signed_msg = encrypt_message(None, plaintext, signkey_blob=str(signer))
+
+    decrypted, signer_fpr, verified = decrypt_message(None, signed_msg)
+    assert decrypted == plaintext
+    assert signer_fpr == signer.fingerprint
+    assert not verified

--- a/tests/test_gpg_message.py
+++ b/tests/test_gpg_message.py
@@ -3,6 +3,10 @@ from pgpy import PGPKey, PGPUID
 from pgpy.constants import PubKeyAlgorithm, KeyFlags
 
 from seedsigner.helpers.gpg_message import encrypt_message, decrypt_message
+from seedsigner.models.encode_qr import UrBytesQrEncoder
+from seedsigner.helpers.ur2.ur_decoder import URDecoder
+from urtypes.bytes import Bytes
+from seedsigner.models.settings import SettingsConstants
 
 
 def test_encrypt_decrypt_roundtrip():
@@ -14,4 +18,27 @@ def test_encrypt_decrypt_roundtrip():
     ciphertext = encrypt_message(str(key.pubkey), plaintext)
     decrypted = decrypt_message(str(key), ciphertext)
 
+    assert decrypted == plaintext
+
+
+def test_encrypt_qr_roundtrip():
+    key = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 1024)
+    uid = PGPUID.new("Test User", email="test@example.com")
+    key.add_uid(uid, usage={KeyFlags.Sign, KeyFlags.EncryptCommunications})
+
+    plaintext = "SeedSigner QR test"
+    ciphertext = encrypt_message(str(key.pubkey), plaintext)
+
+    encoder = UrBytesQrEncoder(
+        data=ciphertext.encode(),
+        qr_density=SettingsConstants.DENSITY__MEDIUM,
+    )
+    decoder = URDecoder()
+    while not decoder.is_complete():
+        part = encoder.next_part()
+        assert decoder.receive_part(part)
+    ur = decoder.result_message()
+    decoded_ciphertext = Bytes.from_cbor(ur.cbor).data.decode()
+
+    decrypted = decrypt_message(str(key), decoded_ciphertext)
     assert decrypted == plaintext

--- a/tests/test_gpg_message.py
+++ b/tests/test_gpg_message.py
@@ -38,7 +38,11 @@ def test_encrypt_qr_roundtrip():
         part = encoder.next_part()
         assert decoder.receive_part(part)
     ur = decoder.result_message()
-    decoded_ciphertext = Bytes.from_cbor(ur.cbor).data.decode()
+    raw = Bytes.from_cbor(ur.cbor).data
+    if isinstance(raw, (bytes, bytearray)):
+        decoded_ciphertext = raw.decode()
+    else:
+        decoded_ciphertext = raw
 
     decrypted = decrypt_message(str(key), decoded_ciphertext)
     assert decrypted == plaintext

--- a/tests/test_gpg_message.py
+++ b/tests/test_gpg_message.py
@@ -68,3 +68,18 @@ def test_sign_encrypt_decrypt_roundtrip():
     # verify signature
     dec_msg = recipient.decrypt(PGPMessage.from_blob(ciphertext))
     assert signer.pubkey.verify(dec_msg)
+
+
+def test_sign_only_roundtrip():
+    signer = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 1024)
+    signer_uid = PGPUID.new("Signer", email="sign@example.com")
+    signer.add_uid(signer_uid, usage={KeyFlags.Sign})
+
+    plaintext = "SeedSigner sign only"
+    signed_msg = encrypt_message(None, plaintext, signkey_blob=str(signer))
+
+    # decrypt_message should return the original message even without a key
+    assert decrypt_message(None, signed_msg) == plaintext
+
+    # verify signature
+    assert signer.pubkey.verify(PGPMessage.from_blob(signed_msg))

--- a/tests/test_gpg_message.py
+++ b/tests/test_gpg_message.py
@@ -1,0 +1,17 @@
+"""Tests for helpers.gpg_message"""
+from pgpy import PGPKey, PGPUID
+from pgpy.constants import PubKeyAlgorithm, KeyFlags
+
+from seedsigner.helpers.gpg_message import encrypt_message, decrypt_message
+
+
+def test_encrypt_decrypt_roundtrip():
+    key = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 1024)
+    uid = PGPUID.new("Test User", email="test@example.com")
+    key.add_uid(uid, usage={KeyFlags.Sign, KeyFlags.EncryptCommunications})
+
+    plaintext = "SeedSigner test message"
+    ciphertext = encrypt_message(str(key.pubkey), plaintext)
+    decrypted = decrypt_message(str(key), ciphertext)
+
+    assert decrypted == plaintext

--- a/tests/test_gpg_message.py
+++ b/tests/test_gpg_message.py
@@ -16,9 +16,10 @@ def test_encrypt_decrypt_roundtrip():
 
     plaintext = "SeedSigner test message"
     ciphertext = encrypt_message(str(key.pubkey), plaintext)
-    decrypted = decrypt_message(str(key), ciphertext)
+    decrypted, signer = decrypt_message(str(key), ciphertext)
 
     assert decrypted == plaintext
+    assert signer is None
 
 
 def test_encrypt_qr_roundtrip():
@@ -44,8 +45,9 @@ def test_encrypt_qr_roundtrip():
     else:
         decoded_ciphertext = raw
 
-    decrypted = decrypt_message(str(key), decoded_ciphertext)
+    decrypted, signer = decrypt_message(str(key), decoded_ciphertext)
     assert decrypted == plaintext
+    assert signer is None
 
 
 def test_sign_encrypt_decrypt_roundtrip():
@@ -63,11 +65,11 @@ def test_sign_encrypt_decrypt_roundtrip():
     )
 
     # decrypt using helper
-    assert decrypt_message(str(recipient), ciphertext) == plaintext
-
-    # verify signature
-    dec_msg = recipient.decrypt(PGPMessage.from_blob(ciphertext))
-    assert signer.pubkey.verify(dec_msg)
+    decrypted, signer_fpr = decrypt_message(
+        str(recipient), ciphertext, pubkey_blobs=[str(signer.pubkey)]
+    )
+    assert decrypted == plaintext
+    assert signer_fpr == signer.fingerprint
 
 
 def test_sign_only_roundtrip():
@@ -79,7 +81,6 @@ def test_sign_only_roundtrip():
     signed_msg = encrypt_message(None, plaintext, signkey_blob=str(signer))
 
     # decrypt_message should return the original message even without a key
-    assert decrypt_message(None, signed_msg) == plaintext
-
-    # verify signature
-    assert signer.pubkey.verify(PGPMessage.from_blob(signed_msg))
+    decrypted, signer_fpr = decrypt_message(None, signed_msg, pubkey_blobs=[str(signer.pubkey)])
+    assert decrypted == plaintext
+    assert signer_fpr == signer.fingerprint

--- a/tests/test_gpg_message.py
+++ b/tests/test_gpg_message.py
@@ -1,5 +1,5 @@
 """Tests for helpers.gpg_message"""
-from pgpy import PGPKey, PGPUID
+from pgpy import PGPKey, PGPUID, PGPMessage
 from pgpy.constants import PubKeyAlgorithm, KeyFlags
 
 from seedsigner.helpers.gpg_message import encrypt_message, decrypt_message
@@ -42,3 +42,25 @@ def test_encrypt_qr_roundtrip():
 
     decrypted = decrypt_message(str(key), decoded_ciphertext)
     assert decrypted == plaintext
+
+
+def test_sign_encrypt_decrypt_roundtrip():
+    recipient = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 1024)
+    recipient_uid = PGPUID.new("Recipient", email="rcpt@example.com")
+    recipient.add_uid(recipient_uid, usage={KeyFlags.EncryptCommunications})
+
+    signer = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 1024)
+    signer_uid = PGPUID.new("Signer", email="sign@example.com")
+    signer.add_uid(signer_uid, usage={KeyFlags.Sign})
+
+    plaintext = "SeedSigner signed message"
+    ciphertext = encrypt_message(
+        str(recipient.pubkey), plaintext, signkey_blob=str(signer)
+    )
+
+    # decrypt using helper
+    assert decrypt_message(str(recipient), ciphertext) == plaintext
+
+    # verify signature
+    dec_msg = recipient.decrypt(PGPMessage.from_blob(ciphertext))
+    assert signer.pubkey.verify(dec_msg)


### PR DESCRIPTION
## Summary
- add `encrypt_message` and `decrypt_message` helpers for ASCII-armored PGP text
- cover helpers with round-trip unit test using generated key pair
- integrate new encrypted message flows into GPG menu with UI for encrypting and decrypting messages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc90f46e648322bf1c0739ca2d0f9f