### PR TITLE
Add secure messaging enhancements for GPG

### DIFF
--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -2,9 +2,9 @@
 
 SeedSigner includes tools to interact with GPG. When `gpg2` is available on the host system, the Tools menu offers a **Load BIP85 Key** option. This feature deterministically derives a keypair (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, RSA 4096, or secp256k1) from the currently loaded seed using [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki#user-content-RSA_GPG) and imports it into GPG. Selecting RSA 2048, RSA 3072, or RSA 4096 displays a warning that generation on a Pi Zero may take about 3 minutes, 15 minutes, or an hour respectively; NIST or Brainpool keys are faster and smaller.
 
-In addition to verifying detached signatures, the **Sign** submenu offers two workflows. Selecting **File** prompts for a file on the microSD card and a private key from the local GPG keyring; a detached signature (`.sig`) is saved alongside the original file.
+Within the **File Operations** submenu the **Sign** option offers two workflows. Selecting **File** prompts for a file on the microSD card and a private key from the local GPG keyring; a detached signature (`.sig`) is saved alongside the original file.
 
-Choosing **Manifest** creates a `sha256.txt` file listing each file's SHA256 hash and signs it in one step, saving both `sha256.txt` and `sha256.txt.sig` to the same microSD folder. The manifest uses the same format as the `sha256sum` utility so it can be verified with the existing **Verify File Sig** workflow. When the `sha256sum` utility isn't available (such as on Windows), SeedSigner calculates the hashes internally for both manifest creation and verification so the workflow still works.
+Choosing **Manifest** creates a `sha256.txt` file listing each file's SHA256 hash and signs it in one step, saving both `sha256.txt` and `sha256.txt.sig` to the same microSD folder. The manifest uses the same format as the `sha256sum` utility so it can be verified with the existing **Verify Signature** workflow. When the `sha256sum` utility isn't available (such as on Windows), SeedSigner calculates the hashes internally for both manifest creation and verification so the workflow still works.
 
 Additional menu options can export existing GPG keys. Public keys are written to the microSD card in ASCII armor, while private keys are first exported and then symmetrically encrypted with a user-provided passphrase before being saved.
 

--- a/docs/gpg_tools.md
+++ b/docs/gpg_tools.md
@@ -4,6 +4,8 @@ SeedSigner includes tools to interact with GPG. When `gpg2` is available on the 
 
 Within the **File Operations** submenu the **Sign** option offers two workflows. Selecting **File** prompts for a file on the microSD card and a private key from the local GPG keyring; a detached signature (`.sig`) is saved alongside the original file.
 
+The **Encrypt** and **Decrypt** options invoke the native ``gpg`` binary rather than the pure-Python ``pgpy`` library so large files are processed quickly.  Encryption can optionally sign the file before writing the ASCII-armored result, and decryption automatically verifies any embedded signature.
+
 Choosing **Manifest** creates a `sha256.txt` file listing each file's SHA256 hash and signs it in one step, saving both `sha256.txt` and `sha256.txt.sig` to the same microSD folder. The manifest uses the same format as the `sha256sum` utility so it can be verified with the existing **Verify Signature** workflow. When the `sha256sum` utility isn't available (such as on Windows), SeedSigner calculates the hashes internally for both manifest creation and verification so the workflow still works.
 
 Additional menu options can export existing GPG keys. Public keys are written to the microSD card in ASCII armor, while private keys are first exported and then symmetrically encrypted with a user-provided passphrase before being saved.

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: seedsigner 0.8.6\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-09-07 19:36+0000\n"
+"POT-Creation-Date: 2025-09-07 20:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.16.0\n"
 
 #: src/seedsigner/controller.py src/seedsigner/views/view.py
 msgid "Data wiped after inactivity"
@@ -82,7 +82,6 @@ msgstr ""
 
 #. Input number will be inserted (e.g. "input 3")
 #: src/seedsigner/gui/screens/psbt_screens.py
-#, python-brace-format
 msgid "input {}"
 msgstr ""
 
@@ -102,7 +101,6 @@ msgstr ""
 
 #. Inserts the recipient number (e.g. the fifth one is: "recipient 5")
 #: src/seedsigner/gui/screens/psbt_screens.py
-#, python-brace-format
 msgid "recipient {}"
 msgstr ""
 
@@ -144,7 +142,6 @@ msgstr[1] ""
 
 #. Denonination is inserted (e.g. your "btc change" or "sats change")
 #: src/seedsigner/gui/screens/psbt_screens.py
-#, python-brace-format
 msgid "{} change"
 msgstr ""
 
@@ -187,7 +184,6 @@ msgstr ""
 
 #. Inserts the percentage value of the animated QR scan progress
 #: src/seedsigner/gui/screens/scan_screens.py
-#, python-brace-format
 msgid "{}%"
 msgstr ""
 
@@ -301,7 +297,6 @@ msgstr ""
 
 #. Displays the page number and total: (e.g. page 1 of 6)
 #: src/seedsigner/gui/screens/seed_screens.py
-#, python-brace-format
 msgid "Seed Words: {}/{}"
 msgstr ""
 
@@ -399,7 +394,6 @@ msgstr ""
 #. Refers to the QR code size: 21x21, 25x25, or 29x29
 #: src/seedsigner/gui/screens/seed_screens.py
 #: src/seedsigner/gui/screens/tools_screens.py
-#, python-brace-format
 msgid "Begin {}x{}"
 msgstr ""
 
@@ -421,7 +415,6 @@ msgstr ""
 
 #. Inserts the nth address number (e.g. "Checking address 7")
 #: src/seedsigner/gui/screens/seed_screens.py
-#, python-brace-format
 msgid "Checking address {}"
 msgstr ""
 
@@ -441,7 +434,6 @@ msgstr ""
 
 #. Describes the address index (e.g. "index 7")
 #: src/seedsigner/gui/screens/seed_screens.py
-#, python-brace-format
 msgid "index {}"
 msgstr ""
 
@@ -601,7 +593,6 @@ msgstr ""
 
 #. current roll number vs total rolls (e.g. roll 7 of 50)
 #: src/seedsigner/gui/screens/tools_screens.py
-#, python-brace-format
 msgid "Dice Roll {}/{}"
 msgstr ""
 
@@ -613,7 +604,6 @@ msgstr ""
 #. Final word calc. `mnemonic_length` = 12 or 24. `num_bits` = 7 or 3 (bits of
 #. entropy in final word).
 #: src/seedsigner/gui/screens/tools_screens.py
-#, python-brace-format
 msgid ""
 "The {mnemonic_length}th word is built from {num_bits} more entropy bits "
 "plus auto-calculated checksum."
@@ -621,7 +611,6 @@ msgstr ""
 
 #. current coin-flip number vs total flips (e.g. flip 3 of 4)
 #: src/seedsigner/gui/screens/tools_screens.py
-#, python-brace-format
 msgid "Coin Flip {}/{}"
 msgstr ""
 
@@ -637,7 +626,6 @@ msgstr ""
 
 #. The additional entropy the user supplied (e.g. coin flips)
 #: src/seedsigner/gui/screens/tools_screens.py
-#, python-brace-format
 msgid "Your input: \"{}\""
 msgstr ""
 
@@ -648,7 +636,6 @@ msgstr ""
 
 #. labeled presentation of the last word in a BIP-39 mnemonic seed phrase.
 #: src/seedsigner/gui/screens/tools_screens.py
-#, python-brace-format
 msgid "Final Word: \"{}\""
 msgstr ""
 
@@ -680,7 +667,6 @@ msgstr ""
 
 #. Insert the number of addrs displayed per screen (e.g. "Next 10")
 #: src/seedsigner/gui/screens/tools_screens.py
-#, python-brace-format
 msgid "Next {}"
 msgstr ""
 
@@ -1043,7 +1029,6 @@ msgstr ""
 #. Inserts fingerprint w/"?" to indicate that this seed can't sign the current
 #. PSBT
 #: src/seedsigner/views/psbt_views.py
-#, python-brace-format
 msgid "{} (?)"
 msgstr ""
 
@@ -1151,13 +1136,11 @@ msgstr ""
 
 #. Variable is either "change" or "self-transfer".
 #: src/seedsigner/views/psbt_views.py
-#, python-brace-format
 msgid "PSBT's {} address could not be verified from wallet descriptor."
 msgstr ""
 
 #. Variable is either "change" or "self-transfer".
 #: src/seedsigner/views/psbt_views.py
-#, python-brace-format
 msgid "PSBT's {} address could not be generated from your seed."
 msgstr ""
 
@@ -1274,7 +1257,6 @@ msgid "Expected an address QR"
 msgstr ""
 
 #: src/seedsigner/views/scan_views.py
-#, python-brace-format
 msgid "Scan {} receive address from the wallet you just exported"
 msgstr ""
 
@@ -1370,7 +1352,6 @@ msgstr ""
 
 #. Inserts the word number (e.g. "Seed Word #6")
 #: src/seedsigner/views/seed_views.py
-#, python-brace-format
 msgid "Seed Word #{}"
 msgstr ""
 
@@ -1436,7 +1417,6 @@ msgstr ""
 
 #. Inserts the seed fingerprint
 #: src/seedsigner/views/seed_views.py
-#, python-brace-format
 msgid "Wipe seed {} from the device?"
 msgstr ""
 
@@ -1469,7 +1449,6 @@ msgid "Load Share"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-#, python-brace-format
 msgid "Share Word #{}"
 msgstr ""
 
@@ -1486,7 +1465,6 @@ msgid "Combine shares"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-#, python-brace-format
 msgid "{} of {} needed"
 msgstr ""
 
@@ -1555,7 +1533,6 @@ msgid "Generating xpub..."
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
-#, python-brace-format
 msgid "Open {} and display a receive address from the wallet you just exported."
 msgstr ""
 
@@ -1569,7 +1546,6 @@ msgstr ""
 
 #. Inserts the child index (e.g. "Child #0")
 #: src/seedsigner/views/seed_views.py
-#, python-brace-format
 msgid "Child #{}"
 msgstr ""
 
@@ -1623,7 +1599,6 @@ msgstr ""
 
 #. Inserts the word number (e.g. "Verify Word #1")
 #: src/seedsigner/views/seed_views.py
-#, python-brace-format
 msgid "Verify Word #{}"
 msgstr ""
 
@@ -1633,7 +1608,6 @@ msgstr ""
 
 #. Inserts the word number and the word (e.g. "Word #1 is not "apple"!")
 #: src/seedsigner/views/seed_views.py
-#, python-brace-format
 msgid "Word #{} is not \"{}\"!"
 msgstr ""
 
@@ -1955,12 +1929,10 @@ msgid "Camera entropy didn't appear random enough. Please try again."
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py
-#, python-brace-format
 msgid "20 words ({} rolls)"
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py
-#, python-brace-format
 msgid "33 words ({} rolls)"
 msgstr ""
 
@@ -2470,7 +2442,6 @@ msgstr ""
 
 #. Inserts mainnet/testnet/regtest and derivation path
 #: src/seedsigner/views/view.py
-#, python-brace-format
 msgid "Current network setting ({}) doesn't match {}."
 msgstr ""
 
@@ -2485,7 +2456,6 @@ msgstr ""
 #. Inserts the name of a settings option (e.g. "Persistent Settings" is
 #. currently...)
 #: src/seedsigner/views/view.py
-#, python-brace-format
 msgid "\"{}\" is currently disabled in Settings."
 msgstr ""
 

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: seedsigner 0.8.6\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-08-04 00:02+0000\n"
+"POT-Creation-Date: 2025-09-07 19:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -221,7 +221,8 @@ msgstr ""
 
 #: src/seedsigner/gui/screens/screen.py
 #: src/seedsigner/gui/screens/seed_screens.py
-#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/tools_views.py
 msgid "OK"
 msgstr ""
 
@@ -234,7 +235,9 @@ msgstr ""
 msgid "Privacy Leak!"
 msgstr ""
 
-#: src/seedsigner/gui/screens/screen.py src/seedsigner/views/tools_views.py
+#: src/seedsigner/gui/screens/screen.py src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/tools_views.py
 msgid "I Understand"
 msgstr ""
 
@@ -312,6 +315,10 @@ msgstr ""
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Optionally verify that your mnemonic backup is correct."
+msgstr ""
+
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
 msgstr ""
 
 #: src/seedsigner/gui/screens/seed_screens.py
@@ -506,6 +513,11 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr ""
+
 #. Short for "Input/Output"; screen to make sure the buttons and camera are
 #. working properly
 #: src/seedsigner/gui/screens/settings_screens.py
@@ -558,6 +570,11 @@ msgstr ""
 
 #: src/seedsigner/gui/screens/settings_screens.py src/seedsigner/views/view.py
 msgid "Home"
+msgstr ""
+
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Device Filter"
 msgstr ""
 
 #: src/seedsigner/gui/screens/tools_screens.py
@@ -711,6 +728,22 @@ msgstr ""
 msgid "270°"
 msgstr ""
 
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr ""
+
 #. QR code density option: Low, Medium, High
 #: src/seedsigner/models/settings_definition.py
 msgid "Low"
@@ -849,6 +882,10 @@ msgid "Show xpub details"
 msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
 msgid "BIP-39 passphrase"
 msgstr ""
 
@@ -916,7 +953,36 @@ msgid "Invert colors"
 msgstr ""
 
 #: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr ""
+
+#: src/seedsigner/models/settings_definition.py
 msgid "QR background color"
+msgstr ""
+
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr ""
+
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr ""
+
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr ""
+
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
@@ -954,7 +1020,24 @@ msgid "Enter 24-word seed"
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/tools_views.py
 msgid "Enter Electrum seed"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
 msgstr ""
 
 #. Inserts fingerprint w/"?" to indicate that this seed can't sign the current
@@ -970,6 +1053,34 @@ msgstr ""
 
 #: src/seedsigner/views/psbt_views.py
 msgid "Parsing PSBT..."
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr ""
+
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
 msgstr ""
 
 #: src/seedsigner/views/psbt_views.py
@@ -1106,7 +1217,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/tools_views.py
 msgid "Decrypt"
 msgstr ""
 
@@ -1136,6 +1247,14 @@ msgstr ""
 
 #: src/seedsigner/views/scan_views.py
 msgid "Expected a SLIP-39 share QR"
+msgstr ""
+
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr ""
+
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
 msgstr ""
 
 #: src/seedsigner/views/scan_views.py
@@ -1213,7 +1332,7 @@ msgstr ""
 msgid "In-Memory Seeds"
 msgstr ""
 
-#: src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
 msgid "SLIP-39 Shares"
 msgstr ""
 
@@ -1237,11 +1356,11 @@ msgstr ""
 msgid " Scan a SeedQR"
 msgstr ""
 
-#: src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
 msgid "From SeedKeeper"
 msgstr ""
 
-#: src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
 msgid " Create a seed"
 msgstr ""
 
@@ -1341,7 +1460,7 @@ msgstr ""
 msgid "Enter 33 words"
 msgstr ""
 
-#: src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
 msgid "Scan QR"
 msgstr ""
 
@@ -1494,7 +1613,7 @@ msgstr ""
 msgid "Review"
 msgstr ""
 
-#: src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
 msgid "Skip"
 msgstr ""
 
@@ -1604,7 +1723,7 @@ msgstr ""
 msgid "Your current mnemonic ID entry will be erased"
 msgstr ""
 
-#: src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
 msgid "Processing..."
 msgstr ""
 
@@ -1697,6 +1816,14 @@ msgstr ""
 
 #: src/seedsigner/views/seed_views.py
 msgid "Signing messages for custom derivation paths not supported"
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Exporting xpub..."
+msgstr ""
+
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
 msgstr ""
 
 #: src/seedsigner/views/settings_views.py
@@ -1937,6 +2064,14 @@ msgid "DIY Tools"
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py
+msgid "Card Info"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Genuine Check"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
 msgid "Change PIN"
 msgstr ""
 
@@ -2009,6 +2144,14 @@ msgid "Load as Descriptor"
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py
+msgid "Already Seeded"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Satochip card already contains a seed."
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
 msgid "Build Applets"
 msgstr ""
 
@@ -2049,15 +2192,175 @@ msgid "All"
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py
-msgid "Verify File Sig"
+msgid "File Operations"
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py
-msgid "Import Pubkey"
+msgid "Import Keys"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Export Keys"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Secure Messaging"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "SmartGPG"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Encrypt"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Sign"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Verify Signature"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Create Message"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Load Message"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "File"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Manifest"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Type Message"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Load Seedkeeper"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Animated QR"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "microSD"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Start"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Load File"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Load Key"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Save to Seedkeeper"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Public Key"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Private Key"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "View Card Info"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Generate On-Card Key"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Change Admin PIN"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Change User PIN"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "uiduidfpr"
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py
 msgid "Check SHA256Sum"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Update"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "From QR"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "From File"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "From Seedkeeper"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Generate New"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Derive BIP85"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "NIST P-256"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Brainpool P-256"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "RSA 2048"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "RSA 3072"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "RSA 4096"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "secp256k1"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Ed25519"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Seedkeeper"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "OpenGPG Card"
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: seedsigner 0.8.6\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-09-07 20:16+0000\n"
+"POT-Creation-Date: 2025-09-07 21:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: src/seedsigner/controller.py src/seedsigner/views/view.py
 msgid "Data wiped after inactivity"
@@ -82,6 +82,7 @@ msgstr ""
 
 #. Input number will be inserted (e.g. "input 3")
 #: src/seedsigner/gui/screens/psbt_screens.py
+#, python-brace-format
 msgid "input {}"
 msgstr ""
 
@@ -101,6 +102,7 @@ msgstr ""
 
 #. Inserts the recipient number (e.g. the fifth one is: "recipient 5")
 #: src/seedsigner/gui/screens/psbt_screens.py
+#, python-brace-format
 msgid "recipient {}"
 msgstr ""
 
@@ -142,6 +144,7 @@ msgstr[1] ""
 
 #. Denonination is inserted (e.g. your "btc change" or "sats change")
 #: src/seedsigner/gui/screens/psbt_screens.py
+#, python-brace-format
 msgid "{} change"
 msgstr ""
 
@@ -184,6 +187,7 @@ msgstr ""
 
 #. Inserts the percentage value of the animated QR scan progress
 #: src/seedsigner/gui/screens/scan_screens.py
+#, python-brace-format
 msgid "{}%"
 msgstr ""
 
@@ -297,6 +301,7 @@ msgstr ""
 
 #. Displays the page number and total: (e.g. page 1 of 6)
 #: src/seedsigner/gui/screens/seed_screens.py
+#, python-brace-format
 msgid "Seed Words: {}/{}"
 msgstr ""
 
@@ -394,6 +399,7 @@ msgstr ""
 #. Refers to the QR code size: 21x21, 25x25, or 29x29
 #: src/seedsigner/gui/screens/seed_screens.py
 #: src/seedsigner/gui/screens/tools_screens.py
+#, python-brace-format
 msgid "Begin {}x{}"
 msgstr ""
 
@@ -415,6 +421,7 @@ msgstr ""
 
 #. Inserts the nth address number (e.g. "Checking address 7")
 #: src/seedsigner/gui/screens/seed_screens.py
+#, python-brace-format
 msgid "Checking address {}"
 msgstr ""
 
@@ -434,6 +441,7 @@ msgstr ""
 
 #. Describes the address index (e.g. "index 7")
 #: src/seedsigner/gui/screens/seed_screens.py
+#, python-brace-format
 msgid "index {}"
 msgstr ""
 
@@ -593,6 +601,7 @@ msgstr ""
 
 #. current roll number vs total rolls (e.g. roll 7 of 50)
 #: src/seedsigner/gui/screens/tools_screens.py
+#, python-brace-format
 msgid "Dice Roll {}/{}"
 msgstr ""
 
@@ -604,6 +613,7 @@ msgstr ""
 #. Final word calc. `mnemonic_length` = 12 or 24. `num_bits` = 7 or 3 (bits of
 #. entropy in final word).
 #: src/seedsigner/gui/screens/tools_screens.py
+#, python-brace-format
 msgid ""
 "The {mnemonic_length}th word is built from {num_bits} more entropy bits "
 "plus auto-calculated checksum."
@@ -611,6 +621,7 @@ msgstr ""
 
 #. current coin-flip number vs total flips (e.g. flip 3 of 4)
 #: src/seedsigner/gui/screens/tools_screens.py
+#, python-brace-format
 msgid "Coin Flip {}/{}"
 msgstr ""
 
@@ -626,6 +637,7 @@ msgstr ""
 
 #. The additional entropy the user supplied (e.g. coin flips)
 #: src/seedsigner/gui/screens/tools_screens.py
+#, python-brace-format
 msgid "Your input: \"{}\""
 msgstr ""
 
@@ -636,6 +648,7 @@ msgstr ""
 
 #. labeled presentation of the last word in a BIP-39 mnemonic seed phrase.
 #: src/seedsigner/gui/screens/tools_screens.py
+#, python-brace-format
 msgid "Final Word: \"{}\""
 msgstr ""
 
@@ -667,6 +680,7 @@ msgstr ""
 
 #. Insert the number of addrs displayed per screen (e.g. "Next 10")
 #: src/seedsigner/gui/screens/tools_screens.py
+#, python-brace-format
 msgid "Next {}"
 msgstr ""
 
@@ -1029,6 +1043,7 @@ msgstr ""
 #. Inserts fingerprint w/"?" to indicate that this seed can't sign the current
 #. PSBT
 #: src/seedsigner/views/psbt_views.py
+#, python-brace-format
 msgid "{} (?)"
 msgstr ""
 
@@ -1136,11 +1151,13 @@ msgstr ""
 
 #. Variable is either "change" or "self-transfer".
 #: src/seedsigner/views/psbt_views.py
+#, python-brace-format
 msgid "PSBT's {} address could not be verified from wallet descriptor."
 msgstr ""
 
 #. Variable is either "change" or "self-transfer".
 #: src/seedsigner/views/psbt_views.py
+#, python-brace-format
 msgid "PSBT's {} address could not be generated from your seed."
 msgstr ""
 
@@ -1257,6 +1274,7 @@ msgid "Expected an address QR"
 msgstr ""
 
 #: src/seedsigner/views/scan_views.py
+#, python-brace-format
 msgid "Scan {} receive address from the wallet you just exported"
 msgstr ""
 
@@ -1352,6 +1370,7 @@ msgstr ""
 
 #. Inserts the word number (e.g. "Seed Word #6")
 #: src/seedsigner/views/seed_views.py
+#, python-brace-format
 msgid "Seed Word #{}"
 msgstr ""
 
@@ -1417,6 +1436,7 @@ msgstr ""
 
 #. Inserts the seed fingerprint
 #: src/seedsigner/views/seed_views.py
+#, python-brace-format
 msgid "Wipe seed {} from the device?"
 msgstr ""
 
@@ -1449,6 +1469,7 @@ msgid "Load Share"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
+#, python-brace-format
 msgid "Share Word #{}"
 msgstr ""
 
@@ -1465,6 +1486,7 @@ msgid "Combine shares"
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
+#, python-brace-format
 msgid "{} of {} needed"
 msgstr ""
 
@@ -1533,6 +1555,7 @@ msgid "Generating xpub..."
 msgstr ""
 
 #: src/seedsigner/views/seed_views.py
+#, python-brace-format
 msgid "Open {} and display a receive address from the wallet you just exported."
 msgstr ""
 
@@ -1546,6 +1569,7 @@ msgstr ""
 
 #. Inserts the child index (e.g. "Child #0")
 #: src/seedsigner/views/seed_views.py
+#, python-brace-format
 msgid "Child #{}"
 msgstr ""
 
@@ -1599,6 +1623,7 @@ msgstr ""
 
 #. Inserts the word number (e.g. "Verify Word #1")
 #: src/seedsigner/views/seed_views.py
+#, python-brace-format
 msgid "Verify Word #{}"
 msgstr ""
 
@@ -1608,6 +1633,7 @@ msgstr ""
 
 #. Inserts the word number and the word (e.g. "Word #1 is not "apple"!")
 #: src/seedsigner/views/seed_views.py
+#, python-brace-format
 msgid "Word #{} is not \"{}\"!"
 msgstr ""
 
@@ -1929,10 +1955,12 @@ msgid "Camera entropy didn't appear random enough. Please try again."
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py
+#, python-brace-format
 msgid "20 words ({} rolls)"
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py
+#, python-brace-format
 msgid "33 words ({} rolls)"
 msgstr ""
 
@@ -2272,6 +2300,18 @@ msgid "uiduidfpr"
 msgstr ""
 
 #: src/seedsigner/views/tools_views.py
+msgid "Encrypting File"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "(May take a while)"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
+msgid "Decrypting File"
+msgstr ""
+
+#: src/seedsigner/views/tools_views.py
 msgid "Check SHA256Sum"
 msgstr ""
 
@@ -2442,6 +2482,7 @@ msgstr ""
 
 #. Inserts mainnet/testnet/regtest and derivation path
 #: src/seedsigner/views/view.py
+#, python-brace-format
 msgid "Current network setting ({}) doesn't match {}."
 msgstr ""
 
@@ -2456,6 +2497,7 @@ msgstr ""
 #. Inserts the name of a settings option (e.g. "Persistent Settings" is
 #. currently...)
 #: src/seedsigner/views/view.py
+#, python-brace-format
 msgid "\"{}\" is currently disabled in Settings."
 msgstr ""
 

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -147,6 +147,7 @@ class Controller(Singleton):
 
     sign_message_data: dict = None
     gpg_keys_imported: bool = False
+    gpg_pending_message: str = None
     # TODO: end refactor section
 
     Satochip_Connector = None
@@ -163,6 +164,7 @@ class Controller(Singleton):
     FLOW__VERIFY_SINGLESIG_ADDR = "singlesig_addr"
     FLOW__ADDRESS_EXPLORER = "address_explorer"
     FLOW__SIGN_MESSAGE = "sign_message"
+    FLOW__GPG_MESSAGE = "gpg_message"
     resume_main_flow: str = None
 
     back_stack: BackStack = None

--- a/src/seedsigner/helpers/gpg_message.py
+++ b/src/seedsigner/helpers/gpg_message.py
@@ -8,14 +8,14 @@ runtime is available.
 """
 from __future__ import annotations
 
-from typing import Iterable, Optional, Tuple
+from typing import Iterable, Optional, Tuple, Union
 
 from pgpy import PGPKey, PGPMessage
 
 
 def encrypt_message(
     pubkey_blob: Optional[str],
-    message: str,
+    message: Union[str, bytes],
     signkey_blob: Optional[str] = None,
     signkey_passphrase: Optional[str] = None,
 ) -> str:
@@ -26,8 +26,8 @@ def encrypt_message(
     pubkey_blob: Optional[str]
         ASCII-armored public key data. If ``None`` the message will not be
         encrypted.
-    message: str
-        Plaintext message to encrypt.
+    message: Union[str, bytes]
+        Plaintext message to encrypt. Can be a ``str`` or raw ``bytes``.
     signkey_blob: Optional[str]
         Optional ASCII-armored private key used to sign the message before
         encryption.
@@ -66,7 +66,7 @@ def decrypt_message(
     ciphertext: str,
     passphrase: Optional[str] = None,
     pubkey_blobs: Optional[Iterable[str]] = None,
-) -> Tuple[str, Optional[str], bool]:
+) -> Tuple[Union[str, bytes], Optional[str], bool]:
     """Decrypt ``ciphertext`` and optionally verify a signature.
 
     Parameters
@@ -82,9 +82,9 @@ def decrypt_message(
 
     Returns
     -------
-    Tuple[str, Optional[str], bool]
-        A tuple containing the decrypted plaintext message (or the original
-        message if it was not encrypted), the fingerprint of the signing
+    Tuple[Union[str, bytes], Optional[str], bool]
+        A tuple containing the decrypted plaintext message (``bytes`` are
+        returned for binary payloads), the fingerprint of the signing
         key if the message included a signature, and a boolean indicating
         whether the signature was verified with the provided public keys.
     """
@@ -108,8 +108,8 @@ def decrypt_message(
             decrypted = privkey.decrypt(message)
 
     result = decrypted.message
-    if isinstance(result, (bytes, bytearray)):
-        plaintext = result.decode("utf-8")
+    if isinstance(result, (bytes, bytearray, memoryview)):
+        plaintext = bytes(result)
     else:
         plaintext = result
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5652,6 +5652,32 @@ class ToolsGPGSignManifestView(View):
 
         return Destination(MainMenuView)
 
+
+def _check_future_key_creation(view, key_blob: str) -> None:
+    """Warn if the key's creation date is in the future and offer to set system time."""
+    from subprocess import run
+    from pgpy import PGPKey
+
+    try:
+        key, _ = PGPKey.from_blob(key_blob)
+    except Exception:
+        return
+
+    import time
+
+    if key.created and key.created.timestamp() > time.time():
+        formatted = key.created.strftime("%Y-%m-%d %H:%M:%S")
+        ret = view.run_screen(
+            WarningScreen,
+            title="Future Date",
+            status_headline=None,
+            text=f"Key date {formatted} is in the future.\nUpdate system time?",
+            show_back_button=False,
+            button_data=[ButtonOption("Update"), ButtonOption("Skip")],
+        )
+        if ret == 0:
+            run(["date", "-s", formatted], capture_output=True)
+
 class ToolsGPGImportPubkeyMenuView(View):
     LOAD_QR = ButtonOption("Import from QR")
     LOAD_FILE = ButtonOption("Import from File")
@@ -5714,6 +5740,8 @@ class ToolsGPGLoadPubkeyQRView(View):
                 button_data=[ButtonOption("I Understand")],
             )
             return Destination(BackStackView)
+
+        _check_future_key_creation(self, key_blob)
 
         imported = run(["gpg", "--import"], input=key_blob, capture_output=True, text=True)
         if imported.returncode != 0:
@@ -5794,8 +5822,13 @@ class ToolsGPGImportPubkeyFileView(View):
 
         verify_file_name = verify_file_list[selected_file_num]
         logger.info("Selected: %s", verify_file_name)
+        filepath = os.path.join(file_list_path, verify_file_name)
+        with open(filepath, "r") as f:
+            key_blob = f.read()
 
-        cmd = f"gpg --import {file_list_path}/{verify_file_name}"
+        _check_future_key_creation(self, key_blob)
+
+        cmd = f"gpg --import {filepath}"
 
         data = run(cmd, capture_output=True, shell=True, text=True)
 
@@ -5886,6 +5919,8 @@ class ToolsGPGImportPubkeySeedkeeperView(View):
             length = (raw[0] << 8) + raw[1]
             key_bytes = bytes(raw[2:2 + length])
         pubkey = key_bytes.decode("utf-8")
+
+        _check_future_key_creation(self, pubkey)
 
         imported = run(
             ["gpg", "--import"],
@@ -5990,6 +6025,8 @@ class ToolsGPGLoadPrivkeyQRView(View):
                 button_data=[ButtonOption("I Understand")],
             )
             return Destination(BackStackView)
+
+        _check_future_key_creation(self, key_blob)
 
         imported = run(["gpg", "--import"], input=key_blob, capture_output=True, text=True)
         if imported.returncode != 0:
@@ -6113,6 +6150,8 @@ class ToolsGPGLoadPrivkeyFileView(View):
             )
             return Destination(BackStackView)
 
+        _check_future_key_creation(self, decrypted.stdout)
+
         imported = run(
             ["gpg", "--import"],
             input=decrypted.stdout,
@@ -6205,6 +6244,8 @@ class ToolsGPGLoadPrivkeySeedkeeperView(View):
             length = (raw[0] << 8) + raw[1]
             key_bytes = bytes(raw[2:2 + length])
         privkey = key_bytes.decode("utf-8")
+
+        _check_future_key_creation(self, privkey)
 
         imported = run(
             ["gpg", "--import"],

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5159,9 +5159,10 @@ class ToolsGPGEncryptFileView(View):
         filename = file_list[selected_file]
         filepath = os.path.join(file_list_path, filename)
         try:
-            with open(filepath, "r", encoding="utf-8") as f:
+            with open(filepath, "rb") as f:
                 plaintext = f.read()
         except Exception as e:
+            logger.exception("Failed to load file %s", filepath)
             self.run_screen(
                 WarningScreen,
                 title="Error",
@@ -5268,7 +5269,8 @@ class ToolsGPGEncryptFileView(View):
                 signkey_blob=signkey_blob,
                 signkey_passphrase=passphrase,
             )
-        except Exception:
+        except Exception as e:
+            logger.exception("Failed to encrypt file %s", filepath)
             self.run_screen(
                 WarningScreen,
                 title="Error",
@@ -5284,7 +5286,8 @@ class ToolsGPGEncryptFileView(View):
         try:
             with open(outpath, "w", encoding="utf-8") as f:
                 f.write(ciphertext)
-        except Exception:
+        except Exception as e:
+            logger.exception("Failed to save file %s", outpath)
             self.run_screen(
                 WarningScreen,
                 title="Error",
@@ -5366,6 +5369,7 @@ class ToolsGPGDecryptFileView(View):
             with open(filepath, "r", encoding="utf-8") as f:
                 ciphertext = f.read()
         except Exception as e:
+            logger.exception("Failed to load file %s", filepath)
             self.run_screen(
                 WarningScreen,
                 title="Error",
@@ -5467,6 +5471,7 @@ class ToolsGPGDecryptFileView(View):
                 except Exception:
                     continue
             if not decrypted:
+                logger.error("Failed to decrypt file %s", filepath)
                 self.run_screen(
                     WarningScreen,
                     title="Error",
@@ -5476,9 +5481,6 @@ class ToolsGPGDecryptFileView(View):
                     button_data=[ButtonOption("I Understand")],
                 )
                 return Destination(BackStackView)
-
-        if isinstance(plaintext, (bytes, bytearray, memoryview)):
-            plaintext = plaintext.decode("utf-8")
 
         if signer_fpr:
             label = signer_fpr[-8:]
@@ -5525,9 +5527,14 @@ class ToolsGPGDecryptFileView(View):
         outname = f"{filename}.dec"
         outpath = os.path.join(file_list_path, outname)
         try:
-            with open(outpath, "w", encoding="utf-8") as f:
-                f.write(plaintext)
-        except Exception:
+            if isinstance(plaintext, str):
+                with open(outpath, "w", encoding="utf-8") as f:
+                    f.write(plaintext)
+            else:
+                with open(outpath, "wb") as f:
+                    f.write(plaintext)
+        except Exception as e:
+            logger.exception("Failed to save file %s", outpath)
             self.run_screen(
                 WarningScreen,
                 title="Error",

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4009,10 +4009,15 @@ class ToolsGPGMenuView(View):
     SIGN = ButtonOption("Sign")
     IMPORT = ButtonOption("Import")
     EXPORT = ButtonOption("Export")
-    MESSAGE = ButtonOption("Encrypted Message")
+    MESSAGE = ButtonOption("Secure Messaging")
     SMART_GPG = ButtonOption("SmartGPG")
 
     def run(self):
+        from seedsigner.controller import Controller
+
+        if self.controller.resume_main_flow == Controller.FLOW__GPG_MESSAGE:
+            self.controller.resume_main_flow = None
+            return Destination(ToolsGPGDecryptMessageView, skip_current_view=True)
 
         button_data = [
             self.VERIFY_FILE,
@@ -4050,15 +4055,15 @@ class ToolsGPGMenuView(View):
 
 
 class ToolsGPGMessageMenuView(View):
-    ENCRYPT = ButtonOption("Encrypt Message")
-    DECRYPT = ButtonOption("Decrypt Message")
+    ENCRYPT = ButtonOption("Create Message")
+    DECRYPT = ButtonOption("Load Message")
 
     def run(self):
         button_data = [self.ENCRYPT, self.DECRYPT]
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,
-            title="Encrypted Message",
+            title="Secure Messaging",
             is_button_text_centered=False,
             button_data=button_data,
         )
@@ -4330,6 +4335,62 @@ class ToolsGPGEncryptMessageView(View):
                 button_data=[ButtonOption("I Understand")],
             )
             return Destination(BackStackView)
+        DEST_QR = ButtonOption("Animated QR")
+        DEST_FILE = ButtonOption("microSD")
+        dest_buttons = [DEST_QR, DEST_FILE]
+
+        dest_selected = self.run_screen(
+            ButtonListScreen,
+            title="Export to",
+            is_button_text_centered=False,
+            button_data=dest_buttons,
+        )
+
+        if dest_selected == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        if dest_buttons[dest_selected] == DEST_FILE:
+            import os
+            from datetime import datetime
+
+            if len(self.controller.storage.seeds) > 0:
+                ret = self.run_screen(
+                    WarningScreen,
+                    title="WARNING",
+                    status_headline=None,
+                    text="These tools write data to the microSD card and may expose loaded secrets.",
+                    show_back_button=True,
+                    button_data=[ButtonOption("Continue")],
+                )
+                if ret == RET_CODE__BACK_BUTTON:
+                    return Destination(BackStackView)
+
+            file_list_path = MicroSD.get_microsd_dir() / "microsd-images"
+            os.makedirs(file_list_path, exist_ok=True)
+            filename = f"gpgmsg_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
+            filepath = os.path.join(file_list_path, filename)
+            try:
+                with open(filepath, "w", encoding="utf-8") as f:
+                    f.write(ciphertext)
+            except Exception:
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text="Failed to save file",
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
+            self.run_screen(
+                LargeIconStatusScreen,
+                title="Success",
+                status_headline=None,
+                text=f"Saved as {filename}",
+                show_back_button=False,
+                button_data=[ButtonOption("Continue")],
+            )
+            return Destination(MainMenuView)
 
         loading = LoadingScreenThread(text="Encoding...")
         loading.start()
@@ -4396,35 +4457,111 @@ class ToolsGPGDecryptMessageView(View):
             elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
                 cur["uid"] = parts[9]
 
-        decoder = DecodeQR()
-        ScanScreen(decoder=decoder, instructions_text="Scan encrypted message").display()
-        self.controller.reset_screensaver_timeout()
-        time.sleep(0.1)
-        if not decoder.is_complete:
-            return Destination(BackStackView)
-
-        if decoder.qr_type == QRType.BYTES__UR:
-            raw = Bytes.from_cbor(
-                decoder.decoder.result_message().cbor
-            ).data
-            if isinstance(raw, memoryview):
-                raw = raw.tobytes()
-            if isinstance(raw, (bytes, bytearray)):
-                ciphertext = raw.decode("utf-8")
-            else:
-                ciphertext = raw
-        elif decoder.qr_type == QRType.TEXT:
-            ciphertext = decoder.get_text()
+        ciphertext = self.controller.gpg_pending_message
+        if ciphertext:
+            self.controller.gpg_pending_message = None
         else:
-            self.run_screen(
-                WarningScreen,
-                title="Error",
-                status_headline=None,
-                text="Unsupported QR format",
-                show_back_button=False,
-                button_data=[ButtonOption("I Understand")],
+            SRC_SCAN = ButtonOption("Scan QR")
+            SRC_FILE = ButtonOption("Load File")
+            src_buttons = [SRC_SCAN, SRC_FILE]
+            src_selected = self.run_screen(
+                ButtonListScreen,
+                title="Message Source",
+                is_button_text_centered=False,
+                button_data=src_buttons,
             )
-            return Destination(BackStackView)
+            if src_selected == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
+
+            if src_buttons[src_selected] == SRC_FILE:
+                import os
+                if len(self.controller.storage.seeds) > 0:
+                    ret = self.run_screen(
+                        WarningScreen,
+                        title="WARNING",
+                        status_headline=None,
+                        text="These tools load data from the microSD card and may expose loaded secrets.",
+                        show_back_button=True,
+                        button_data=[ButtonOption("Continue")],
+                    )
+                    if ret == RET_CODE__BACK_BUTTON:
+                        return Destination(BackStackView)
+
+                file_list_path = MicroSD.get_microsd_dir() / "microsd-images"
+                os.makedirs(file_list_path, exist_ok=True)
+                file_list = [
+                    f
+                    for f in os.listdir(file_list_path)
+                    if (
+                        not f.startswith('.')
+                        and f != '__MACOSX'
+                        and os.path.isfile(os.path.join(file_list_path, f))
+                    )
+                ]
+                buttons = [ButtonOption(file) for file in file_list]
+                if not buttons:
+                    self.run_screen(
+                        WarningScreen,
+                        title="Error",
+                        status_headline=None,
+                        text="No files found in microsd-images.",
+                        show_back_button=False,
+                        button_data=[ButtonOption("OK")],
+                    )
+                    return Destination(BackStackView)
+                selected_file_num = self.run_screen(
+                    ButtonListScreen,
+                    title="Select File",
+                    is_button_text_centered=False,
+                    button_data=buttons,
+                )
+                if selected_file_num == RET_CODE__BACK_BUTTON:
+                    return Destination(BackStackView)
+                filename = file_list[selected_file_num]
+                filepath = os.path.join(file_list_path, filename)
+                try:
+                    with open(filepath, "r", encoding="utf-8") as f:
+                        ciphertext = f.read()
+                except Exception:
+                    self.run_screen(
+                        WarningScreen,
+                        title="Error",
+                        status_headline=None,
+                        text="Failed to load file",
+                        show_back_button=False,
+                        button_data=[ButtonOption("I Understand")],
+                    )
+                    return Destination(BackStackView)
+            else:
+                decoder = DecodeQR()
+                ScanScreen(decoder=decoder, instructions_text="Scan secure message").display()
+                self.controller.reset_screensaver_timeout()
+                time.sleep(0.1)
+                if not decoder.is_complete:
+                    return Destination(BackStackView)
+
+                if decoder.qr_type == QRType.BYTES__UR:
+                    raw = Bytes.from_cbor(
+                        decoder.decoder.result_message().cbor
+                    ).data
+                    if isinstance(raw, memoryview):
+                        raw = raw.tobytes()
+                    if isinstance(raw, (bytes, bytearray)):
+                        ciphertext = raw.decode("utf-8")
+                    else:
+                        ciphertext = raw
+                elif decoder.qr_type == QRType.TEXT:
+                    ciphertext = decoder.get_text()
+                else:
+                    self.run_screen(
+                        WarningScreen,
+                        title="Error",
+                        status_headline=None,
+                        text="Unsupported QR format",
+                        show_back_button=False,
+                        button_data=[ButtonOption("I Understand")],
+                    )
+                    return Destination(BackStackView)
 
         # gather public keys for signature verification
         pub_result = run([
@@ -4512,14 +4649,21 @@ class ToolsGPGDecryptMessageView(View):
                 err_text = (
                     "No private keys found" if not keys else "Failed to decrypt message"
                 )
-                self.run_screen(
+                load = ButtonOption("Load Key")
+                cont = ButtonOption("Continue")
+                selected = self.run_screen(
                     WarningScreen,
                     title="Error",
                     status_headline=None,
                     text=err_text,
                     show_back_button=False,
-                    button_data=[ButtonOption("I Understand")],
+                    button_data=[load, cont],
                 )
+                if selected == 0:
+                    from seedsigner.controller import Controller
+                    self.controller.gpg_pending_message = ciphertext
+                    self.controller.resume_main_flow = Controller.FLOW__GPG_MESSAGE
+                    return Destination(ToolsGPGImportPrivkeyMenuView)
                 return Destination(BackStackView)
 
         if isinstance(plaintext, (bytes, bytearray, memoryview)):
@@ -4530,10 +4674,28 @@ class ToolsGPGDecryptMessageView(View):
 
         if signer_fpr:
             label = signer_fpr[-8:]
+            have_pub = False
             for pk in pubkeys:
                 if pk["fpr"] == signer_fpr:
+                    have_pub = True
                     label = pk["uid"] if pk["uid"] else pk["fpr"][-8:]
                     break
+            if not verified and not have_pub:
+                load = ButtonOption("Load Key")
+                cont = ButtonOption("Continue")
+                selected = self.run_screen(
+                    WarningScreen,
+                    title="Warning",
+                    status_headline=None,
+                    text="Missing public key to verify signature",
+                    show_back_button=False,
+                    button_data=[load, cont],
+                )
+                if selected == 0:
+                    from seedsigner.controller import Controller
+                    self.controller.gpg_pending_message = ciphertext
+                    self.controller.resume_main_flow = Controller.FLOW__GPG_MESSAGE
+                    return Destination(ToolsGPGImportPubkeyMenuView)
             if verified:
                 self.run_screen(
                     LargeIconStatusScreen,
@@ -5491,11 +5653,12 @@ class ToolsGPGSignManifestView(View):
         return Destination(MainMenuView)
 
 class ToolsGPGImportPubkeyMenuView(View):
+    LOAD_QR = ButtonOption("Import from QR")
     LOAD_FILE = ButtonOption("Import from File")
     LOAD_SEEDKEEPER = ButtonOption("Import from Seedkeeper")
 
     def run(self):
-        button_data = [self.LOAD_FILE, self.LOAD_SEEDKEEPER]
+        button_data = [self.LOAD_QR, self.LOAD_FILE, self.LOAD_SEEDKEEPER]
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,
@@ -5507,10 +5670,73 @@ class ToolsGPGImportPubkeyMenuView(View):
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
+        if button_data[selected_menu_num] == self.LOAD_QR:
+            return Destination(ToolsGPGLoadPubkeyQRView)
         if button_data[selected_menu_num] == self.LOAD_FILE:
             return Destination(ToolsGPGImportPubkeyFileView)
         if button_data[selected_menu_num] == self.LOAD_SEEDKEEPER:
             return Destination(ToolsGPGImportPubkeySeedkeeperView)
+
+
+class ToolsGPGLoadPubkeyQRView(View):
+    def run(self):
+        from subprocess import run
+        from urtypes.bytes import Bytes
+        from seedsigner.gui.screens.screen import WarningScreen, LargeIconStatusScreen
+        from seedsigner.gui.screens.scan_screens import ScanScreen
+        from seedsigner.models.decode_qr import DecodeQR, QRType
+        import time
+
+        decoder = DecodeQR()
+        ScanScreen(decoder=decoder, instructions_text="Scan public key").display()
+        self.controller.reset_screensaver_timeout()
+        time.sleep(0.1)
+        if not decoder.is_complete:
+            return Destination(BackStackView)
+
+        if decoder.qr_type == QRType.BYTES__UR:
+            raw = Bytes.from_cbor(decoder.decoder.result_message().cbor).data
+            if isinstance(raw, memoryview):
+                raw = raw.tobytes()
+            if isinstance(raw, (bytes, bytearray)):
+                key_blob = raw.decode("utf-8")
+            else:
+                key_blob = raw
+        elif decoder.qr_type == QRType.TEXT:
+            key_blob = decoder.get_text()
+        else:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Unsupported QR format",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        imported = run(["gpg", "--import"], input=key_blob, capture_output=True, text=True)
+        if imported.returncode != 0:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to import key",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        self.run_screen(
+            LargeIconStatusScreen,
+            title="Success",
+            status_headline=None,
+            text="Pubkey imported",
+            show_back_button=False,
+            button_data=[ButtonOption("Continue")],
+        )
+
+        return Destination(ToolsGPGMenuView)
 
 
 class ToolsGPGImportPubkeyFileView(View):
@@ -5693,6 +5919,7 @@ class ToolsGPGImportPubkeySeedkeeperView(View):
 class ToolsGPGImportPrivkeyMenuView(View):
     GENERATE_NEW = ButtonOption("Generate New")
     LOAD_BIP85_KEY = ButtonOption("Derive BIP85")
+    LOAD_QR = ButtonOption("From QR")
     LOAD_FILE = ButtonOption("From File")
     LOAD_SEEDKEEPER = ButtonOption("From Seedkeeper")
 
@@ -5700,6 +5927,7 @@ class ToolsGPGImportPrivkeyMenuView(View):
         button_data = [
             self.GENERATE_NEW,
             self.LOAD_BIP85_KEY,
+            self.LOAD_QR,
             self.LOAD_FILE,
             self.LOAD_SEEDKEEPER,
         ]
@@ -5718,10 +5946,73 @@ class ToolsGPGImportPrivkeyMenuView(View):
             return Destination(ToolsGPGGenerateKeyView)
         if button_data[selected_menu_num] == self.LOAD_BIP85_KEY:
             return Destination(ToolsGPGLoadBIP85KeyView)
+        if button_data[selected_menu_num] == self.LOAD_QR:
+            return Destination(ToolsGPGLoadPrivkeyQRView)
         if button_data[selected_menu_num] == self.LOAD_FILE:
             return Destination(ToolsGPGLoadPrivkeyFileView)
         if button_data[selected_menu_num] == self.LOAD_SEEDKEEPER:
             return Destination(ToolsGPGLoadPrivkeySeedkeeperView)
+
+
+class ToolsGPGLoadPrivkeyQRView(View):
+    def run(self):
+        from subprocess import run
+        from urtypes.bytes import Bytes
+        from seedsigner.gui.screens.screen import WarningScreen, LargeIconStatusScreen
+        from seedsigner.gui.screens.scan_screens import ScanScreen
+        from seedsigner.models.decode_qr import DecodeQR, QRType
+        import time
+
+        decoder = DecodeQR()
+        ScanScreen(decoder=decoder, instructions_text="Scan private key").display()
+        self.controller.reset_screensaver_timeout()
+        time.sleep(0.1)
+        if not decoder.is_complete:
+            return Destination(BackStackView)
+
+        if decoder.qr_type == QRType.BYTES__UR:
+            raw = Bytes.from_cbor(decoder.decoder.result_message().cbor).data
+            if isinstance(raw, memoryview):
+                raw = raw.tobytes()
+            if isinstance(raw, (bytes, bytearray)):
+                key_blob = raw.decode("utf-8")
+            else:
+                key_blob = raw
+        elif decoder.qr_type == QRType.TEXT:
+            key_blob = decoder.get_text()
+        else:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Unsupported QR format",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        imported = run(["gpg", "--import"], input=key_blob, capture_output=True, text=True)
+        if imported.returncode != 0:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to import key",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        self.run_screen(
+            LargeIconStatusScreen,
+            title="Success",
+            status_headline=None,
+            text="Privkey imported",
+            show_back_button=False,
+            button_data=[ButtonOption("Continue")],
+        )
+
+        return Destination(ToolsGPGMenuView)
 
 
 class ToolsGPGLoadPrivkeyFileView(View):

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4005,10 +4005,9 @@ class ToolsMicroSDWipeRandomView(View):
     GPG Views
 ****************************************************************************"""
 class ToolsGPGMenuView(View):
-    VERIFY_FILE = ButtonOption("Verify File Sig")
-    SIGN = ButtonOption("Sign")
-    IMPORT = ButtonOption("Import")
-    EXPORT = ButtonOption("Export")
+    FILE_OPS = ButtonOption("File Operations")
+    IMPORT = ButtonOption("Import Keys")
+    EXPORT = ButtonOption("Export Keys")
     MESSAGE = ButtonOption("Secure Messaging")
     SMART_GPG = ButtonOption("SmartGPG")
 
@@ -4020,8 +4019,7 @@ class ToolsGPGMenuView(View):
             return Destination(ToolsGPGDecryptMessageView, skip_current_view=True)
 
         button_data = [
-            self.VERIFY_FILE,
-            self.SIGN,
+            self.FILE_OPS,
             self.IMPORT,
             self.EXPORT,
             self.MESSAGE,
@@ -4038,11 +4036,8 @@ class ToolsGPGMenuView(View):
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        elif button_data[selected_menu_num] == self.VERIFY_FILE:
-            return Destination(ToolsGPGVerifyFileView)
-
-        elif button_data[selected_menu_num] == self.SIGN:
-            return Destination(ToolsGPGSignMenuView)
+        elif button_data[selected_menu_num] == self.FILE_OPS:
+            return Destination(ToolsGPGFileOpsMenuView)
 
         elif button_data[selected_menu_num] == self.IMPORT:
             return Destination(ToolsGPGImportMenuView)
@@ -4052,6 +4047,35 @@ class ToolsGPGMenuView(View):
             return Destination(ToolsGPGMessageMenuView)
         elif button_data[selected_menu_num] == self.SMART_GPG:
             return Destination(ToolsGPGSmartMenuView)
+
+
+class ToolsGPGFileOpsMenuView(View):
+    ENCRYPT = ButtonOption("Encrypt")
+    DECRYPT = ButtonOption("Decrypt")
+    SIGN = ButtonOption("Sign")
+    VERIFY = ButtonOption("Verify Signature")
+
+    def run(self):
+        button_data = [self.ENCRYPT, self.DECRYPT, self.SIGN, self.VERIFY]
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title="File Operations",
+            is_button_text_centered=False,
+            button_data=button_data,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        selected = button_data[selected_menu_num]
+        if selected == self.ENCRYPT:
+            return Destination(ToolsGPGEncryptFileView)
+        if selected == self.DECRYPT:
+            return Destination(ToolsGPGDecryptFileView)
+        if selected == self.SIGN:
+            return Destination(ToolsGPGSignMenuView)
+        return Destination(ToolsGPGVerifyFileView)
 
 
 class ToolsGPGMessageMenuView(View):
@@ -5073,6 +5097,454 @@ class ToolsGPGChangeUserPinView(View):
             text="PIN updated. Please remove and re-insert the card.",
             show_back_button=False,
             button_data=[ButtonOption("Continue")],
+        )
+        return Destination(MainMenuView)
+
+
+class ToolsGPGEncryptFileView(View):
+    def run(self):
+        from subprocess import run
+        import os
+        from seedsigner.helpers.gpg_message import encrypt_message
+        from seedsigner.gui.screens.screen import (
+            ButtonListScreen,
+            WarningScreen,
+            LargeIconStatusScreen,
+        )
+        from seedsigner.gui.screens.tools_screens import ToolsTextQRTextEntryScreen
+
+        if len(self.controller.storage.seeds) > 0:
+            ret = self.run_screen(
+                WarningScreen,
+                title="WARNING",
+                status_headline=None,
+                text="These tools load data from the microSD card and may expose loaded secrets.",
+                show_back_button=True,
+                button_data=[ButtonOption("Continue")],
+            )
+            if ret == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
+
+        file_list_path = MicroSD.get_microsd_dir() / "microsd-images"
+        os.makedirs(file_list_path, exist_ok=True)
+        file_list = [
+            f
+            for f in os.listdir(file_list_path)
+            if (
+                not f.startswith('.')
+                and f != '__MACOSX'
+                and os.path.isfile(os.path.join(file_list_path, f))
+            )
+        ]
+        buttons = [ButtonOption(file) for file in file_list]
+        if not buttons:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="No files found in microsd-images.",
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(BackStackView)
+
+        selected_file = self.run_screen(
+            ButtonListScreen,
+            title="Select File",
+            is_button_text_centered=False,
+            button_data=buttons,
+        )
+        if selected_file == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+        filename = file_list[selected_file]
+        filepath = os.path.join(file_list_path, filename)
+        try:
+            with open(filepath, "r", encoding="utf-8") as f:
+                plaintext = f.read()
+        except Exception:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to load file",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        result = run([
+            "gpg",
+            "--list-keys",
+            "--with-colons",
+        ], capture_output=True, text=True)
+        keys = []
+        cur = None
+        for line in result.stdout.splitlines():
+            parts = line.split(":")
+            if parts[0] == "pub":
+                cur = {"fpr": None, "uid": None}
+                keys.append(cur)
+            elif parts[0] == "fpr" and cur is not None:
+                cur["fpr"] = parts[9]
+            elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
+                cur["uid"] = parts[9]
+        if not keys:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="No public keys found",
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(BackStackView)
+        key_buttons = [ButtonOption(k["uid"] if k["uid"] else k["fpr"][-8:]) for k in keys]
+        selected_key = self.run_screen(
+            ButtonListScreen,
+            title="Select Recipient",
+            is_button_text_centered=False,
+            button_data=key_buttons,
+        )
+        if selected_key == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+        rec_key = keys[selected_key]
+        exported = run([
+            "gpg",
+            "--armor",
+            "--export",
+            rec_key["fpr"],
+        ], capture_output=True, text=True)
+        pub_blob = exported.stdout
+
+        result = run([
+            "gpg",
+            "--list-secret-keys",
+            "--with-colons",
+        ], capture_output=True, text=True)
+        skeys = []
+        cur = None
+        for line in result.stdout.splitlines():
+            parts = line.split(":")
+            if parts[0] == "sec":
+                cur = {"fpr": None, "uid": None}
+                skeys.append(cur)
+            elif parts[0] == "fpr" and cur is not None:
+                cur["fpr"] = parts[9]
+            elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
+                cur["uid"] = parts[9]
+        SKIP = ButtonOption("Skip")
+        sign_buttons = [SKIP]
+        for k in skeys:
+            label = k["uid"] if k["uid"] else k["fpr"][-8:]
+            sign_buttons.append(ButtonOption(label))
+        selected_sign = self.run_screen(
+            ButtonListScreen,
+            title="Sign with",
+            is_button_text_centered=False,
+            button_data=sign_buttons,
+        )
+        if selected_sign == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+        signkey_blob = None
+        if sign_buttons[selected_sign] is not SKIP:
+            sign_key = skeys[selected_sign - 1]
+            exported = run([
+                "gpg",
+                "--armor",
+                "--export-secret-keys",
+                sign_key["fpr"],
+            ], capture_output=True, text=True)
+            signkey_blob = exported.stdout
+        try:
+            ciphertext = encrypt_message(pub_blob, plaintext, signkey_blob=signkey_blob)
+        except ValueError:
+            ret_dict = ToolsTextQRTextEntryScreen(textToEncode="", title="Passphrase").display()
+            if "is_back_button" in ret_dict:
+                return Destination(BackStackView)
+            passphrase = ret_dict["textToEncode"]
+            ciphertext = encrypt_message(
+                pub_blob,
+                plaintext,
+                signkey_blob=signkey_blob,
+                signkey_passphrase=passphrase,
+            )
+        except Exception:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to encrypt file",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        outname = f"{filename}.gpg"
+        outpath = os.path.join(file_list_path, outname)
+        try:
+            with open(outpath, "w", encoding="utf-8") as f:
+                f.write(ciphertext)
+        except Exception:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to save file",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        self.run_screen(
+            LargeIconStatusScreen,
+            title="Success",
+            status_headline=None,
+            text=f"Saved as {outname}",
+            show_back_button=False,
+            button_data=[ButtonOption("Done")],
+        )
+        return Destination(MainMenuView)
+
+
+class ToolsGPGDecryptFileView(View):
+    def run(self):
+        from subprocess import run
+        import os
+        from seedsigner.helpers.gpg_message import decrypt_message
+        from seedsigner.gui.screens.screen import (
+            ButtonListScreen,
+            WarningScreen,
+            LargeIconStatusScreen,
+        )
+        from seedsigner.gui.screens.tools_screens import ToolsTextQRTextEntryScreen
+
+        if len(self.controller.storage.seeds) > 0:
+            ret = self.run_screen(
+                WarningScreen,
+                title="WARNING",
+                status_headline=None,
+                text="These tools load data from the microSD card and may expose loaded secrets.",
+                show_back_button=True,
+                button_data=[ButtonOption("Continue")],
+            )
+            if ret == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
+
+        file_list_path = MicroSD.get_microsd_dir() / "microsd-images"
+        os.makedirs(file_list_path, exist_ok=True)
+        file_list = [
+            f
+            for f in os.listdir(file_list_path)
+            if (
+                not f.startswith('.')
+                and f != '__MACOSX'
+                and os.path.isfile(os.path.join(file_list_path, f))
+            )
+        ]
+        buttons = [ButtonOption(file) for file in file_list]
+        if not buttons:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="No files found in microsd-images.",
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(BackStackView)
+        selected_file = self.run_screen(
+            ButtonListScreen,
+            title="Select File",
+            is_button_text_centered=False,
+            button_data=buttons,
+        )
+        if selected_file == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+        filename = file_list[selected_file]
+        filepath = os.path.join(file_list_path, filename)
+        try:
+            with open(filepath, "r", encoding="utf-8") as f:
+                ciphertext = f.read()
+        except Exception:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to load file",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        result = run([
+            "gpg",
+            "--list-secret-keys",
+            "--with-colons",
+        ], capture_output=True, text=True)
+        keys = []
+        cur = None
+        for line in result.stdout.splitlines():
+            parts = line.split(":")
+            if parts[0] == "sec":
+                cur = {"fpr": None, "uid": None}
+                keys.append(cur)
+            elif parts[0] == "fpr" and cur is not None:
+                cur["fpr"] = parts[9]
+            elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
+                cur["uid"] = parts[9]
+
+        pub_result = run([
+            "gpg",
+            "--list-keys",
+            "--with-colons",
+        ], capture_output=True, text=True)
+        pubkeys = []
+        cur = None
+        for line in pub_result.stdout.splitlines():
+            parts = line.split(":")
+            if parts[0] == "pub":
+                cur = {"fpr": None, "uid": None}
+                pubkeys.append(cur)
+            elif parts[0] == "fpr" and cur is not None:
+                cur["fpr"] = parts[9]
+            elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
+                cur["uid"] = parts[9]
+        for pk in pubkeys:
+            exp = run([
+                "gpg",
+                "--armor",
+                "--export",
+                pk["fpr"],
+            ], capture_output=True, text=True)
+            pk["blob"] = exp.stdout
+
+        try:
+            plaintext, signer_fpr, verified = decrypt_message(
+                None,
+                ciphertext,
+                pubkey_blobs=[pk["blob"] for pk in pubkeys],
+            )
+        except ValueError:
+            decrypted = False
+            for key in keys:
+                exported = run([
+                    "gpg",
+                    "--armor",
+                    "--export-secret-keys",
+                    key["fpr"],
+                ], capture_output=True, text=True)
+                if exported.returncode != 0:
+                    continue
+                try:
+                    plaintext, signer_fpr, verified = decrypt_message(
+                        exported.stdout,
+                        ciphertext,
+                        pubkey_blobs=[pk["blob"] for pk in pubkeys],
+                    )
+                    decrypted = True
+                    break
+                except ValueError as e:
+                    if "Passphrase required" in str(e):
+                        ret_dict = ToolsTextQRTextEntryScreen(
+                            textToEncode="", title="Passphrase"
+                        ).display()
+                        if "is_back_button" in ret_dict:
+                            return Destination(BackStackView)
+                        passphrase = ret_dict["textToEncode"]
+                        try:
+                            plaintext, signer_fpr, verified = decrypt_message(
+                                exported.stdout,
+                                ciphertext,
+                                passphrase=passphrase,
+                                pubkey_blobs=[pk["blob"] for pk in pubkeys],
+                            )
+                            decrypted = True
+                            break
+                        except Exception:
+                            continue
+                    else:
+                        continue
+                except Exception:
+                    continue
+            if not decrypted:
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text=("No private keys found" if not keys else "Failed to decrypt file"),
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
+
+        if isinstance(plaintext, (bytes, bytearray, memoryview)):
+            plaintext = plaintext.decode("utf-8")
+
+        if signer_fpr:
+            label = signer_fpr[-8:]
+            have_pub = False
+            for pk in pubkeys:
+                if pk["fpr"] == signer_fpr:
+                    have_pub = True
+                    label = pk["uid"] if pk["uid"] else pk["fpr"][-8:]
+                    break
+            if not verified and not have_pub:
+                load = ButtonOption("Load Key")
+                cont = ButtonOption("Continue")
+                selected = self.run_screen(
+                    WarningScreen,
+                    title="Warning",
+                    status_headline=None,
+                    text="Missing public key to verify signature",
+                    show_back_button=False,
+                    button_data=[load, cont],
+                )
+                if selected == 0:
+                    return Destination(ToolsGPGImportPubkeyMenuView)
+            if verified:
+                self.run_screen(
+                    LargeIconStatusScreen,
+                    title="Success",
+                    status_headline=None,
+                    text=f"Valid Signature from\n{label}",
+                    show_back_button=False,
+                    button_data=[ButtonOption("Next")],
+                )
+            else:
+                self.run_screen(
+                    LargeIconStatusScreen,
+                    title="Warning",
+                    status_icon_name=SeedSignerIconConstants.WARNING,
+                    status_color=GUIConstants.WARNING_COLOR,
+                    status_headline=None,
+                    text=f"Unverified Signature from\n{label}",
+                    show_back_button=False,
+                    button_data=[ButtonOption("Next")],
+                )
+
+        outname = f"{filename}.dec"
+        outpath = os.path.join(file_list_path, outname)
+        try:
+            with open(outpath, "w", encoding="utf-8") as f:
+                f.write(plaintext)
+        except Exception:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to save file",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        self.run_screen(
+            LargeIconStatusScreen,
+            title="Success",
+            status_headline=None,
+            text=f"Saved as {outname}",
+            show_back_button=False,
+            button_data=[ButtonOption("Done")],
         )
         return Destination(MainMenuView)
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5679,9 +5679,9 @@ def _check_future_key_creation(view, key_blob: str) -> None:
             run(["date", "-s", formatted], capture_output=True)
 
 class ToolsGPGImportPubkeyMenuView(View):
-    LOAD_QR = ButtonOption("Import from QR")
-    LOAD_FILE = ButtonOption("Import from File")
-    LOAD_SEEDKEEPER = ButtonOption("Import from Seedkeeper")
+    LOAD_QR = ButtonOption("From QR")
+    LOAD_FILE = ButtonOption("From File")
+    LOAD_SEEDKEEPER = ButtonOption("From Seedkeeper")
 
     def run(self):
         button_data = [self.LOAD_QR, self.LOAD_FILE, self.LOAD_SEEDKEEPER]

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5161,12 +5161,12 @@ class ToolsGPGEncryptFileView(View):
         try:
             with open(filepath, "r", encoding="utf-8") as f:
                 plaintext = f.read()
-        except Exception:
+        except Exception as e:
             self.run_screen(
                 WarningScreen,
                 title="Error",
                 status_headline=None,
-                text="Failed to load file",
+                text=f"Failed to load file:\n{e}",
                 show_back_button=False,
                 button_data=[ButtonOption("I Understand")],
             )
@@ -5365,12 +5365,12 @@ class ToolsGPGDecryptFileView(View):
         try:
             with open(filepath, "r", encoding="utf-8") as f:
                 ciphertext = f.read()
-        except Exception:
+        except Exception as e:
             self.run_screen(
                 WarningScreen,
                 title="Error",
                 status_headline=None,
-                text="Failed to load file",
+                text=f"Failed to load file:\n{e}",
                 show_back_button=False,
                 button_data=[ButtonOption("I Understand")],
             )

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5109,6 +5109,7 @@ class ToolsGPGEncryptFileView(View):
             ButtonListScreen,
             WarningScreen,
             LargeIconStatusScreen,
+            LoadingScreenThread,
         )
         from seedsigner.gui.screens.tools_screens import ToolsTextQRTextEntryScreen
 
@@ -5246,6 +5247,10 @@ class ToolsGPGEncryptFileView(View):
         outname = f"{filename}.gpg"
 
         def gpg_encrypt(passphrase: str | None = None):
+            self.loading_screen = LoadingScreenThread(
+                text=_("Encrypting File") + "\n\n\n\n\n\n" + _("(May take a while)")
+            )
+            self.loading_screen.start()
             cmd = [
                 "gpg",
                 "--batch",
@@ -5261,7 +5266,9 @@ class ToolsGPGEncryptFileView(View):
             if sign_key is not None:
                 cmd.extend(["--local-user", sign_key["fpr"], "--sign"])
             cmd.extend(["--recipient", rec_key["fpr"], "--encrypt", filename])
-            return run(cmd, capture_output=True, text=True, cwd=file_list_path)
+            result = run(cmd, capture_output=True, text=True, cwd=file_list_path)
+            self.loading_screen.stop()
+            return result
 
         result = gpg_encrypt()
         if result.returncode != 0 and sign_key is not None:
@@ -5303,6 +5310,7 @@ class ToolsGPGDecryptFileView(View):
             ButtonListScreen,
             WarningScreen,
             LargeIconStatusScreen,
+            LoadingScreenThread,
         )
         from seedsigner.gui.screens.tools_screens import ToolsTextQRTextEntryScreen
 
@@ -5368,6 +5376,10 @@ class ToolsGPGDecryptFileView(View):
         outname = f"{filename}.dec"
 
         def gpg_decrypt(passphrase: str | None = None):
+            self.loading_screen = LoadingScreenThread(
+                text=_("Decrypting File") + "\n\n\n\n\n\n" + _("(May take a while)")
+            )
+            self.loading_screen.start()
             cmd = [
                 "gpg",
                 "--batch",
@@ -5381,7 +5393,9 @@ class ToolsGPGDecryptFileView(View):
             if passphrase is not None:
                 cmd.extend(["--pinentry-mode", "loopback", "--passphrase", passphrase])
             cmd.append(filename)
-            return run(cmd, capture_output=True, text=True, cwd=file_list_path)
+            result = run(cmd, capture_output=True, text=True, cwd=file_list_path)
+            self.loading_screen.stop()
+            return result
 
         def parse_status(output: str):
             need_passphrase = False

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5105,7 +5105,6 @@ class ToolsGPGEncryptFileView(View):
     def run(self):
         from subprocess import run
         import os
-        from seedsigner.helpers.gpg_message import encrypt_message
         from seedsigner.gui.screens.screen import (
             ButtonListScreen,
             WarningScreen,
@@ -5159,8 +5158,9 @@ class ToolsGPGEncryptFileView(View):
         filename = file_list[selected_file]
         filepath = os.path.join(file_list_path, filename)
         try:
-            with open(filepath, "rb") as f:
-                plaintext = f.read()
+            # Sanity-check that the file is readable before invoking gpg
+            with open(filepath, "rb"):
+                pass
         except Exception as e:
             logger.exception("Failed to load file %s", filepath)
             self.run_screen(
@@ -5209,13 +5209,6 @@ class ToolsGPGEncryptFileView(View):
         if selected_key == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
         rec_key = keys[selected_key]
-        exported = run([
-            "gpg",
-            "--armor",
-            "--export",
-            rec_key["fpr"],
-        ], capture_output=True, text=True)
-        pub_blob = exported.stdout
 
         result = run([
             "gpg",
@@ -5246,53 +5239,46 @@ class ToolsGPGEncryptFileView(View):
         )
         if selected_sign == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
-        signkey_blob = None
+        sign_key = None
         if sign_buttons[selected_sign] is not SKIP:
             sign_key = skeys[selected_sign - 1]
-            exported = run([
+
+        outname = f"{filename}.gpg"
+
+        def gpg_encrypt(passphrase: str | None = None):
+            cmd = [
                 "gpg",
+                "--batch",
+                "--yes",
+                "--trust-model",
+                "always",
+                "--output",
+                outname,
                 "--armor",
-                "--export-secret-keys",
-                sign_key["fpr"],
-            ], capture_output=True, text=True)
-            signkey_blob = exported.stdout
-        try:
-            ciphertext = encrypt_message(pub_blob, plaintext, signkey_blob=signkey_blob)
-        except ValueError:
+            ]
+            if passphrase is not None:
+                cmd.extend(["--pinentry-mode", "loopback", "--passphrase", passphrase])
+            if sign_key is not None:
+                cmd.extend(["--local-user", sign_key["fpr"], "--sign"])
+            cmd.extend(["--recipient", rec_key["fpr"], "--encrypt", filename])
+            return run(cmd, capture_output=True, text=True, cwd=file_list_path)
+
+        result = gpg_encrypt()
+        if result.returncode != 0 and sign_key is not None:
+            # Likely needs a passphrase for the signing key
             ret_dict = ToolsTextQRTextEntryScreen(textToEncode="", title="Passphrase").display()
             if "is_back_button" in ret_dict:
                 return Destination(BackStackView)
             passphrase = ret_dict["textToEncode"]
-            ciphertext = encrypt_message(
-                pub_blob,
-                plaintext,
-                signkey_blob=signkey_blob,
-                signkey_passphrase=passphrase,
-            )
-        except Exception as e:
-            logger.exception("Failed to encrypt file %s", filepath)
+            result = gpg_encrypt(passphrase)
+
+        if result.returncode != 0:
+            logger.warning("gpg encrypt failed: %s", result.stderr)
             self.run_screen(
                 WarningScreen,
                 title="Error",
                 status_headline=None,
                 text="Failed to encrypt file",
-                show_back_button=False,
-                button_data=[ButtonOption("I Understand")],
-            )
-            return Destination(BackStackView)
-
-        outname = f"{filename}.gpg"
-        outpath = os.path.join(file_list_path, outname)
-        try:
-            with open(outpath, "w", encoding="utf-8") as f:
-                f.write(ciphertext)
-        except Exception as e:
-            logger.exception("Failed to save file %s", outpath)
-            self.run_screen(
-                WarningScreen,
-                title="Error",
-                status_headline=None,
-                text="Failed to save file",
                 show_back_button=False,
                 button_data=[ButtonOption("I Understand")],
             )
@@ -5313,7 +5299,6 @@ class ToolsGPGDecryptFileView(View):
     def run(self):
         from subprocess import run
         import os
-        from seedsigner.helpers.gpg_message import decrypt_message
         from seedsigner.gui.screens.screen import (
             ButtonListScreen,
             WarningScreen,
@@ -5366,8 +5351,8 @@ class ToolsGPGDecryptFileView(View):
         filename = file_list[selected_file]
         filepath = os.path.join(file_list_path, filename)
         try:
-            with open(filepath, "r", encoding="utf-8") as f:
-                ciphertext = f.read()
+            with open(filepath, "rb"):
+                pass
         except Exception as e:
             logger.exception("Failed to load file %s", filepath)
             self.run_screen(
@@ -5380,109 +5365,104 @@ class ToolsGPGDecryptFileView(View):
             )
             return Destination(BackStackView)
 
-        result = run([
-            "gpg",
-            "--list-secret-keys",
-            "--with-colons",
-        ], capture_output=True, text=True)
-        keys = []
-        cur = None
-        for line in result.stdout.splitlines():
-            parts = line.split(":")
-            if parts[0] == "sec":
-                cur = {"fpr": None, "uid": None}
-                keys.append(cur)
-            elif parts[0] == "fpr" and cur is not None:
-                cur["fpr"] = parts[9]
-            elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
-                cur["uid"] = parts[9]
+        outname = f"{filename}.dec"
 
-        pub_result = run([
-            "gpg",
-            "--list-keys",
-            "--with-colons",
-        ], capture_output=True, text=True)
-        pubkeys = []
-        cur = None
-        for line in pub_result.stdout.splitlines():
-            parts = line.split(":")
-            if parts[0] == "pub":
-                cur = {"fpr": None, "uid": None}
-                pubkeys.append(cur)
-            elif parts[0] == "fpr" and cur is not None:
-                cur["fpr"] = parts[9]
-            elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
-                cur["uid"] = parts[9]
-        for pk in pubkeys:
-            exp = run([
+        def gpg_decrypt(passphrase: str | None = None):
+            cmd = [
                 "gpg",
-                "--armor",
-                "--export",
-                pk["fpr"],
-            ], capture_output=True, text=True)
-            pk["blob"] = exp.stdout
+                "--batch",
+                "--yes",
+                "--output",
+                outname,
+                "--decrypt",
+                "--status-fd",
+                "1",
+            ]
+            if passphrase is not None:
+                cmd.extend(["--pinentry-mode", "loopback", "--passphrase", passphrase])
+            cmd.append(filename)
+            return run(cmd, capture_output=True, text=True, cwd=file_list_path)
 
-        try:
-            plaintext, signer_fpr, verified = decrypt_message(
-                None,
-                ciphertext,
-                pubkey_blobs=[pk["blob"] for pk in pubkeys],
-            )
-        except ValueError:
-            decrypted = False
-            for key in keys:
-                exported = run([
-                    "gpg",
-                    "--armor",
-                    "--export-secret-keys",
-                    key["fpr"],
-                ], capture_output=True, text=True)
-                if exported.returncode != 0:
+        def parse_status(output: str):
+            need_passphrase = False
+            missing_priv = False
+            signer_fpr = None
+            verified = False
+            missing_pub = False
+            for line in output.splitlines():
+                if not line.startswith("[GNUPG:]"):
                     continue
-                try:
-                    plaintext, signer_fpr, verified = decrypt_message(
-                        exported.stdout,
-                        ciphertext,
-                        pubkey_blobs=[pk["blob"] for pk in pubkeys],
-                    )
-                    decrypted = True
-                    break
-                except ValueError as e:
-                    if "Passphrase required" in str(e):
-                        ret_dict = ToolsTextQRTextEntryScreen(
-                            textToEncode="", title="Passphrase"
-                        ).display()
-                        if "is_back_button" in ret_dict:
-                            return Destination(BackStackView)
-                        passphrase = ret_dict["textToEncode"]
-                        try:
-                            plaintext, signer_fpr, verified = decrypt_message(
-                                exported.stdout,
-                                ciphertext,
-                                passphrase=passphrase,
-                                pubkey_blobs=[pk["blob"] for pk in pubkeys],
-                            )
-                            decrypted = True
-                            break
-                        except Exception:
-                            continue
-                    else:
-                        continue
-                except Exception:
-                    continue
-            if not decrypted:
-                logger.error("Failed to decrypt file %s", filepath)
-                self.run_screen(
-                    WarningScreen,
-                    title="Error",
-                    status_headline=None,
-                    text=("No private keys found" if not keys else "Failed to decrypt file"),
-                    show_back_button=False,
-                    button_data=[ButtonOption("I Understand")],
-                )
+                parts = line[9:].split()
+                tag = parts[0]
+                if tag in {"NEED_PASSPHRASE", "MISSING_PASSPHRASE", "BAD_PASSPHRASE"}:
+                    need_passphrase = True
+                elif tag == "NO_SECKEY":
+                    missing_priv = True
+                elif tag == "NO_PUBKEY":
+                    missing_pub = True
+                    if len(parts) > 1:
+                        signer_fpr = parts[1]
+                elif tag == "BADSIG":
+                    signer_fpr = parts[1]
+                    verified = False
+                elif tag == "VALIDSIG":
+                    signer_fpr = parts[1]
+                    verified = True
+            return need_passphrase, missing_priv, signer_fpr, verified, missing_pub
+
+        result = gpg_decrypt()
+        need_pw, missing_priv, signer_fpr, verified, missing_pub = parse_status(result.stdout)
+
+        if result.returncode != 0 and need_pw:
+            ret_dict = ToolsTextQRTextEntryScreen(textToEncode="", title="Passphrase").display()
+            if "is_back_button" in ret_dict:
                 return Destination(BackStackView)
+            passphrase = ret_dict["textToEncode"]
+            result = gpg_decrypt(passphrase)
+            need_pw, missing_priv, signer_fpr, verified, missing_pub = parse_status(result.stdout)
+
+        if result.returncode != 0:
+            if missing_priv:
+                load = ButtonOption("Load Key")
+                cont = ButtonOption("Continue")
+                selected = self.run_screen(
+                    WarningScreen,
+                    title="Warning",
+                    status_headline=None,
+                    text="Missing private key to decrypt",
+                    show_back_button=False,
+                    button_data=[load, cont],
+                )
+                if selected == 0:
+                    return Destination(ToolsGPGImportPrivkeyMenuView)
+            logger.warning("gpg decrypt failed: %s", result.stderr)
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Failed to decrypt file",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
 
         if signer_fpr:
+            pub_result = run([
+                "gpg",
+                "--list-keys",
+                "--with-colons",
+            ], capture_output=True, text=True)
+            pubkeys = []
+            cur = None
+            for line in pub_result.stdout.splitlines():
+                parts = line.split(":")
+                if parts[0] == "pub":
+                    cur = {"fpr": None, "uid": None}
+                    pubkeys.append(cur)
+                elif parts[0] == "fpr" and cur is not None:
+                    cur["fpr"] = parts[9]
+                elif parts[0] == "uid" and cur is not None and cur.get("uid") is None:
+                    cur["uid"] = parts[9]
             label = signer_fpr[-8:]
             have_pub = False
             for pk in pubkeys:
@@ -5490,7 +5470,7 @@ class ToolsGPGDecryptFileView(View):
                     have_pub = True
                     label = pk["uid"] if pk["uid"] else pk["fpr"][-8:]
                     break
-            if not verified and not have_pub:
+            if (not verified or missing_pub) and not have_pub:
                 load = ButtonOption("Load Key")
                 cont = ButtonOption("Continue")
                 selected = self.run_screen(
@@ -5523,27 +5503,6 @@ class ToolsGPGDecryptFileView(View):
                     show_back_button=False,
                     button_data=[ButtonOption("Next")],
                 )
-
-        outname = f"{filename}.dec"
-        outpath = os.path.join(file_list_path, outname)
-        try:
-            if isinstance(plaintext, str):
-                with open(outpath, "w", encoding="utf-8") as f:
-                    f.write(plaintext)
-            else:
-                with open(outpath, "wb") as f:
-                    f.write(plaintext)
-        except Exception as e:
-            logger.exception("Failed to save file %s", outpath)
-            self.run_screen(
-                WarningScreen,
-                title="Error",
-                status_headline=None,
-                text="Failed to save file",
-                show_back_button=False,
-                button_data=[ButtonOption("I Understand")],
-            )
-            return Destination(BackStackView)
 
         self.run_screen(
             LargeIconStatusScreen,

--- a/tests/test_gpg_message.py
+++ b/tests/test_gpg_message.py
@@ -158,3 +158,18 @@ def test_encrypt_decrypt_roundtrip_key_types(key_type):
     assert decrypted == plaintext
     assert signer is None
     assert not verified
+
+
+def test_encrypt_decrypt_binary_roundtrip():
+    key = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 1024)
+    uid = PGPUID.new("Test", email="test@example.com")
+    key.add_uid(uid, usage={KeyFlags.Sign, KeyFlags.EncryptCommunications})
+
+    plaintext = bytes(range(256))
+    ciphertext = encrypt_message(str(key.pubkey), plaintext)
+    decrypted, signer, verified = decrypt_message(str(key), ciphertext)
+
+    assert isinstance(decrypted, bytes)
+    assert decrypted == plaintext
+    assert signer is None
+    assert not verified

--- a/tests/test_gpg_message.py
+++ b/tests/test_gpg_message.py
@@ -1,6 +1,7 @@
 """Tests for helpers.gpg_message"""
+import pytest
 from pgpy import PGPKey, PGPUID, PGPMessage
-from pgpy.constants import PubKeyAlgorithm, KeyFlags
+from pgpy.constants import PubKeyAlgorithm, KeyFlags, EllipticCurveOID
 
 from seedsigner.helpers.gpg_message import encrypt_message, decrypt_message
 from seedsigner.models.encode_qr import UrBytesQrEncoder
@@ -103,4 +104,53 @@ def test_unverified_signature():
     decrypted, signer_fpr, verified = decrypt_message(None, signed_msg)
     assert decrypted == plaintext
     assert signer_fpr == signer.fingerprint
+    assert not verified
+
+
+@pytest.mark.parametrize(
+    "key_type",
+    ["rsa", "p256", "brainpoolp256r1", "secp256k1", "ed25519"],
+)
+def test_encrypt_decrypt_roundtrip_key_types(key_type):
+    """Round-trip test for message encryption/decryption across key types."""
+    try:
+        if key_type == "rsa":
+            key = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 1024)
+            uid = PGPUID.new("Test", email="test@example.com")
+            key.add_uid(uid, usage={KeyFlags.Sign, KeyFlags.EncryptCommunications})
+        elif key_type == "p256":
+            key = PGPKey.new(PubKeyAlgorithm.ECDSA, EllipticCurveOID.NIST_P256)
+            uid = PGPUID.new("Test", email="test@example.com")
+            key.add_uid(uid, usage={KeyFlags.Sign})
+            sub = PGPKey.new(PubKeyAlgorithm.ECDH, EllipticCurveOID.NIST_P256)
+            key.add_subkey(sub, usage={KeyFlags.EncryptCommunications})
+        elif key_type == "brainpoolp256r1":
+            key = PGPKey.new(PubKeyAlgorithm.ECDSA, EllipticCurveOID.Brainpool_P256)
+            uid = PGPUID.new("Test", email="test@example.com")
+            key.add_uid(uid, usage={KeyFlags.Sign})
+            sub = PGPKey.new(PubKeyAlgorithm.ECDH, EllipticCurveOID.Brainpool_P256)
+            key.add_subkey(sub, usage={KeyFlags.EncryptCommunications})
+        elif key_type == "secp256k1":
+            key = PGPKey.new(PubKeyAlgorithm.ECDSA, EllipticCurveOID.SECP256K1)
+            uid = PGPUID.new("Test", email="test@example.com")
+            key.add_uid(uid, usage={KeyFlags.Sign})
+            sub = PGPKey.new(PubKeyAlgorithm.ECDH, EllipticCurveOID.SECP256K1)
+            key.add_subkey(sub, usage={KeyFlags.EncryptCommunications})
+        elif key_type == "ed25519":
+            key = PGPKey.new(PubKeyAlgorithm.EdDSA, EllipticCurveOID.Ed25519)
+            uid = PGPUID.new("Test", email="test@example.com")
+            key.add_uid(uid, usage={KeyFlags.Sign})
+            sub = PGPKey.new(PubKeyAlgorithm.ECDH, EllipticCurveOID.Curve25519)
+            key.add_subkey(sub, usage={KeyFlags.EncryptCommunications})
+        else:
+            raise ValueError(key_type)
+    except Exception as exc:
+        pytest.skip(f"{key_type} keys unsupported: {exc}")
+
+    plaintext = f"SeedSigner {key_type} test"
+    ciphertext = encrypt_message(str(key.pubkey), plaintext)
+    decrypted, signer, verified = decrypt_message(str(key), ciphertext)
+
+    assert decrypted == plaintext
+    assert signer is None
     assert not verified

--- a/tests/test_gpg_message.py
+++ b/tests/test_gpg_message.py
@@ -40,6 +40,10 @@ def test_encrypt_qr_roundtrip():
     while not decoder.is_complete():
         part = encoder.next_part()
         assert decoder.receive_part(part)
+        # Duplicate fragments may be encountered in animated QR streams but
+        # should still be treated as successfully received parts.
+        if not decoder.is_complete():
+            assert decoder.receive_part(part)
     ur = decoder.result_message()
     raw = Bytes.from_cbor(ur.cbor).data
     if isinstance(raw, (bytes, bytearray)):


### PR DESCRIPTION
## Summary
- rename GPG "Encrypted Message" menu to "Secure Messaging" and update message option labels
- allow importing GPG private keys from animated QR codes
- allow importing GPG public keys from animated QR codes
- prompt to load missing public/private keys and resume secure message processing after import
- support loading secure messages from microSD files and saving encrypted messages to microSD text files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bce75353fc832297d2fc87a2fed7ad