### PR TITLE
Add QR-based system time setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ If you have specific questions about the project, our [Telegram Group](https://t
   * Scan a software wallet's receive or change address to verify that it's correct.
   * Address Explorer for single sig and multisig wallets.
   * Message signing to prove address ownership.
+  * Sync the system clock using a [GoPro Labs timecode QR](https://gopro.github.io/labs/control/) for camera alignment.
   * BIP85 child seed generation.
 
 * Compatible with:

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -2,6 +2,7 @@ import base64
 import json
 import logging
 import re
+from datetime import datetime
 
 from binascii import a2b_base64, b2a_base64
 from enum import IntEnum
@@ -127,6 +128,9 @@ class DecodeQR:
             elif self.qr_type == QRType.BIP38:
                 self.decoder = Bip38QrDecoder()
 
+            elif self.qr_type == QRType.SET_TIME:
+                self.decoder = TimeQrDecoder()
+
             elif self.qr_type == QRType.TEXT:
                 self.decoder = TextQrDecoder()
 
@@ -239,6 +243,10 @@ class DecodeQR:
     def get_address_type(self):
         if self.is_address:
             return self.decoder.get_address_type()
+
+    def get_time(self):
+        if self.is_time:
+            return self.decoder.get_time()
 
 
     def get_passphrase(self):
@@ -368,6 +376,10 @@ class DecodeQR:
         return self.qr_type == QRType.SIGN_MESSAGE
 
     @property
+    def is_time(self):
+        return self.qr_type == QRType.SET_TIME
+
+    @property
     def is_wif(self):
         return self.qr_type == QRType.WIF
 
@@ -478,6 +490,10 @@ class DecodeQR:
             # config data
             if s.startswith("settings::"):
                 return QRType.SETTINGS
+
+            # GoPro Labs precision time command
+            if re.match(r'^oT(\d{12}(\.\d{2})?|0)$', s):
+                return QRType.SET_TIME
 
             # Seed
             # create 4 letter wordlist only if not PSBT (performance gain)
@@ -1445,4 +1461,41 @@ class TextQrDecoder(BaseSingleFrameQrDecoder):
 
     def get_text(self):
         return self.text
+
+
+class TimeQrDecoder(BaseSingleFrameQrDecoder):
+    def __init__(self):
+        super().__init__()
+        self.time_str = None
+
+    def add(self, segment, qr_type=QRType.SET_TIME):
+        if qr_type == QRType.SET_TIME:
+            try:
+                self.time_str = segment
+                self.complete = True
+                self.collected_segments = 1
+                return DecodeQRStatus.COMPLETE
+            except Exception as e:
+                logger.exception(repr(e))
+        return DecodeQRStatus.INVALID
+
+    def get_time(self):
+        if self.time_str is None:
+            return None
+        # strip prefix 'oT'
+        data = self.time_str[2:]
+        if data == "0":
+            return None
+        if "." in data:
+            data = data.split(".")[0]
+        try:
+            yy = int(data[0:2]) + 2000
+            mm = int(data[2:4])
+            dd = int(data[4:6])
+            hh = int(data[6:8])
+            mi = int(data[8:10])
+            ss = int(data[10:12])
+            return datetime(yy, mm, dd, hh, mi, ss)
+        except Exception:
+            return None
 

--- a/src/seedsigner/models/qr_type.py
+++ b/src/seedsigner/models/qr_type.py
@@ -25,6 +25,8 @@ class QRType:
 
     SIGN_MESSAGE = "sign_message"
 
+    SET_TIME = "set_time"
+
     PASSPHRASE = "passphrase"
 
     WIF = "wif"

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -1,11 +1,13 @@
 import logging
 import re
 import time
+import subprocess
 
 #from embit.descriptor import Descriptor
 
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, ButtonListScreen, WarningScreen, DireWarningScreen
 from seedsigner.gui.screens.scan_screens import ScanEncryptedQRScreen, ScanTypeEncryptionKeyScreen, ScanReviewEncryptionKeyScreen
+from seedsigner.gui.screens import LargeIconStatusScreen
 from seedsigner.models.decode_qr import DecodeQR, DecodeQRStatus
 from seedsigner.models.seed import Seed, InvalidSeedException
 
@@ -16,6 +18,7 @@ from seedsigner.models.settings import SettingsConstants
 from seedsigner.views.view import BackStackView, ErrorView, MainMenuView, NotYetImplementedView, View, Destination
 from seedsigner.views.seed_views import SeedSlip39MoreSharesView, SeedSlip39ShareInvalidView
 from seedsigner.gui.screens.screen import ButtonOption
+from seedsigner.hardware.microsd import MicroSD
 
 logger = logging.getLogger(__name__)
 
@@ -172,6 +175,57 @@ class ScanView(View):
                         message=qr_data["message"],
                     )
                 )
+
+            elif self.decoder.is_time:
+                dt = self.decoder.get_time()
+                if dt:
+                    if MicroSD.is_desktop_mode():
+                        self.run_screen(
+                            WarningScreen,
+                            title="Unavailable",
+                            status_headline=None,
+                            text="Setting the system time is not supported on desktop.",
+                            show_back_button=False,
+                            button_data=[ButtonOption("OK")],
+                        )
+                        return Destination(MainMenuView)
+                    try:
+                        subprocess.run([
+                            "sudo",
+                            "date",
+                            "-s",
+                            dt.strftime("%Y-%m-%d %H:%M:%S"),
+                        ], check=True)
+                        self.run_screen(
+                            LargeIconStatusScreen,
+                            title="Success",
+                            status_headline=None,
+                            text=dt.strftime("%Y-%m-%d %H:%M:%S"),
+                            show_back_button=False,
+                        )
+                    except Exception as e:
+                        return Destination(
+                            ErrorView,
+                            view_args=dict(
+                                title="Error",
+                                status_headline=_("Set Time Failed"),
+                                text=str(e),
+                                button_text=_("Back"),
+                                next_destination=Destination(MainMenuView, skip_current_view=True),
+                            ),
+                        )
+                    return Destination(MainMenuView)
+                else:
+                    return Destination(
+                        ErrorView,
+                        view_args=dict(
+                            title="Error",
+                            status_headline=_("Invalid Time"),
+                            text=_("Could not parse time from QR"),
+                            button_text=_("Back"),
+                            next_destination=Destination(MainMenuView, skip_current_view=True),
+                        ),
+                    )
 
             elif self.decoder.is_bip38:
                 if self.settings.get_value(SettingsConstants.SETTING__BIP38_KEYS) == SettingsConstants.OPTION__ENABLED:

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -195,6 +195,8 @@ class ScanView(View):
                             "-s",
                             dt.strftime("%Y-%m-%d %H:%M:%S"),
                         ], check=True)
+                        # Reset activity-based timers since system time changed
+                        self.controller.reset_screensaver_timeout()
                         self.run_screen(
                             LargeIconStatusScreen,
                             title="Success",

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -199,7 +199,7 @@ class ScanView(View):
                             LargeIconStatusScreen,
                             title="Success",
                             status_headline=None,
-                            text=dt.strftime("%Y-%m-%d %H:%M:%S"),
+                            text=_("Time set to:") + f" {dt.strftime('%Y-%m-%d %H:%M:%S')}",
                             show_back_button=False,
                         )
                     except Exception as e:

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -191,7 +191,6 @@ class ScanView(View):
                         return Destination(MainMenuView)
                     try:
                         subprocess.run([
-                            "sudo",
                             "date",
                             "-s",
                             dt.strftime("%Y-%m-%d %H:%M:%S"),

--- a/tests/test_time_qr.py
+++ b/tests/test_time_qr.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch
+
+from base import BaseTest
+from seedsigner.views import scan_views
+
+
+class TestTimeQr(BaseTest):
+    def test_time_qr_resets_timers(self):
+        view = scan_views.ScanView()
+        view.decoder.add_data("oT230906235204")
+        with patch.object(view, "run_screen"), \
+             patch("seedsigner.views.scan_views.MicroSD.is_desktop_mode", return_value=False), \
+             patch("seedsigner.views.scan_views.subprocess.run") as mock_run, \
+             patch.object(view.controller, "reset_screensaver_timeout") as mock_reset:
+            view.run()
+            assert mock_run.called
+            # Should reset once after the scan completes and again after setting time
+            assert mock_reset.call_count == 2


### PR DESCRIPTION
## Summary
- add new QRType for GoPro Labs `oT` time codes
- parse and decode time QR codes and set system clock when scanned
- warn when setting time from QR is attempted in desktop mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdd76e6b208322acbe45d4e194bded