### PR TITLE
Align BIP85 GPG creation time

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -6240,7 +6240,7 @@ class ToolsGPGLoadBIP85KeyView(View):
         if email is None:
             return Destination(BackStackView)
 
-        created = datetime.fromtimestamp(1231006505, tz=timezone.utc)
+        created = datetime.fromtimestamp(1231005905, tz=timezone.utc)
         if key_type == "rsa2048":
             default_expiration = date(2029, 12, 31)
         else:


### PR DESCRIPTION
## Summary
- Use BIP85-specified genesis timestamp (2009-01-03 18:05:05 UTC) when generating BIP85-derived GPG keys

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bde32616dc8322b0112d06314dc0c1