### PR TITLE
Reset timers when GPG key update adjusts system time

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -6129,6 +6129,8 @@ def _check_future_key_creation(view, key_blob: str) -> None:
         )
         if ret == 0:
             run(["date", "-s", formatted], capture_output=True)
+            # Reset activity-based timers since system time changed
+            view.controller.reset_screensaver_timeout()
 
 class ToolsGPGImportPubkeyMenuView(View):
     LOAD_QR = ButtonOption("From QR")

--- a/tests/test_gpg_time_update.py
+++ b/tests/test_gpg_time_update.py
@@ -1,0 +1,19 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch, Mock
+
+from base import BaseTest
+from seedsigner.views import tools_views
+
+
+class TestGpgTimeUpdate(BaseTest):
+    def test_future_key_resets_timers(self):
+        view = tools_views.ToolsGPGImportPubkeyMenuView()
+        future_dt = datetime.now() + timedelta(days=1)
+        fake_key = Mock(created=future_dt)
+        with patch.object(view, "run_screen", return_value=0), \
+             patch("pgpy.PGPKey.from_blob", return_value=(fake_key, None)), \
+             patch("subprocess.run") as mock_run, \
+             patch.object(view.controller, "reset_screensaver_timeout") as mock_reset:
+            tools_views._check_future_key_creation(view, "dummy")
+            assert mock_run.called
+            assert mock_reset.called


### PR DESCRIPTION
## Summary
- reset activity timers after setting system time from GPG key creation date
- add regression test ensuring timers are reset

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf86a25dc8322a1bce9b5f75664b1