### PR TITLE
Enable Satochip option during address verification

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -122,7 +122,7 @@ class SeedSelectSeedView(View):
         for seed in seeds:
             button_str = seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
             button_data.append(ButtonOption(button_str, SeedSignerIconConstants.FINGERPRINT, icon_color="blue"))
-        if self.flow == Controller.FLOW__SIGN_MESSAGE:
+        if self.flow in [Controller.FLOW__SIGN_MESSAGE, Controller.FLOW__VERIFY_SINGLESIG_ADDR]:
             button_data.append(self.SATOCHIP)
 
         button_data.append(self.SCAN_SEED)
@@ -165,13 +165,16 @@ class SeedSelectSeedView(View):
 
         self.controller.resume_main_flow = self.flow
 
-        if self.flow == Controller.FLOW__SIGN_MESSAGE and button_data[selected_menu_num] == self.SATOCHIP:
-            connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
-            if not connector:
-                return Destination(BackStackView)
-            self.controller.sign_message_with_satochip = True
-            self.controller.sign_message_data["seed_num"] = None
-            return Destination(SeedSignMessageConfirmMessageView)
+        if button_data[selected_menu_num] == self.SATOCHIP:
+            if self.flow == Controller.FLOW__SIGN_MESSAGE:
+                connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
+                if not connector:
+                    return Destination(BackStackView)
+                self.controller.sign_message_with_satochip = True
+                self.controller.sign_message_data["seed_num"] = None
+                return Destination(SeedSignMessageConfirmMessageView)
+            elif self.flow == Controller.FLOW__VERIFY_SINGLESIG_ADDR:
+                return Destination(SeedKeeperSelectView)
 
         if button_data[selected_menu_num] == self.SCAN_SEED:
             from seedsigner.views.scan_views import ScanView

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -1155,3 +1155,26 @@ class TestSatochipImportSeedView(BaseTest):
         assert "already" in view.run_screen.call_args.kwargs["text"].lower()
         assert destination.View_cls == tools_views.MainMenuView
 
+
+class TestSatochipVerifyAddressOption(BaseTest):
+    def test_seed_select_view_includes_satochip(self, monkeypatch):
+        from seedsigner.views import seed_views
+        from seedsigner.controller import Controller
+        from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
+        from seedsigner.views.view import BackStackView
+
+        view = seed_views.SeedSelectSeedView(flow=Controller.FLOW__VERIFY_SINGLESIG_ADDR)
+
+        captured = {}
+
+        def fake_run_screen(screen_cls, **kwargs):
+            captured["button_data"] = kwargs.get("button_data")
+            return RET_CODE__BACK_BUTTON
+
+        monkeypatch.setattr(view, "run_screen", fake_run_screen)
+
+        destination = view.run()
+
+        assert destination.View_cls == BackStackView
+        assert seed_views.SeedSelectSeedView.SATOCHIP in captured["button_data"]
+


### PR DESCRIPTION
## Summary
- show "Use Satochip card" option when verifying a single-sig address
- allow loading the seed from a Satochip card via SeedKeeperSelectView
- add regression test for the Satochip address verification option

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf58cd5f0883228d8023eb75ce0099