### PR TITLE
Add Satochip option to seed picker for address verification

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -122,7 +122,7 @@ class SeedSelectSeedView(View):
         for seed in seeds:
             button_str = seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
             button_data.append(ButtonOption(button_str, SeedSignerIconConstants.FINGERPRINT, icon_color="blue"))
-        if self.flow == Controller.FLOW__SIGN_MESSAGE:
+        if self.flow in [Controller.FLOW__SIGN_MESSAGE, Controller.FLOW__VERIFY_SINGLESIG_ADDR]:
             button_data.append(self.SATOCHIP)
 
         button_data.append(self.SCAN_SEED)
@@ -164,6 +164,10 @@ class SeedSelectSeedView(View):
                 return Destination(SeedSignMessageConfirmMessageView)
 
         self.controller.resume_main_flow = self.flow
+
+        if self.flow == Controller.FLOW__VERIFY_SINGLESIG_ADDR and button_data[selected_menu_num] == self.SATOCHIP:
+            from seedsigner.views.tools_views import SatochipLoadDescriptorScriptTypeView
+            return Destination(SatochipLoadDescriptorScriptTypeView)
 
         if self.flow == Controller.FLOW__SIGN_MESSAGE and button_data[selected_menu_num] == self.SATOCHIP:
             connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -3245,6 +3245,10 @@ class SatochipLoadDescriptorDetailsView(View):
         if self.controller.resume_main_flow == Controller.FLOW__ADDRESS_EXPLORER:
             from seedsigner.views.seed_views import MultisigWalletDescriptorView
             return Destination(MultisigWalletDescriptorView, skip_current_view=True)
+        elif self.controller.resume_main_flow == Controller.FLOW__VERIFY_SINGLESIG_ADDR:
+            from seedsigner.views.seed_views import SeedAddressVerificationView
+            self.controller.resume_main_flow = None
+            return Destination(SeedAddressVerificationView, skip_current_view=True)
 
         self.run_screen(
             LargeIconStatusScreen,

--- a/tests/test_flows_tools.py
+++ b/tests/test_flows_tools.py
@@ -11,6 +11,7 @@ from embit.bip32 import HDKey
 from embit import bip39, networks
 from seedsigner.helpers import seedkeeper_utils
 from binascii import hexlify
+from unittest import mock
 
 
 
@@ -330,3 +331,19 @@ class TestToolsFlows(FlowTest):
                 FlowStep(seed_views.SeedAddressVerificationView),
                 FlowStep(seed_views.SeedAddressVerificationSuccessView),
             ])
+
+    def test__seed_select_includes_satochip_for_verify_address(self):
+        """Seed picker should offer Satochip option when verifying an address."""
+
+        controller = Controller.get_instance()
+        controller.storage.seeds.clear()
+        view = seed_views.SeedSelectSeedView(flow=Controller.FLOW__VERIFY_SINGLESIG_ADDR)
+
+        def fake_run_screen(*args, **kwargs):
+            # Return immediately to inspect button_data
+            return RET_CODE__BACK_BUTTON
+
+        with mock.patch.object(view, "run_screen", side_effect=fake_run_screen) as mocked:
+            view.run()
+        button_data = mocked.call_args.kwargs["button_data"]
+        assert seed_views.SeedSelectSeedView.SATOCHIP in button_data


### PR DESCRIPTION
## Summary
- Allow the seed selection screen to offer "Use Satochip card" when verifying a scanned address
- After loading a descriptor from Satochip during address verification, go straight to the verification screen
- Test that the seed picker lists the Satochip option for address verification

## Testing
- `pytest tests/test_flows_tools.py::TestToolsFlows::test__verify_address__singlesig__flow tests/test_flows_tools.py::TestToolsFlows::test__seed_select_includes_satochip_for_verify_address -q`
- `pytest tests/test_flows_tools.py::TestToolsFlows::test__address_explorer__satochip_descriptor__flow -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf798752688322938fd9cebf47f650