### PR TITLE
Add dummy and randomized double signing for Satochip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Entries marked "(SeedSigner official)" originate from the upstream project, whil
 
 ## Unreleased - SS0.8.6+Satochip+Earthdiver-B4 (smartcard fork)
 - Randomized dummy Satochip signing requests (0-8) and optional extra per-input signatures with random selection among them to reduce potential nonce leakage
+- Enforce 5-second timeout for each Satochip signing request
 - Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to the end of 2029 for RSA 2048 keys and the end of 2035 for other key types), and key type (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, RSA 4096, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
 - RSA key selections warn that generation on a Pi Zero may take approximately 3 minutes (2048), 15 minutes (3072), or an hour (4096) and recommend NIST or Brainpool keys as faster, smaller alternatives
 - MicroSD and GPG tools now display seed-loaded warnings only when opening file pickers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 Entries marked "(SeedSigner official)" originate from the upstream project, while "(smartcard fork)" indicates releases and changes unique to this repository.
 
 ## Unreleased - SS0.8.6+Satochip+Earthdiver-B4 (smartcard fork)
-- Randomized dummy Satochip signing requests and optional double-signing of inputs with random signature selection to reduce potential nonce leakage
+- Randomized dummy Satochip signing requests (0-8) and optional extra per-input signatures with random selection among them to reduce potential nonce leakage
 - Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to the end of 2029 for RSA 2048 keys and the end of 2035 for other key types), and key type (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, RSA 4096, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
 - RSA key selections warn that generation on a Pi Zero may take approximately 3 minutes (2048), 15 minutes (3072), or an hour (4096) and recommend NIST or Brainpool keys as faster, smaller alternatives
 - MicroSD and GPG tools now display seed-loaded warnings only when opening file pickers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 Entries marked "(SeedSigner official)" originate from the upstream project, while "(smartcard fork)" indicates releases and changes unique to this repository.
 
 ## Unreleased - SS0.8.6+Satochip+Earthdiver-B4 (smartcard fork)
+- Randomized dummy Satochip signing requests and optional double-signing of inputs with random signature selection to reduce potential nonce leakage
 - Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to the end of 2029 for RSA 2048 keys and the end of 2035 for other key types), and key type (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, RSA 4096, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
 - RSA key selections warn that generation on a Pi Zero may take approximately 3 minutes (2048), 15 minutes (3072), or an hour (4096) and recommend NIST or Brainpool keys as faster, smaller alternatives
 - MicroSD and GPG tools now display seed-loaded warnings only when opening file pickers

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -4,6 +4,7 @@ from binascii import b2a_base64
 import logging
 import os
 import random
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
 
 from embit.ec import PublicKey
 from embit.psbt import PSBT
@@ -17,6 +18,15 @@ except ImportError:  # pragma: no cover - support older embit releases
     HARDENED_INDEX = 0x80000000
 
 logger = logging.getLogger(__name__)
+
+SIGN_TIMEOUT = 5  # seconds
+
+
+def _call_with_timeout(func, *args):
+    """Execute ``func`` with ``SIGN_TIMEOUT`` seconds limit."""
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(func, *args)
+        return future.result(timeout=SIGN_TIMEOUT)
 
 def _format_path(derivation: list[int]) -> str:
     """Convert a list of BIP32 indices to string path"""
@@ -57,7 +67,8 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
     For each input that the card can sign there is a 50% chance that 1-3
     additional signatures will be generated, and the signature ultimately
     included in the PSBT is randomly selected from among all signatures
-    produced for that input.
+    produced for that input. Each signing attempt is limited to five
+    seconds.
 
     Returns the number of signatures added to ``psbt``.
     """
@@ -67,7 +78,9 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
     for _ in range(random.randint(0, 8)):
         dummy_hash = os.urandom(32)
         try:
-            connector.card_sign_transaction_hash(0xFF, list(dummy_hash), None)
+            _call_with_timeout(
+                connector.card_sign_transaction_hash, 0xFF, list(dummy_hash), None
+            )
         except Exception:
             pass
 
@@ -93,7 +106,17 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
             results: list[tuple | None] = []
             for _ in range(1 + extra_sigs):
                 try:
-                    results.append(connector.card_sign_transaction_hash(0xFF, list(tx_hash), None))
+                    results.append(
+                        _call_with_timeout(
+                            connector.card_sign_transaction_hash,
+                            0xFF,
+                            list(tx_hash),
+                            None,
+                        )
+                    )
+                except TimeoutError:
+                    logger.warning("Satochip signing timed out")
+                    results.append(None)
                 except Exception:
                     results.append(None)
             chosen = random.choice(results) if results else None
@@ -132,11 +155,18 @@ def sign_message_with_satochip(derivation_path: str, message: str, connector) ->
 
     Returns:
         Base64 encoded compact signature string.
+
+    Signing requests time out after five seconds.
     """
 
     path = format_path_string(derivation_path)
     key, _chaincode = connector.card_bip32_get_extendedkey(path)
-    _resp, sw1, sw2, compsig = connector.card_sign_message(0xFF, key, message)
+    try:
+        _resp, sw1, sw2, compsig = _call_with_timeout(
+            connector.card_sign_message, 0xFF, key, message
+        )
+    except TimeoutError:
+        raise Exception("Satochip signing timed out")
     if sw1 != 0x90 or sw2 != 0x00 or not compsig:
         raise Exception(
             f"Failed to sign message with Satochip: {format_sw_error(sw1, sw2)}"

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -53,39 +53,18 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
     """Sign the given PSBT using a connected Satochip card.
 
     To obfuscate potential chosen-nonce attacks, a random number of dummy
-    signing requests are issued prior to signing the real transaction. In
-    addition, roughly half of the inputs that require a signature are signed
-    twice with one of the signatures randomly selected and the other
-    discarded.
+    signing requests (0-8) are issued prior to signing the real transaction.
+    For each input that the card can sign there is a 50% chance that 1-3
+    additional signatures will be generated, and the signature ultimately
+    included in the PSBT is randomly selected from among all signatures
+    produced for that input.
 
     Returns the number of signatures added to ``psbt``.
     """
     signed = 0
 
-    # Determine which inputs are signable so we can randomly pick some for
-    # double-signing.
-    signable_indices: list[int] = []
-    for i, inp in enumerate(psbt.inputs):
-        if len(inp.bip32_derivations) == 0:
-            continue
-        for pubkey, deriv in inp.bip32_derivations.items():
-            path = _format_path(deriv.derivation)
-            try:
-                key, _chaincode = connector.card_bip32_get_extendedkey(path)
-                card_pub = PublicKey.parse(
-                    key.get_public_key_bytes(compressed=True)
-                )
-            except Exception:
-                continue
-            if card_pub == pubkey:
-                signable_indices.append(i)
-                break
-
-    double_count = len(signable_indices) // 2
-    double_indices = set(random.sample(signable_indices, double_count)) if double_count else set()
-
-    # Issue 1-3 dummy signing requests and discard the results.
-    for _ in range(random.randint(1, 3)):
+    # Issue 0-8 dummy signing requests and discard the results.
+    for _ in range(random.randint(0, 8)):
         dummy_hash = os.urandom(32)
         try:
             connector.card_sign_transaction_hash(0xFF, list(dummy_hash), None)
@@ -110,25 +89,20 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
 
             tx_hash = psbt.sighash(i)
 
-            sig, sw1, sw2 = None, None, None
-            if i in double_indices:
-                # Sign twice and randomly keep one signature to obfuscate nonce usage.
-                first = None
-                second = None
+            extra_sigs = random.randint(1, 3) if random.random() < 0.5 else 0
+            results: list[tuple | None] = []
+            for _ in range(1 + extra_sigs):
                 try:
-                    first = connector.card_sign_transaction_hash(0xFF, list(tx_hash), None)
+                    results.append(connector.card_sign_transaction_hash(0xFF, list(tx_hash), None))
                 except Exception:
-                    pass
-                try:
-                    second = connector.card_sign_transaction_hash(0xFF, list(tx_hash), None)
-                except Exception:
-                    pass
-                chosen = random.choice([first, second])
-                if chosen is None:
-                    chosen = first if second is None else second
-                sig, sw1, sw2 = chosen if chosen is not None else (None, None, None)
-            else:
-                sig, sw1, sw2 = connector.card_sign_transaction_hash(0xFF, list(tx_hash), None)
+                    results.append(None)
+            chosen = random.choice(results) if results else None
+            if chosen is None:
+                for res in results:
+                    if res is not None:
+                        chosen = res
+                        break
+            sig, sw1, sw2 = chosen if chosen is not None else (None, None, None)
             if sw1 != 0x90 or sw2 != 0x00:
                 if sw1 is None or sw2 is None:
                     logger.warning("Satochip signing failed")

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from binascii import b2a_base64
 import logging
+import os
+import random
 
 from embit.ec import PublicKey
 from embit.psbt import PSBT
@@ -50,16 +52,54 @@ def format_path_string(path: str) -> str:
 def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
     """Sign the given PSBT using a connected Satochip card.
 
-    Returns the number of signatures added.
+    To obfuscate potential chosen-nonce attacks, a random number of dummy
+    signing requests are issued prior to signing the real transaction. In
+    addition, roughly half of the inputs that require a signature are signed
+    twice with one of the signatures randomly selected and the other
+    discarded.
+
+    Returns the number of signatures added to ``psbt``.
     """
     signed = 0
+
+    # Determine which inputs are signable so we can randomly pick some for
+    # double-signing.
+    signable_indices: list[int] = []
     for i, inp in enumerate(psbt.inputs):
         if len(inp.bip32_derivations) == 0:
             continue
         for pubkey, deriv in inp.bip32_derivations.items():
             path = _format_path(deriv.derivation)
             try:
-                key, chaincode = connector.card_bip32_get_extendedkey(path)
+                key, _chaincode = connector.card_bip32_get_extendedkey(path)
+                card_pub = PublicKey.parse(
+                    key.get_public_key_bytes(compressed=True)
+                )
+            except Exception:
+                continue
+            if card_pub == pubkey:
+                signable_indices.append(i)
+                break
+
+    double_count = len(signable_indices) // 2
+    double_indices = set(random.sample(signable_indices, double_count)) if double_count else set()
+
+    # Issue 1-3 dummy signing requests and discard the results.
+    for _ in range(random.randint(1, 3)):
+        dummy_hash = os.urandom(32)
+        try:
+            connector.card_sign_transaction_hash(0xFF, list(dummy_hash), None)
+        except Exception:
+            pass
+
+    # Now sign the actual PSBT inputs.
+    for i, inp in enumerate(psbt.inputs):
+        if len(inp.bip32_derivations) == 0:
+            continue
+        for pubkey, deriv in inp.bip32_derivations.items():
+            path = _format_path(deriv.derivation)
+            try:
+                key, _chaincode = connector.card_bip32_get_extendedkey(path)
                 card_pub = PublicKey.parse(
                     key.get_public_key_bytes(compressed=True)
                 )
@@ -67,10 +107,35 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
                 continue
             if card_pub != pubkey:
                 continue
+
             tx_hash = psbt.sighash(i)
-            sig, sw1, sw2 = connector.card_sign_transaction_hash(0xFF, list(tx_hash), None)
+
+            sig, sw1, sw2 = None, None, None
+            if i in double_indices:
+                # Sign twice and randomly keep one signature to obfuscate nonce usage.
+                first = None
+                second = None
+                try:
+                    first = connector.card_sign_transaction_hash(0xFF, list(tx_hash), None)
+                except Exception:
+                    pass
+                try:
+                    second = connector.card_sign_transaction_hash(0xFF, list(tx_hash), None)
+                except Exception:
+                    pass
+                chosen = random.choice([first, second])
+                if chosen is None:
+                    chosen = first if second is None else second
+                sig, sw1, sw2 = chosen if chosen is not None else (None, None, None)
+            else:
+                sig, sw1, sw2 = connector.card_sign_transaction_hash(0xFF, list(tx_hash), None)
             if sw1 != 0x90 or sw2 != 0x00:
-                logger.warning("Satochip signing failed: %s", format_sw_error(sw1, sw2))
+                if sw1 is None or sw2 is None:
+                    logger.warning("Satochip signing failed")
+                else:
+                    logger.warning(
+                        "Satochip signing failed: %s", format_sw_error(sw1, sw2)
+                    )
                 continue
             sig_der = bytes(sig)
             # ensure low-S signature


### PR DESCRIPTION
## Summary
- add randomized dummy Satochip signing requests
- double-sign half of Satochip PSBT inputs and randomly keep one signature
- document Satochip signing obfuscation in changelog

## Testing
- `pytest tests/test_flows_psbt.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17e8fcb44832287d3daf1fdbbb982