### PR TITLE
Add dummy and randomized extra signing with timeout for Satochip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file.
 Entries marked "(SeedSigner official)" originate from the upstream project, while "(smartcard fork)" indicates releases and changes unique to this repository.
 
 ## Unreleased - SS0.8.6+Satochip+Earthdiver-B4 (smartcard fork)
+- Randomized dummy Satochip signing requests (0-8) and optional extra per-input signatures with random selection among them to reduce potential nonce leakage
+- Enforce configurable per-signature timeout (default 5s) and allow tuning of pre-signing dummies, in-transaction dummy count, and per-input dummy probability
 - Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to the end of 2029 for RSA 2048 keys and the end of 2035 for other key types), and key type (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, RSA 4096, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
 - RSA key selections warn that generation on a Pi Zero may take approximately 3 minutes (2048), 15 minutes (3072), or an hour (4096) and recommend NIST or Brainpool keys as faster, smaller alternatives
 - MicroSD and GPG tools now display seed-loaded warnings only when opening file pickers

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 from binascii import b2a_base64
 import logging
+import os
+import random
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
 
 from embit.ec import PublicKey
 from embit.psbt import PSBT
 from embit.util import secp256k1
 from seedsigner.helpers.iso7816 import format_sw_error
+from seedsigner.models.settings import Settings, SettingsConstants
 
 try:
     # Constant introduced in newer embit versions
@@ -15,6 +19,13 @@ except ImportError:  # pragma: no cover - support older embit releases
     HARDENED_INDEX = 0x80000000
 
 logger = logging.getLogger(__name__)
+
+
+def _call_with_timeout(func, timeout: int, *args):
+    """Execute ``func`` with the provided timeout."""
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(func, *args)
+        return future.result(timeout=timeout)
 
 def _format_path(derivation: list[int]) -> str:
     """Convert a list of BIP32 indices to string path"""
@@ -50,16 +61,51 @@ def format_path_string(path: str) -> str:
 def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
     """Sign the given PSBT using a connected Satochip card.
 
-    Returns the number of signatures added.
+    To obfuscate potential chosen-nonce attacks, a random number of dummy
+    signing requests are issued prior to signing the real transaction.
+    For each input that the card can sign there is a configurable chance
+    that additional signatures will be generated, and the signature
+    ultimately included in the PSBT is randomly selected from among all
+    signatures produced for that input. Each signing attempt is limited
+    to a configurable timeout.
+
+    Returns the number of signatures added to ``psbt``.
     """
+    settings = Settings.get_instance()
+    timeout = settings.get_value(SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT)
+    pre_dummy_max = settings.get_value(
+        SettingsConstants.SETTING__SATOCHIP_MAX_PRE_DUMMIES
+    )
+    in_tx_dummy_max = settings.get_value(
+        SettingsConstants.SETTING__SATOCHIP_MAX_IN_TX_DUMMIES
+    )
+    dummy_prob = (
+        settings.get_value(SettingsConstants.SETTING__SATOCHIP_DUMMY_PROBABILITY) / 100
+    )
     signed = 0
+
+    # Issue 0-N dummy signing requests and discard the results.
+    for _ in range(random.randint(0, pre_dummy_max)):
+        dummy_hash = os.urandom(32)
+        try:
+            _call_with_timeout(
+                connector.card_sign_transaction_hash,
+                timeout,
+                0xFF,
+                list(dummy_hash),
+                None,
+            )
+        except Exception:
+            pass
+
+    # Now sign the actual PSBT inputs.
     for i, inp in enumerate(psbt.inputs):
         if len(inp.bip32_derivations) == 0:
             continue
         for pubkey, deriv in inp.bip32_derivations.items():
             path = _format_path(deriv.derivation)
             try:
-                key, chaincode = connector.card_bip32_get_extendedkey(path)
+                key, _chaincode = connector.card_bip32_get_extendedkey(path)
                 card_pub = PublicKey.parse(
                     key.get_public_key_bytes(compressed=True)
                 )
@@ -67,10 +113,43 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
                 continue
             if card_pub != pubkey:
                 continue
+
             tx_hash = psbt.sighash(i)
-            sig, sw1, sw2 = connector.card_sign_transaction_hash(0xFF, list(tx_hash), None)
+
+            extra_sigs = (
+                random.randint(1, in_tx_dummy_max) if random.random() < dummy_prob else 0
+            )
+            results: list[tuple | None] = []
+            for _ in range(1 + extra_sigs):
+                try:
+                    results.append(
+                        _call_with_timeout(
+                            connector.card_sign_transaction_hash,
+                            timeout,
+                            0xFF,
+                            list(tx_hash),
+                            None,
+                        )
+                    )
+                except TimeoutError:
+                    logger.warning("Satochip signing timed out")
+                    results.append(None)
+                except Exception:
+                    results.append(None)
+            chosen = random.choice(results) if results else None
+            if chosen is None:
+                for res in results:
+                    if res is not None:
+                        chosen = res
+                        break
+            sig, sw1, sw2 = chosen if chosen is not None else (None, None, None)
             if sw1 != 0x90 or sw2 != 0x00:
-                logger.warning("Satochip signing failed: %s", format_sw_error(sw1, sw2))
+                if sw1 is None or sw2 is None:
+                    logger.warning("Satochip signing failed")
+                else:
+                    logger.warning(
+                        "Satochip signing failed: %s", format_sw_error(sw1, sw2)
+                    )
                 continue
             sig_der = bytes(sig)
             # ensure low-S signature
@@ -93,11 +172,20 @@ def sign_message_with_satochip(derivation_path: str, message: str, connector) ->
 
     Returns:
         Base64 encoded compact signature string.
+
+    Signing requests time out according to configuration.
     """
 
+    settings = Settings.get_instance()
+    timeout = settings.get_value(SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT)
     path = format_path_string(derivation_path)
     key, _chaincode = connector.card_bip32_get_extendedkey(path)
-    _resp, sw1, sw2, compsig = connector.card_sign_message(0xFF, key, message)
+    try:
+        _resp, sw1, sw2, compsig = _call_with_timeout(
+            connector.card_sign_message, timeout, 0xFF, key, message
+        )
+    except TimeoutError:
+        raise Exception("Satochip signing timed out")
     if sw1 != 0x90 or sw2 != 0x00 or not compsig:
         raise Exception(
             f"Failed to sign message with Satochip: {format_sw_error(sw1, sw2)}"

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -295,6 +295,37 @@ class SettingsConstants:
     ALL_SCARD_PIN_ATTEMPTS = [(i, str(i)) for i in range(SCARD_PIN_ATTEMPTS_MIN, SCARD_PIN_ATTEMPTS_MAX + 1)]
     DEFAULT_SCARD_PIN_ATTEMPTS = 5
 
+    # Satochip signing behavior
+    SATOCHIP_TIMEOUT_MIN = 2
+    SATOCHIP_TIMEOUT_MAX = 10
+    ALL_SATOCHIP_TIMEOUTS = [
+        (i, f"{i}s") for i in range(SATOCHIP_TIMEOUT_MIN, SATOCHIP_TIMEOUT_MAX + 1)
+    ]
+    DEFAULT_SATOCHIP_TIMEOUT = 5
+
+    SATOCHIP_PRE_DUMMY_MAX_MIN = 0
+    SATOCHIP_PRE_DUMMY_MAX_MAX = 12
+    ALL_SATOCHIP_PRE_DUMMY_MAX = [
+        (i, str(i))
+        for i in range(SATOCHIP_PRE_DUMMY_MAX_MIN, SATOCHIP_PRE_DUMMY_MAX_MAX + 1)
+    ]
+    DEFAULT_SATOCHIP_PRE_DUMMY_MAX = 8
+
+    SATOCHIP_IN_TX_DUMMY_MAX_MIN = 1
+    SATOCHIP_IN_TX_DUMMY_MAX_MAX = 5
+    ALL_SATOCHIP_IN_TX_DUMMY_MAX = [
+        (i, str(i))
+        for i in range(SATOCHIP_IN_TX_DUMMY_MAX_MIN, SATOCHIP_IN_TX_DUMMY_MAX_MAX + 1)
+    ]
+    DEFAULT_SATOCHIP_IN_TX_DUMMY_MAX = 3
+
+    SATOCHIP_DUMMY_PROB_MIN = 0
+    SATOCHIP_DUMMY_PROB_MAX = 100
+    ALL_SATOCHIP_DUMMY_PROB = [
+        (i, f"{i}%") for i in range(SATOCHIP_DUMMY_PROB_MIN, SATOCHIP_DUMMY_PROB_MAX + 1, 5)
+    ]
+    DEFAULT_SATOCHIP_DUMMY_PROB = 50
+
     @classmethod
     def map_network_to_embit(cls, network) -> str:
         # Note these are `embit` constants; do not wrap for translation
@@ -404,6 +435,11 @@ class SettingsConstants:
     SETTING__ENCRYPTION_ITER = "pbkdf2_iterations"
     SETTING__WIF_KEYS = "wif_keys"
     SETTING__BIP38_KEYS = "bip38_keys"
+
+    SETTING__SATOCHIP_SIGN_TIMEOUT = "satochip_sign_timeout"
+    SETTING__SATOCHIP_MAX_PRE_DUMMIES = "satochip_max_pre_dummies"
+    SETTING__SATOCHIP_MAX_IN_TX_DUMMIES = "satochip_max_in_tx_dummies"
+    SETTING__SATOCHIP_DUMMY_PROBABILITY = "satochip_dummy_probability"
 
     SETTING__DEBUG = "debug"
 
@@ -899,6 +935,42 @@ class SettingsDefinition:
                       display_name=_mft("Show partner logos"),
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__ENABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT,
+                      abbreviated_name="satotime",
+                      display_name="Satochip sign timeout",
+                      type=SettingsConstants.TYPE__SELECT_1,
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      selection_options=SettingsConstants.ALL_SATOCHIP_TIMEOUTS,
+                      default_value=SettingsConstants.DEFAULT_SATOCHIP_TIMEOUT),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__SATOCHIP_MAX_PRE_DUMMIES,
+                      abbreviated_name="satopre",
+                      display_name="Satochip pre-sign dummies",
+                      type=SettingsConstants.TYPE__SELECT_1,
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      selection_options=SettingsConstants.ALL_SATOCHIP_PRE_DUMMY_MAX,
+                      default_value=SettingsConstants.DEFAULT_SATOCHIP_PRE_DUMMY_MAX),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__SATOCHIP_MAX_IN_TX_DUMMIES,
+                      abbreviated_name="satointx",
+                      display_name="Satochip in-tx dummies",
+                      type=SettingsConstants.TYPE__SELECT_1,
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      selection_options=SettingsConstants.ALL_SATOCHIP_IN_TX_DUMMY_MAX,
+                      default_value=SettingsConstants.DEFAULT_SATOCHIP_IN_TX_DUMMY_MAX),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__SATOCHIP_DUMMY_PROBABILITY,
+                      abbreviated_name="satoprob",
+                      display_name="Satochip dummy prob",
+                      type=SettingsConstants.TYPE__SELECT_1,
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      selection_options=SettingsConstants.ALL_SATOCHIP_DUMMY_PROB,
+                      default_value=SettingsConstants.DEFAULT_SATOCHIP_DUMMY_PROB),
 
 
         # Hardware config


### PR DESCRIPTION
## Summary
- randomize Satochip dummy signing requests (0-8) before PSBT signing
- optionally issue 1-3 extra signatures per input and randomly select the final signature
- enforce 5-second timeout for each Satochip signing request
- make Satochip timeout, dummy counts, and dummy probability configurable

## Testing
- `pytest tests/test_flows_psbt.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17e8fcb44832287d3daf1fdbbb982