### PR TITLE
Randomize Satochip PSBT signing order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Entries marked "(SeedSigner official)" originate from the upstream project, whil
 - Log dummy signing counts and per-operation signing durations for Satochip actions
 - Gracefully handle Satochip signature normalization failures to avoid crashes
 - Enhance Satochip benchmark signing tool to run 20 signatures and report min/avg/max times
+- Randomize order of PSBT inputs during Satochip signing to further obfuscate input processing
 - Deterministic BIP85 GPG key derivation with configurable name, email, expiration (defaulting to the end of 2029 for RSA 2048 keys and the end of 2035 for other key types), and key type (NIST P-256, Brainpool P-256, RSA 2048, RSA 3072, RSA 4096, or secp256k1); metadata such as expiration, deprecation, and end-of-use dates can be modified after import
 - RSA key selections warn that generation on a Pi Zero may take approximately 3 minutes (2048), 15 minutes (3072), or an hour (4096) and recommend NIST or Brainpool keys as faster, smaller alternatives
 - MicroSD and GPG tools now display seed-loaded warnings only when opening file pickers

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -115,8 +115,14 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
             except Exception:
                 pass
 
-    # Now sign the actual PSBT inputs.
-    for i, inp in enumerate(psbt.inputs):
+    # Now sign the actual PSBT inputs. To avoid leaking the original
+    # ordering, process the inputs in a random sequence. Signatures are
+    # still written back to their original input index so the final PSBT
+    # ordering matches the caller's expectations.
+    indices = list(range(len(psbt.inputs)))
+    random.shuffle(indices)
+    for i in indices:
+        inp = psbt.inputs[i]
         if len(inp.bip32_derivations) == 0:
             continue
         for pubkey, deriv in inp.bip32_derivations.items():

--- a/tests/test_satochip_sign_psbt.py
+++ b/tests/test_satochip_sign_psbt.py
@@ -1,0 +1,70 @@
+import random
+import types
+
+from embit.psbt import PSBT, InputScope, DerivationPath
+from embit.ec import PrivateKey
+
+from seedsigner.helpers.satochip_signer import sign_psbt_with_satochip
+from seedsigner.models.settings import Settings
+from seedsigner.models.settings_definition import SettingsConstants
+
+
+class DummySettings:
+    def get_value(self, setting):
+        if setting == SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT:
+            return 1
+        return 0
+
+
+class DummyKey:
+    def __init__(self, pub):
+        self._pub = pub
+
+    def get_public_key_bytes(self, compressed=True):
+        return self._pub
+
+
+class DummyConnector:
+    def __init__(self, pubkeys):
+        self.pubkeys = pubkeys
+        self.sign_order = []
+
+    def card_bip32_get_extendedkey(self, path):
+        idx = int(path.split("/")[1])
+        return DummyKey(self.pubkeys[idx]), b""
+
+    def card_sign_transaction_hash(self, keynbr, h, none):
+        idx = h[0]
+        self.sign_order.append(idx)
+        # return a deterministic signature unique to the input index so we
+        # can later verify that signatures are written back in the original
+        # order, despite the randomized signing sequence
+        return (bytes([idx]) * 70, 0x90, 0x00)
+
+
+def test_sign_psbt_processes_inputs_in_random_order(monkeypatch):
+    psbt = PSBT()
+    psbt.inputs = [InputScope(), InputScope(), InputScope()]
+    pubkeys = []
+    for i, inp in enumerate(psbt.inputs):
+        priv = PrivateKey(bytes([i + 1]) * 32)
+        pub = priv.get_public_key()
+        inp.bip32_derivations[pub] = DerivationPath(b"\x00" * 4, [i])
+        pubkeys.append(pub.sec())
+
+    psbt.sighash = types.MethodType(lambda self, idx, sighash=None: bytes([idx]) * 32, psbt)
+
+    connector = DummyConnector(pubkeys)
+    monkeypatch.setattr(Settings, "get_instance", classmethod(lambda cls: DummySettings()))
+    random.seed(0)
+    signed = sign_psbt_with_satochip(psbt, connector)
+    assert signed == 3
+    assert connector.sign_order != [0, 1, 2]
+    assert sorted(connector.sign_order) == [0, 1, 2]
+
+    # Verify that each input's signature corresponds to its original
+    # index, confirming that results are returned in input order even
+    # though the signing operations occurred in a shuffled sequence
+    for i, inp in enumerate(psbt.inputs):
+        pub = next(iter(inp.bip32_derivations.keys()))
+        assert inp.partial_sigs[pub] == bytes([i]) * 70 + b"\x01"


### PR DESCRIPTION
## Summary
- randomize PSBT input order when signing with Satochip
- ensure signatures are written back in original input order
- add regression test verifying input order is shuffled while results remain ordered

## Testing
- `pytest tests/test_satochip_sign_psbt.py tests/test_satochip_sign_message.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c72cdf834c83229ad65e1e8a2128f5