### PR TITLE
Add BIP85 private key warning

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -9305,6 +9305,18 @@ class ToolsGPGLoadBIP85KeyView(View):
             )
             return Destination(BackStackView)
 
+        self.run_screen(
+            WarningScreen,
+            title="WARNING",
+            status_headline=None,
+            text=(
+                "This feature extends BIP85 past current spec.\n"
+                "Record your SeedSigner Version."
+            ),
+            show_back_button=False,
+            button_data=[ButtonOption("I Understand")],
+        )
+
         if len(self.controller.storage.seeds) > 1:
             seed_buttons = []
             for seed in self.controller.storage.seeds:

--- a/tests/test_bip85_gpg.py
+++ b/tests/test_bip85_gpg.py
@@ -6,7 +6,7 @@ import shutil
 from embit import bip32, bip85
 from seedsigner.models.seed import Seed
 from seedsigner.controller import Controller
-from seedsigner.gui.screens import RET_CODE__BACK_BUTTON
+from seedsigner.gui.screens import RET_CODE__BACK_BUTTON, WarningScreen
 from seedsigner.views import tools_views
 from seedsigner.views.tools_views import (
     bip85_brainpoolp256r1_from_root,
@@ -666,7 +666,7 @@ def test_load_bip85_key_selects_seed(monkeypatch):
     original = list(controller.storage.seeds)
     controller.storage.seeds = [Seed(mnemonic=MNEMONIC), Seed(mnemonic=MNEMONIC)]
 
-    responses = iter([1, RET_CODE__BACK_BUTTON])
+    responses = iter([0, 1, RET_CODE__BACK_BUTTON])
     screens = []
 
     def fake_run_screen(self, screen, *args, **kwargs):
@@ -700,7 +700,8 @@ def test_load_bip85_key_selects_seed(monkeypatch):
         controller.storage.seeds = original
 
     assert captured["idx"] == 1
-    assert screens[0] == tools_views.seed_screens.SeedSelectSeedScreen
+    assert screens[0] == WarningScreen
+    assert screens[1] == tools_views.seed_screens.SeedSelectSeedScreen
 
 
 def test_filter_deletable_subkeys_bip85_only_latest():


### PR DESCRIPTION
## Summary
- warn users that BIP85 private key import extends BIP85 spec
- update tests for warning screen

## Testing
- `pytest tests/test_bip85_gpg.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7707e219483229087d3c840974dfc