### PR TITLE
Add setting to toggle BIP85 ECC key support

### DIFF
--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -433,6 +433,7 @@ class SettingsConstants:
     SETTING__CAMERA_DEVICE = "camera_device"
     SETTING__COMPACT_SEEDQR = "compact_seedqr"
     SETTING__BIP85_CHILD_SEEDS = "bip85_child_seeds"
+    SETTING__BIP85_ECC_KEYS = "bip85_ecc_keys"
     SETTING__SLIP39_SEEDS = "slip39_seeds"
     SETTING__SLIP39_EXTENDABLE = "slip39_extendable"
     SETTING__ELECTRUM_SEEDS = "electrum_seeds"
@@ -886,6 +887,13 @@ class SettingsDefinition:
                       display_name=_mft("BIP-85 child seeds"),
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__ENABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__BIP85_ECC_KEYS,
+                      abbreviated_name="bip85_ecc",
+                      display_name=_mft("BIP85 ECC curves"),
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      default_value=SettingsConstants.OPTION__DISABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__SLIP39_SEEDS,

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -9302,6 +9302,34 @@ def bip85_brainpoolp256r1_from_root(
     return priv
 
 
+def _bip85_key_type_choices(include_ecc: bool) -> list[tuple[str, str]]:
+    """Return available key type labels and identifiers for BIP85 GPG keys."""
+
+    choices: list[tuple[str, str]] = []
+    if include_ecc:
+        choices.extend(
+            [
+                ("NIST P-256", "p256"),
+                ("Brainpool P-256", "brainpoolp256r1"),
+            ]
+        )
+    choices.extend(
+        [
+            ("RSA 2048", "rsa2048"),
+            ("RSA 3072", "rsa3072"),
+            ("RSA 4096", "rsa4096"),
+        ]
+    )
+    if include_ecc:
+        choices.extend(
+            [
+                ("secp256k1", "secp256k1"),
+                ("Ed25519", "ed25519"),
+            ]
+        )
+    return choices
+
+
 class ToolsGPGLoadBIP85KeyView(View):
     def run(self):
         from embit import bip32
@@ -9334,17 +9362,23 @@ class ToolsGPGLoadBIP85KeyView(View):
             )
             return Destination(BackStackView)
 
-        self.run_screen(
-            WarningScreen,
-            title="WARNING",
-            status_headline=None,
-            text=(
-                "This feature extends BIP85 past current spec.\n"
-                "Record your SeedSigner Version."
-            ),
-            show_back_button=False,
-            button_data=[ButtonOption("I Understand")],
+        ecc_enabled = (
+            self.settings.get_value(SettingsConstants.SETTING__BIP85_ECC_KEYS)
+            == SettingsConstants.OPTION__ENABLED
         )
+
+        if ecc_enabled:
+            self.run_screen(
+                WarningScreen,
+                title="WARNING",
+                status_headline=None,
+                text=(
+                    "This feature extends BIP85 past current spec.\n"
+                    "Record your SeedSigner Version."
+                ),
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
 
         if len(self.controller.storage.seeds) > 1:
             seed_buttons = []
@@ -9377,15 +9411,8 @@ class ToolsGPGLoadBIP85KeyView(View):
             return Destination(BackStackView)
         key_index = int(ret)
 
-        keytype_buttons = [
-            ButtonOption("NIST P-256"),
-            ButtonOption("Brainpool P-256"),
-            ButtonOption("RSA 2048"),
-            ButtonOption("RSA 3072"),
-            ButtonOption("RSA 4096"),
-            ButtonOption("secp256k1"),
-            ButtonOption("Ed25519"),
-        ]
+        keytype_choices = _bip85_key_type_choices(ecc_enabled)
+        keytype_buttons = [ButtonOption(label) for label, _ in keytype_choices]
         selected_type = self.run_screen(
             ButtonListScreen,
             title="Key Type",
@@ -9395,15 +9422,7 @@ class ToolsGPGLoadBIP85KeyView(View):
         if selected_type == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
         key_type_label = keytype_buttons[selected_type].button_label
-        key_type = [
-            "p256",
-            "brainpoolp256r1",
-            "rsa2048",
-            "rsa3072",
-            "rsa4096",
-            "secp256k1",
-            "ed25519",
-        ][selected_type]
+        key_type = keytype_choices[selected_type][1]
 
         if key_type in ["secp256k1", "ed25519"]:
             ret = self.run_screen(
@@ -9801,15 +9820,12 @@ class ToolsGPGAddSubkeysView(View):
                 base_index,
                 key_index,
             )
-        keytype_buttons = [
-            ButtonOption("NIST P-256"),
-            ButtonOption("Brainpool P-256"),
-            ButtonOption("RSA 2048"),
-            ButtonOption("RSA 3072"),
-            ButtonOption("RSA 4096"),
-            ButtonOption("secp256k1"),
-            ButtonOption("Ed25519"),
-        ]
+        ecc_enabled = (
+            self.settings.get_value(SettingsConstants.SETTING__BIP85_ECC_KEYS)
+            == SettingsConstants.OPTION__ENABLED
+        )
+        keytype_choices = _bip85_key_type_choices(ecc_enabled)
+        keytype_buttons = [ButtonOption(label) for label, _ in keytype_choices]
         selected_type = self.run_screen(
             ButtonListScreen,
             title="Key Type",
@@ -9831,15 +9847,7 @@ class ToolsGPGAddSubkeysView(View):
             if ret == RET_CODE__BACK_BUTTON:
                 return Destination(BackStackView)
 
-        alg = [
-            "nistp256",
-            "brainpoolP256r1",
-            "rsa2048",
-            "rsa3072",
-            "rsa4096",
-            "secp256k1",
-            "ed25519",
-        ][selected_type]
+        alg = keytype_choices[selected_type][1]
         self.loading_screen = LoadingScreenThread(
             text="Generating subkeys\n\n\n\n\n(This takes a while)"
         )

--- a/tests/test_bip85_gpg.py
+++ b/tests/test_bip85_gpg.py
@@ -27,6 +27,7 @@ from seedsigner.views.tools_views import (
     _select_import_algo,
     bip85_verify_existing,
 )
+from seedsigner.models.settings_definition import SettingsConstants
 from seedsigner.helpers.bip85_drng import BIP85DRNG
 
 pytestmark = pytest.mark.skipif(
@@ -667,11 +668,17 @@ def test_load_bip85_key_selects_seed(monkeypatch):
     original = list(controller.storage.seeds)
     controller.storage.seeds = [Seed(mnemonic=MNEMONIC), Seed(mnemonic=MNEMONIC)]
 
-    responses = iter([0, 1, RET_CODE__BACK_BUTTON])
+    responses = iter([1])
     screens = []
+    captured = {}
 
     def fake_run_screen(self, screen, *args, **kwargs):
         screens.append(screen)
+        if kwargs.get("title") == "Key Type":
+            captured["key_type_options"] = [
+                button.button_label for button in kwargs.get("button_data", [])
+            ]
+            return RET_CODE__BACK_BUTTON
         return next(responses)
 
     class DummyIndexScreen:
@@ -686,8 +693,6 @@ def test_load_bip85_key_selects_seed(monkeypatch):
         tools_views.seed_screens, "SeedBIP85SelectChildIndexScreen", DummyIndexScreen
     )
 
-    captured = {}
-
     def fake_get_seed(idx):
         captured["idx"] = idx
         return controller.storage.seeds[idx]
@@ -701,8 +706,73 @@ def test_load_bip85_key_selects_seed(monkeypatch):
         controller.storage.seeds = original
 
     assert captured["idx"] == 1
-    assert screens[0] == WarningScreen
-    assert screens[1] == tools_views.seed_screens.SeedSelectSeedScreen
+    assert screens[0] == tools_views.seed_screens.SeedSelectSeedScreen
+    assert WarningScreen not in screens
+    assert captured["key_type_options"] == ["RSA 2048", "RSA 3072", "RSA 4096"]
+
+
+def test_load_bip85_key_warning_when_ecc_enabled(monkeypatch):
+    from seedsigner.views import tools_views
+
+    controller = Controller.get_instance()
+    original = list(controller.storage.seeds)
+    controller.storage.seeds = [Seed(mnemonic=MNEMONIC)]
+
+    responses = iter([0])
+    screens = []
+    captured = {}
+
+    def fake_run_screen(self, screen, *args, **kwargs):
+        screens.append(screen)
+        if kwargs.get("title") == "Key Type":
+            captured["key_type_options"] = [
+                button.button_label for button in kwargs.get("button_data", [])
+            ]
+            return RET_CODE__BACK_BUTTON
+        return next(responses)
+
+    class DummyIndexScreen:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def display(self):
+            return "0"
+
+    monkeypatch.setattr(tools_views.ToolsGPGLoadBIP85KeyView, "run_screen", fake_run_screen)
+    monkeypatch.setattr(
+        tools_views.seed_screens, "SeedBIP85SelectChildIndexScreen", DummyIndexScreen
+    )
+
+    view = tools_views.ToolsGPGLoadBIP85KeyView()
+    base_settings = view.settings
+
+    class DummySettings:
+        def __init__(self, base):
+            self._base = base
+
+        def get_value(self, attr_name):
+            if attr_name == SettingsConstants.SETTING__BIP85_ECC_KEYS:
+                return SettingsConstants.OPTION__ENABLED
+            return self._base.get_value(attr_name)
+
+    view.settings = DummySettings(base_settings)
+
+    try:
+        view.run()
+    finally:
+        controller.storage.seeds = original
+        view.settings = base_settings
+
+    assert screens and screens[0] == WarningScreen
+    assert captured["key_type_options"] == [
+        "NIST P-256",
+        "Brainpool P-256",
+        "RSA 2048",
+        "RSA 3072",
+        "RSA 4096",
+        "secp256k1",
+        "Ed25519",
+    ]
 
 
 def test_filter_deletable_subkeys_bip85_only_latest():

--- a/tests/test_bip85_pgp_cli.py
+++ b/tests/test_bip85_pgp_cli.py
@@ -25,3 +25,16 @@ def test_generate_pgp_key_and_export():
     priv = bip85_pgp.export_private_key(key)
     assert pub.startswith("-----BEGIN PGP PUBLIC KEY BLOCK-----")
     assert priv.startswith("-----BEGIN PGP PRIVATE KEY BLOCK-----")
+
+
+def test_cli_key_type_choices_include_all_curves():
+    expected = {
+        "p256",
+        "brainpoolp256r1",
+        "rsa2048",
+        "rsa3072",
+        "rsa4096",
+        "secp256k1",
+        "ed25519",
+    }
+    assert expected.issubset(set(bip85_pgp.CLI_KEY_TYPE_CODES))

--- a/tools/bip85_pgp.py
+++ b/tools/bip85_pgp.py
@@ -44,7 +44,13 @@ from seedsigner.views.tools_views import (
     bip85_p256_from_root,
     bip85_brainpoolp256r1_from_root,
     _bip85_subkey_specs,
+    _bip85_key_type_choices,
 )
+
+
+# CLI test tool should expose every supported key type regardless of UI settings.
+CLI_KEY_TYPE_CHOICES = tuple(_bip85_key_type_choices(include_ecc=True))
+CLI_KEY_TYPE_CODES = tuple(code for _, code in CLI_KEY_TYPE_CHOICES)
 
 
 # ---------------------------------------------------------------------------
@@ -312,15 +318,7 @@ def main():
     parser.add_argument("--index", type=int, default=None, help="BIP85 key index")
     parser.add_argument(
         "--type",
-        choices=[
-            "p256",
-            "brainpoolp256r1",
-            "rsa2048",
-            "rsa3072",
-            "rsa4096",
-            "secp256k1",
-            "ed25519",
-        ],
+        choices=CLI_KEY_TYPE_CODES,
         help="Key type",
     )
     parser.add_argument("--name", help="User name")
@@ -328,15 +326,7 @@ def main():
     parser.add_argument("--expiration", help="Expiration date YYYY-MM-DD")
     parser.add_argument(
         "--subkey-type",
-        choices=[
-            "p256",
-            "brainpoolp256r1",
-            "rsa2048",
-            "rsa3072",
-            "rsa4096",
-            "secp256k1",
-            "ed25519",
-        ],
+        choices=CLI_KEY_TYPE_CODES,
         help="Generate three subkeys of this type",
     )
     parser.add_argument(
@@ -359,19 +349,11 @@ def main():
     if args.type:
         key_type = args.type
     else:
-        options = [
-            ("p256", "NIST P-256"),
-            ("brainpoolp256r1", "Brainpool P-256"),
-            ("rsa2048", "RSA 2048"),
-            ("rsa3072", "RSA 3072"),
-            ("rsa4096", "RSA 4096"),
-            ("secp256k1", "secp256k1"),
-            ("ed25519", "Ed25519"),
-        ]
-        for i, (_, label) in enumerate(options, 1):
+        options = CLI_KEY_TYPE_CHOICES
+        for i, (label, _) in enumerate(options, 1):
             print(f"{i}: {label}")
         sel = int(input("Select key type: ")) - 1
-        key_type = options[sel][0]
+        key_type = options[sel][1]
     name = args.name or input("Name: ")
     email = args.email or input("Email: ")
     expiration = args.expiration
@@ -384,19 +366,11 @@ def main():
     if subkey_type is None:
         gen = input("Generate trio of subkeys? [y/N]: ").strip().lower()
         if gen in {"y", "yes"}:
-            options = [
-                ("p256", "NIST P-256"),
-                ("brainpoolp256r1", "Brainpool P-256"),
-                ("rsa2048", "RSA 2048"),
-                ("rsa3072", "RSA 3072"),
-                ("rsa4096", "RSA 4096"),
-                ("secp256k1", "secp256k1"),
-                ("ed25519", "Ed25519"),
-            ]
-            for i, (_, label) in enumerate(options, 1):
+            options = CLI_KEY_TYPE_CHOICES
+            for i, (label, _) in enumerate(options, 1):
                 print(f"{i}: {label}")
             sel = int(input("Select subkey type: ")) - 1
-            subkey_type = options[sel][0]
+            subkey_type = options[sel][1]
             if additional is None:
                 additional = int(
                     input("Additional subkey sets (each adds three subkeys) [0]: ")


### PR DESCRIPTION
## Summary
- add an advanced setting that controls whether BIP85-derived GPG keys can use ECC curves
- hide the BIP85-spec warning and ECC key options unless the new setting is enabled
- update the BIP85 GPG tests to cover the default RSA-only flow and the ECC-enabled flow

## Testing
- pytest tests/test_bip85_gpg.py

------
https://chatgpt.com/codex/tasks/task_e_68c856abc03483229b4a35951410c64c