### PR TITLE
Align BIP85 ECC derivations with updated GPG paths

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4743,15 +4743,8 @@ class ToolsGPGRebuildBip85KeyView(View):
 
         key_index = entry["index"]
         key_type_label = entry["key_type"]
-        key_type = {
-            "NIST P-256": "p256",
-            "Brainpool P-256": "brainpoolp256r1",
-            "RSA 2048": "rsa2048",
-            "RSA 3072": "rsa3072",
-            "RSA 4096": "rsa4096",
-            "secp256k1": "secp256k1",
-            "Ed25519": "ed25519",
-        }[key_type_label]
+        key_type_lookup = dict(_bip85_key_type_choices(True))
+        key_type = key_type_lookup[key_type_label]
 
         uid_list = entry.get("uids", [])
         if not uid_list:
@@ -4781,15 +4774,15 @@ class ToolsGPGRebuildBip85KeyView(View):
 
         # Map primary key type to algorithm details for verification
         algo_map = {
-            "Ed25519": ("22", "", "ed25519"),
+            "ed25519": ("22", "", "ed25519"),
             "secp256k1": ("19", "", "secp256k1"),
-            "NIST P-256": ("19", "", "nistp256"),
-            "Brainpool P-256": ("19", "", "brainpoolp256r1"),
-            "RSA 2048": ("1", "2048", ""),
-            "RSA 3072": ("1", "3072", ""),
-            "RSA 4096": ("1", "4096", ""),
+            "p256": ("19", "", "nistp256"),
+            "brainpoolp256r1": ("19", "", "brainpoolp256r1"),
+            "rsa2048": ("1", "2048", ""),
+            "rsa3072": ("1", "3072", ""),
+            "rsa4096": ("1", "4096", ""),
         }
-        primary_algo, primary_bits, primary_curve = algo_map[key_type_label]
+        primary_algo, primary_bits, primary_curve = algo_map[key_type]
 
         # Build subkey info for verification
         verify_subkeys = []
@@ -4808,9 +4801,12 @@ class ToolsGPGRebuildBip85KeyView(View):
                 curve = ""
             else:
                 algo = {"ECDH": "18", "ECDSA": "19", "EdDSA": "22"}[parts[0]]
-                curve_label = " ".join(parts[1:]).lower()
-                curve = curve_map.get(curve_label, curve_label)
-                if parts[0] == "ECDH" and curve_label == "ed25519":
+                curve_label = " ".join(parts[1:])
+                if curve_label.startswith("ECC "):
+                    curve_label = curve_label[4:]
+                curve_label_lc = curve_label.lower()
+                curve = curve_map.get(curve_label_lc, curve_label_lc)
+                if parts[0] == "ECDH" and curve_label_lc == "ed25519":
                     curve = "cv25519"
                 bits = ""
             verify_subkeys.append(
@@ -4960,7 +4956,10 @@ class ToolsGPGRebuildBip85KeyView(View):
                         subpkt.keymaterial = rsa_to_privpacket(rsa_sub)
                     else:
                         alg_name = parts[0]
-                        curve_label = " ".join(parts[1:]).lower()
+                        curve_label = " ".join(parts[1:])
+                        if curve_label.startswith("ECC "):
+                            curve_label = curve_label[4:]
+                        curve_label_lc = curve_label.lower()
                         func_map = {
                             "secp256k1": bip85_secp256k1_from_root,
                             "nist p-256": bip85_p256_from_root,
@@ -4973,7 +4972,7 @@ class ToolsGPGRebuildBip85KeyView(View):
                             "EdDSA": PubKeyAlgorithm.EdDSA,
                         }
                         subpkt.pkalg = pkalg_map[parts[0]]
-                        func = func_map[curve_label]
+                        func = func_map[curve_label_lc]
                         subpkt.keymaterial = func(root, group_idx, idx, alg_name)
                     subpkt.created = created
                     subpkt.update_hlen()
@@ -9093,11 +9092,11 @@ def bip85_add_subkeys(
 
     subkey_specs = _bip85_subkey_specs(alg)
     type_map = {
-        "nistp256": "NIST P-256",
-        "p256": "NIST P-256",
-        "brainpoolP256r1": "Brainpool P-256",
-        "secp256k1": "secp256k1",
-        "ed25519": "Ed25519",
+        "nistp256": "ECC NIST P-256",
+        "p256": "ECC NIST P-256",
+        "brainpoolP256r1": "ECC Brainpool P-256",
+        "secp256k1": "ECC secp256k1",
+        "ed25519": "ECC Ed25519",
         "rsa2048": "RSA 2048",
         "rsa3072": "RSA 3072",
         "rsa4096": "RSA 4096",
@@ -9318,8 +9317,8 @@ def _bip85_key_type_choices(include_ecc: bool) -> list[tuple[str, str]]:
     if include_ecc:
         choices.extend(
             [
-                ("NIST P-256", "p256"),
-                ("Brainpool P-256", "brainpoolp256r1"),
+                ("ECC NIST P-256", "p256"),
+                ("ECC Brainpool P-256", "brainpoolp256r1"),
             ]
         )
     choices.extend(
@@ -9332,8 +9331,8 @@ def _bip85_key_type_choices(include_ecc: bool) -> list[tuple[str, str]]:
     if include_ecc:
         choices.extend(
             [
-                ("secp256k1", "secp256k1"),
-                ("Ed25519", "ed25519"),
+                ("ECC secp256k1", "secp256k1"),
+                ("ECC Ed25519", "ed25519"),
             ]
         )
     return choices
@@ -9382,7 +9381,7 @@ class ToolsGPGLoadBIP85KeyView(View):
                 title="WARNING",
                 status_headline=None,
                 text=(
-                    "This feature extends BIP85 past current spec.\n"
+                    "ECC Curves extend beyond current BIP85 spec..\n"
                     "Record your SeedSigner Version."
                 ),
                 show_back_button=False,
@@ -9844,7 +9843,9 @@ class ToolsGPGAddSubkeysView(View):
         if selected_type == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        if keytype_buttons[selected_type].button_label in ["secp256k1", "Ed25519"]:
+        _, alg = keytype_choices[selected_type]
+
+        if alg in ["secp256k1", "ed25519"]:
             ret = self.run_screen(
                 WarningScreen,
                 title="WARNING",
@@ -9856,7 +9857,6 @@ class ToolsGPGAddSubkeysView(View):
             if ret == RET_CODE__BACK_BUTTON:
                 return Destination(BackStackView)
 
-        alg = keytype_choices[selected_type][1]
         self.loading_screen = LoadingScreenThread(
             text="Generating subkeys\n\n\n\n\n(This takes a while)"
         )
@@ -9935,15 +9935,44 @@ class ToolsGPGGenerateKeyView(View):
             tools_screens,
         )
 
-        keytype_buttons = [
-            ButtonOption("NIST P-256"),
-            ButtonOption("Brainpool P-256"),
-            ButtonOption("RSA 2048"),
-            ButtonOption("RSA 3072"),
-            ButtonOption("RSA 4096"),
-            ButtonOption("secp256k1"),
-            ButtonOption("Ed25519"),
+        keytype_data = [
+            (
+                "ECC NIST P-256",
+                (PubKeyAlgorithm.ECDSA, EllipticCurveOID.NIST_P256),
+                False,
+            ),
+            (
+                "ECC Brainpool P-256",
+                (PubKeyAlgorithm.ECDSA, EllipticCurveOID.Brainpool_P256),
+                False,
+            ),
+            (
+                "RSA 2048",
+                (PubKeyAlgorithm.RSAEncryptOrSign, 2048),
+                False,
+            ),
+            (
+                "RSA 3072",
+                (PubKeyAlgorithm.RSAEncryptOrSign, 3072),
+                False,
+            ),
+            (
+                "RSA 4096",
+                (PubKeyAlgorithm.RSAEncryptOrSign, 4096),
+                False,
+            ),
+            (
+                "ECC secp256k1",
+                (PubKeyAlgorithm.ECDSA, EllipticCurveOID.SECP256K1),
+                True,
+            ),
+            (
+                "ECC Ed25519",
+                (PubKeyAlgorithm.EdDSA, EllipticCurveOID.Ed25519),
+                True,
+            ),
         ]
+        keytype_buttons = [ButtonOption(label) for label, _, _ in keytype_data]
         selected_type = self.run_screen(
             ButtonListScreen,
             title="Key Type",
@@ -9953,7 +9982,9 @@ class ToolsGPGGenerateKeyView(View):
         if selected_type == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        if keytype_buttons[selected_type].button_label in ["secp256k1", "Ed25519"]:
+        _, (alg, param), warn_export_blocked = keytype_data[selected_type]
+
+        if warn_export_blocked:
             ret = self.run_screen(
                 WarningScreen,
                 title="WARNING",
@@ -9964,16 +9995,6 @@ class ToolsGPGGenerateKeyView(View):
             )
             if ret == RET_CODE__BACK_BUTTON:
                 return Destination(BackStackView)
-
-        alg, param = [
-            (PubKeyAlgorithm.ECDSA, EllipticCurveOID.NIST_P256),
-            (PubKeyAlgorithm.ECDSA, EllipticCurveOID.Brainpool_P256),
-            (PubKeyAlgorithm.RSAEncryptOrSign, 2048),
-            (PubKeyAlgorithm.RSAEncryptOrSign, 3072),
-            (PubKeyAlgorithm.RSAEncryptOrSign, 4096),
-            (PubKeyAlgorithm.ECDSA, EllipticCurveOID.SECP256K1),
-            (PubKeyAlgorithm.EdDSA, EllipticCurveOID.Ed25519),
-        ][selected_type]
 
         if alg == PubKeyAlgorithm.RSAEncryptOrSign:
             warn_text = {

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -9317,6 +9317,7 @@ def _bip85_key_type_choices(include_ecc: bool) -> list[tuple[str, str]]:
     if include_ecc:
         choices.extend(
             [
+                ("ECC Ed25519", "ed25519"),
                 ("ECC NIST P-256", "p256"),
                 ("ECC Brainpool P-256", "brainpoolp256r1"),
             ]
@@ -9329,12 +9330,7 @@ def _bip85_key_type_choices(include_ecc: bool) -> list[tuple[str, str]]:
         ]
     )
     if include_ecc:
-        choices.extend(
-            [
-                ("ECC secp256k1", "secp256k1"),
-                ("ECC Ed25519", "ed25519"),
-            ]
-        )
+        choices.append(("ECC secp256k1", "secp256k1"))
     return choices
 
 
@@ -9937,6 +9933,11 @@ class ToolsGPGGenerateKeyView(View):
 
         keytype_data = [
             (
+                "ECC Ed25519",
+                (PubKeyAlgorithm.EdDSA, EllipticCurveOID.Ed25519),
+                True,
+            ),
+            (
                 "ECC NIST P-256",
                 (PubKeyAlgorithm.ECDSA, EllipticCurveOID.NIST_P256),
                 False,
@@ -9964,11 +9965,6 @@ class ToolsGPGGenerateKeyView(View):
             (
                 "ECC secp256k1",
                 (PubKeyAlgorithm.ECDSA, EllipticCurveOID.SECP256K1),
-                True,
-            ),
-            (
-                "ECC Ed25519",
-                (PubKeyAlgorithm.EdDSA, EllipticCurveOID.Ed25519),
                 True,
             ),
         ]

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4148,6 +4148,15 @@ def parse_subkey_list(colon_output: str):
 # human-readable typo of "2009-01-03 18:05:05" UTC, which has propagated elsewhere.
 BIP85_GPG_CREATED_TS = 1231006505
 
+# BIP85 application numbers for supported GPG key types
+BIP85_GPG_APP_RSA = 828365
+BIP85_GPG_APP_CURVE25519 = 828366
+BIP85_GPG_APP_SECP256K1 = 828367
+BIP85_GPG_APP_NIST_P256 = 828368
+BIP85_GPG_APP_BRAINPOOL_P256 = 828369
+
+BIP85_GPG_ECC_KEY_BITS = 256
+
 # In-memory registry of BIP85-derived keys
 BIP85_DATA = {}
 
@@ -8720,7 +8729,7 @@ def bip85_rsa_from_root(root, bits: int, index: int, sub_index: int | None = Non
     path = [bits, index]
     if sub_index is not None:
         path.append(sub_index)
-    entropy = bip85.derive_entropy(root, 828365, path)
+    entropy = bip85.derive_entropy(root, BIP85_GPG_APP_RSA, path)
     drng = BIP85DRNG.new(entropy)
     return RSA.generate(bits, randfunc=drng.read)
 
@@ -8734,10 +8743,10 @@ def bip85_ed25519_from_root(
     from pgpy.constants import EllipticCurveOID
     from pgpy.packet import fields
 
-    path = [259, index]
+    path = [BIP85_GPG_ECC_KEY_BITS, index]
     if sub_index is not None:
         path.append(sub_index)
-    entropy = bip85.derive_entropy(root, 828365, path)
+    entropy = bip85.derive_entropy(root, BIP85_GPG_APP_CURVE25519, path)
     d_bytes = entropy[:32]
     if alg == "EdDSA":
         priv = fields.EdDSAPriv()
@@ -9197,10 +9206,10 @@ def bip85_secp256k1_from_root(
     from pgpy.constants import EllipticCurveOID
     from pgpy.packet import fields
 
-    path = [256, index]
+    path = [BIP85_GPG_ECC_KEY_BITS, index]
     if sub_index is not None:
         path.append(sub_index)
-    entropy = bip85.derive_entropy(root, 828365, path)
+    entropy = bip85.derive_entropy(root, BIP85_GPG_APP_SECP256K1, path)
     order = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
     d = int.from_bytes(entropy[:32], "big") % order
     if d == 0:
@@ -9233,10 +9242,10 @@ def bip85_p256_from_root(
     from pgpy.constants import EllipticCurveOID
     from pgpy.packet import fields
 
-    path = [257, index]
+    path = [BIP85_GPG_ECC_KEY_BITS, index]
     if sub_index is not None:
         path.append(sub_index)
-    entropy = bip85.derive_entropy(root, 828365, path)
+    entropy = bip85.derive_entropy(root, BIP85_GPG_APP_NIST_P256, path)
     # Avoid relying on cryptography's ``group_order`` attribute since
     # some versions (such as those bundled with seedsigner-os) do not
     # expose it. Instead, use the well-known group order for P-256.
@@ -9272,10 +9281,10 @@ def bip85_brainpoolp256r1_from_root(
     from pgpy.constants import EllipticCurveOID
     from pgpy.packet import fields
 
-    path = [258, index]
+    path = [BIP85_GPG_ECC_KEY_BITS, index]
     if sub_index is not None:
         path.append(sub_index)
-    entropy = bip85.derive_entropy(root, 828365, path)
+    entropy = bip85.derive_entropy(root, BIP85_GPG_APP_BRAINPOOL_P256, path)
     # Hardcode BrainpoolP256r1 group order to avoid relying on attributes
     # that may be missing in some cryptography builds.
     order = 0xA9FB57DBA1EEA9BC3E660A909D838D718C397AA3B561A6F7901E0E82974856A7

--- a/tests/test_bip85_gpg.py
+++ b/tests/test_bip85_gpg.py
@@ -830,13 +830,13 @@ def test_load_bip85_key_warning_when_ecc_enabled(monkeypatch):
 
     assert screens and screens[0] == WarningScreen
     assert captured["key_type_options"] == [
+        "ECC Ed25519",
         "ECC NIST P-256",
         "ECC Brainpool P-256",
         "RSA 2048",
         "RSA 3072",
         "RSA 4096",
         "ECC secp256k1",
-        "ECC Ed25519",
     ]
 
 

--- a/tests/test_bip85_gpg.py
+++ b/tests/test_bip85_gpg.py
@@ -830,13 +830,13 @@ def test_load_bip85_key_warning_when_ecc_enabled(monkeypatch):
 
     assert screens and screens[0] == WarningScreen
     assert captured["key_type_options"] == [
-        "NIST P-256",
-        "Brainpool P-256",
+        "ECC NIST P-256",
+        "ECC Brainpool P-256",
         "RSA 2048",
         "RSA 3072",
         "RSA 4096",
-        "secp256k1",
-        "Ed25519",
+        "ECC secp256k1",
+        "ECC Ed25519",
     ]
 
 
@@ -847,12 +847,12 @@ def test_filter_deletable_subkeys_bip85_only_latest():
         "primary_fpr": fpr,
         "seed_fpr": "S",
         "index": 0,
-        "key_type": "NIST P-256",
+        "key_type": "ECC NIST P-256",
         "ss_version": Controller.VERSION,
         "uids": [],
         "subkeys": [
-            {"index": 0, "type": "ECDH NIST P-256", "fingerprint": "A"},
-            {"index": 1, "type": "ECDSA NIST P-256", "fingerprint": "B"},
+            {"index": 0, "type": "ECDH ECC NIST P-256", "fingerprint": "A"},
+            {"index": 1, "type": "ECDSA ECC NIST P-256", "fingerprint": "B"},
         ],
         "revocations": [],
     }
@@ -879,11 +879,11 @@ def test_bip85_save_and_load(tmp_path):
         "primary_fpr": fpr,
         "seed_fpr": "seedfpr",
         "index": 0,
-        "key_type": "NIST P-256",
+        "key_type": "ECC NIST P-256",
         "ss_version": Controller.VERSION,
         "uids": ["User <user@example.com>"],
         "primary_uid": "User <user@example.com>",
-        "subkeys": [{"index": 0, "type": "ECDH NIST P-256", "fingerprint": "A"}],
+        "subkeys": [{"index": 0, "type": "ECDH ECC NIST P-256", "fingerprint": "A"}],
         "revocations": ["A"],
     }
     bip85_save_data(tmp_path)
@@ -891,10 +891,10 @@ def test_bip85_save_and_load(tmp_path):
     BIP85_DATA.clear()
     bip85_load_data(tmp_path)
     assert BIP85_DATA[fpr]["seed_fpr"] == "seedfpr"
-    assert BIP85_DATA[fpr]["key_type"] == "NIST P-256"
+    assert BIP85_DATA[fpr]["key_type"] == "ECC NIST P-256"
     assert BIP85_DATA[fpr]["uids"][0] == "User <user@example.com>"
     assert BIP85_DATA[fpr]["primary_uid"] == "User <user@example.com>"
-    assert BIP85_DATA[fpr]["subkeys"][0]["type"] == "ECDH NIST P-256"
+    assert BIP85_DATA[fpr]["subkeys"][0]["type"] == "ECDH ECC NIST P-256"
 
 
 def test_load_bip85_data_from_microsd(monkeypatch, tmp_path):
@@ -935,7 +935,7 @@ def test_bip85_save_to_qr(monkeypatch):
         "primary_fpr": fpr,
         "seed_fpr": "S",
         "index": 0,
-        "key_type": "NIST P-256",
+        "key_type": "ECC NIST P-256",
         "ss_version": Controller.VERSION,
         "uids": [],
         "subkeys": [],
@@ -972,7 +972,7 @@ def test_bip85_save_to_microsd_logs_path(monkeypatch, tmp_path):
         "primary_fpr": "F",
         "seed_fpr": "S",
         "index": 0,
-        "key_type": "NIST P-256",
+        "key_type": "ECC NIST P-256",
         "ss_version": Controller.VERSION,
         "uids": [],
         "subkeys": [],
@@ -1036,7 +1036,7 @@ def test_bip85_save_to_seedkeeper(monkeypatch):
         "primary_fpr": "F",
         "seed_fpr": "S",
         "index": 0,
-        "key_type": "NIST P-256",
+        "key_type": "ECC NIST P-256",
         "ss_version": Controller.VERSION,
         "uids": [],
         "subkeys": [],
@@ -1064,7 +1064,7 @@ def test_bip85_seedkeeper_import_format():
                 "primary_fpr": "F",
                 "seed_fpr": "S",
                 "index": 0,
-                "key_type": "NIST P-256",
+                "key_type": "ECC NIST P-256",
                 "uids": [],
                 "subkeys": [],
                 "revocations": [],
@@ -1078,7 +1078,7 @@ def test_bip85_seedkeeper_import_format():
     decoded = binascii.unhexlify(secret_hex)[2:]
     tools_views.bip85_import_json(decoded.decode())
     assert BIP85_DATA["F"]["seed_fpr"] == "S"
-    assert BIP85_DATA["F"]["key_type"] == "NIST P-256"
+    assert BIP85_DATA["F"]["key_type"] == "ECC NIST P-256"
 
 
 def test_advanced_menu_has_bip85_data_options(monkeypatch):
@@ -1124,14 +1124,14 @@ def test_rebuild_bip85_key(monkeypatch):
         "primary_fpr": "X",
         "seed_fpr": fpr,
         "index": 1,
-        "key_type": "NIST P-256",
+        "key_type": "ECC NIST P-256",
         "ss_version": Controller.VERSION,
         "uids": ["Other <o@b.com>", "Primary <a@b.com>"],
         "primary_uid": "Primary <a@b.com>",
         "subkeys": [
-            {"index": 0, "type": "ECDH NIST P-256", "fingerprint": "F0"},
-            {"index": 1, "type": "ECDSA NIST P-256", "fingerprint": "F1"},
-            {"index": 2, "type": "ECDSA NIST P-256", "fingerprint": "F2"},
+            {"index": 0, "type": "ECDH ECC NIST P-256", "fingerprint": "F0"},
+            {"index": 1, "type": "ECDSA ECC NIST P-256", "fingerprint": "F1"},
+            {"index": 2, "type": "ECDSA ECC NIST P-256", "fingerprint": "F2"},
             {"index": 3, "type": "RSA 2048", "fingerprint": "F3"},
             {"index": 4, "type": "RSA 2048", "fingerprint": "F4"},
             {"index": 5, "type": "RSA 2048", "fingerprint": "F5"},
@@ -1444,14 +1444,14 @@ def test_add_subkeys_auto_bip85_index(monkeypatch):
         "primary_fpr": "FPR",
         "seed_fpr": "seedfpr",
         "index": 0,
-        "key_type": "NIST P-256",
+        "key_type": "ECC NIST P-256",
         "ss_version": Controller.VERSION,
         "uids": ["User"],
         "primary_uid": "User",
         "subkeys": [
-            {"index": 0, "type": "ECDH NIST P-256", "fingerprint": "A"},
-            {"index": 1, "type": "ECDSA NIST P-256", "fingerprint": "B"},
-            {"index": 2, "type": "ECDSA NIST P-256", "fingerprint": "C"},
+            {"index": 0, "type": "ECDH ECC NIST P-256", "fingerprint": "A"},
+            {"index": 1, "type": "ECDSA ECC NIST P-256", "fingerprint": "B"},
+            {"index": 2, "type": "ECDSA ECC NIST P-256", "fingerprint": "C"},
         ],
         "revocations": [],
     }
@@ -1493,7 +1493,7 @@ def test_add_subkeys_auto_bip85_index(monkeypatch):
 
     seed_obj = SeedObj()
 
-    # Simulate selecting the only key and NIST P-256 type
+    # Simulate selecting the only key and ECC NIST P-256 type
     def fake_run_screen(self, screen, **kwargs):
         assert kwargs.get("text") != "Choose seed for BIP85 subkeys"
         if kwargs.get("title") == "Select Key":
@@ -1551,7 +1551,7 @@ def test_add_subkeys_registry_index_correction(monkeypatch):
         "primary_fpr": "FPR",
         "seed_fpr": "seedfpr",
         "index": 1,
-        "key_type": "NIST P-256",
+        "key_type": "ECC NIST P-256",
         "ss_version": Controller.VERSION,
         "uids": ["User"],
         "primary_uid": "User",
@@ -1648,14 +1648,14 @@ def test_add_subkeys_missing_seed(monkeypatch):
         "primary_fpr": "FPR",
         "seed_fpr": "seedfpr",
         "index": 0,
-        "key_type": "NIST P-256",
+        "key_type": "ECC NIST P-256",
         "ss_version": Controller.VERSION,
         "uids": ["User"],
         "primary_uid": "User",
         "subkeys": [
-            {"index": 0, "type": "ECDH NIST P-256", "fingerprint": "A"},
-            {"index": 1, "type": "ECDSA NIST P-256", "fingerprint": "B"},
-            {"index": 2, "type": "ECDSA NIST P-256", "fingerprint": "C"},
+            {"index": 0, "type": "ECDH ECC NIST P-256", "fingerprint": "A"},
+            {"index": 1, "type": "ECDSA ECC NIST P-256", "fingerprint": "B"},
+            {"index": 2, "type": "ECDSA ECC NIST P-256", "fingerprint": "C"},
         ],
         "revocations": [],
     }
@@ -1737,24 +1737,24 @@ def test_delete_subkeys_bip85_only_latest(monkeypatch):
         "primary_fpr": "FPR",
         "seed_fpr": "seedfpr",
         "index": 0,
-        "key_type": "NIST P-256",
+        "key_type": "ECC NIST P-256",
         "ss_version": Controller.VERSION,
         "uids": ["User"],
         "primary_uid": "User",
         "subkeys": [
             {
                 "index": 0,
-                "type": "ECDH NIST P-256",
+                "type": "ECDH ECC NIST P-256",
                 "fingerprint": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
             },
             {
                 "index": 1,
-                "type": "ECDSA NIST P-256",
+                "type": "ECDSA ECC NIST P-256",
                 "fingerprint": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
             },
             {
                 "index": 2,
-                "type": "ECDSA NIST P-256",
+                "type": "ECDSA ECC NIST P-256",
                 "fingerprint": "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
             },
         ],

--- a/tests/test_bip85_gpg.py
+++ b/tests/test_bip85_gpg.py
@@ -116,7 +116,7 @@ def test_bip85_drng_vector():
 def test_bip85_rsa_entropy_vectors_match_libwally():
     root = bip32.HDKey.from_string(LIBWALLY_RSA_MASTER_XPRV)
     for expected, bits, index in BIP85_GPG_RSA_VECTORS:
-        entropy = bip85.derive_entropy(root, 828365, [bits, index])
+        entropy = bip85.derive_entropy(root, tools_views.BIP85_GPG_APP_RSA, [bits, index])
         assert entropy.hex() == expected
 
 
@@ -154,7 +154,7 @@ def test_bip85_secp256k1_deterministic():
     root = bip32.HDKey.from_seed(seed.seed_bytes)
     key = bip85_secp256k1_from_root(root, 0)
     assert int(key.s) == int(
-        "cefbb3197f44cbcd28ca548e7d6c22e2b67f497caeebb71fa91d1cc6ab78e502", 16
+        "f57c35cfe2bc7d15d847bb82951188d9b72c604cf052de9f9fd41dff545d5743", 16
     )
 
 
@@ -163,7 +163,7 @@ def test_bip85_p256_deterministic():
     root = bip32.HDKey.from_seed(seed.seed_bytes)
     key = bip85_p256_from_root(root, 0)
     assert int(key.s) == int(
-        "ef959a78fb241496d3b56bf1307f142a1c4b141b7bdb6ec95afc11f66eafad2f", 16
+        "236c5de595d7306949afe92f0f0086ef5fed541e4ca7e374eee414499a365f3f", 16
     )
 
 
@@ -172,7 +172,7 @@ def test_bip85_brainpoolp256r1_deterministic():
     root = bip32.HDKey.from_seed(seed.seed_bytes)
     key = bip85_brainpoolp256r1_from_root(root, 0)
     assert int(key.s) == int(
-        "6f48a0f8172149dd27c6d18e43017e2083e3dcf9ac58144ca054e4e86a7d3a24", 16
+        "6dedd2fd032d8153fbea2ec026e2df265897af0c070c544324a3c24a2964d755", 16
     )
 
 
@@ -181,7 +181,7 @@ def test_bip85_ed25519_deterministic():
     root = bip32.HDKey.from_seed(seed.seed_bytes)
     key = bip85_ed25519_from_root(root, 0)
     assert int(key.s) == int(
-        "7b947d4d726e678ce219948c837221b6712cdf74862b453921442d038f55040c", 16
+        "738a622e2b889989a272da3350053d42978c94e56cec646da180e206010924d3", 16
     )
 
 
@@ -277,12 +277,12 @@ def test_bip85_gpg_mixed_subkeys_deterministic():
             created=created,
         )
 
-    assert pgp_key.fingerprint == "E22DC9A7FDC9F51B7E795EA4134E37F3677DD798"
+    assert pgp_key.fingerprint == "662A9BF1670B7704A41C1FBC74054CC86CF4AB2C"
     fingerprints = [str(sk.fingerprint).replace(" ", "") for sk in pgp_key.subkeys.values()]
     assert fingerprints == [
-        "CF79EEF39935329B69CFCD6FD73018577F0CBE35",
-        "15BD8E20336AD1CFFA0B4363DEC612E5764867B6",
-        "BFD31BC4A4579ADD568D6C3B5FB00DCBCB25E073",
+        "71DD02A0E5E9033287EF85EA0E7275FA96AF991C",
+        "36B51EB5B9D11A2EEA976CF47D8B9EEB49E3B336",
+        "34599F081AA651F1A03EE7EF2F985087816EEBDA",
         "0938B62C0B8FE641FE528A8411A26272C153E6CF",
         "9696B4AAFCA808BFFDE2A04AD2CA980F3652A5D4",
         "07A435FD12E96F72C09B31966577C9E71A248706",


### PR DESCRIPTION
## Summary
- add constants for the new BIP85 GPG application numbers and reuse a shared 256-bit key size for ECC curves
- update the ECC BIP85 derivation helpers to use the curve-specific application numbers and adjust the deterministic fingerprints used in tests

## Testing
- pytest tests/test_bip85_gpg.py

------
https://chatgpt.com/codex/tasks/task_e_68c86b8db1f48322a59992ac702c9388