### PR TITLE
Add secp256k1 coverage to bip85 CLI PGP tests

### DIFF
--- a/tests/test_bip85_pgp_cli.py
+++ b/tests/test_bip85_pgp_cli.py
@@ -27,6 +27,28 @@ def test_generate_pgp_key_and_export():
     assert priv.startswith("-----BEGIN PGP PRIVATE KEY BLOCK-----")
 
 
+def test_generate_pgp_key_and_export_secp256k1():
+    mnemonic = (
+        "abandon abandon abandon abandon abandon abandon "
+        "abandon abandon abandon abandon abandon about"
+    )
+    key = bip85_pgp.create_bip85_pgp_key(
+        mnemonic,
+        key_index=0,
+        primary_type="secp256k1",
+        name="Tester",
+        email="test@example.com",
+        subkey_type="secp256k1",
+        additional_sets=1,
+    )
+    assert key.fingerprint == "501587912640CB9C6CA3E4A0FAB3C5734A95416E"
+    assert len(key.subkeys) == 6
+    pub = bip85_pgp.export_public_key(key)
+    priv = bip85_pgp.export_private_key(key)
+    assert pub.startswith("-----BEGIN PGP PUBLIC KEY BLOCK-----")
+    assert priv.startswith("-----BEGIN PGP PRIVATE KEY BLOCK-----")
+
+
 def test_cli_key_type_choices_include_all_curves():
     expected = {
         "p256",


### PR DESCRIPTION
## Summary
- add a new CLI test that generates a secp256k1 PGP key using the BIP85 mnemonic fixture
- verify the expected fingerprint, subkey count, and key export headers

## Testing
- pytest tests/test_bip85_pgp_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68c8be5073dc8322a54483e8756d0a26