### PR TITLE
Disable OpenCT smartcard interface by default

### DIFF
--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -739,7 +739,11 @@ class SettingsDefinition:
                     type=SettingsConstants.TYPE__MULTISELECT,
                     visibility=SettingsConstants.VISIBILITY__HARDWARE,
                     selection_options=SettingsConstants.ALL_SMARTCARD_INTERFACES,
-                    default_value=[opt[0] for opt in SettingsConstants.ALL_SMARTCARD_INTERFACES]),
+                    default_value=[
+                        opt[0]
+                        for opt in SettingsConstants.ALL_SMARTCARD_INTERFACES
+                        if opt[0] != SettingsConstants.SMARTCARD_INTERFACE_PHOENIX
+                    ]),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__SYSTEM,
                     attr_name=SettingsConstants.SETTING__CACHE_SCARD_PIN,


### PR DESCRIPTION
## Summary
- update the smartcard interface defaults so the Phoenix/OpenCT reader is not enabled automatically (enabling OpenCT on boot interferes with other USB readers on Pi0 and Pi02w)
- keep other reader types enabled by default while preserving the existing selection options

## Testing
- pytest tests/test_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68caf62aa5f48322a8b8255b120285ba