### PR TITLE
Fix flaky export verification and UR decoding tests

### DIFF
--- a/src/seedsigner/helpers/qr.py
+++ b/src/seedsigner/helpers/qr.py
@@ -1,8 +1,11 @@
+import os
+import subprocess
+import tempfile
+
 import qrcode
 from qrcode.image.styledpil import StyledPilImage
 from qrcode.image.styles.moduledrawers import CircleModuleDrawer, GappedSquareModuleDrawer
 from PIL import Image, ImageDraw
-import subprocess
 
 class QR:
     STYLE__DEFAULT = 1
@@ -112,22 +115,42 @@ class QR:
         else:
             border_str = "3"
 
-        if type(data) is str:
-            cmd = f"""qrencode -m {border_str} -s 3 -l L --foreground=000000 --background={background_color} -t PNG    -r "/tmp/data.in" -o "/tmp/qrcode.png" """
-            with open("/tmp/data.in", "w") as f:
-                f.write(data)
+        if isinstance(data, str):
+            encoded_data = data.encode()
+            mode_flag = ""
         else:
-            cmd = f"""qrencode -m {border_str} -s 3 -l L --foreground=000000 --background={background_color} -t PNG -8 -r "/tmp/data.in" -o "/tmp/qrcode.png" """
-            with open("/tmp/data.in", "wb") as f:
-                f.write(data)
+            encoded_data = data
+            mode_flag = "-8 "
 
-        rv = subprocess.call(cmd, shell=True)
+        data_path = None
+        output_path = None
 
-        # if qrencode fails, fall back to only encoder
-        if rv != 0:
-            return self.qrimage(data,width,height,border)
+        try:
+            with tempfile.NamedTemporaryFile(delete=False) as data_file:
+                data_file.write(encoded_data)
+                data_file.flush()
+                data_path = data_file.name
 
-        img = Image.open("/tmp/qrcode.png").resize((width,height), Image.Resampling.NEAREST).convert("RGBA")
-        rv = subprocess.call("rm -f /tmp/data.in /tmp/qrcode.png", shell=True)
+            with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as output_file:
+                output_path = output_file.name
 
-        return img
+            cmd = (
+                f"qrencode -m {border_str} -s 3 -l L --foreground=000000 --background={background_color} "
+                f"-t PNG {mode_flag}-r \"{data_path}\" -o \"{output_path}\""
+            )
+
+            rv = subprocess.call(cmd, shell=True)
+
+            # if qrencode fails, fall back to only encoder
+            if rv != 0:
+                return self.qrimage(data, width, height, border)
+
+            with Image.open(output_path) as img_file:
+                img = img_file.resize((width, height), Image.Resampling.NEAREST).convert("RGBA")
+
+            return img
+        finally:
+            if data_path and os.path.exists(data_path):
+                os.remove(data_path)
+            if output_path and os.path.exists(output_path):
+                os.remove(output_path)

--- a/src/seedsigner/helpers/ur2/crc32.py
+++ b/src/seedsigner/helpers/ur2/crc32.py
@@ -33,4 +33,8 @@ def crc32(buf):
 
 def crc32n(buf):
     n = crc32(buf)
-    return n.to_bytes((bit_length(n) + 7) // 8, 'big')
+    # Always emit a full 4-byte big-endian CRC so downstream consumers can
+    # rely on a fixed-size checksum.  The previous implementation truncated
+    # leading null bytes which caused the Bytewords minimal encoder to drop
+    # payload bytes when the checksum happened to start with zeros.
+    return n.to_bytes(4, 'big')

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -3373,8 +3373,6 @@ class SeedAddressVerificationView(View):
             # and resume displaying the screen. User won't even notice that the Screen is
             # being re-constructed.
             while True:
-                if max_iterations is not None and self.threadsafe_counter.cur_count >= max_iterations:
-                    break
                 selected_menu_num = self.run_screen(
                     seed_screens.SeedAddressVerificationScreen,
                     address=self.address,
@@ -3399,12 +3397,14 @@ class SeedAddressVerificationView(View):
                     # Only happens in the test suite; the screen isn't actually executed so
                     # it returns before the brute force thread has completed.
                     time.sleep(0.1)
-                    continue
+                else:
+                    if button_data[selected_menu_num] == self.SKIP_10:
+                        self.threadsafe_counter.increment(10)
 
-                if button_data[selected_menu_num] == self.SKIP_10:
-                    self.threadsafe_counter.increment(10)
+                    elif button_data[selected_menu_num] == self.CANCEL:
+                        break
 
-                elif button_data[selected_menu_num] == self.CANCEL:
+                if max_iterations is not None and self.threadsafe_counter.cur_count >= max_iterations:
                     break
 
             if self.verified_index.cur_count is not None:


### PR DESCRIPTION
## Summary
- prevent the xpub verification view from skipping its screen when the max-iteration guard triggers
- ensure UR Bytewords CRCs are always four bytes so decoder never truncates payloads

## Testing
- pytest tests/test_flows_seed.py::TestSeedFlows::test_export_xpub_verification_no_match -q
- pytest tests/test_gpg_message.py -q


------
https://chatgpt.com/codex/tasks/task_e_68caf8d4f3a08322a250b7970eaeec66