### PR TITLE
Check Seedkeeper free space before saving secrets

### DIFF
--- a/src/seedsigner/helpers/seedkeeper_utils.py
+++ b/src/seedsigner/helpers/seedkeeper_utils.py
@@ -27,6 +27,78 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def calculate_seedkeeper_secret_size(secret_dic: dict) -> int:
+    """Estimate the number of bytes the secret will occupy on the Seedkeeper.
+
+    The Seedkeeper stores both the secret header (including the automatically
+    assigned id) and an AES-padded copy of the secret payload. This helper
+    mirrors :func:`CardConnector.seedkeeper_import_secret`'s padding behaviour
+    so that we can compare the required storage with the remaining free space
+    reported by the card before attempting an import.
+    """
+
+    header_hex = secret_dic.get("header")
+    if not header_hex:
+        raise ValueError("Secret dictionary missing Seedkeeper header data")
+
+    try:
+        header_length = len(bytes.fromhex(header_hex))
+    except ValueError as exc:
+        raise ValueError("Invalid Seedkeeper header encoding") from exc
+
+    if "secret_list" in secret_dic and secret_dic["secret_list"] is not None:
+        secret_length = len(secret_dic["secret_list"])
+        # Seedkeeper always pads to the next 16 byte boundary, even when the
+        # plaintext length already aligns with the block size.
+        padding = 16 - (secret_length % 16)
+        if padding == 0:
+            padding = 16
+        padded_secret_length = secret_length + padding
+    elif "secret_encrypted" in secret_dic and secret_dic["secret_encrypted"] is not None:
+        padded_secret_length = len(bytes.fromhex(secret_dic["secret_encrypted"]))
+    else:
+        raise ValueError("Secret dictionary missing Seedkeeper secret data")
+
+    return header_length + padded_secret_length
+
+
+def get_seedkeeper_free_memory(connector) -> int:
+    """Return the free memory (in bytes) currently reported by the Seedkeeper."""
+
+    _, _, _, status = connector.seedkeeper_get_status()
+    free_memory = status.get("free_memory")
+    if free_memory is None:
+        raise ValueError("Seedkeeper did not report available memory")
+    return free_memory
+
+
+def ensure_seedkeeper_capacity(connector, secret_dic: dict, free_memory: int | None = None):
+    """Check whether the Seedkeeper has enough space for the provided secret.
+
+    Returns a tuple ``(fits, required_bytes, available_bytes)``. When
+    ``free_memory`` is ``None`` the helper will query the Seedkeeper for the
+    latest free space value, otherwise the supplied ``free_memory`` will be used
+    for the comparison.
+    """
+
+    required_bytes = calculate_seedkeeper_secret_size(secret_dic)
+    available_bytes = free_memory
+    if available_bytes is None:
+        available_bytes = get_seedkeeper_free_memory(connector)
+
+    return required_bytes <= available_bytes, required_bytes, available_bytes
+
+
+def format_seedkeeper_space_error(required_bytes: int, free_bytes: int) -> str:
+    """Return a human-readable message describing a space shortfall."""
+
+    return (
+        "Not enough space on Seedkeeper\n"
+        f"Requires {required_bytes} bytes\n"
+        f"{free_bytes} bytes free"
+    )
+
+
 def prompt_for_pin(parent_view, title: str):
     """Prompt for a PIN and enforce length requirements."""
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -3999,6 +3999,30 @@ class SaveToSeedkeeperView(View):
                     header = Satochip_Connector.make_header(type, export_rights, label, subtype=subtype)
                     secret_dic = {'header': header, 'secret_list': secret_list}
 
+            try:
+                fits, required_bytes, free_bytes = seedkeeper_utils.ensure_seedkeeper_capacity(
+                    Satochip_Connector, secret_dic
+                )
+            except Exception as e:
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text=str(e),
+                    show_back_button=True,
+                )
+                return Destination(BackStackView)
+
+            if not fits:
+                self.run_screen(
+                    WarningScreen,
+                    title="Not Enough Space",
+                    status_headline=None,
+                    text=seedkeeper_utils.format_seedkeeper_space_error(required_bytes, free_bytes),
+                    show_back_button=True,
+                )
+                return Destination(BackStackView)
+
             self.loading_screen = LoadingScreenThread(text="Saving Seed\n\n\n\n\n\n")
             self.loading_screen.start()
             (sid, fingerprint) = Satochip_Connector.seedkeeper_import_secret(secret_dic)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -1806,12 +1806,12 @@ class ToolsSeedkeeperView(View):
 
     def run(self):
         button_data = [
-            self.VIEW_FREE_SPACE,
             self.VIEW_SECRETS,
             self.IMPORT_PASSWORD,
             self.DELETE_SECRET,
             self.LOAD_DESCRIPTOR,
             self.SAVE_DESCRIPTOR,
+            self.VIEW_FREE_SPACE,
         ]
 
         selected_menu_num = self.run_screen(
@@ -1823,9 +1823,6 @@ class ToolsSeedkeeperView(View):
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
-
-        elif button_data[selected_menu_num] == self.VIEW_FREE_SPACE:
-            return Destination(ToolsSeedkeeperFreeSpaceView)
 
         elif button_data[selected_menu_num] == self.VIEW_SECRETS:
             return Destination(ToolsSeedkeeperViewSecretsView)
@@ -1842,6 +1839,9 @@ class ToolsSeedkeeperView(View):
         elif button_data[selected_menu_num] == self.SAVE_DESCRIPTOR:
             return Destination(ToolsSeedkeeperSaveDescriptorView)
 
+        elif button_data[selected_menu_num] == self.VIEW_FREE_SPACE:
+            return Destination(ToolsSeedkeeperFreeSpaceView)
+
 
 class ToolsSeedkeeperFreeSpaceView(View):
 
@@ -1851,7 +1851,7 @@ class ToolsSeedkeeperFreeSpaceView(View):
             connector = seedkeeper_utils.init_satochip(
                 self,
                 init_card_filter=["seedkeeper"],
-                require_pin=False,
+                require_pin=True,
             )
 
             if not connector:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -1797,6 +1797,7 @@ class ToolsSatochipChangeLabelView(View):
         return Destination(MainMenuView)
 
 class ToolsSeedkeeperView(View):
+    VIEW_FREE_SPACE = ButtonOption("View Free Space")
     VIEW_SECRETS = ButtonOption("View Secrets on Card")
     IMPORT_PASSWORD = ButtonOption("Save Password to Card")
     DELETE_SECRET = ButtonOption("Delete Secret from Card")
@@ -1804,7 +1805,14 @@ class ToolsSeedkeeperView(View):
     SAVE_DESCRIPTOR = ButtonOption("Save MultiSig Descriptor")
 
     def run(self):
-        button_data = [self.VIEW_SECRETS, self.IMPORT_PASSWORD, self.DELETE_SECRET, self.LOAD_DESCRIPTOR, self.SAVE_DESCRIPTOR]
+        button_data = [
+            self.VIEW_FREE_SPACE,
+            self.VIEW_SECRETS,
+            self.IMPORT_PASSWORD,
+            self.DELETE_SECRET,
+            self.LOAD_DESCRIPTOR,
+            self.SAVE_DESCRIPTOR,
+        ]
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,
@@ -1815,6 +1823,9 @@ class ToolsSeedkeeperView(View):
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
+
+        elif button_data[selected_menu_num] == self.VIEW_FREE_SPACE:
+            return Destination(ToolsSeedkeeperFreeSpaceView)
 
         elif button_data[selected_menu_num] == self.VIEW_SECRETS:
             return Destination(ToolsSeedkeeperViewSecretsView)
@@ -1830,6 +1841,59 @@ class ToolsSeedkeeperView(View):
         
         elif button_data[selected_menu_num] == self.SAVE_DESCRIPTOR:
             return Destination(ToolsSeedkeeperSaveDescriptorView)
+
+
+class ToolsSeedkeeperFreeSpaceView(View):
+
+    def run(self):
+        connector = None
+        try:
+            connector = seedkeeper_utils.init_satochip(
+                self,
+                init_card_filter=["seedkeeper"],
+                require_pin=False,
+            )
+
+            if not connector:
+                return Destination(BackStackView)
+
+            try:
+                free_bytes = seedkeeper_utils.get_seedkeeper_free_memory(connector)
+            except Exception as exc:
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text=str(exc),
+                    show_back_button=True,
+                )
+                return Destination(BackStackView)
+
+            free_kib = free_bytes / 1024
+            text = f"{free_bytes} bytes free\n({free_kib:.1f} KiB)"
+
+            self.run_screen(
+                LargeIconStatusScreen,
+                title="Seedkeeper Free Space",
+                status_headline=None,
+                text=text,
+                show_back_button=True,
+            )
+            return Destination(BackStackView)
+
+        except Exception as exc:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text=str(exc),
+                show_back_button=True,
+            )
+            return Destination(BackStackView)
+
+        finally:
+            if connector:
+                seedkeeper_utils.disconnect_smartcard_connections(self.controller)
 
 class ToolsSeedkeeperViewSecretsView(View):
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2089,6 +2089,32 @@ class ToolsSeedkeeperImportPasswordView(View):
         secret_text_list = list(bytes(secret_text['passphrase'], 'utf-8'))
         secret_list = [len(secret_text_list)] + secret_text_list
         secret_dic = {'header': header, 'secret_list': secret_list}
+
+        try:
+            fits, required_bytes, free_bytes = seedkeeper_utils.ensure_seedkeeper_capacity(
+                Satochip_Connector, secret_dic
+            )
+        except Exception as e:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text=str(e),
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        if not fits:
+            self.run_screen(
+                WarningScreen,
+                title="Not Enough Space",
+                status_headline=None,
+                text=seedkeeper_utils.format_seedkeeper_space_error(required_bytes, free_bytes),
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
         try:
             self.loading_screen = LoadingScreenThread(text="Saving Secret\n\n\n\n\n\n")
             self.loading_screen.start()
@@ -2467,10 +2493,35 @@ class ToolsSeedkeeperSaveDescriptorView(View):
                     secret_text_list = list(bytes(secret_text, 'utf-8'))
                     secret_list = list(len(secret_text_list).to_bytes(2,"big")) + secret_text_list
                 secret_dic = {'header': header, 'secret_list': secret_list}
+                try:
+                    fits, required_bytes, free_bytes = seedkeeper_utils.ensure_seedkeeper_capacity(
+                        Satochip_Connector, secret_dic
+                    )
+                except Exception as e:
+                    self.loading_screen.stop()
+                    self.run_screen(
+                        WarningScreen,
+                        title="Error",
+                        status_headline=None,
+                        text=str(e),
+                        show_back_button=True,
+                    )
+                    return Destination(BackStackView)
+
+                if not fits:
+                    self.loading_screen.stop()
+                    self.run_screen(
+                        WarningScreen,
+                        title="Not Enough Space",
+                        status_headline=None,
+                        text=seedkeeper_utils.format_seedkeeper_space_error(required_bytes, free_bytes),
+                        show_back_button=True,
+                    )
+                    return Destination(BackStackView)
                 (sid, fingerprint) = Satochip_Connector.seedkeeper_import_secret(secret_dic)
                 logger.info("Imported - SID:", sid, " Fingerprint:", fingerprint)
                 secrets_imported += 1
-                
+
             self.loading_screen.stop()
 
             self.run_screen(
@@ -4745,6 +4796,32 @@ class ToolsGPGSaveBip85DataView(View):
             "Data", "Plaintext export allowed", label
         )
         secret_dic = {"header": header, "secret_list": secret_list}
+
+        try:
+            fits, required_bytes, free_bytes = seedkeeper_utils.ensure_seedkeeper_capacity(
+                Satochip_Connector, secret_dic
+            )
+        except Exception as e:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text=str(e),
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        if not fits:
+            self.run_screen(
+                WarningScreen,
+                title="Not Enough Space",
+                status_headline=None,
+                text=seedkeeper_utils.format_seedkeeper_space_error(required_bytes, free_bytes),
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
 
         try:
             loading = LoadingScreenThread(text="Saving Secret\n\n\n\n\n\n")
@@ -7047,6 +7124,32 @@ class ToolsGPGDecryptMessageView(View):
                 "Data", "Plaintext export allowed", label
             )
             secret_dic = {"header": header, "secret_list": secret_list}
+
+            try:
+                fits, required_bytes, free_bytes = seedkeeper_utils.ensure_seedkeeper_capacity(
+                    Satochip_Connector, secret_dic
+                )
+            except Exception as e:
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text=str(e),
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
+
+            if not fits:
+                self.run_screen(
+                    WarningScreen,
+                    title="Not Enough Space",
+                    status_headline=None,
+                    text=seedkeeper_utils.format_seedkeeper_space_error(required_bytes, free_bytes),
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
 
             try:
                 loading = LoadingScreenThread(text="Saving Secret\n\n\n\n\n\n")
@@ -10630,6 +10733,32 @@ class ToolsGPGExportPubkeyView(View):
             secret_dic = {"header": header, "secret_list": secret_list}
 
             try:
+                fits, required_bytes, free_bytes = seedkeeper_utils.ensure_seedkeeper_capacity(
+                    Satochip_Connector, secret_dic
+                )
+            except Exception as e:
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text=str(e),
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
+
+            if not fits:
+                self.run_screen(
+                    WarningScreen,
+                    title="Not Enough Space",
+                    status_headline=None,
+                    text=seedkeeper_utils.format_seedkeeper_space_error(required_bytes, free_bytes),
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
+
+            try:
                 self.loading_screen = LoadingScreenThread(
                     text="Saving Secret\n\n\n\n\n\n",
                 )
@@ -10881,6 +11010,32 @@ class ToolsGPGExportPrivkeyView(View):
                 "Data", "Plaintext export allowed", label
             )
             secret_dic = {"header": header, "secret_list": secret_list}
+
+            try:
+                fits, required_bytes, free_bytes = seedkeeper_utils.ensure_seedkeeper_capacity(
+                    Satochip_Connector, secret_dic
+                )
+            except Exception as e:
+                self.run_screen(
+                    WarningScreen,
+                    title="Error",
+                    status_headline=None,
+                    text=str(e),
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
+
+            if not fits:
+                self.run_screen(
+                    WarningScreen,
+                    title="Not Enough Space",
+                    status_headline=None,
+                    text=seedkeeper_utils.format_seedkeeper_space_error(required_bytes, free_bytes),
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
 
             try:
                 self.loading_screen = LoadingScreenThread(

--- a/tests/test_bip85_gpg.py
+++ b/tests/test_bip85_gpg.py
@@ -1018,15 +1018,20 @@ def test_bip85_save_to_seedkeeper(monkeypatch):
     class DummyConnector:
         def __init__(self):
             self.saved = None
+            self.last_label = None
 
         def card_get_status(self):
             return (None, None, None, {"protocol_minor_version": 2})
 
         def make_header(self, t, rights, label):
-            return {"label": label}
+            self.last_label = label
+            return "00" * 20
 
         def seedkeeper_import_secret(self, secret_dic):
             self.saved = secret_dic
+
+        def seedkeeper_get_status(self):
+            return (None, None, None, {"free_memory": 4096})
 
     dummy = DummyConnector()
     monkeypatch.setattr(
@@ -1054,7 +1059,8 @@ def test_bip85_save_to_seedkeeper(monkeypatch):
     view = tools_views.ToolsGPGSaveBip85DataView()
     view.run()
     assert dummy.saved is not None
-    assert dummy.saved["header"]["label"].startswith("BIP85-GPG-")
+    assert dummy.last_label is not None
+    assert dummy.last_label.startswith("BIP85-GPG-")
 
 
 def test_bip85_seedkeeper_import_format():


### PR DESCRIPTION
## Summary
- add helper utilities to estimate Seedkeeper storage usage and retrieve free space from the card
- validate available capacity before every Seedkeeper save workflow, surfacing an informative warning when the secret will not fit
- update the Seedkeeper unit test fixture to reflect the new free-space queries

## Testing
- pytest tests/test_bip85_gpg.py

------
https://chatgpt.com/codex/tasks/task_e_68cc0227c9fc8322b8e787110c436f44