### PR TITLE
Warn when Satochip card fingerprint mismatches PSBT

### DIFF
--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -146,12 +146,15 @@ class PSBTSelectSeedView(View):
             from seedsigner.gui.screens.screen import LoadingScreenThread
             loading = LoadingScreenThread(text=_("Parsing PSBT..."))
             loading.start()
+            loading_stopped = False
             try:
                 try:
                     account_xpub = connector.card_bip32_get_xpub(account_path_str, xtype, is_mainnet)
                     master_xpub = connector.card_bip32_get_xpub("", xtype, is_mainnet)
                 except Exception as e:
                     logger.exception("Failed to export xpub from Satochip card")
+                    loading.stop()
+                    loading_stopped = True
                     self.run_screen(
                         WarningScreen,
                         title="Failed",
@@ -174,6 +177,8 @@ class PSBTSelectSeedView(View):
                     )
                 except Exception as e:
                     logger.exception("Failed to parse PSBT with Satochip data")
+                    loading.stop()
+                    loading_stopped = True
                     self.run_screen(
                         WarningScreen,
                         title="Failed",
@@ -197,6 +202,8 @@ class PSBTSelectSeedView(View):
                     )
                     self.controller.psbt_parser = None
                     self.controller.psbt_sign_with_satochip = False
+                    loading.stop()
+                    loading_stopped = True
                     self.run_screen(
                         WarningScreen,
                         title=_("Fingerprint mismatch"),
@@ -208,7 +215,8 @@ class PSBTSelectSeedView(View):
                     )
                     return Destination(PSBTSelectSeedView, clear_history=True)
             finally:
-                loading.stop()
+                if not loading_stopped:
+                    loading.stop()
 
             self.controller.psbt_seed = None
             self.controller.psbt_sign_with_satochip = True

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -1,6 +1,8 @@
 from gettext import gettext as _
 
 from binascii import hexlify
+from binascii import hexlify
+
 from embit import bip32
 import logging
 
@@ -177,6 +179,32 @@ class PSBTSelectSeedView(View):
                         title="Failed",
                         status_headline=None,
                         text=str(e),
+                    )
+                    return Destination(PSBTSelectSeedView, clear_history=True)
+
+                card_fingerprints = {hexlify(master_fp).decode()}
+                try:
+                    card_fingerprints.add(hexlify(root_key.child(0).fingerprint).decode())
+                except Exception:
+                    pass
+
+                psbt_fingerprints = set(PSBTParser.get_input_fingerprints(self.controller.psbt))
+                if not card_fingerprints.intersection(psbt_fingerprints):
+                    logger.warning(
+                        "Satochip fingerprint mismatch: card %s vs psbt %s",
+                        sorted(card_fingerprints),
+                        sorted(psbt_fingerprints),
+                    )
+                    self.controller.psbt_parser = None
+                    self.controller.psbt_sign_with_satochip = False
+                    self.run_screen(
+                        WarningScreen,
+                        title=_("Fingerprint mismatch"),
+                        status_icon_name=SeedSignerIconConstants.WARNING,
+                        status_headline=_("Card cannot sign PSBT"),
+                        text=_(
+                            "Card fingerprint ({}) not in PSBT signers."
+                        ).format(sorted(card_fingerprints)[0]),
                     )
                     return Destination(PSBTSelectSeedView, clear_history=True)
             finally:

--- a/tests/test_flows_psbt.py
+++ b/tests/test_flows_psbt.py
@@ -262,3 +262,47 @@ class TestPSBTSatochip(FlowTest):
             FlowStep(psbt_views.PSBTSelectSeedView, button_data_selection=psbt_views.PSBTSelectSeedView.SATOCHIP),
             FlowStep(psbt_views.PSBTSelectSeedView),
         ])
+
+    def test_satochip_fingerprint_mismatch_shows_warning(self, monkeypatch):
+        """Mismatch between card fingerprint and PSBT should warn and return to selection."""
+        from embit.bip32 import HDKey
+        from embit import networks
+        from seedsigner.views import scan_views, psbt_views
+        from seedsigner.views.view import MainMenuView
+        from seedsigner.helpers import seedkeeper_utils
+
+        def load_psbt_into_decoder(view: scan_views.ScanView):
+            view.decoder.add_data(
+                "cHNidP8BAHECAAAAAX9/d6VyI7nvVTyhLBfqu05za2AJ2Z0dKMC0cUX+S2U7AQAAAAD9////AgeHAAAAAAAAFgAUOnNPuZMD1sQudt3+7LvHBUvGhyd//gAAAAAAABYAFGO9QLvu4V9/hz6ZjbIGMrqsEiIYAjQTAAABAR+ghgEAAAAAABYAFKawrgcT62jmIVQwyHPCV0thmJWbAQDBAQAAAAABAYeHL9UQlz/jEKUuNNY3LTeQRjudjBinsP2L0ppvgRt0AAAAAAD/////AnbP3rsPAAAAIlEgtgmCioGjfKwp6f8rOoI4OPb+ZV8db581J9IizZPskl2ghgEAAAAAABYAFKawrgcT62jmIVQwyHPCV0thmJWbAUDCBlMh9VjZN2NdU9Wabi0o3Ct1q9YHTsJRLAkLfUuIHB+BE+ucR4bdGAJG5nBhCWOmCXbpRwKP1INRYvkuQ2fHAAAAACIGA2+PEYHyVy6nhYwAx5SJKBIWXjsWgjhhf/2FEWqXgxnoEKNOC3gAAACAAAAAAAAAAAAAACICA0SBeeHxfHdny6rUnQJuteAnQ7shSydexjJCkSJarn3mEKNOC3gAAACAAQAAAAEAAAAA"
+            )
+
+        seed = b"\x01" * 32
+        root = HDKey.from_seed(seed, version=networks.NETWORKS["main"]["xprv"])
+        master_xpub = root.to_public().to_base58()
+        account_xpub = root.derive("m/84h/0h/0h").to_public().to_base58()
+
+        class MockConnector:
+            def card_bip32_get_xpub(self, path, xtype, is_mainnet):
+                if path == "":
+                    return master_xpub
+                if path == "m/84'/0'/0'":
+                    return account_xpub
+                raise ValueError("unexpected path")
+
+        monkeypatch.setattr(seedkeeper_utils, "init_satochip", lambda *args, **kwargs: MockConnector())
+
+        controller = Controller.get_instance()
+        controller.storage.seeds = []
+        controller.psbt_parser = None
+        controller.psbt_sign_with_satochip = False
+        controller.Satochip_Connector = None
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_psbt_into_decoder),
+            FlowStep(psbt_views.PSBTSelectSeedView, screen_return_value=0),
+            FlowStep(psbt_views.PSBTSelectSeedView),
+        ])
+
+        assert controller.psbt_parser is None
+        assert controller.psbt_sign_with_satochip is False


### PR DESCRIPTION
## Summary
- add a fingerprint cross-check after parsing PSBT data from a Satochip card
- warn and return to signer selection when the card fingerprint is not required by the PSBT
- shorten the Satochip mismatch warning copy so it fits comfortably on screen
- cover the mismatch warning behaviour with a flow test

## Testing
- pytest tests/test_flows_psbt.py::TestPSBTSatochip -q

------
https://chatgpt.com/codex/tasks/task_e_68cc019ee8108322bfcee2d3cb9754dd