### PR TITLE
Fix Satochip message signing authentikey comparison crash

### DIFF
--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -13,6 +13,22 @@ from embit.util import secp256k1
 from seedsigner.helpers.iso7816 import format_sw_error
 from seedsigner.models.settings import Settings, SettingsConstants
 
+try:  # pragma: no cover - pysatochip optional at runtime
+    from pysatochip import ecc as pysatochip_ecc
+except ImportError:  # pragma: no cover - pysatochip not installed
+    pysatochip_ecc = None
+else:  # pragma: no cover - behaviour validated via unit tests
+    if not hasattr(pysatochip_ecc.ECPubkey, "_seedsigner_safe_eq"):
+        _orig_eq = pysatochip_ecc.ECPubkey.__eq__
+
+        def _safe_eq(self, other):
+            if not isinstance(other, pysatochip_ecc.ECPubkey):
+                return False
+            return _orig_eq(self, other)
+
+        pysatochip_ecc.ECPubkey.__eq__ = _safe_eq
+        pysatochip_ecc.ECPubkey._seedsigner_safe_eq = True
+
 try:
     # Constant introduced in newer embit versions
     from embit.bip32 import HARDENED_INDEX  # type: ignore

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -195,7 +195,55 @@ def test_get_xpub():
         # call with named params
         print(f'  {func.__name__}(seed_bytes={args[0]}, derivation_path="{args[1]}", embit_network="{args[2]}") == "{expected}"')
         assert str(func(seed_bytes=args[0], derivation_path=args[1], embit_network=args[2])) == expected
-        
+
+
+def test_sign_message_vectors():
+    """Verify sign_message outputs match known-good signatures"""
+
+    from embit import bip39
+
+    seed = bip39.mnemonic_to_seed("abandon " * 11 + "about")
+
+    vectors = (
+        (
+            "m/84'/0'/0'/0/3",
+            "a test message with a colon ':' character.",
+            "IN/4LmcGRaI5sgvBP2mrTXQFvD6FecXd8La03SixPabsb/255ElRGTcXhicT3KFsNJbfQ9te909ZXeKMaqUcaPM=",
+            None,
+        ),
+        (
+            "m/84'/1'/0'/0/3",
+            "A test message.",
+            "ILc30ti8OPSpCtzfj7sNnftANBCuVpyRX7pnM3iAgOk9F9IUtnXNPus0+MF12y5HKYHAB6IVYr66sLmL3Vi3oEE=",
+            "test",
+        ),
+        (
+            "m/86'/0'/0'/0/3",
+            "a test message with a colon ':' character.",
+            "H3Z5VioeLaC0rpdI2CflUu34IANgGxum0Rr9lmCziQRfUQv+vFND+nHvxHmJZA0uvLLI1/mTEEHD2bBfN6Y2d6w=",
+            None,
+        ),
+        (
+            "m/44'/0'/0'/0/3",
+            "a test message with a colon ':' character.",
+            "IEpq8rUwSmDxO3GgwaZ75tw3DArtHtLi08kgQuRNXdteMI5KNEAWbpzsY8gRzGkspZN4YFiRu4RNCM+IsKkWys8=",
+            None,
+        ),
+        (
+            "m/49'/0'/0'/0/3",
+            "a test message with a colon ':' character.",
+            "HyH8898c2S6eF8hTPGhRqLC6UQrJrhw/fdguBeFG0cCrOFkbG8TCVURXOgxXaEV93vrFlHyxNGEvL10IcsLtvvI=",
+            None,
+        ),
+    )
+
+    for derivation, message, expected, network in vectors:
+        kwargs = {}
+        if network:
+            kwargs["embit_network"] = network
+        signature = embit_utils.sign_message(seed, derivation, message.encode(), **kwargs)
+        assert signature == expected
+
 
 def test_get_single_sig_address():
     """

--- a/tests/test_satochip_sign_message.py
+++ b/tests/test_satochip_sign_message.py
@@ -1,5 +1,7 @@
 from binascii import b2a_base64
 
+import pytest
+
 from seedsigner.helpers.satochip_signer import sign_message_with_satochip
 
 
@@ -27,4 +29,14 @@ def test_sign_message_with_satochip_accepts_hardened_notation_without_m_prefix()
     connector = DummyConnector()
     sig = sign_message_with_satochip("84h/0h/0h/0/0", "hello", connector)
     assert sig == b2a_base64(b"\x01" * 65).strip().decode()
+
+
+def test_pysatochip_pubkey_equality_is_hardened():
+    try:
+        from pysatochip.ecc import ECPubkey
+    except ImportError:  # pragma: no cover - pysatochip not installed
+        pytest.skip("pysatochip not available")
+
+    pubkey = ECPubkey(b"\x02" + b"\x00" * 32)
+    assert not (pubkey == None)  # noqa: E711 - explicit None comparison for regression
 


### PR DESCRIPTION
## Summary
- monkey patch pysatochip's `ECPubkey.__eq__` to safely handle non-ECPubkey comparisons and prevent crashes during message signing
- add a regression test ensuring the patched equality no longer raises and cover the new guard

## Testing
- pytest tests/test_embit_utils.py::test_sign_message_vectors -q
- pytest tests/test_satochip_sign_message.py -q


------
https://chatgpt.com/codex/tasks/task_e_68cc9db4f4b0832290c259569318e980