### PR TITLE
Handle Satochip authentikey absence gracefully

### DIFF
--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -7,9 +7,11 @@ import random
 import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 
+from embit import bip32
 from embit.ec import PublicKey
 from embit.psbt import PSBT
 from embit.util import secp256k1
+from seedsigner.helpers import embit_utils
 from seedsigner.helpers.iso7816 import format_sw_error
 from seedsigner.models.settings import Settings, SettingsConstants
 
@@ -25,6 +27,11 @@ logger = logging.getLogger(__name__)
 _MISSING_AUTHENTIKEY_ERROR = (
     "Satochip authentikey is unavailable. Verify the card PIN has been entered and "
     "that the card has been initialised with current firmware."
+)
+
+_ADDRESS_MISMATCH_ERROR = (
+    "Selected address does not belong to the inserted Satochip card. Ensure you are "
+    "using the correct card for this wallet before signing."
 )
 
 
@@ -58,6 +65,55 @@ def _get_extended_key(connector, path):
         if "_pubkey" in str(exc):
             raise Exception(_MISSING_AUTHENTIKEY_ERROR) from exc
         raise
+
+
+def verify_satochip_message_address(connector, addr_format: dict, expected_address: str) -> None:
+    """Ensure ``expected_address`` belongs to the Satochip wallet described by ``addr_format``."""
+
+    if not expected_address:
+        raise Exception("Missing address for Satochip message signing verification")
+
+    wallet_path = addr_format.get("wallet_derivation_path")
+    is_change = addr_format.get("is_change")
+    index = addr_format.get("index")
+    script_type = addr_format.get("script_type")
+    network = addr_format.get("network")
+
+    if wallet_path is None or is_change is None or index is None:
+        raise Exception(
+            "Sign message request must reference a standard receive or change path "
+            "(m/.../0/* or m/.../1/*)."
+        )
+
+    if script_type is None or network is None:
+        raise Exception("Unable to determine script type or network for address verification")
+
+    if script_type == SettingsConstants.NATIVE_SEGWIT:
+        xtype = "p2wpkh"
+    elif script_type == SettingsConstants.NESTED_SEGWIT:
+        xtype = "p2wpkh-p2sh"
+    elif script_type == SettingsConstants.LEGACY_P2PKH:
+        xtype = "standard"
+    elif script_type == SettingsConstants.TAPROOT:
+        xtype = "standard"
+    else:
+        raise Exception("Unsupported script type for Satochip message signing")
+
+    is_mainnet = network == SettingsConstants.MAINNET
+    path = format_path_string(wallet_path)
+    xpub_base58 = connector.card_bip32_get_xpub(path, xtype, is_mainnet)
+    xpub = bip32.HDKey.from_base58(xpub_base58)
+    embit_network = embit_utils.get_embit_network_name(network)
+    derived_address = embit_utils.get_single_sig_address(
+        xpub=xpub,
+        script_type=script_type,
+        index=index,
+        is_change=is_change,
+        embit_network=embit_network,
+    )
+
+    if derived_address != expected_address:
+        raise Exception(_ADDRESS_MISMATCH_ERROR)
 
 
 def _call_with_timeout(func, timeout: float, *args):

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -22,6 +22,44 @@ except ImportError:  # pragma: no cover - support older embit releases
 logger = logging.getLogger(__name__)
 
 
+_MISSING_AUTHENTIKEY_ERROR = (
+    "Satochip authentikey is unavailable. Verify the card PIN has been entered and "
+    "that the card has been initialised with current firmware."
+)
+
+
+def _ensure_satochip_authentikey(connector) -> None:
+    """Ensure the connector has loaded the authentikey into its parser."""
+
+    parser = getattr(connector, "parser", None)
+    if parser is None:
+        return
+
+    authentikey = getattr(parser, "authentikey", None)
+    if authentikey is not None:
+        return
+
+    get_authentikey = getattr(connector, "card_bip32_get_authentikey", None)
+    if get_authentikey is None:
+        return
+
+    authentikey = get_authentikey()
+    if getattr(parser, "authentikey", None) is None and authentikey is None:
+        raise Exception(_MISSING_AUTHENTIKEY_ERROR)
+
+
+def _get_extended_key(connector, path):
+    """Retrieve the extended key for ``path`` with helpful error reporting."""
+
+    _ensure_satochip_authentikey(connector)
+    try:
+        return connector.card_bip32_get_extendedkey(path)
+    except AttributeError as exc:
+        if "_pubkey" in str(exc):
+            raise Exception(_MISSING_AUTHENTIKEY_ERROR) from exc
+        raise
+
+
 def _call_with_timeout(func, timeout: float, *args):
     """Execute ``func`` with the provided timeout and log duration."""
     start = time.monotonic()
@@ -128,7 +166,7 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
         for pubkey, deriv in inp.bip32_derivations.items():
             path = _format_path(deriv.derivation)
             try:
-                key, _chaincode = connector.card_bip32_get_extendedkey(path)
+                key, _chaincode = _get_extended_key(connector, path)
                 card_pub = PublicKey.parse(
                     key.get_public_key_bytes(compressed=True)
                 )
@@ -233,7 +271,7 @@ def sign_message_with_satochip(derivation_path: str, message: str, connector) ->
     settings = Settings.get_instance()
     timeout = settings.get_value(SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT)
     path = format_path_string(derivation_path)
-    key, _chaincode = connector.card_bip32_get_extendedkey(path)
+    key, _chaincode = _get_extended_key(connector, path)
     try:
         _resp, sw1, sw2, compsig = _call_with_timeout(
             connector.card_sign_message, timeout, 0xFF, key, message

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -324,7 +324,7 @@ def sign_message_with_satochip(derivation_path: str, message: str, connector) ->
     """
 
     settings = Settings.get_instance()
-    timeout = settings.get_value(SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT)
+    timeout = settings.get_value(SettingsConstants.SETTING__SATOCHIP_MSG_SIGN_TIMEOUT)
     path = format_path_string(derivation_path)
     key, _chaincode = _get_extended_key(connector, path)
     try:

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -30,8 +30,7 @@ _MISSING_AUTHENTIKEY_ERROR = (
 )
 
 _ADDRESS_MISMATCH_ERROR = (
-    "Selected address does not belong to the inserted Satochip card. Ensure you are "
-    "using the correct card for this wallet before signing."
+    "Address isn't on this Satochip card. Use the matching card before signing."
 )
 
 

--- a/src/seedsigner/helpers/seedkeeper_utils.py
+++ b/src/seedsigner/helpers/seedkeeper_utils.py
@@ -154,21 +154,22 @@ def init_satochip(parentObject, init_card_filter=None, require_pin=True):
 
     # Check for existing card connector
     print("Checking existing card connector...")
-    try:
-        if parentObject.controller.Satochip_Connector is not None:
+    Satochip_Connector = getattr(parentObject.controller, "Satochip_Connector", None)
+    if Satochip_Connector is not None:
+        try:
             print("Found existing connector, try to use it...")
-            parentObject.controller.Satochip_Connector.card_get_label()
-
+            Satochip_Connector.card_get_label()
             print("Found Card:", Satochip_Connector.UID_SHA1)
-            print("Expecting Card:", parentObject.controller.Satochip_Last_UID_SHA1)
-
-            # If the card connector is still good, we will get to this line :)
-            return parentObject.controller.Satochip_Connector
-    except:
-        parentObject.controller.Satochip_Connector = None
+            print(
+                "Expecting Card:",
+                getattr(parentObject.controller, "Satochip_Last_UID_SHA1", None),
+            )
+        except Exception:
+            parentObject.controller.Satochip_Connector = None
+            Satochip_Connector = None
 
     try:
-        if parentObject.controller.Satochip_Connector is None:
+        if Satochip_Connector is None:
             print("No Working CardConnector, Connecting")
             print("Card Filter:", init_card_filter)
             Satochip_Connector = CardConnector(card_filter=init_card_filter)

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -305,6 +305,15 @@ class SettingsConstants:
     ]
     DEFAULT_SATOCHIP_TIMEOUT = 0.5
 
+    SATOCHIP_MSG_TIMEOUT_MIN = 0.5
+    SATOCHIP_MSG_TIMEOUT_MAX = 2
+
+    ALL_SATOCHIP_MSG_TIMEOUTS = [
+        (i / 4, f"{i / 4:g}s")
+        for i in range(int(SATOCHIP_MSG_TIMEOUT_MIN * 4), int(SATOCHIP_MSG_TIMEOUT_MAX * 4) + 1)
+    ]
+    DEFAULT_SATOCHIP_MSG_TIMEOUT = 1.25
+
     SATOCHIP_PRE_DUMMY_MAX_MIN = 0
     SATOCHIP_PRE_DUMMY_MAX_MAX = 12
     ALL_SATOCHIP_PRE_DUMMY_MAX = [
@@ -450,6 +459,7 @@ class SettingsConstants:
     SETTING__BIP38_KEYS = "bip38_keys"
 
     SETTING__SATOCHIP_SIGN_TIMEOUT = "satochip_sign_timeout"
+    SETTING__SATOCHIP_MSG_SIGN_TIMEOUT = "satochip_msg_sign_timeout"
     SETTING__SATOCHIP_MAX_PRE_DUMMIES = "satochip_max_pre_dummies"
     SETTING__SATOCHIP_MAX_POST_DUMMIES = "satochip_max_post_dummies"
     SETTING__SATOCHIP_MAX_IN_TX_DUMMIES = "satochip_max_in_tx_dummies"
@@ -972,11 +982,20 @@ class SettingsDefinition:
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT,
                       abbreviated_name="satotime",
-                      display_name="Satochip sign timeout",
+                      display_name="Satochip tx sign timeout",
                       type=SettingsConstants.TYPE__SELECT_1,
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       selection_options=SettingsConstants.ALL_SATOCHIP_TIMEOUTS,
                       default_value=SettingsConstants.DEFAULT_SATOCHIP_TIMEOUT),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__SATOCHIP_MSG_SIGN_TIMEOUT,
+                      abbreviated_name="satomsig",
+                      display_name="Satochip message sign timeout",
+                      type=SettingsConstants.TYPE__SELECT_1,
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      selection_options=SettingsConstants.ALL_SATOCHIP_MSG_TIMEOUTS,
+                      default_value=SettingsConstants.DEFAULT_SATOCHIP_MSG_TIMEOUT),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__SATOCHIP_MAX_PRE_DUMMIES,

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -3780,6 +3780,7 @@ class SeedSignMessageConfirmAddressView(View):
             seed = self.controller.get_seed(self.seed_num)
             xpub = seed.get_xpub(wallet_path=addr_format["wallet_derivation_path"], network=addr_format["network"])
 
+        data["addr_format"] = addr_format
         embit_network = embit_utils.get_embit_network_name(addr_format["network"])
         self.address = embit_utils.get_single_sig_address(
             xpub=xpub,
@@ -3788,6 +3789,7 @@ class SeedSignMessageConfirmAddressView(View):
             is_change=addr_format["is_change"],
             embit_network=embit_network,
         )
+        data["address"] = self.address
 
 
     def run(self):
@@ -3819,17 +3821,37 @@ class SeedSignMessageSignedMessageQRView(View):
         message: str = data["message"]
 
         if self.controller.sign_message_with_satochip:
-            from seedsigner.helpers.satochip_signer import sign_message_with_satochip
+            from seedsigner.helpers.satochip_signer import (
+                sign_message_with_satochip,
+                verify_satochip_message_address,
+            )
             from seedsigner.gui.screens.screen import LoadingScreenThread
 
             loading = LoadingScreenThread(text=_("Signing message..."))
             loading.start()
+            error: str | None = None
             try:
+                verify_satochip_message_address(
+                    self.controller.Satochip_Connector,
+                    data.get("addr_format", {}),
+                    data.get("address"),
+                )
                 self.signed_message = sign_message_with_satochip(
                     derivation_path, message, self.controller.Satochip_Connector
                 )
+            except Exception as exc:
+                error = str(exc)
             finally:
                 loading.stop()
+            if error:
+                self.set_redirect(
+                    Destination(
+                        SeedSignMessageSatochipVerificationFailedView,
+                        view_args=dict(error=error),
+                        skip_current_view=True,
+                    )
+                )
+                return
         else:
             self.seed_num = data["seed_num"]
             seed = self.controller.get_seed(self.seed_num)
@@ -3855,6 +3877,30 @@ class SeedSignMessageSignedMessageQRView(View):
         self.controller.sign_message_with_satochip = False
 
         # Exiting/Canceling the QR display screen always returns Home
+        return Destination(MainMenuView, skip_current_view=True)
+
+
+class SeedSignMessageSatochipVerificationFailedView(View):
+    def __init__(self, error: str):
+        super().__init__()
+        self.error = error
+
+    def run(self):
+        from seedsigner.gui.screens.screen import WarningScreen, ButtonOption
+
+        self.run_screen(
+            WarningScreen,
+            title=_("Verification Failed"),
+            status_headline=None,
+            text=self.error,
+            button_data=[ButtonOption(_("OK"))],
+            show_back_button=False,
+        )
+
+        self.controller.resume_main_flow = None
+        self.controller.sign_message_data = None
+        self.controller.sign_message_with_satochip = False
+
         return Destination(MainMenuView, skip_current_view=True)
 
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2687,14 +2687,7 @@ class ToolsSatochipBenchmarkSignView(View):
         if not connector:
             return Destination(BackStackView)
 
-        timeout_setting = self.settings.get_value(
-            SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT
-        )
-        try:
-            timeout_value = float(timeout_setting)
-        except (TypeError, ValueError):
-            timeout_value = 0.0
-        timeout = max(timeout_value, 5.0)
+        timeout = 5.0
         durations: list[float] = []
         loading = LoadingScreenThread(text="Benchmarking\n\n\n\n\n\n")
         loading.start()
@@ -2753,39 +2746,7 @@ class ToolsSatochipBenchmarkMessageSignView(View):
         if not connector:
             return Destination(BackStackView)
 
-        tx_timeout_setting = self.settings.get_value(
-            SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT
-        )
-        msg_timeout_setting = self.settings.get_value(
-            SettingsConstants.SETTING__SATOCHIP_MSG_SIGN_TIMEOUT
-        )
-        try:
-            tx_timeout_value = float(tx_timeout_setting)
-        except (TypeError, ValueError):
-            tx_timeout_value = 0.0
-        try:
-            msg_timeout_value = float(msg_timeout_setting)
-        except (TypeError, ValueError):
-            msg_timeout_value = 0.0
-
-        signing_timeout = max(tx_timeout_value, 5.0)
-        message_timeout = max(msg_timeout_value, 5.0)
-        timeout = max(message_timeout, signing_timeout * 2.0)
-
-        # When the user hasn't customised the timeouts, default the benchmark to
-        # five seconds instead of the doubled value so results reflect the new
-        # higher baseline requested for benchmarking specifically.
-        default_tx_timeout = SettingsConstants.DEFAULT_SATOCHIP_TIMEOUT
-        default_msg_timeout = SettingsConstants.DEFAULT_SATOCHIP_MSG_TIMEOUT
-        if (
-            (tx_timeout_setting is None
-            or abs(tx_timeout_value - float(default_tx_timeout)) < 1e-9)
-            and (
-                msg_timeout_setting is None
-                or abs(msg_timeout_value - float(default_msg_timeout)) < 1e-9
-            )
-        ):
-            timeout = 5.0
+        timeout = 5.0
         network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
         coin_type = "0" if network == SettingsConstants.MAINNET else "1"
         derivation_path = f"m/84'/{coin_type}'/0'/0/0"

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2687,7 +2687,14 @@ class ToolsSatochipBenchmarkSignView(View):
         if not connector:
             return Destination(BackStackView)
 
-        timeout = self.settings.get_value(SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT)
+        timeout_setting = self.settings.get_value(
+            SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT
+        )
+        try:
+            timeout_value = float(timeout_setting)
+        except (TypeError, ValueError):
+            timeout_value = 0.0
+        timeout = max(timeout_value, 5.0)
         durations: list[float] = []
         loading = LoadingScreenThread(text="Benchmarking\n\n\n\n\n\n")
         loading.start()
@@ -2746,7 +2753,15 @@ class ToolsSatochipBenchmarkMessageSignView(View):
         if not connector:
             return Destination(BackStackView)
 
-        timeout = self.settings.get_value(SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT)
+        timeout_setting = self.settings.get_value(
+            SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT
+        )
+        try:
+            timeout_value = float(timeout_setting)
+        except (TypeError, ValueError):
+            timeout_value = 0.0
+        signing_timeout = max(timeout_value, 5.0)
+        timeout = max(signing_timeout * 2.0, 10.0)
         network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
         coin_type = "0" if network == SettingsConstants.MAINNET else "1"
         derivation_path = f"m/84'/{coin_type}'/0'/0/0"
@@ -2757,24 +2772,29 @@ class ToolsSatochipBenchmarkMessageSignView(View):
         loading = LoadingScreenThread(text="Benchmarking\n\n\n\n\n\n")
         loading.start()
         try:
-            for _ in range(20):
-                start = time.monotonic()
-                try:
-                    key, _ = _get_extended_key(connector, path)
+            try:
+                key, _ = _get_extended_key(connector, path)
+            except Exception as exc:
+                logger.warning("Benchmark message signing failed: %s", exc)
+                error = str(exc)
+            else:
+                for _ in range(20):
                     message = os.urandom(16).hex()
-                    _call_with_timeout(
-                        connector.card_sign_message,
-                        timeout,
-                        0xFF,
-                        key,
-                        message,
-                    )
-                except Exception as exc:
-                    logger.warning("Benchmark message signing failed: %s", exc)
-                    error = str(exc)
-                    break
-                else:
-                    durations.append(time.monotonic() - start)
+                    start = time.monotonic()
+                    try:
+                        _call_with_timeout(
+                            connector.card_sign_message,
+                            timeout,
+                            0xFF,
+                            key,
+                            message,
+                        )
+                    except Exception as exc:
+                        logger.warning("Benchmark message signing failed: %s", exc)
+                        error = str(exc)
+                        break
+                    else:
+                        durations.append(time.monotonic() - start)
         finally:
             loading.stop()
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -58,7 +58,11 @@ from .satochip_bias import ToolsSatochipBiasCheckView
 
 from seedsigner.hardware.microsd import MicroSD
 from seedsigner.helpers import seedkeeper_utils
-from seedsigner.helpers.satochip_signer import _call_with_timeout
+from seedsigner.helpers.satochip_signer import (
+    _call_with_timeout,
+    _get_extended_key,
+    format_path_string,
+)
 from seedsigner.gui.screens import seed_screens
 logger = logging.getLogger(__name__)
 
@@ -2646,10 +2650,11 @@ class ToolsSatochipView(View):
 class ToolsSatochipAdvancedView(View):
     ENABLE_2FA = ButtonOption("Enable 2FA")
     BENCHMARK = ButtonOption("Benchmark Signing")
+    BENCHMARK_MESSAGE = ButtonOption("Benchmark Message Signing")
     BIAS_TEST = ButtonOption("Check signing bias")
 
     def run(self):
-        button_data = [self.ENABLE_2FA, self.BENCHMARK, self.BIAS_TEST]
+        button_data = [self.ENABLE_2FA, self.BENCHMARK, self.BENCHMARK_MESSAGE, self.BIAS_TEST]
         selected_menu_num = self.run_screen(
             ButtonListScreen,
             title="Satochip Advanced",
@@ -2665,6 +2670,9 @@ class ToolsSatochipAdvancedView(View):
 
         elif button_data[selected_menu_num] == self.BENCHMARK:
             return Destination(ToolsSatochipBenchmarkSignView)
+
+        elif button_data[selected_menu_num] == self.BENCHMARK_MESSAGE:
+            return Destination(ToolsSatochipBenchmarkMessageSignView)
 
         elif button_data[selected_menu_num] == self.BIAS_TEST:
             return Destination(ToolsSatochipBiasCheckView)
@@ -2717,6 +2725,77 @@ class ToolsSatochipBenchmarkSignView(View):
             ).format(min_time=min_time, avg=avg, max_time=max_time)
         else:
             text = "Benchmark signing failed"
+
+        self.run_screen(
+            LargeIconStatusScreen,
+            title="Benchmark",
+            status_headline=None,
+            text=text,
+            show_back_button=False,
+        )
+        return Destination(MainMenuView)
+
+
+class ToolsSatochipBenchmarkMessageSignView(View):
+    """Benchmark Satochip message signing performance."""
+
+    def run(self):
+        from seedsigner.gui.screens.screen import LoadingScreenThread
+
+        connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
+        if not connector:
+            return Destination(BackStackView)
+
+        timeout = self.settings.get_value(SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT)
+        network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+        coin_type = "0" if network == SettingsConstants.MAINNET else "1"
+        derivation_path = f"m/84'/{coin_type}'/0'/0/0"
+        path = format_path_string(derivation_path)
+
+        durations: list[float] = []
+        error: str | None = None
+        loading = LoadingScreenThread(text="Benchmarking\n\n\n\n\n\n")
+        loading.start()
+        try:
+            for _ in range(20):
+                start = time.monotonic()
+                try:
+                    key, _ = _get_extended_key(connector, path)
+                    message = os.urandom(16).hex()
+                    _call_with_timeout(
+                        connector.card_sign_message,
+                        timeout,
+                        0xFF,
+                        key,
+                        message,
+                    )
+                except Exception as exc:
+                    logger.warning("Benchmark message signing failed: %s", exc)
+                    error = str(exc)
+                    break
+                else:
+                    durations.append(time.monotonic() - start)
+        finally:
+            loading.stop()
+
+        if durations:
+            avg = sum(durations) / len(durations)
+            min_time = min(durations)
+            max_time = max(durations)
+            logger.info(
+                "Benchmark message signing results: min=%.3fs avg=%.3fs max=%.3fs over %d signatures",
+                min_time,
+                avg,
+                max_time,
+                len(durations),
+            )
+            text = (
+                "Min: {min_time:.3f}s\n"
+                "Avg: {avg:.3f}s\n"
+                "Max: {max_time:.3f}s"
+            ).format(min_time=min_time, avg=avg, max_time=max_time)
+        else:
+            text = error or "Benchmark signing failed"
 
         self.run_screen(
             LargeIconStatusScreen,

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2770,7 +2770,22 @@ class ToolsSatochipBenchmarkMessageSignView(View):
 
         signing_timeout = max(tx_timeout_value, 5.0)
         message_timeout = max(msg_timeout_value, 5.0)
-        timeout = max(message_timeout, signing_timeout * 2.0, 10.0)
+        timeout = max(message_timeout, signing_timeout * 2.0)
+
+        # When the user hasn't customised the timeouts, default the benchmark to
+        # five seconds instead of the doubled value so results reflect the new
+        # higher baseline requested for benchmarking specifically.
+        default_tx_timeout = SettingsConstants.DEFAULT_SATOCHIP_TIMEOUT
+        default_msg_timeout = SettingsConstants.DEFAULT_SATOCHIP_MSG_TIMEOUT
+        if (
+            (tx_timeout_setting is None
+            or abs(tx_timeout_value - float(default_tx_timeout)) < 1e-9)
+            and (
+                msg_timeout_setting is None
+                or abs(msg_timeout_value - float(default_msg_timeout)) < 1e-9
+            )
+        ):
+            timeout = 5.0
         network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
         coin_type = "0" if network == SettingsConstants.MAINNET else "1"
         derivation_path = f"m/84'/{coin_type}'/0'/0/0"

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2753,15 +2753,24 @@ class ToolsSatochipBenchmarkMessageSignView(View):
         if not connector:
             return Destination(BackStackView)
 
-        timeout_setting = self.settings.get_value(
+        tx_timeout_setting = self.settings.get_value(
             SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT
         )
+        msg_timeout_setting = self.settings.get_value(
+            SettingsConstants.SETTING__SATOCHIP_MSG_SIGN_TIMEOUT
+        )
         try:
-            timeout_value = float(timeout_setting)
+            tx_timeout_value = float(tx_timeout_setting)
         except (TypeError, ValueError):
-            timeout_value = 0.0
-        signing_timeout = max(timeout_value, 5.0)
-        timeout = max(signing_timeout * 2.0, 10.0)
+            tx_timeout_value = 0.0
+        try:
+            msg_timeout_value = float(msg_timeout_setting)
+        except (TypeError, ValueError):
+            msg_timeout_value = 0.0
+
+        signing_timeout = max(tx_timeout_value, 5.0)
+        message_timeout = max(msg_timeout_value, 5.0)
+        timeout = max(message_timeout, signing_timeout * 2.0, 10.0)
         network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
         coin_type = "0" if network == SettingsConstants.MAINNET else "1"
         derivation_path = f"m/84'/{coin_type}'/0'/0/0"

--- a/tests/test_satochip_sign_message.py
+++ b/tests/test_satochip_sign_message.py
@@ -1,4 +1,7 @@
 from binascii import b2a_base64
+from types import SimpleNamespace
+
+import pytest
 
 from seedsigner.helpers.satochip_signer import sign_message_with_satochip
 
@@ -9,6 +12,16 @@ class DummyKey:
 
 
 class DummyConnector:
+    def __init__(self, authentikey_available: bool = True):
+        authentikey = object() if authentikey_available else None
+        self.parser = SimpleNamespace(authentikey=authentikey)
+        self._authentikey_response = authentikey
+
+    def card_bip32_get_authentikey(self):
+        if self._authentikey_response is not None:
+            self.parser.authentikey = self._authentikey_response
+        return self._authentikey_response
+
     def card_bip32_get_extendedkey(self, path):
         return DummyKey(), b""
 
@@ -27,4 +40,11 @@ def test_sign_message_with_satochip_accepts_hardened_notation_without_m_prefix()
     connector = DummyConnector()
     sig = sign_message_with_satochip("84h/0h/0h/0/0", "hello", connector)
     assert sig == b2a_base64(b"\x01" * 65).strip().decode()
+
+
+def test_sign_message_with_satochip_raises_when_authentikey_missing():
+    connector = DummyConnector(authentikey_available=False)
+    with pytest.raises(Exception) as exc:
+        sign_message_with_satochip("m/84'/0'/0'/0/0", "hello", connector)
+    assert "authentikey" in str(exc.value)
 

--- a/tests/test_satochip_sign_message.py
+++ b/tests/test_satochip_sign_message.py
@@ -3,7 +3,14 @@ from types import SimpleNamespace
 
 import pytest
 
-from seedsigner.helpers.satochip_signer import sign_message_with_satochip
+from embit import bip32
+
+from seedsigner.helpers import embit_utils
+from seedsigner.helpers.satochip_signer import (
+    sign_message_with_satochip,
+    verify_satochip_message_address,
+)
+from seedsigner.models.settings_definition import SettingsConstants
 
 
 class DummyKey:
@@ -12,10 +19,11 @@ class DummyKey:
 
 
 class DummyConnector:
-    def __init__(self, authentikey_available: bool = True):
+    def __init__(self, authentikey_available: bool = True, xpub: str | None = None):
         authentikey = object() if authentikey_available else None
         self.parser = SimpleNamespace(authentikey=authentikey)
         self._authentikey_response = authentikey
+        self._xpub = xpub
 
     def card_bip32_get_authentikey(self):
         if self._authentikey_response is not None:
@@ -24,6 +32,11 @@ class DummyConnector:
 
     def card_bip32_get_extendedkey(self, path):
         return DummyKey(), b""
+
+    def card_bip32_get_xpub(self, path, xtype, is_mainnet):
+        if self._xpub is None:
+            raise Exception("xpub unavailable")
+        return self._xpub
 
     def card_sign_message(self, keynbr, pubkey, message, hmac=None):
         compsig = b"\x01" * 65
@@ -47,4 +60,47 @@ def test_sign_message_with_satochip_raises_when_authentikey_missing():
     with pytest.raises(Exception) as exc:
         sign_message_with_satochip("m/84'/0'/0'/0/0", "hello", connector)
     assert "authentikey" in str(exc.value)
+
+
+def test_verify_satochip_message_address_accepts_receive_address():
+    seed = bytes(range(32))
+    root = bip32.HDKey.from_seed(seed)
+    wallet = root.derive("m/84h/0h/0h")
+    xpub = wallet.to_public()
+    expected_address = embit_utils.get_single_sig_address(
+        xpub=xpub,
+        script_type=SettingsConstants.NATIVE_SEGWIT,
+        index=5,
+        is_change=False,
+        embit_network="main",
+    )
+    addr_format = {
+        "wallet_derivation_path": "m/84h/0h/0h",
+        "is_change": False,
+        "index": 5,
+        "script_type": SettingsConstants.NATIVE_SEGWIT,
+        "network": SettingsConstants.MAINNET,
+    }
+    connector = DummyConnector(xpub=xpub.to_base58())
+
+    verify_satochip_message_address(connector, addr_format, expected_address)
+
+
+def test_verify_satochip_message_address_rejects_mismatch():
+    seed = bytes(range(32))
+    root = bip32.HDKey.from_seed(seed)
+    wallet = root.derive("m/84h/0h/0h")
+    xpub = wallet.to_public()
+    addr_format = {
+        "wallet_derivation_path": "m/84h/0h/0h",
+        "is_change": True,
+        "index": 0,
+        "script_type": SettingsConstants.NATIVE_SEGWIT,
+        "network": SettingsConstants.MAINNET,
+    }
+    connector = DummyConnector(xpub=xpub.to_base58())
+
+    with pytest.raises(Exception) as exc:
+        verify_satochip_message_address(connector, addr_format, "bc1qnotavalidaddress")
+    assert "Satochip card" in str(exc.value)
 


### PR DESCRIPTION
## Summary
- remove the global pysatochip ECPubkey monkey patch added previously
- ensure Satochip PSBT and message signing flows load the authentikey before requesting keys and raise a clear error when it is missing
- extend the Satochip message signing tests to cover the missing-authentikey case
- ensure init_satochip re-verifies the PIN when reusing an existing connector so signing workflows always run behind a validated PIN

## Testing
- pytest tests/test_satochip_sign_message.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cead38c22483228ef6eac26ba8140d