### PR TITLE
Handle Satochip multisig PSBTs without xpub lookup

### DIFF
--- a/src/seedsigner/models/psbt_parser.py
+++ b/src/seedsigner/models/psbt_parser.py
@@ -67,11 +67,10 @@ class PSBTParser():
 
     @property
     def is_multisig(self):
-        print(self.policy)
         """
             Multisig psbts will have "m" and "n" defined in policy
         """
-        return "m" in self.policy
+        return isinstance(self.policy, dict) and "m" in self.policy
 
 
     @property
@@ -98,12 +97,15 @@ class PSBTParser():
             logger.info(f"self.psbt is None!!")
             return False
 
-        if self.root is None:
+        if self.seed is not None and self.root is None:
             self._set_root()
 
         rt = self._parse_inputs()
         if rt == False:
             return False
+
+        if self.root is None and self.seed is None and not self.is_multisig:
+            raise RuntimeError("No seed or root key available")
 
         rt = self._parse_outputs()
         if rt == False:

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -117,6 +117,43 @@ class PSBTSelectSeedView(View):
             if not connector:
                 return Destination(PSBTSelectSeedView, clear_history=True)
 
+            psbt = self.controller.psbt
+            is_multisig_psbt = False
+            try:
+                if psbt and psbt.inputs:
+                    first_input = psbt.inputs[0]
+                    if first_input.witness_utxo:
+                        script_pubkey = first_input.witness_utxo.script_pubkey
+                    elif first_input.non_witness_utxo:
+                        script_pubkey = first_input.script_pubkey
+                    else:
+                        script_pubkey = None
+
+                    if script_pubkey is not None:
+                        policy = PSBTParser._get_policy(first_input, script_pubkey, psbt.xpubs)
+                        is_multisig_psbt = isinstance(policy, dict) and "m" in policy
+            except Exception as exc:
+                logger.debug("Unable to determine PSBT policy", exc_info=exc)
+
+            if is_multisig_psbt:
+                try:
+                    parser = PSBTParser(psbt)
+                    parser.parse()
+                except Exception as e:
+                    logger.exception("Failed to parse PSBT with Satochip data")
+                    self.run_screen(
+                        WarningScreen,
+                        title="Failed",
+                        status_headline=None,
+                        text=str(e),
+                    )
+                    return Destination(PSBTSelectSeedView, clear_history=True)
+
+                self.controller.psbt_parser = parser
+                self.controller.psbt_seed = None
+                self.controller.psbt_sign_with_satochip = True
+                return Destination(PSBTOverviewView)
+
             network = self.settings.get_value(SettingsConstants.SETTING__NETWORK)
             is_mainnet = network == SettingsConstants.MAINNET
             first_der = next(iter(self.controller.psbt.inputs[0].bip32_derivations.values())).derivation
@@ -572,22 +609,36 @@ class PSBTChangeDetailsView(View):
 
         # Single-sig verification is easy. We expect to find a single fingerprint
         # and derivation path.
+        fingerprints = change_data.get("fingerprint") or []
+        derivation_paths = change_data.get("derivation_path") or []
+
         if self.controller.psbt_seed:
             seed_fingerprint = self.controller.psbt_seed.get_fingerprint(
                 self.settings.get_value(SettingsConstants.SETTING__NETWORK)
             )
         else:
-            seed_fingerprint = hexlify(psbt_parser.master_fingerprint).decode()
+            master_fp = getattr(psbt_parser, "master_fingerprint", None)
+            seed_fingerprint = hexlify(master_fp).decode() if master_fp else None
 
-        if seed_fingerprint not in change_data.get("fingerprint"):
-            # TODO: Something is wrong with this psbt(?). Reroute to warning?
-            return Destination(NotYetImplementedView)
+        if seed_fingerprint:
+            if seed_fingerprint not in fingerprints:
+                # TODO: Something is wrong with this psbt(?). Reroute to warning?
+                return Destination(NotYetImplementedView)
+            index = fingerprints.index(seed_fingerprint)
+        else:
+            index = 0 if fingerprints else None
+            if index is not None:
+                seed_fingerprint = fingerprints[index]
 
-        i = change_data.get("fingerprint").index(seed_fingerprint)
-        derivation_path = change_data.get("derivation_path")[i]
+        derivation_path = ""
+        if index is not None and index < len(derivation_paths):
+            derivation_path = derivation_paths[index]
 
         # 'm/84h/1h/0h/1/0' would be a change addr while 'm/84h/1h/0h/0/0' is a self-receive
-        path_ints = bip32.parse_path(derivation_path)
+        if derivation_path:
+            path_ints = bip32.parse_path(derivation_path)
+        else:
+            path_ints = []
         is_change_derivation_path = len(path_ints) >= 2 and (path_ints[-2] & 0x7FFFFFFF) == 1
         derivation_path_addr_index = path_ints[-1] & 0x7FFFFFFF if path_ints else 0
 
@@ -605,11 +656,34 @@ class PSBTChangeDetailsView(View):
             print("isMultisig")
             # if the known-good multisig descriptor is already onboard:
             if self.controller.multisig_wallet_descriptor:
-                is_change_addr_verified = psbt_parser.verify_multisig_output(self.controller.multisig_wallet_descriptor, change_num=self.change_address_num)
+                is_change_addr_verified = psbt_parser.verify_multisig_output(
+                    self.controller.multisig_wallet_descriptor,
+                    change_num=self.change_address_num,
+                )
+                if not is_change_addr_verified:
+                    self.controller.multisig_wallet_descriptor = None
+                    self.run_screen(
+                        WarningScreen,
+                        title=_("Descriptor mismatch"),
+                        status_icon_name=SeedSignerIconConstants.WARNING,
+                        status_headline=_("Descriptor cleared"),
+                        text=_(
+                            "Loaded multisig wallet descriptor does not match this PSBT. "
+                            "Load the correct descriptor or skip verification to continue."
+                        ),
+                        show_back_button=False,
+                        button_data=[ButtonOption(_("OK"))],
+                    )
+                    return Destination(
+                        PSBTChangeDetailsView,
+                        view_args={"change_address_num": self.change_address_num},
+                        skip_current_view=True,
+                    )
+
                 button_data = [self.NEXT]
 
             else:
-                # Have the Screen offer to load in the multisig descriptor.            
+                # Have the Screen offer to load in the multisig descriptor.
                 button_data = [self.VERIFY_MULTISIG, self.SKIP_VERIFICATION]
 
         else:
@@ -686,8 +760,8 @@ class PSBTChangeDetailsView(View):
             address=change_data.get("address"),
             amount=change_data.get("amount"),
             is_multisig=psbt_parser.is_multisig,
-            fingerprint=seed_fingerprint,
-            derivation_path=derivation_path,
+            fingerprint=seed_fingerprint or "",
+            derivation_path=derivation_path or "",
             is_change_derivation_path=is_change_derivation_path,
             derivation_path_addr_index=derivation_path_addr_index,
             is_change_addr_verified=is_change_addr_verified,

--- a/tests/test_flows_psbt.py
+++ b/tests/test_flows_psbt.py
@@ -1,4 +1,6 @@
-from base import FlowTest, FlowStep
+from base import BaseTest, FlowTest, FlowStep
+
+from unittest.mock import Mock
 
 from seedsigner.controller import Controller
 from seedsigner.views.view import MainMenuView
@@ -306,3 +308,56 @@ class TestPSBTSatochip(FlowTest):
 
         assert controller.psbt_parser is None
         assert controller.psbt_sign_with_satochip is False
+
+
+class TestPSBTMultisigDescriptorMismatch(BaseTest):
+
+    def test_descriptor_mismatch_clears_descriptor_and_prompts(self):
+        from embit import psbt
+        from embit.descriptor import Descriptor
+
+        from seedsigner.gui.screens.screen import WarningScreen, RET_CODE__BACK_BUTTON
+        from seedsigner.models.psbt_parser import PSBTParser
+
+        psbt_b64 = "cHNidP8BAIkCAAAAAc9dCSh2RcRPfHaT5bNVBpbg0jAekRLqOK+bpN/QA0jeAAAAAAD9////AtAHAAAAAAAAIlEg24shYsV3IRCzlgmMKjAsR4Ad9tX896z7zDAi5q0TU9H3CgAAAAAAACIAIByGQg/VP2aRID62ty40E64HYZeRRsKRGLt8J/76R6stQ04FAE8BBDWHzwSLLGdzgAAAAq3q6nR20JnHR+vKrBQdWxN9C7xU8zNX942mVF7AQpl2ArrdLwVlkGxaatQJ4wwkvypNBKbwOq9hXGLNlKi7rZWAFDUxzXUwAACAAQAAgAAAAIACAACATwEENYfPBHOCZmWAAAACmH6KTXIny0vueRgQFBq4M6oMuG8f1QM0I/RzKQ03bCgCHrF0fyUtV0+FD2N34u/woqb8MAt/o+7Ed58RddhY8zYUCUjSaDAAAIABAACAAAAAgAIAAIAAAQEriBMAAAAAAAAiACBY4WsjDgJXLj3VW222jU1tkIIhT26ce/2efH73BWGGBiICAqyfkrdUO662QBrdvJcSOZMFxniD7M1awm9U0Kb5XCm5RzBEAiAPkQTY84YjFFkpD6MI2cc5rJySqws5fsTQA/8XEZFpbAIgTNVykbEH4Z7bqyzhhy6lty0K8rtCUDCaHNv+47NNIWgBAQMEAQAAAAEFR1IhApL4XO+VE1pPYn5wnRFyJQKVSc9TX2dO6KIBH6jwvgPaIQKsn5K3VDuutkAa3byXEjmTBcZ4g+zNWsJvVNCm+VwpuVKuIgYCkvhc75UTWk9ifnCdEXIlApVJz1NfZ07oogEfqPC+A9ocNTHNdTAAAIABAACAAAAAgAIAAIAAAAAAAAAAACIGAqyfkrdUO662QBrdvJcSOZMFxniD7M1awm9U0Kb5XCm5HAlI0mgwAACAAQAAgAAAAIACAACAAAAAAAAAAAAAAAEBR1IhApYXaczuYbBM/A+EH639Ir2yIB4PxL46dK/I1V1O9aHgIQLa02HCI/+EP+9gGpxHskjYWFN5hZzXY7RRvwV4UF42ylKuIgIClhdpzO5hsEz8D4Qfrf0ivbIgHg/Evjp0r8jVXU71oeAcNTHNdTAAAIABAACAAAAAgAIAAIABAAAAAAAAACICAtrTYcIj/4Q/72AanEeySNhYU3mFnNdjtFG/BXhQXjbKHAlI0mgwAACAAQAAgAAAAIACAACAAQAAAAAAAAAA"
+
+        psbt_obj = psbt.PSBT.from_string(psbt_b64)
+        parser = PSBTParser(psbt_obj)
+        parser.parse()
+
+        self.controller.psbt = psbt_obj
+        self.controller.psbt_parser = parser
+
+        mismatch_descriptor = Descriptor.from_string(
+            "wsh(sortedmulti(1,[3531cd75/48h/1h/0h/2h]tpubDEvs8aQCFkexBPVGJoqctrxgK9zeFwejWUWsAn7fKeSbbSUQ8sW6BJHrkKpNGRXwAfk7UWZDKz6amomvE2bo7DzokRtH8gnfweyQZf2ufFz/0/*,"
+            "[0948d268/48h/1h/0h/2h]tpubDEkn1ih27ZcgHeu4tLzDw5EceCBa8hYMhRoCP7QmfijsrxDgchvMEC8ukFncE9Y7qBCBozBzYjEz4ophQ2quGRZsbN2bTziJxpLeK7mHq4L/0/*))"
+        )
+        self.controller.multisig_wallet_descriptor = mismatch_descriptor
+
+        change_view = psbt_views.PSBTChangeDetailsView(change_address_num=0)
+        change_view.run_screen = Mock(return_value=0)
+
+        destination = change_view.run()
+
+        assert self.controller.multisig_wallet_descriptor is None
+        assert destination.View_cls == psbt_views.PSBTChangeDetailsView
+        assert destination.view_args == {"change_address_num": 0}
+        assert destination.skip_current_view is True
+
+        change_view.run_screen.assert_called_once()
+        args, kwargs = change_view.run_screen.call_args
+        assert args[0] is WarningScreen
+        assert kwargs["show_back_button"] is False
+        assert len(kwargs["button_data"]) == 1
+        assert kwargs["button_data"][0].button_label == "OK"
+
+        follow_up_view = psbt_views.PSBTChangeDetailsView(change_address_num=0)
+        follow_up_view.run_screen = Mock(return_value=RET_CODE__BACK_BUTTON)
+
+        follow_up_destination = follow_up_view.run()
+
+        follow_up_view.run_screen.assert_called_once()
+        _, follow_up_kwargs = follow_up_view.run_screen.call_args
+        assert follow_up_kwargs["button_data"][0] is follow_up_view.VERIFY_MULTISIG
+        assert follow_up_kwargs["button_data"][1] is follow_up_view.SKIP_VERIFICATION
+        assert follow_up_destination.View_cls.__name__ == "BackStackView"


### PR DESCRIPTION
## Summary
- detect multisig PSBTs when using the Satochip signer and skip the xpub export, relying on the standard multisig review flow
- allow PSBTParser to parse multisig transactions without a root key and adjust change details to cope with missing Satochip fingerprints
- inform the user when a loaded multisig descriptor does not match the PSBT, clear it, and return to the change verification options

## Testing
- pytest tests/test_flows_psbt.py

------
https://chatgpt.com/codex/tasks/task_e_68d2b5b7b4e0832286e0bd1b09028805