### PR TITLE
Add microSD PSBT loading to Satochip tools

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -2,6 +2,7 @@ import logging
 import time
 import traceback
 from gettext import gettext as _
+from pathlib import Path
 
 from embit.descriptor import Descriptor
 from embit.psbt import PSBT
@@ -134,6 +135,9 @@ class Controller(Singleton):
     psbt_seed: Seed = None
     psbt_parser: PSBTParser = None
     psbt_sign_with_satochip: bool = False
+    psbt_from_microsd: bool = False
+    psbt_microsd_save_path: Path | None = None
+    psbt_microsd_seed_warning_shown: bool = False
     sign_message_with_satochip: bool = False
 
     unverified_address = None
@@ -222,6 +226,9 @@ class Controller(Singleton):
         controller.psbt = None
         controller.psbt_parser = None
         controller.psbt_sign_with_satochip = False
+        controller.psbt_from_microsd = False
+        controller.psbt_microsd_save_path = None
+        controller.psbt_microsd_seed_warning_shown = False
         controller.sign_message_with_satochip = False
 
         # Configure the Renderer

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -9,8 +9,17 @@ import logging
 from seedsigner.models.psbt_parser import PSBTParser
 from seedsigner.models.settings import SettingsConstants
 from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
-from seedsigner.gui.screens.screen import (RET_CODE__BACK_BUTTON, ButtonListScreen, ButtonOption, WarningScreen, DireWarningScreen, QRDisplayScreen)
+from seedsigner.gui.screens.screen import (
+    RET_CODE__BACK_BUTTON,
+    ButtonListScreen,
+    ButtonOption,
+    WarningScreen,
+    DireWarningScreen,
+    QRDisplayScreen,
+    LargeIconStatusScreen,
+)
 from seedsigner.views.view import BackStackView, MainMenuView, NotYetImplementedView, View, Destination
+from seedsigner.hardware.microsd import MicroSD
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +42,24 @@ class PSBTSelectSeedView(View):
 
     def run(self):
         from seedsigner.controller import Controller
+
+        def ensure_microsd_seed_warning() -> bool:
+            if not getattr(self.controller, "psbt_from_microsd", False):
+                return True
+            if getattr(self.controller, "psbt_microsd_seed_warning_shown", False):
+                return True
+            ret = self.run_screen(
+                WarningScreen,
+                title="WARNING",
+                status_headline=None,
+                text="These tools load data from the microSD card and may expose loaded secrets.",
+                show_back_button=True,
+                button_data=[ButtonOption("Continue")],
+            )
+            if ret == RET_CODE__BACK_BUTTON:
+                return False
+            self.controller.psbt_microsd_seed_warning_shown = True
+            return True
 
         # Note: we can't just autoroute to the PSBT Overview because we might have a
         # multisig where we want to sign with more than one key on this device.
@@ -87,25 +114,37 @@ class PSBTSelectSeedView(View):
         )
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
+            if getattr(self.controller, "psbt_from_microsd", False):
+                self.controller.psbt_from_microsd = False
+                self.controller.psbt_microsd_save_path = None
+                self.controller.psbt_microsd_seed_warning_shown = False
             return Destination(BackStackView)
 
         if len(seeds) > 0 and selected_menu_num < len(seeds):
             # User selected one of the n seeds
+            if not ensure_microsd_seed_warning():
+                return Destination(PSBTSelectSeedView)
             self.controller.psbt_seed = self.controller.get_seed(selected_menu_num)
             return Destination(PSBTOverviewView)
-        
+
         # The remaining flows are a sub-flow; resume PSBT flow once the seed is loaded.
         self.controller.resume_main_flow = Controller.FLOW__PSBT
 
         if button_data[selected_menu_num] == self.SCAN_SEED:
+            if not ensure_microsd_seed_warning():
+                return Destination(PSBTSelectSeedView)
             from seedsigner.views.scan_views import ScanSeedQRView
             return Destination(ScanSeedQRView)
 
         elif button_data[selected_menu_num] == self.SCAN_WIF:
+            if not ensure_microsd_seed_warning():
+                return Destination(PSBTSelectSeedView)
             from seedsigner.views.scan_views import ScanWIFQRView
             return Destination(ScanWIFQRView)
 
         elif button_data[selected_menu_num] == self.SCAN_BIP38:
+            if not ensure_microsd_seed_warning():
+                return Destination(PSBTSelectSeedView)
             from seedsigner.views.scan_views import ScanBIP38QRView
             return Destination(ScanBIP38QRView)
 
@@ -260,18 +299,26 @@ class PSBTSelectSeedView(View):
             return Destination(PSBTOverviewView)
 
         elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_15WORD, self.TYPE_18WORD, self.TYPE_21WORD, self.TYPE_24WORD]:
+            if not ensure_microsd_seed_warning():
+                return Destination(PSBTSelectSeedView)
             from seedsigner.views.seed_views import SeedMnemonicEntryView
             self.controller.storage.init_pending_mnemonic(num_words=button_data[selected_menu_num].return_data)
             return Destination(SeedMnemonicEntryView)
 
         elif button_data[selected_menu_num] == self.TYPE_ELECTRUM:
+            if not ensure_microsd_seed_warning():
+                return Destination(PSBTSelectSeedView)
             from seedsigner.views.seed_views import SeedElectrumMnemonicStartView
             return Destination(SeedElectrumMnemonicStartView)
 
         elif button_data[selected_menu_num] == self.TYPE_WIF:
+            if not ensure_microsd_seed_warning():
+                return Destination(PSBTSelectSeedView)
             return Destination(PSBTWIFEntryView)
 
         elif button_data[selected_menu_num] == self.TYPE_BIP38:
+            if not ensure_microsd_seed_warning():
+                return Destination(PSBTSelectSeedView)
             return Destination(PSBTBIP38EntryView)
 
 
@@ -913,6 +960,39 @@ class PSBTSignedQRDisplayView(View):
         from seedsigner.models.encode_qr import UrPsbtQrEncoder, GenericStringEncoder
         from seedsigner.models.wif import WIFKey
         from seedsigner.gui.screens.screen import LoadingScreenThread
+
+        save_path = getattr(self.controller, "psbt_microsd_save_path", None)
+        if save_path:
+            signed_path = save_path.with_name(save_path.name + ".signed")
+            try:
+                signed_path.parent.mkdir(parents=True, exist_ok=True)
+                signed_path.write_bytes(self.controller.psbt.serialize())
+                try:
+                    display_path = str(signed_path.relative_to(MicroSD.get_microsd_dir()))
+                except ValueError:
+                    display_path = signed_path.name
+                self.run_screen(
+                    LargeIconStatusScreen,
+                    title=_("Success"),
+                    status_headline=None,
+                    text=_("Saved as {}.").format(display_path),
+                    show_back_button=False,
+                    button_data=[ButtonOption(_("Continue"))],
+                )
+            except Exception as e:
+                logger.exception("Failed to save signed PSBT", exc_info=e)
+                self.run_screen(
+                    WarningScreen,
+                    title=_("Error"),
+                    status_headline=None,
+                    text=_("Failed to save PSBT: {}").format(str(e)),
+                    show_back_button=False,
+                    button_data=[ButtonOption(_("OK"))],
+                )
+            finally:
+                self.controller.psbt_microsd_save_path = None
+                self.controller.psbt_from_microsd = False
+                self.controller.psbt_microsd_seed_warning_shown = False
 
         if isinstance(self.controller.psbt_seed, WIFKey) and getattr(self.controller, "signed_tx_hex", None):
             qr_encoder = GenericStringEncoder(self.controller.signed_tx_hex)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5,7 +5,9 @@ import time
 import platform
 import binascii
 import subprocess
+from pathlib import Path
 from embit.util import secp256k1
+from embit.psbt import PSBT
 
 from embit.descriptor import Descriptor
 from embit.descriptor.checksum import checksum
@@ -2617,6 +2619,7 @@ class ToolsSatochipView(View):
     IMPORT_SEED = ButtonOption("Initialise with Seed")
     EXPORT_XPUB = ButtonOption("Export Xpub")
     LOAD_DESCRIPTOR = ButtonOption("Load as Descriptor")
+    LOAD_PSBT = ButtonOption("Load PSBT")
     ADVANCED = ButtonOption("Advanced")
 
     def run(self):
@@ -2624,6 +2627,7 @@ class ToolsSatochipView(View):
             self.IMPORT_SEED,
             self.EXPORT_XPUB,
             self.LOAD_DESCRIPTOR,
+            self.LOAD_PSBT,
             self.ADVANCED,
         ]
         selected_menu_num = self.run_screen(
@@ -2644,8 +2648,104 @@ class ToolsSatochipView(View):
 
         elif button_data[selected_menu_num] == self.LOAD_DESCRIPTOR:
             return Destination(SatochipLoadDescriptorScriptTypeView)
+        elif button_data[selected_menu_num] == self.LOAD_PSBT:
+            return Destination(ToolsSatochipLoadPsbtView)
         elif button_data[selected_menu_num] == self.ADVANCED:
             return Destination(ToolsSatochipAdvancedView)
+
+
+class ToolsSatochipLoadPsbtView(View):
+    def run(self):
+        from seedsigner.views.psbt_views import PSBTSelectSeedView
+
+        # Reset microSD PSBT context before prompting the user.
+        self.controller.psbt_from_microsd = False
+        self.controller.psbt_microsd_save_path = None
+        self.controller.psbt_microsd_seed_warning_shown = False
+
+        if len(self.controller.storage.seeds) > 0:
+            ret = self.run_screen(
+                WarningScreen,
+                title="WARNING",
+                status_headline=None,
+                text="These tools load data from the microSD card and may expose loaded secrets.",
+                show_back_button=True,
+                button_data=[ButtonOption("Continue")],
+            )
+            if ret == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
+            self.controller.psbt_microsd_seed_warning_shown = True
+
+        psbt_dir = MicroSD.get_microsd_dir() / "psbt"
+        try:
+            psbt_dir.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            logger.exception("Failed to access PSBT directory", exc_info=e)
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text=str(e),
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(BackStackView)
+
+        psbt_files = sorted(
+            [
+                p
+                for p in psbt_dir.iterdir()
+                if p.is_file() and not p.name.startswith(".") and p.suffix.lower() == ".psbt"
+            ],
+            key=lambda p: p.name.lower(),
+        )
+
+        if not psbt_files:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="No PSBT files found in psbt/.",
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(BackStackView)
+
+        button_data = [ButtonOption(path.name) for path in psbt_files]
+        selected = self.run_screen(
+            ButtonListScreen,
+            title="Select PSBT",
+            is_button_text_centered=False,
+            button_data=button_data,
+        )
+
+        if selected == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        selected_path = psbt_files[selected]
+        try:
+            psbt_data = selected_path.read_bytes()
+            psbt = PSBT.parse(psbt_data)
+        except Exception as e:
+            logger.exception("Failed to load PSBT from microSD", exc_info=e)
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text=str(e),
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(ToolsSatochipLoadPsbtView)
+
+        self.controller.psbt = psbt
+        self.controller.psbt_parser = None
+        self.controller.psbt_seed = None
+        self.controller.psbt_sign_with_satochip = False
+        self.controller.psbt_from_microsd = True
+        self.controller.psbt_microsd_save_path = selected_path
+
+        return Destination(PSBTSelectSeedView, skip_current_view=True)
 
 class ToolsSatochipAdvancedView(View):
     ENABLE_2FA = ButtonOption("Enable 2FA")

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -197,6 +197,9 @@ class MainMenuView(View):
         controller = Controller.get_instance()
         controller.storage.discard_pending_slip39_shares()
         controller.tools_common_card_filter = None
+        controller.psbt_from_microsd = False
+        controller.psbt_microsd_save_path = None
+        controller.psbt_microsd_seed_warning_shown = False
         if controller.auto_wiped:
             controller.auto_wiped = False
             controller.activate_toast(InfoToast(label_text=_("Data wiped after inactivity")))


### PR DESCRIPTION
## Summary
- add a Load PSBT option to the Satochip tools menu that reads PSBT files from the microSD card and feeds them into the signing flow
- track when a PSBT originates from microSD so the PSBT flow can warn before loading secrets and write the signed PSBT back to the card
- reset controller state related to microSD PSBT signing when returning to the main menu

## Testing
- pytest tests/test_flows_psbt.py -k Satochip


------
https://chatgpt.com/codex/tasks/task_e_68e66e6490a88322b6f13506d54c27ab