### PR TITLE
Align workflow paths with seedsigner-os docker builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,14 +62,9 @@ jobs:
         with:
           # ref defaults to source-ref input (workflow_dispatch) or SHA of event
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['source-ref'] || github.sha }}
-          path: "seedsigner-os/opt/rootfs-overlay/opt"
+          path: "seedsigner-os/opt/app"
           # get full history + tags for "git describe"
           fetch-depth: 0
-
-      - name: Prepare app repo checkout for builder
-        run: |
-          mkdir -p seedsigner-os/opt/app
-          rsync -a --delete seedsigner-os/opt/rootfs-overlay/opt/ seedsigner-os/opt/app/
 
       - name: Get and set meta data
         run: |
@@ -80,8 +75,8 @@ jobs:
           # or just e.g. 0.7.0, if we are exactly on a 0.7.0 tagged commit.
           # --always to fall back to commit sha, if no tag present like in partial forks of the repo
           os_version="$(git -C seedsigner-os describe --tags --always)"
-          source_version="$(git -C seedsigner-os/opt/rootfs-overlay/opt describe --tags --always)"
-          echo "source_commit=$(git -C seedsigner-os/opt/rootfs-overlay/opt rev-parse HEAD)" | tee -a $GITHUB_ENV
+          source_version="$(git -C seedsigner-os/opt/app describe --tags --always)"
+          echo "source_commit=$(git -C seedsigner-os/opt/app rev-parse HEAD)" | tee -a $GITHUB_ENV
 
           # Combine seedsigner and seedsigner-os version into one version string and squash the versions, if
           # they are identical: So os_version=0.7.0 + source_version=0.7.0 combine to just only "0.7.0",
@@ -185,11 +180,11 @@ jobs:
       - name: download images
         uses: actions/download-artifact@v4
         with:
-          path: seedsigner-os/images
+          path: images
 
       - name: list images
         run: |
-          ls -lRa seedsigner-os/images
+          ls -lRa images
 
       - name: get seedsigner latest commit hash
         id: get-seedsigner-hash
@@ -199,7 +194,7 @@ jobs:
 
       - name: write sha256sum
         run: |
-          cd seedsigner-os/images
+          cd images
           # each downloaded image is in its own subfolder
           find . -name "*.img.zip" -exec mv {} . \;
           sha256sum *.img.zip > seedsigner_os.${{ env.source_hash }}.sha256
@@ -208,7 +203,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: seedsigner_os_images_sha256
-          path: "seedsigner-os/images/*.sha256"
+          path: "images/*.sha256"
           if-no-files-found: error
           # maximum 90 days retention
           retention-days: 90

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: checkout seedsigner-os
         uses: actions/checkout@v4
         with:
-          repository: "seedsigner/seedsigner-os"
+          repository: "3rdIteration/seedsigner-os"
           # use the os-ref input parameter in case of workflow_dispatch or default to main in case of cron triggers
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.os-ref || 'main' }}
           submodules: true
@@ -66,6 +66,11 @@ jobs:
           # get full history + tags for "git describe"
           fetch-depth: 0
 
+      - name: Prepare app repo checkout for builder
+        run: |
+          mkdir -p seedsigner-os/opt/app
+          rsync -a --delete seedsigner-os/opt/rootfs-overlay/opt/ seedsigner-os/opt/app/
+
       - name: Get and set meta data
         run: |
           # The builder_hash (seedsigner-os hash) for the cache action step key
@@ -76,6 +81,7 @@ jobs:
           # --always to fall back to commit sha, if no tag present like in partial forks of the repo
           os_version="$(git -C seedsigner-os describe --tags --always)"
           source_version="$(git -C seedsigner-os/opt/rootfs-overlay/opt describe --tags --always)"
+          echo "source_commit=$(git -C seedsigner-os/opt/rootfs-overlay/opt rev-parse HEAD)" | tee -a $GITHUB_ENV
 
           # Combine seedsigner and seedsigner-os version into one version string and squash the versions, if
           # they are identical: So os_version=0.7.0 + source_version=0.7.0 combine to just only "0.7.0",
@@ -91,44 +97,49 @@ jobs:
             echo "DEV_FLAG=--dev" >> $GITHUB_ENV
           fi
 
-      - name: delete unnecessary files
-        run: |
-          cd seedsigner-os/opt/rootfs-overlay/opt
-          find . -mindepth 1 -maxdepth 1 ! -name src -exec rm -rf {} +
-          ls -la .
-          ls -la src
-
       - name: restore build cache
         uses: actions/cache@v4
         # Caching reduces the build time to ~50% (currently: ~30 mins instead of ~1 hour,
         # while consuming ~850 MB storage space).
         with:
           path: |
-            ~/.buildroot-ccache/
-            seedsigner-os/buildroot_dl
+            seedsigner-os/.buildroot-ccache/
+            seedsigner-os/.ccache/
+            seedsigner-os/opt/buildroot/dl
           key: build-cache-${{ matrix.target }}-${{ env.builder_hash }}
           restore-keys: |
             build-cache-${{ matrix.target }}-
-
-      - name: Create build container
-        run: |
-          cd seedsigner-os
-          docker build -t seedsigner-os-build .
-
-      - name: build
+      - name: Prepare build directories
         run: |
           mkdir -p \
-            ~/.buildroot-ccache \
-            seedsigner-os/buildroot_dl
-          docker run \
-            --rm \
-            -v "$(pwd)/seedsigner-os/opt:/opt" \
-            -v "$(pwd)/seedsigner-os/images:/images" \
-            -v "$(pwd)/seedsigner-os/buildroot_dl:/buildroot_dl" \
-            -v "${HOME}/.buildroot-ccache:/root/.buildroot-ccache" \
-            seedsigner-os-build \
-            --${{ matrix.target }} --skip-repo --no-clean $DEV_FLAG
-          sudo chown -R $USER:$USER seedsigner-os/images seedsigner-os/buildroot_dl ~/.buildroot-ccache/
+            seedsigner-os/images \
+            seedsigner-os/.buildroot-ccache \
+            seedsigner-os/.ccache \
+            seedsigner-os/opt/buildroot/dl
+          rm -f seedsigner-os/images/seedsigner_os*.img.zip
+
+      - name: build
+        env:
+          DEV_FLAG: ${{ env.DEV_FLAG }}
+          SOURCE_COMMIT: ${{ env.source_commit }}
+          TARGET: ${{ matrix.target }}
+          DOCKER_DEFAULT_PLATFORM: linux/amd64
+        run: |
+          cd seedsigner-os
+          SS_ARGS="--${TARGET} --app-repo=/opt/app --app-commit-id=${SOURCE_COMMIT}"
+          if [ -n "${DEV_FLAG}" ]; then
+            SS_ARGS="${SS_ARGS} ${DEV_FLAG}"
+          fi
+          export SS_ARGS
+          docker compose up --force-recreate --build --abort-on-container-exit
+          status=$?
+          docker compose down --volumes --remove-orphans
+          exit $status
+          
+      - name: Fix ownership of artifacts
+        if: always()
+        run: |
+          sudo chown -R $USER:$USER seedsigner-os/images seedsigner-os/.buildroot-ccache seedsigner-os/.ccache
 
       - name: list image (before rename)
         run: |
@@ -137,12 +148,21 @@ jobs:
       - name: rename image
         run: |
           cd seedsigner-os/images
-          mv seedsigner_os*.img seedsigner_os.${{ env.img_version }}.${{ matrix.target }}.img
+          shopt -s nullglob
+          count=0
+          for file in seedsigner_os*.${{ matrix.target }}.img.zip; do
+            mv "$file" "seedsigner_os.${{ env.img_version }}.${{ matrix.target }}.img.zip"
+            count=$((count+1))
+          done
+          if [ "$count" -eq 0 ]; then
+            echo "No image zip found for target ${{ matrix.target }}" >&2
+            exit 1
+          fi
 
       - name: print sha256sum
         run: |
           cd seedsigner-os/images
-          sha256sum *.img
+          sha256sum *.img.zip
 
       - name: list image (after rename)
         run: |
@@ -152,7 +172,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: seedsigner_os_images-${{ matrix.target }}
-          path: "seedsigner-os/images/*.img"
+          path: "seedsigner-os/images/*.img.zip"
           if-no-files-found: error
           # maximum 90 days retention
           retention-days: 90
@@ -165,11 +185,11 @@ jobs:
       - name: download images
         uses: actions/download-artifact@v4
         with:
-          path: images
+          path: seedsigner-os/images
 
       - name: list images
         run: |
-          ls -lRa images
+          ls -lRa seedsigner-os/images
 
       - name: get seedsigner latest commit hash
         id: get-seedsigner-hash
@@ -179,16 +199,16 @@ jobs:
 
       - name: write sha256sum
         run: |
-          cd images
+          cd seedsigner-os/images
           # each downloaded image is in its own subfolder
-          find . -name "*.img" -exec mv {} . \;
-          sha256sum *.img > seedsigner_os.${{ env.source_hash }}.sha256
+          find . -name "*.img.zip" -exec mv {} . \;
+          sha256sum *.img.zip > seedsigner_os.${{ env.source_hash }}.sha256
 
       - name: upload checksums
         uses: actions/upload-artifact@v4
         with:
           name: seedsigner_os_images_sha256
-          path: "images/*.sha256"
+          path: "seedsigner-os/images/*.sha256"
           if-no-files-found: error
           # maximum 90 days retention
           retention-days: 90


### PR DESCRIPTION
## Summary
- check out the application code back into `opt/rootfs-overlay/opt` and sync it to `/opt/app` for the docker builder
- source version metadata now reads from the original overlay path while the sha job downloads artifacts into the same images directory structure

## Testing
- not run (workflow changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f784c51108322aac7a514a2fcc0d5)