### PR TITLE
Align build workflow with official build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,9 @@ jobs:
       matrix:
         target: [ "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target || 'pi0' }}" ]
         # Default target pi0 to keep within 500mb storage limit for Github free
+    outputs:
+      source_commit: ${{ steps.app_params.outputs.app_commit }}
+      source_hash: ${{ steps.app_params.outputs.app_commit_short }}
     steps:
       - name: checkout seedsigner-os
         uses: actions/checkout@v4
@@ -55,14 +58,41 @@ jobs:
           # get full history + tags for "git describe"
           fetch-depth: 0
 
+      - name: checkout source (pull request)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: source
+          # get full history + tags for "git describe"
+          fetch-depth: 0
+
       - name: checkout source
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v4
         with:
           # ref defaults to source-ref input (workflow_dispatch) or SHA of event
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['source-ref'] || github.sha }}
-          path: "seedsigner-os/opt/rootfs-overlay/opt"
+          path: source
           # get full history + tags for "git describe"
           fetch-depth: 0
+
+      - name: Determine application repo parameters
+        id: app_params
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            app_repo="https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git"
+          else
+            app_repo="https://github.com/${{ github.repository }}.git"
+          fi
+
+          app_commit=$(git -C source rev-parse HEAD)
+          app_commit_short=$(git -C source rev-parse --short HEAD)
+
+          echo "app_repo=${app_repo}" >> "$GITHUB_OUTPUT"
+          echo "app_commit=${app_commit}" >> "$GITHUB_OUTPUT"
+          echo "app_commit_short=${app_commit_short}" >> "$GITHUB_OUTPUT"
 
       - name: Get and set meta data
         run: |
@@ -73,7 +103,7 @@ jobs:
           # or just e.g. 0.7.0, if we are exactly on a 0.7.0 tagged commit.
           # --always to fall back to commit sha, if no tag present like in partial forks of the repo
           os_version="$(git -C seedsigner-os describe --tags --always)"
-          source_version="$(git -C seedsigner-os/opt/rootfs-overlay/opt describe --tags --always)"
+          source_version="$(git -C source describe --tags --always)"
 
           # Combine seedsigner and seedsigner-os version into one version string and squash the versions, if
           # they are identical: So os_version=0.7.0 + source_version=0.7.0 combine to just only "0.7.0",
@@ -88,13 +118,6 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.dev }}" = "true" ]; then
             echo "DEV_FLAG=--dev" >> $GITHUB_ENV
           fi
-
-      - name: delete unnecessary files
-        run: |
-          cd seedsigner-os/opt/rootfs-overlay/opt
-          find . -mindepth 1 -maxdepth 1 ! -name src -exec rm -rf {} +
-          ls -la .
-          ls -la src
 
       - name: restore build cache
         uses: actions/cache@v4
@@ -118,6 +141,7 @@ jobs:
           mkdir -p \
             ~/.buildroot-ccache \
             seedsigner-os/buildroot_dl
+          app_args=("--app-repo=${{ steps.app_params.outputs.app_repo }}" "--app-commit-id=${{ steps.app_params.outputs.app_commit }}")
           docker run \
             --rm \
             -v "$(pwd)/seedsigner-os/opt:/opt" \
@@ -125,7 +149,7 @@ jobs:
             -v "$(pwd)/seedsigner-os/buildroot_dl:/buildroot_dl" \
             -v "${HOME}/.buildroot-ccache:/root/.buildroot-ccache" \
             seedsigner-os-build \
-            --${{ matrix.target }} --skip-repo --no-clean --smartcard $DEV_FLAG
+            --${{ matrix.target }} --smartcard $DEV_FLAG "${app_args[@]}"
           sudo chown -R $USER:$USER seedsigner-os/images seedsigner-os/buildroot_dl ~/.buildroot-ccache/
 
       - name: list image (before rename)
@@ -172,8 +196,7 @@ jobs:
       - name: get seedsigner latest commit hash
         id: get-seedsigner-hash
         run: |
-          git init
-          echo "source_hash=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
+          echo "source_hash=${{ needs.build.outputs.source_hash }}" >> $GITHUB_ENV
 
       - name: write sha256sum
         run: |


### PR DESCRIPTION
## Summary
- check out the application repository separately and derive repo/commit metadata for the build
- invoke the official build.sh workflow inside the container so it clones the requested commit itself
- propagate the built commit hash to the checksum stage for consistent artifact naming

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fa89ece348322851a819b36bd3ead)