### PR TITLE
Allow toggling smartcard flag in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,18 @@
 name: Build
+run-name: >-
+  Build${{ github.event_name == 'workflow_dispatch'
+    && format(
+      ' target {0} from {1}@{2} (os {3}, smartcard {4})',
+      github.event.inputs.target || 'pi0',
+      github.event.inputs['app-repo'] || github.repository,
+      github.event.inputs['source-ref'],
+      github.event.inputs['os-ref'],
+      (fromJSON(github.event.inputs.smartcard || 'true') && 'enabled') || 'disabled'
+    )
+    || github.event_name == 'push' && format(' push {0}', github.ref_name)
+    || github.event_name == 'pull_request' && format(' PR #{0}', github.event.pull_request.number)
+    || ''
+  }}
 
 on:
   pull_request:
@@ -43,7 +57,17 @@ on:
 
 jobs:
   build:
-    name: build
+    name: >-
+      build${{ github.event_name == 'workflow_dispatch'
+        && format(
+          ' ({0} from {1}@{2}, smartcard {3})',
+          github.event.inputs.target || 'pi0',
+          github.event.inputs['app-repo'] || github.repository,
+          github.event.inputs['source-ref'],
+          (fromJSON(github.event.inputs.smartcard || 'true') && 'enabled') || 'disabled'
+        )
+        || ''
+      }}
     runs-on: ubuntu-latest
     # Prevent resource consuming cron triggered runs in forks
     if: (!github.event.repository.fork || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ on:
       app-repo:
         description: The repository containing the SeedSigner application sources
         required: false
-        default: SeedSigner/seedsigner
+        default: 3rdIteration/seedsigner
       smartcard:
         description: Enable smartcard support for the build
         required: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,11 +42,6 @@ on:
         description: The seedsigner ref (tag/branch/sha1) to use
         default: dev
         required: true
-      dev:
-        description: Build dev image
-        required: false
-        default: 'false'
-        type: boolean
       target:
         description: Build target profile (e.g., pi0, pi2, pi02w, pi4)
         required: false
@@ -55,6 +50,11 @@ on:
         description: Enable smartcard support for the build
         required: false
         default: 'true'
+        type: boolean
+      dev:
+        description: Build dev image
+        required: false
+        default: 'false'
         type: boolean
 
 # Increment this number as part of a PR to trigger an image build for the PR

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,15 @@ on:
         description: Build target profile (e.g., pi0, pi2, pi02w, pi4)
         required: false
         default: pi0
+      app-repo:
+        description: The repository containing the SeedSigner application sources
+        required: false
+        default: SeedSigner/seedsigner
+      smartcard:
+        description: Enable smartcard support for the build
+        required: false
+        default: 'true'
+        type: boolean
 
 # Increment this number as part of a PR to trigger an image build for the PR
 # trigger = 0
@@ -58,6 +67,7 @@ jobs:
       - name: checkout source
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['app-repo'] || github.repository }}
           # ref defaults to source-ref input (workflow_dispatch) or SHA of event
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['source-ref'] || github.sha }}
           path: "seedsigner-os/opt/rootfs-overlay/opt"
@@ -87,6 +97,16 @@ jobs:
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.dev }}" = "true" ]; then
             echo "DEV_FLAG=--dev" >> $GITHUB_ENV
+          fi
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "${{ github.event.inputs.smartcard }}" = "true" ]; then
+              echo "SMARTCARD_FLAG=--smartcard" >> $GITHUB_ENV
+            else
+              echo "SMARTCARD_FLAG=" >> $GITHUB_ENV
+            fi
+          else
+            echo "SMARTCARD_FLAG=--smartcard" >> $GITHUB_ENV
           fi
 
       - name: delete unnecessary files
@@ -125,7 +145,7 @@ jobs:
             -v "$(pwd)/seedsigner-os/buildroot_dl:/buildroot_dl" \
             -v "${HOME}/.buildroot-ccache:/root/.buildroot-ccache" \
             seedsigner-os-build \
-            --${{ matrix.target }} --skip-repo --no-clean --smartcard $DEV_FLAG
+            --${{ matrix.target }} --skip-repo --no-clean $SMARTCARD_FLAG $DEV_FLAG
           sudo chown -R $USER:$USER seedsigner-os/images seedsigner-os/buildroot_dl ~/.buildroot-ccache/
 
       - name: list image (before rename)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,14 +26,18 @@ on:
       - dev
   workflow_dispatch:
     inputs:
-      os-ref:
-        description: The seedsigner-os ref (tag/branch/sha1) to use
-        default: main
-        required: true
       os-repo:
         description: The repository containing the SeedSigner OS sources
         required: false
         default: 3rdIteration/seedsigner-os
+      os-ref:
+        description: The seedsigner-os ref (tag/branch/sha1) to use
+        default: main
+        required: true
+      app-repo:
+        description: The repository containing the SeedSigner application sources
+        required: false
+        default: 3rdIteration/seedsigner
       source-ref:
         description: The seedsigner ref (tag/branch/sha1) to use
         default: dev
@@ -47,10 +51,6 @@ on:
         description: Build target profile (e.g., pi0, pi2, pi02w, pi4)
         required: false
         default: pi0
-      app-repo:
-        description: The repository containing the SeedSigner application sources
-        required: false
-        default: 3rdIteration/seedsigner
       smartcard:
         description: Enable smartcard support for the build
         required: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,11 @@ name: Build
 run-name: >-
   Build${{ github.event_name == 'workflow_dispatch'
     && format(
-      ' target {0} from {1}@{2} (os {3}, smartcard {4})',
+      ' target {0} from {1}@{2} (os {3}@{4}, smartcard {5})',
       github.event.inputs.target || 'pi0',
       github.event.inputs['app-repo'] || github.repository,
       github.event.inputs['source-ref'],
+      github.event.inputs['os-repo'] || '3rdIteration/seedsigner-os',
       github.event.inputs['os-ref'],
       (fromJSON(github.event.inputs.smartcard || 'true') && 'enabled') || 'disabled'
     )
@@ -29,6 +30,10 @@ on:
         description: The seedsigner-os ref (tag/branch/sha1) to use
         default: main
         required: true
+      os-repo:
+        description: The repository containing the SeedSigner OS sources
+        required: false
+        default: 3rdIteration/seedsigner-os
       source-ref:
         description: The seedsigner ref (tag/branch/sha1) to use
         default: dev
@@ -60,10 +65,12 @@ jobs:
     name: >-
       build${{ github.event_name == 'workflow_dispatch'
         && format(
-          ' ({0} from {1}@{2}, smartcard {3})',
+          ' ({0} from {1}@{2}, os {3}@{4}, smartcard {5})',
           github.event.inputs.target || 'pi0',
           github.event.inputs['app-repo'] || github.repository,
           github.event.inputs['source-ref'],
+          github.event.inputs['os-repo'] || '3rdIteration/seedsigner-os',
+          github.event.inputs['os-ref'],
           (fromJSON(github.event.inputs.smartcard || 'true') && 'enabled') || 'disabled'
         )
         || ''
@@ -80,7 +87,7 @@ jobs:
       - name: checkout seedsigner-os
         uses: actions/checkout@v4
         with:
-          repository: "3rditeration/seedsigner-os"
+          repository: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['os-repo'] || '3rdIteration/seedsigner-os' }}
           # use the os-ref input parameter in case of workflow_dispatch or default to main in case of cron triggers
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.os-ref || 'main' }}
           submodules: true


### PR DESCRIPTION
## Summary
- add a workflow_dispatch input to control whether the smartcard flag is passed to the build
- default the smartcard flag to enabled to preserve current behavior for non-manual runs

## Testing
- no tests were run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910eee98b0c8322a89003fd57a74961)