### PR TITLE
Add BitBox02 microSD backup import option

### DIFF
--- a/src/seedsigner/helpers/bitbox02_backup.py
+++ b/src/seedsigner/helpers/bitbox02_backup.py
@@ -1,0 +1,235 @@
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from embit import bip39
+
+
+class Bitbox02BackupError(Exception):
+    pass
+
+
+@dataclass
+class Bitbox02BackupDetails:
+    mnemonic: list[str]
+    name: Optional[str]
+    generator: Optional[str]
+    birthdate: Optional[int]
+    timestamp: Optional[int]
+    seed_length: int
+
+
+def _read_varint(data: bytes, offset: int) -> tuple[int, int]:
+    value = 0
+    shift = 0
+    while True:
+        if offset >= len(data):
+            raise Bitbox02BackupError("Unexpected end of data while parsing varint")
+
+        byte = data[offset]
+        offset += 1
+        value |= (byte & 0x7F) << shift
+
+        if not byte & 0x80:
+            break
+
+        shift += 7
+        if shift > 63:
+            raise Bitbox02BackupError("Invalid varint encoding")
+
+    return value, offset
+
+
+def _read_length_delimited(data: bytes, offset: int) -> tuple[bytes, int]:
+    length, offset = _read_varint(data, offset)
+    end = offset + length
+    if end > len(data):
+        raise Bitbox02BackupError("Length-delimited field exceeds available data")
+    return data[offset:end], end
+
+
+def _skip_value(data: bytes, offset: int, wire_type: int) -> int:
+    if wire_type == 0:
+        _, offset = _read_varint(data, offset)
+    elif wire_type == 1:
+        offset += 8
+    elif wire_type == 2:
+        _, offset = _read_length_delimited(data, offset)
+    elif wire_type == 5:
+        offset += 4
+    else:
+        raise Bitbox02BackupError(f"Unsupported wire type: {wire_type}")
+    if offset > len(data):
+        raise Bitbox02BackupError("Unexpected end of data while skipping field")
+    return offset
+
+
+def _decode_backup_metadata(data: bytes) -> tuple[Optional[int], Optional[str], Optional[int]]:
+    timestamp = None
+    name = None
+    mode = None
+    offset = 0
+
+    while offset < len(data):
+        tag, offset = _read_varint(data, offset)
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+
+        if field_number == 1 and wire_type == 0:
+            timestamp, offset = _read_varint(data, offset)
+        elif field_number == 2 and wire_type == 2:
+            raw_name, offset = _read_length_delimited(data, offset)
+            name = raw_name.decode("utf-8", errors="replace")
+        elif field_number == 3 and wire_type == 0:
+            mode, offset = _read_varint(data, offset)
+        else:
+            offset = _skip_value(data, offset, wire_type)
+
+    return timestamp, name, mode
+
+
+def _decode_backup_data(data: bytes) -> tuple[int, bytes, Optional[int], Optional[str]]:
+    seed_length = None
+    seed_bytes: bytes | None = None
+    birthdate = None
+    generator = None
+    offset = 0
+
+    while offset < len(data):
+        tag, offset = _read_varint(data, offset)
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+
+        if field_number == 1 and wire_type == 0:
+            seed_length, offset = _read_varint(data, offset)
+        elif field_number == 2 and wire_type == 2:
+            seed_bytes, offset = _read_length_delimited(data, offset)
+        elif field_number == 3 and wire_type == 0:
+            birthdate, offset = _read_varint(data, offset)
+        elif field_number == 4 and wire_type == 2:
+            raw_generator, offset = _read_length_delimited(data, offset)
+            generator = raw_generator.decode("utf-8", errors="replace")
+        else:
+            offset = _skip_value(data, offset, wire_type)
+
+    if seed_length is None or seed_bytes is None:
+        raise Bitbox02BackupError("Missing seed data in backup")
+
+    if seed_length <= 0 or seed_length > len(seed_bytes) or seed_length % 4 != 0:
+        raise Bitbox02BackupError("Invalid seed length in backup")
+
+    if seed_length > 32:
+        raise Bitbox02BackupError("Invalid seed length in backup")
+
+    return seed_length, seed_bytes[:seed_length], birthdate, generator
+
+
+def _decode_backup_content(data: bytes) -> tuple[bytes, Optional[int], Optional[str], Optional[int], Optional[str]]:
+    metadata = None
+    content_length = None
+    backup_data_bytes = None
+    offset = 0
+
+    while offset < len(data):
+        tag, offset = _read_varint(data, offset)
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+
+        if field_number == 1 and wire_type == 2:
+            # checksum; ignore value for now
+            _, offset = _read_length_delimited(data, offset)
+        elif field_number == 2 and wire_type == 2:
+            metadata_bytes, offset = _read_length_delimited(data, offset)
+            metadata = _decode_backup_metadata(metadata_bytes)
+        elif field_number == 3 and wire_type == 0:
+            content_length, offset = _read_varint(data, offset)
+        elif field_number == 4 and wire_type == 2:
+            backup_data_bytes, offset = _read_length_delimited(data, offset)
+        else:
+            offset = _skip_value(data, offset, wire_type)
+
+    if backup_data_bytes is None:
+        raise Bitbox02BackupError("Backup payload missing backup data")
+
+    if content_length is not None and content_length != len(backup_data_bytes):
+        raise Bitbox02BackupError("Backup data length does not match content length")
+
+    seed_length, seed_bytes, birthdate, generator = _decode_backup_data(backup_data_bytes)
+
+    timestamp = None
+    name = None
+    if metadata:
+        timestamp, name, _ = metadata
+
+    return seed_bytes, timestamp, name, birthdate, generator
+
+
+def decode_bitbox02_backup(data: bytes) -> Bitbox02BackupDetails:
+    """Decode a BitBox02 microSD backup file.
+
+    Args:
+        data: The raw bytes read from the backup file.
+
+    Returns:
+        Bitbox02BackupDetails with mnemonic words and metadata.
+
+    Raises:
+        Bitbox02BackupError: If the backup payload cannot be parsed.
+    """
+
+    if not data:
+        raise Bitbox02BackupError("Backup file is empty")
+
+    offset = 0
+    backup_v1_bytes = None
+
+    while offset < len(data):
+        tag, offset = _read_varint(data, offset)
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+
+        if field_number == 1 and wire_type == 2:
+            backup_v1_bytes, offset = _read_length_delimited(data, offset)
+        else:
+            offset = _skip_value(data, offset, wire_type)
+
+    if backup_v1_bytes is None:
+        raise Bitbox02BackupError("Unsupported backup format")
+
+    # BackupV1 -> BackupContent
+    content_offset = 0
+    backup_content_bytes = None
+    while content_offset < len(backup_v1_bytes):
+        tag, content_offset = _read_varint(backup_v1_bytes, content_offset)
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+
+        if field_number == 1 and wire_type == 2:
+            backup_content_bytes, content_offset = _read_length_delimited(backup_v1_bytes, content_offset)
+        else:
+            content_offset = _skip_value(backup_v1_bytes, content_offset, wire_type)
+
+    if backup_content_bytes is None:
+        raise Bitbox02BackupError("Backup content missing")
+
+    seed_bytes, timestamp, name, birthdate, generator = _decode_backup_content(backup_content_bytes)
+
+    mnemonic = bip39.mnemonic_from_bytes(seed_bytes).split()
+
+    return Bitbox02BackupDetails(
+        mnemonic=mnemonic,
+        name=name,
+        generator=generator,
+        birthdate=birthdate,
+        timestamp=timestamp,
+        seed_length=len(seed_bytes),
+    )
+
+
+def format_timestamp(timestamp: Optional[int]) -> str:
+    if timestamp is None:
+        return ""
+    try:
+        return time.strftime("%Y-%m-%d", time.localtime(timestamp))
+    except Exception:
+        return str(timestamp)

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -446,6 +446,7 @@ class SettingsConstants:
     SETTING__SLIP39_SEEDS = "slip39_seeds"
     SETTING__SLIP39_EXTENDABLE = "slip39_extendable"
     SETTING__ELECTRUM_SEEDS = "electrum_seeds"
+    SETTING__BITBOX_BACKUP = "bitbox_backup"
     SETTING__MESSAGE_SIGNING = "message_signing"
     SETTING__PRIVACY_WARNINGS = "privacy_warnings"
     SETTING__DIRE_WARNINGS = "dire_warnings"
@@ -936,6 +937,13 @@ class SettingsDefinition:
                       abbreviated_name="electrum",
                       display_name=_mft("Electrum seeds"),
                       help_text=_mft("Native Segwit only"),
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      default_value=SettingsConstants.OPTION__DISABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__BITBOX_BACKUP,
+                      abbreviated_name="bitbox",
+                      display_name=_mft("BitBox02 backups"),
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__DISABLED),
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -4,6 +4,7 @@ import time
 import hashlib
 import os
 import binascii
+from pathlib import Path
 
 from binascii import hexlify
 from gettext import gettext as _
@@ -19,6 +20,13 @@ from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconCo
 from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
     WarningScreen, DireWarningScreen, seed_screens, LargeIconStatusScreen)
 from seedsigner.gui.screens.screen import ButtonOption
+from seedsigner.hardware.microsd import MicroSD
+from seedsigner.helpers.bitbox02_backup import (
+    Bitbox02BackupDetails,
+    Bitbox02BackupError,
+    decode_bitbox02_backup,
+    format_timestamp,
+)
 from seedsigner.models.encode_qr import CompactSeedQrEncoder, GenericStaticQrEncoder, SeedQrEncoder, SpecterXPubQrEncoder, StaticXpubQrEncoder, UrXpubQrEncoder
 from seedsigner.models.qr_type import QRType
 from seedsigner.models.seed import Seed, Slip39Seed, ElectrumSeed, InvalidSeedException
@@ -84,6 +92,7 @@ class SeedSelectSeedView(View):
                 verify single sig addr or sign message).
     """
     SCAN_SEED = ButtonOption("Scan a seed", SeedSignerIconConstants.QRCODE)
+    BITBOX_BACKUP = ButtonOption("BitBox02 backup", SeedSignerIconConstants.MICROSD)
     SATOCHIP = ButtonOption("Use Satochip card", SeedSignerIconConstants.FINGERPRINT)
     TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=12)
     TYPE_15WORD = ButtonOption("Enter 15-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=15)
@@ -126,6 +135,8 @@ class SeedSelectSeedView(View):
             button_data.append(self.SATOCHIP)
 
         button_data.append(self.SCAN_SEED)
+        if self.settings.get_value(SettingsConstants.SETTING__BITBOX_BACKUP) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.BITBOX_BACKUP)
         seed_lengths = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
         options = {
             12: self.TYPE_12WORD,
@@ -181,6 +192,9 @@ class SeedSelectSeedView(View):
             from seedsigner.views.scan_views import ScanView
             return Destination(ScanView)
 
+        if button_data[selected_menu_num] == self.BITBOX_BACKUP:
+            return Destination(SeedBitbox02BackupSelectView)
+
         elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_15WORD, self.TYPE_18WORD, self.TYPE_21WORD, self.TYPE_24WORD]:
             from seedsigner.views.seed_views import SeedMnemonicEntryView
             self.controller.storage.init_pending_mnemonic(num_words=button_data[selected_menu_num].return_data)
@@ -207,6 +221,7 @@ class LoadSeedView(View):
     TYPE_ELECTRUM = ButtonOption("Enter Electrum seed", FontAwesomeIconConstants.KEYBOARD)
     TYPE_SLIP39 = ButtonOption("SLIP-39 Shares", FontAwesomeIconConstants.KEYBOARD)
     IMPORT_SEEDKEEPER = ButtonOption("From SeedKeeper", FontAwesomeIconConstants.LOCK)
+    BITBOX_BACKUP = ButtonOption("BitBox02 backup", SeedSignerIconConstants.MICROSD)
     CREATE = ButtonOption(" Create a seed", SeedSignerIconConstants.PLUS)
 
     def run(self):
@@ -228,6 +243,9 @@ class LoadSeedView(View):
 
         if self.settings.get_value(SettingsConstants.SETTING__SLIP39_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_SLIP39)
+
+        if self.settings.get_value(SettingsConstants.SETTING__BITBOX_BACKUP) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.BITBOX_BACKUP)
 
         button_data.append(self.CREATE)
 
@@ -260,6 +278,9 @@ class LoadSeedView(View):
 
         elif button_data[selected_menu_num] == self.TYPE_SLIP39:
             return Destination(SeedSlip39MnemonicStartView)
+
+        elif button_data[selected_menu_num] == self.BITBOX_BACKUP:
+            return Destination(SeedBitbox02BackupSelectView)
 
         elif button_data[selected_menu_num] == self.CREATE:
             from .tools_views import ToolsMenuView
@@ -408,6 +429,144 @@ class SeedKeeperSelectView(View):
             self.seed = self.controller.storage.get_pending_seed()
             self.seed.set_passphrase(secret_passphrase)
             return Destination(SeedReviewPassphraseView)
+
+        return Destination(SeedFinalizeView)
+
+
+class SeedBitbox02BackupSelectView(View):
+    def __init__(self):
+        super().__init__()
+        self.microsd_dir: Path = MicroSD.get_microsd_dir()
+        self.extensions = {".bin", ".dat", ".bb02", ".backup"}
+
+    def _get_backup_files(self) -> list[Path]:
+        backup_files: list[Path] = []
+        if not self.microsd_dir.exists():
+            raise Bitbox02BackupError(_("microSD card not detected."))
+        for path in self.microsd_dir.rglob("*"):
+            if not path.is_file():
+                continue
+
+            try:
+                rel_parts = path.relative_to(self.microsd_dir).parts
+            except ValueError:
+                continue
+
+            if any(part.startswith(".") for part in rel_parts):
+                continue
+
+            if path.suffix.lower() in self.extensions:
+                backup_files.append(path)
+
+        backup_files.sort(key=lambda p: p.relative_to(self.microsd_dir).as_posix().lower())
+        return backup_files
+
+    def run(self):
+        if len(self.controller.storage.seeds) > 0:
+            ret = self.run_screen(
+                WarningScreen,
+                title="WARNING",
+                status_headline=None,
+                text="These tools load data from the microSD card and may expose loaded secrets.",
+                show_back_button=True,
+                button_data=[ButtonOption("Continue")],
+            )
+            if ret == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
+
+        try:
+            backup_files = self._get_backup_files()
+        except Exception as e:
+            logger.exception("Failed to scan microSD for BitBox02 backups", exc_info=e)
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text=str(e),
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(BackStackView)
+
+        if not backup_files:
+            self.run_screen(
+                WarningScreen,
+                title=_("No Backups Found"),
+                status_headline=None,
+                text=_("No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."),
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(BackStackView)
+
+        button_data = [
+            ButtonOption(path.relative_to(self.microsd_dir).as_posix(), SeedSignerIconConstants.MICROSD)
+            for path in backup_files
+        ]
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title=_("Select BitBox02 backup"),
+            is_button_text_centered=False,
+            button_data=button_data,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        selected_path = backup_files[selected_menu_num]
+
+        try:
+            details = decode_bitbox02_backup(selected_path.read_bytes())
+        except (OSError, Bitbox02BackupError, ValueError) as e:
+            logger.exception("Failed to load BitBox02 backup", exc_info=e)
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text=str(e),
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(SeedBitbox02BackupSelectView)
+
+        try:
+            seed = Seed(details.mnemonic)
+        except InvalidSeedException:
+            return Destination(SeedMnemonicInvalidView)
+
+        self.controller.storage.set_pending_seed(seed)
+
+        return Destination(SeedBitbox02BackupSummaryView, view_args={"details": details})
+
+
+class SeedBitbox02BackupSummaryView(View):
+    CONTINUE = ButtonOption(_("Continue"))
+
+    def __init__(self, details: Bitbox02BackupDetails):
+        super().__init__()
+        self.details = details
+
+    def run(self):
+        text_lines = []
+        if self.details.name:
+            text_lines.append(_("Backup name: {}").format(self.details.name))
+        if self.details.timestamp:
+            text_lines.append(_("Created: {}").format(format_timestamp(self.details.timestamp)))
+        if self.details.generator:
+            text_lines.append(_("Firmware: {}").format(self.details.generator))
+        if self.details.birthdate:
+            text_lines.append(_("Birthdate: {}").format(format_timestamp(self.details.birthdate)))
+        text_lines.append(_("Seed length: {} words").format(len(self.details.mnemonic)))
+
+        self.run_screen(
+            LargeIconStatusScreen,
+            title=_("BitBox02 backup"),
+            status_headline=_("Seed loaded"),
+            text="\n".join(text_lines),
+            show_back_button=False,
+            button_data=[self.CONTINUE],
+        )
 
         return Destination(SeedFinalizeView)
 

--- a/tests/test_bitbox02_backup.py
+++ b/tests/test_bitbox02_backup.py
@@ -1,0 +1,85 @@
+import os
+
+import pytest
+from embit import bip39
+
+from seedsigner.helpers.bitbox02_backup import Bitbox02BackupError, decode_bitbox02_backup
+
+
+def _encode_varint(value: int) -> bytes:
+    pieces = []
+    while True:
+        to_write = value & 0x7F
+        value >>= 7
+        if value:
+            to_write |= 0x80
+            pieces.append(to_write)
+        else:
+            pieces.append(to_write)
+            break
+    return bytes(pieces)
+
+
+def _length_delimited(field_number: int, payload: bytes) -> bytes:
+    tag = (field_number << 3) | 2
+    return _encode_varint(tag) + _encode_varint(len(payload)) + payload
+
+
+def _varint_field(field_number: int, value: int) -> bytes:
+    tag = (field_number << 3) | 0
+    return _encode_varint(tag) + _encode_varint(value)
+
+
+def _build_backup_bytes(seed: bytes, seed_length: int = None) -> bytes:
+    seed_length = seed_length or len(seed)
+
+    backup_data = b"".join(
+        [
+            _varint_field(1, seed_length),
+            _length_delimited(2, seed),
+            _varint_field(3, 1_700_000_001),
+            _length_delimited(4, b"bb02-firmware"),
+        ]
+    )
+
+    metadata = b"".join(
+        [
+            _varint_field(1, 1_700_000_000),
+            _length_delimited(2, b"test-backup"),
+            _varint_field(3, 0),
+        ]
+    )
+
+    backup_content = b"".join(
+        [
+            _length_delimited(1, b"".rjust(32, b"\x00")),
+            _length_delimited(2, metadata),
+            _varint_field(3, len(backup_data)),
+            _length_delimited(4, backup_data),
+        ]
+    )
+
+    backup_v1 = _length_delimited(1, backup_content)
+    return _length_delimited(1, backup_v1)
+
+
+def test_decode_round_trip_backup():
+    entropy = bytes.fromhex("000102030405060708090a0b0c0d0e0f")
+    backup_bytes = _build_backup_bytes(entropy)
+
+    details = decode_bitbox02_backup(backup_bytes)
+
+    assert details.mnemonic == bip39.mnemonic_from_bytes(entropy).split()
+    assert details.name == "test-backup"
+    assert details.generator == "bb02-firmware"
+    assert details.birthdate == 1_700_000_001
+    assert details.timestamp == 1_700_000_000
+    assert details.seed_length == len(entropy)
+
+
+def test_decode_rejects_mismatched_length():
+    entropy = os.urandom(16)
+    backup_bytes = _build_backup_bytes(entropy, seed_length=len(entropy) - 2)
+
+    with pytest.raises(Bitbox02BackupError):
+        decode_bitbox02_backup(backup_bytes)


### PR DESCRIPTION
## Summary
- add a BitBox02 backup decoder for microSD backup files and tests
- gate the feature behind a new advanced setting and expose it in seed loading flows
- provide a BitBox02 backup selection/summary screen before finalizing the seed

## Testing
- pytest tests/test_bitbox02_backup.py
- pytest tests/test_settings_definition.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b75aceba883229aefe391663dc282)