### PR TITLE
Improve build workflow naming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,18 @@
 name: Build
+run-name: >-
+  Build${{ github.event_name == 'workflow_dispatch'
+    && format(
+      ' target {0} from {1}@{2} (os {3}@{4})',
+      github.event.inputs.target || 'pi0',
+      github.repository,
+      github.event.inputs['source-ref'],
+      'seedsigner/seedsigner-os',
+      github.event.inputs['os-ref']
+    )
+    || github.event_name == 'push' && format(' push {0}', github.ref_name)
+    || github.event_name == 'pull_request' && format(' PR #{0}', github.event.pull_request.number)
+    || ''
+  }}
 
 on:
   pull_request:
@@ -34,7 +48,17 @@ on:
 
 jobs:
   build:
-    name: build
+    name: >-
+      build (${{ matrix.target }})${{ github.event_name == 'workflow_dispatch'
+        && format(
+          ' from {0}@{1} (os {2}@{3})',
+          github.repository,
+          github.event.inputs['source-ref'],
+          'seedsigner/seedsigner-os',
+          github.event.inputs['os-ref']
+        )
+        || ''
+      }}
     runs-on: ubuntu-latest
     # Prevent resource consuming cron triggered runs in forks
     if: (!github.event.repository.fork || github.event_name == 'workflow_dispatch')


### PR DESCRIPTION
## Summary
- add a descriptive `run-name` to the build workflow so manual runs clearly show the requested target and refs
- enhance the build job name to include the matrix target and dispatch metadata, mirroring the upstream SeedSigner project

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd1be1b74832296611bab435016f1)