### PR TITLE
Add runner disk cleanup step to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,16 @@ jobs:
             echo "DEV_FLAG=--dev" >> $GITHUB_ENV
           fi
 
+      - name: Free disk space on runner
+        run: |
+          echo "Disk usage before cleanup:"
+          df -h
+          sudo docker system prune --all --force --volumes || true
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android
+          sudo apt-get clean
+          echo "Disk usage after cleanup:"
+          df -h
+
       - name: delete unnecessary files
         run: |
           cd seedsigner-os/opt/rootfs-overlay/opt


### PR DESCRIPTION
## Summary
- add a disk cleanup step to the build workflow to free space before heavy work runs
- clean docker caches and pre-installed SDKs and show disk usage before/after cleanup

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de267f110832285cf65b000b9d98a)