### PR TITLE
Include translations submodule in CI build checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,7 @@ jobs:
           repository: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['app-repo'] || github.repository }}
           # ref defaults to source-ref input (workflow_dispatch) or SHA of event
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['source-ref'] || github.sha }}
+          submodules: true
           path: "seedsigner-os/opt/rootfs-overlay/opt"
           # get full history + tags for "git describe"
           fetch-depth: 0


### PR DESCRIPTION
## Summary
- ensure the GitHub Actions build workflow checks out submodules for the application source so translation data is included

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a04c7ccf88322b41e5dadcdf0fb16)