### PR TITLE
Add Passport backup import support

### DIFF
--- a/src/seedsigner/helpers/passport_backup.py
+++ b/src/seedsigner/helpers/passport_backup.py
@@ -1,0 +1,97 @@
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+class PassportBackupError(Exception):
+    """Raised when a Passport backup cannot be processed."""
+
+
+@dataclass
+class PassportBackupDetails:
+    mnemonic: list[str]
+    chain: Optional[str] = None
+    firmware: Optional[str] = None
+    xfp: Optional[str] = None
+
+
+def _format_backup_code(code: str) -> str:
+    digits = [c for c in code if c.isdigit()]
+    if len(digits) != 20:
+        raise PassportBackupError("Backup code must include exactly 20 digits.")
+
+    parts = ["".join(digits[i : i + 4]) for i in range(0, 20, 4)]
+    return "-".join(parts)
+
+
+def _extract_backup_text(path: Path, password: str) -> str:
+    if not path.is_file():
+        raise PassportBackupError("Backup file not found.")
+
+    try:
+        proc = subprocess.run(
+            ["7z", "x", "-so", f"-p{password}", str(path)],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        raise PassportBackupError("p7zip (7z) is not installed.") from exc
+
+    if proc.returncode != 0:
+        msg = proc.stderr.decode(errors="ignore").strip() or "Unable to decrypt backup."
+        raise PassportBackupError(msg)
+
+    return proc.stdout.decode("utf-8", errors="ignore")
+
+
+def _parse_backup_text(text: str) -> PassportBackupDetails:
+    if not text.strip():
+        raise PassportBackupError("Backup content is empty.")
+
+    values: dict[str, object] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        if "=" not in line:
+            continue
+
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        raw_value = raw_value.strip()
+
+        try:
+            value = json.loads(raw_value)
+        except json.JSONDecodeError as exc:
+            raise PassportBackupError(f"Invalid JSON value for '{key}'.") from exc
+
+        values[key] = value
+
+    mnemonic = values.get("mnemonic")
+    if not mnemonic:
+        raise PassportBackupError("Mnemonic not found in backup.")
+    if not isinstance(mnemonic, str):
+        raise PassportBackupError("Mnemonic value is invalid.")
+
+    words = mnemonic.split()
+    if len(words) not in (12, 18, 24):
+        raise PassportBackupError("Unsupported mnemonic length in backup.")
+
+    return PassportBackupDetails(
+        mnemonic=words,
+        chain=values.get("chain") if isinstance(values.get("chain"), str) else None,
+        firmware=values.get("fw_version") if isinstance(values.get("fw_version"), str) else None,
+        xfp=values.get("xfp") if isinstance(values.get("xfp"), str) else None,
+    )
+
+
+def decode_passport_backup(path: Path, backup_code: str) -> PassportBackupDetails:
+    """Decode a Passport backup using the supplied backup code."""
+
+    formatted_code = _format_backup_code(backup_code)
+    text = _extract_backup_text(path, formatted_code)
+    return _parse_backup_text(text)

--- a/src/seedsigner/helpers/passport_backup.py
+++ b/src/seedsigner/helpers/passport_backup.py
@@ -32,13 +32,13 @@ def _extract_backup_text(path: Path, password: str) -> str:
 
     try:
         proc = subprocess.run(
-            ["7z", "x", "-so", f"-p{password}", str(path)],
+            ["7za", "x", "-so", f"-p{password}", str(path)],
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
     except FileNotFoundError as exc:
-        raise PassportBackupError("p7zip (7z) is not installed.") from exc
+        raise PassportBackupError("p7zip (7za) is not installed.") from exc
 
     if proc.returncode != 0:
         msg = proc.stderr.decode(errors="ignore").strip() or "Unable to decrypt backup."

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -447,6 +447,7 @@ class SettingsConstants:
     SETTING__SLIP39_EXTENDABLE = "slip39_extendable"
     SETTING__ELECTRUM_SEEDS = "electrum_seeds"
     SETTING__BITBOX_BACKUP = "bitbox_backup"
+    SETTING__PASSPORT_BACKUP = "passport_backup"
     SETTING__MESSAGE_SIGNING = "message_signing"
     SETTING__PRIVACY_WARNINGS = "privacy_warnings"
     SETTING__DIRE_WARNINGS = "dire_warnings"
@@ -944,6 +945,13 @@ class SettingsDefinition:
                       attr_name=SettingsConstants.SETTING__BITBOX_BACKUP,
                       abbreviated_name="bitbox",
                       display_name=_mft("BitBox02 backups"),
+                      visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                      default_value=SettingsConstants.OPTION__DISABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                      attr_name=SettingsConstants.SETTING__PASSPORT_BACKUP,
+                      abbreviated_name="passport",
+                      display_name=_mft("Passport backups"),
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__DISABLED),
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -19,13 +19,18 @@ import shamir_mnemonic
 from seedsigner.gui.components import FontAwesomeIconConstants, SeedSignerIconConstants
 from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen,
     WarningScreen, DireWarningScreen, seed_screens, LargeIconStatusScreen)
-from seedsigner.gui.screens.screen import ButtonOption
+from seedsigner.gui.screens.screen import ButtonOption, KeyboardScreen
 from seedsigner.hardware.microsd import MicroSD
 from seedsigner.helpers.bitbox02_backup import (
     Bitbox02BackupDetails,
     Bitbox02BackupError,
     decode_bitbox02_backup,
     format_timestamp,
+)
+from seedsigner.helpers.passport_backup import (
+    PassportBackupDetails,
+    PassportBackupError,
+    decode_passport_backup,
 )
 from seedsigner.models.encode_qr import CompactSeedQrEncoder, GenericStaticQrEncoder, SeedQrEncoder, SpecterXPubQrEncoder, StaticXpubQrEncoder, UrXpubQrEncoder
 from seedsigner.models.qr_type import QRType
@@ -93,6 +98,7 @@ class SeedSelectSeedView(View):
     """
     SCAN_SEED = ButtonOption("Scan a seed", SeedSignerIconConstants.QRCODE)
     BITBOX_BACKUP = ButtonOption("BitBox02 backup", SeedSignerIconConstants.MICROSD)
+    PASSPORT_BACKUP = ButtonOption("Passport backup", SeedSignerIconConstants.MICROSD)
     SATOCHIP = ButtonOption("Use Satochip card", SeedSignerIconConstants.FINGERPRINT)
     TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=12)
     TYPE_15WORD = ButtonOption("Enter 15-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=15)
@@ -137,6 +143,8 @@ class SeedSelectSeedView(View):
         button_data.append(self.SCAN_SEED)
         if self.settings.get_value(SettingsConstants.SETTING__BITBOX_BACKUP) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.BITBOX_BACKUP)
+        if self.settings.get_value(SettingsConstants.SETTING__PASSPORT_BACKUP) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.PASSPORT_BACKUP)
         seed_lengths = self.settings.get_value(SettingsConstants.SETTING__SEED_WORD_LENGTHS)
         options = {
             12: self.TYPE_12WORD,
@@ -195,6 +203,9 @@ class SeedSelectSeedView(View):
         if button_data[selected_menu_num] == self.BITBOX_BACKUP:
             return Destination(SeedBitbox02BackupSelectView)
 
+        if button_data[selected_menu_num] == self.PASSPORT_BACKUP:
+            return Destination(SeedPassportBackupSelectView)
+
         elif button_data[selected_menu_num] in [self.TYPE_12WORD, self.TYPE_15WORD, self.TYPE_18WORD, self.TYPE_21WORD, self.TYPE_24WORD]:
             from seedsigner.views.seed_views import SeedMnemonicEntryView
             self.controller.storage.init_pending_mnemonic(num_words=button_data[selected_menu_num].return_data)
@@ -222,6 +233,7 @@ class LoadSeedView(View):
     TYPE_SLIP39 = ButtonOption("SLIP-39 Shares", FontAwesomeIconConstants.KEYBOARD)
     IMPORT_SEEDKEEPER = ButtonOption("From SeedKeeper", FontAwesomeIconConstants.LOCK)
     BITBOX_BACKUP = ButtonOption("BitBox02 backup", SeedSignerIconConstants.MICROSD)
+    PASSPORT_BACKUP = ButtonOption("Passport backup", SeedSignerIconConstants.MICROSD)
     CREATE = ButtonOption(" Create a seed", SeedSignerIconConstants.PLUS)
 
     def run(self):
@@ -246,6 +258,9 @@ class LoadSeedView(View):
 
         if self.settings.get_value(SettingsConstants.SETTING__BITBOX_BACKUP) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.BITBOX_BACKUP)
+
+        if self.settings.get_value(SettingsConstants.SETTING__PASSPORT_BACKUP) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.PASSPORT_BACKUP)
 
         button_data.append(self.CREATE)
 
@@ -281,6 +296,9 @@ class LoadSeedView(View):
 
         elif button_data[selected_menu_num] == self.BITBOX_BACKUP:
             return Destination(SeedBitbox02BackupSelectView)
+
+        elif button_data[selected_menu_num] == self.PASSPORT_BACKUP:
+            return Destination(SeedPassportBackupSelectView)
 
         elif button_data[selected_menu_num] == self.CREATE:
             from .tools_views import ToolsMenuView
@@ -562,6 +580,179 @@ class SeedBitbox02BackupSummaryView(View):
         self.run_screen(
             LargeIconStatusScreen,
             title=_("BitBox02 backup"),
+            status_headline=_("Seed loaded"),
+            text="\n".join(text_lines),
+            show_back_button=False,
+            button_data=[self.CONTINUE],
+        )
+
+        return Destination(SeedFinalizeView)
+
+
+class SeedPassportBackupSelectView(View):
+    def __init__(self):
+        super().__init__()
+        self.microsd_dir: Path = MicroSD.get_microsd_dir()
+        self.extensions = {".7z"}
+
+    def _get_backup_files(self) -> list[Path]:
+        backup_files: list[Path] = []
+        if not self.microsd_dir.exists():
+            raise PassportBackupError(_("microSD card not detected."))
+
+        for path in self.microsd_dir.rglob("*"):
+            if not path.is_file():
+                continue
+
+            try:
+                rel_parts = path.relative_to(self.microsd_dir).parts
+            except ValueError:
+                continue
+
+            if any(part.startswith(".") for part in rel_parts):
+                continue
+
+            if path.suffix.lower() in self.extensions:
+                backup_files.append(path)
+
+        backup_files.sort(key=lambda p: p.relative_to(self.microsd_dir).as_posix().lower())
+        return backup_files
+
+    def run(self):
+        if len(self.controller.storage.seeds) > 0:
+            ret = self.run_screen(
+                WarningScreen,
+                title="WARNING",
+                status_headline=None,
+                text="These tools load data from the microSD card and may expose loaded secrets.",
+                show_back_button=True,
+                button_data=[ButtonOption("Continue")],
+            )
+            if ret == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
+
+        try:
+            backup_files = self._get_backup_files()
+        except Exception as e:
+            logger.exception("Failed to scan microSD for Passport backups", exc_info=e)
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text=str(e),
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(BackStackView)
+
+        if not backup_files:
+            self.run_screen(
+                WarningScreen,
+                title=_("No Backups Found"),
+                status_headline=None,
+                text=_("No Passport backups (.7z) were found on the microSD card."),
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(BackStackView)
+
+        button_data = [
+            ButtonOption(path.relative_to(self.microsd_dir).as_posix(), SeedSignerIconConstants.MICROSD)
+            for path in backup_files
+        ]
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title=_("Select Passport backup"),
+            is_button_text_centered=False,
+            button_data=button_data,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        selected_path = backup_files[selected_menu_num]
+
+        return Destination(
+            SeedPassportBackupCodeEntryView,
+            view_args={"backup_path": selected_path},
+        )
+
+
+class SeedPassportBackupCodeEntryView(View):
+    def __init__(self, backup_path: Path):
+        super().__init__()
+        self.backup_path = Path(backup_path)
+
+    def run(self):
+        backup_code = self.run_screen(
+            KeyboardScreen,
+            title=_("Passport backup code"),
+            rows=4,
+            cols=5,
+            keys_charset="0123456789",
+            show_save_button=True,
+        )
+
+        if backup_code == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        backup_code = str(backup_code).strip()
+        if not backup_code:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text=_("Backup code cannot be empty."),
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(SeedPassportBackupCodeEntryView, view_args={"backup_path": self.backup_path})
+
+        try:
+            details = decode_passport_backup(self.backup_path, backup_code)
+        except (OSError, PassportBackupError, ValueError) as e:
+            logger.exception("Failed to load Passport backup", exc_info=e)
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text=str(e),
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            return Destination(SeedPassportBackupCodeEntryView, view_args={"backup_path": self.backup_path})
+
+        try:
+            seed = Seed(details.mnemonic)
+        except InvalidSeedException:
+            return Destination(SeedMnemonicInvalidView)
+
+        self.controller.storage.set_pending_seed(seed)
+
+        return Destination(SeedPassportBackupSummaryView, view_args={"details": details})
+
+
+class SeedPassportBackupSummaryView(View):
+    CONTINUE = ButtonOption(_("Continue"))
+
+    def __init__(self, details: PassportBackupDetails):
+        super().__init__()
+        self.details = details
+
+    def run(self):
+        text_lines = []
+        if self.details.chain:
+            text_lines.append(_("Chain: {}".format(self.details.chain)))
+        if self.details.xfp:
+            text_lines.append(_("XFP: {}".format(self.details.xfp)))
+        if self.details.firmware:
+            text_lines.append(_("Firmware: {}".format(self.details.firmware)))
+        text_lines.append(_("Seed length: {} words").format(len(self.details.mnemonic)))
+
+        self.run_screen(
+            LargeIconStatusScreen,
+            title=_("Passport backup"),
             status_headline=_("Seed loaded"),
             text="\n".join(text_lines),
             show_back_button=False,

--- a/tests/test_passport_backup.py
+++ b/tests/test_passport_backup.py
@@ -12,7 +12,7 @@ from seedsigner.helpers.passport_backup import (
 )
 
 
-pytestmark = pytest.mark.skipif(shutil.which("7z") is None, reason="p7zip not installed")
+pytestmark = pytest.mark.skipif(shutil.which("7za") is None, reason="p7zip not installed")
 
 
 def _create_backup_archive(tmp_path: Path, password: str, mnemonic: str) -> Path:
@@ -33,7 +33,7 @@ def _create_backup_archive(tmp_path: Path, password: str, mnemonic: str) -> Path
     archive_path = tmp_path / "passport-backup.7z"
     subprocess.run(
         [
-            "7z",
+            "7za",
             "a",
             "-t7z",
             f"-p{password}",

--- a/tests/test_passport_backup.py
+++ b/tests/test_passport_backup.py
@@ -1,0 +1,70 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from seedsigner.helpers.passport_backup import (
+    PassportBackupDetails,
+    PassportBackupError,
+    decode_passport_backup,
+)
+
+
+pytestmark = pytest.mark.skipif(shutil.which("7z") is None, reason="p7zip not installed")
+
+
+def _create_backup_archive(tmp_path: Path, password: str, mnemonic: str) -> Path:
+    backup_text = "\n".join(
+        [
+            "# Passport backup file! DO NOT CHANGE.",
+            "mnemonic = " + json.dumps(mnemonic),
+            "chain = " + json.dumps("BTC"),
+            "xfp = " + json.dumps("12345678"),
+            "fw_version = " + json.dumps("1.0.0"),
+            "# EOF",
+        ]
+    )
+
+    backup_txt = tmp_path / "passport-backup.txt"
+    backup_txt.write_text(backup_text)
+
+    archive_path = tmp_path / "passport-backup.7z"
+    subprocess.run(
+        [
+            "7z",
+            "a",
+            "-t7z",
+            f"-p{password}",
+            str(archive_path),
+            str(backup_txt),
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    return archive_path
+
+
+def test_decode_passport_backup(tmp_path):
+    mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    password = "1111-2222-3333-4444-5555"
+    archive = _create_backup_archive(tmp_path, password, mnemonic)
+
+    details = decode_passport_backup(archive, password)
+
+    assert isinstance(details, PassportBackupDetails)
+    assert details.mnemonic == mnemonic.split()
+    assert details.chain == "BTC"
+    assert details.firmware == "1.0.0"
+    assert details.xfp == "12345678"
+
+
+def test_invalid_password_raises(tmp_path):
+    mnemonic = "legal winner thank year wave sausage worth useful legal winner thank yellow"
+    archive = _create_backup_archive(tmp_path, "9999-8888-7777-6666-5555", mnemonic)
+
+    with pytest.raises(PassportBackupError):
+        decode_passport_backup(archive, "0000-0000-0000-0000-0000")


### PR DESCRIPTION
## Summary
- add Passport microSD backup decoding using the system 7z utility
- expose a settings toggle and UI flow for loading Passport backups alongside BitBox02
- validate backup code input and show backup metadata, with tests covering the 7z workflow

## Testing
- pytest tests/test_passport_backup.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c5517d6808322b41791ff96cff464)