### PR TITLE
Update build workflow to mirror seedsigner-os compose build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     # Prevent resource consuming cron triggered runs in forks
     if: (!github.event.repository.fork || github.event_name == 'workflow_dispatch')
+    env:
+      DOCKER_DEFAULT_PLATFORM: linux/amd64
     strategy:
       fail-fast: false
       matrix:
@@ -95,58 +97,30 @@ jobs:
           # get full history + tags for "git describe"
           fetch-depth: 0
 
-      - name: checkout source
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['app-repo'] || github.repository }}
-          # ref defaults to source-ref input (workflow_dispatch) or SHA of event
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['source-ref'] || github.sha }}
-          submodules: true
-          path: "seedsigner-os/opt/rootfs-overlay/opt"
-          # get full history + tags for "git describe"
-          fetch-depth: 0
-
-      - name: Get and set meta data
+      - name: Prepare build metadata
         run: |
-          # The builder_hash (seedsigner-os hash) for the cache action step key
-          echo "builder_hash=$(git -C seedsigner-os rev-parse --short HEAD)"| tee -a $GITHUB_ENV
+          echo "builder_hash=$(git -C seedsigner-os rev-parse --short HEAD)" | tee -a "$GITHUB_ENV"
 
-          # Derive tag based versions, like 0.7.0-40-g0424967 (=$tag-$number-of-commits-since-tag-$short-sha1),
-          # or just e.g. 0.7.0, if we are exactly on a 0.7.0 tagged commit.
-          # --always to fall back to commit sha, if no tag present like in partial forks of the repo
-          os_version="$(git -C seedsigner-os describe --tags --always)"
-          source_version="$(git -C seedsigner-os/opt/rootfs-overlay/opt describe --tags --always)"
-
-          # Combine seedsigner and seedsigner-os version into one version string and squash the versions, if
-          # they are identical: So os_version=0.7.0 + source_version=0.7.0 combine to just only "0.7.0",
-          # whereas os_version=0.6.0-61-g9fafebe + source_version=0.7.0-40-g0424967 combine to "os0.6.0-61-g9fafebe_sw0.7.0-40-g0424967"
-          if [ "${os_version}" = "${source_version}" ]; then
-            # seedsigner + seedsigner_os have the same tag
-            echo "img_version=${source_version}"| tee -a $GITHUB_ENV
+          APP_REPO_INPUT="${{ github.event_name == 'workflow_dispatch' && github.event.inputs['app-repo'] || github.repository }}"
+          if [[ "${APP_REPO_INPUT}" =~ ^https?:// ]]; then
+            APP_REPO_URL="${APP_REPO_INPUT}"
           else
-            echo "img_version=os${os_version}_sw${source_version}"| tee -a $GITHUB_ENV
+            APP_REPO_URL="https://github.com/${APP_REPO_INPUT}"
           fi
+
+          APP_REF="${{ github.event_name == 'workflow_dispatch' && github.event.inputs['source-ref'] || github.sha }}"
+
+          SS_ARGS="--${{ matrix.target }} --app-repo=${APP_REPO_URL} --app-commit-id=${APP_REF}"
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.dev }}" = "true" ]; then
-            echo "DEV_FLAG=--dev" >> $GITHUB_ENV
+            SS_ARGS+=" --dev"
           fi
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [ "${{ github.event.inputs.smartcard }}" = "true" ]; then
-              echo "SMARTCARD_FLAG=--smartcard" >> $GITHUB_ENV
-            else
-              echo "SMARTCARD_FLAG=" >> $GITHUB_ENV
-            fi
-          else
-            echo "SMARTCARD_FLAG=--smartcard" >> $GITHUB_ENV
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ] || [ "${{ github.event.inputs.smartcard }}" = "true" ]; then
+            SS_ARGS+=" --smartcard"
           fi
 
-      - name: delete unnecessary files
-        run: |
-          cd seedsigner-os/opt/rootfs-overlay/opt
-          find . -mindepth 1 -maxdepth 1 ! -name src -exec rm -rf {} +
-          ls -la .
-          ls -la src
+          echo "SS_ARGS=${SS_ARGS}" | tee -a "$GITHUB_ENV"
 
       - name: free disk space
         run: |
@@ -169,58 +143,31 @@ jobs:
         # while consuming ~850 MB storage space).
         with:
           path: |
-            ~/.buildroot-ccache/
-            seedsigner-os/buildroot_dl
+            seedsigner-os/.buildroot-ccache
+            seedsigner-os/.ccache
           key: build-cache-${{ matrix.target }}-${{ env.builder_hash }}
           restore-keys: |
             build-cache-${{ matrix.target }}-
 
-      - name: Create build container
+      - name: Build image with docker compose
         run: |
           cd seedsigner-os
-          docker build -t seedsigner-os-build .
+          mkdir -p .buildroot-ccache .ccache images
+          docker compose up --force-recreate --build
+          docker compose down
 
-      - name: build
+      - name: Fix permissions
         run: |
-          mkdir -p \
-            ~/.buildroot-ccache \
-            seedsigner-os/buildroot_dl
-          docker run \
-            --rm \
-            -v "$(pwd)/seedsigner-os/opt:/opt" \
-            -v "$(pwd)/seedsigner-os/images:/images" \
-            -v "$(pwd)/seedsigner-os/buildroot_dl:/buildroot_dl" \
-            -v "${HOME}/.buildroot-ccache:/root/.buildroot-ccache" \
-            seedsigner-os-build \
-            --${{ matrix.target }} --skip-repo --no-clean $SMARTCARD_FLAG $DEV_FLAG
-          sudo chown -R $USER:$USER seedsigner-os/images seedsigner-os/buildroot_dl ~/.buildroot-ccache/
+          sudo chown -R $USER:$USER seedsigner-os/images seedsigner-os/.buildroot-ccache seedsigner-os/.ccache
 
-      - name: list image (before rename)
+      - name: list images
         run: |
           ls -la seedsigner-os/images
-
-      - name: rename image
-        run: |
-          cd seedsigner-os/images
-          if compgen -G "seedsigner_os*.img.zip" > /dev/null; then
-            mv seedsigner_os*.img.zip seedsigner_os.${{ env.img_version }}.${{ matrix.target }}.img.zip
-          elif compgen -G "seedsigner_os*.img" > /dev/null; then
-            mv seedsigner_os*.img seedsigner_os.${{ env.img_version }}.${{ matrix.target }}.img
-            zip -j seedsigner_os.${{ env.img_version }}.${{ matrix.target }}.img.zip seedsigner_os.${{ env.img_version }}.${{ matrix.target }}.img
-            rm seedsigner_os.${{ env.img_version }}.${{ matrix.target }}.img
-          else
-            echo "No image file found to rename" >&2
-            exit 1
-          fi
 
       - name: print sha256sum
         run: |
           cd seedsigner-os/images
           sha256sum *.img.zip
-
-      - name: list image (after rename)
-        run: |
-          ls -la seedsigner-os/images
 
       - name: upload images
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,14 @@ jobs:
             sha256sum "${img_files[@]}"
           fi
 
+      - name: zip images for upload
+        run: |
+          cd seedsigner-os/images
+          shopt -s nullglob
+          for img in *.img; do
+            zip "${img}.zip" "$img"
+          done
+
       - name: upload images
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,6 +164,29 @@ jobs:
         run: |
           ls -la seedsigner-os/images
 
+      - name: normalize image archives for reproducibility
+        run: |
+          # The seedsigner-os build script stamps images with a fixed timestamp using
+          # "touch -d '2025-07-01 00:00:00'" before zipping. That call is interpreted in
+          # the host's local timezone, which shifts the stored mtime across systems and
+          # makes otherwise identical .img.zip files hash differently. Normalize here by
+          # re-zipping with a fixed UTC timestamp.
+          cd seedsigner-os/images
+          shopt -s nullglob
+          zip_files=(*.img.zip)
+
+          SOURCE_DATE_EPOCH=1751328000  # 2025-07-01 00:00:00 UTC
+          if ((${#zip_files[@]})); then
+            for zip in "${zip_files[@]}"; do
+              img_file="${zip%.zip}"
+              unzip -o "$zip"
+              TZ=UTC touch -d "@${SOURCE_DATE_EPOCH}" "$img_file"
+              rm -f "$zip"
+              TZ=UTC SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} zip -X -j "$zip" "$img_file"
+              TZ=UTC touch -d "@${SOURCE_DATE_EPOCH}" "$zip"
+            done
+          fi
+
       - name: print sha256sum
         run: |
           cd seedsigner-os/images

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,21 @@ jobs:
       - name: print sha256sum
         run: |
           cd seedsigner-os/images
-          sha256sum *.img.zip
+          shopt -s nullglob
+          zip_files=(*.img.zip)
+
+          if ((${#zip_files[@]})); then
+            unzip -o "${zip_files[@]}"
+          fi
+
+          if ((${#zip_files[@]})); then
+            sha256sum "${zip_files[@]}"
+          fi
+
+          img_files=(*.img)
+          if ((${#img_files[@]})); then
+            sha256sum "${img_files[@]}"
+          fi
 
       - name: upload images
         uses: actions/upload-artifact@v4
@@ -203,7 +217,25 @@ jobs:
           cd images
           # each downloaded image is in its own subfolder
           find . -name "*.img.zip" -exec mv {} . \;
-          sha256sum *.img.zip > seedsigner_os.${{ env.source_hash }}.sha256
+          shopt -s nullglob
+          zip_files=(*.img.zip)
+
+          if ((${#zip_files[@]})); then
+            unzip -o "${zip_files[@]}"
+          fi
+
+          img_files=(*.img)
+
+          checksum_files=()
+          ((${#zip_files[@]})) && checksum_files+=("${zip_files[@]}")
+          ((${#img_files[@]})) && checksum_files+=("${img_files[@]}")
+
+          if ((${#checksum_files[@]})); then
+            sha256sum "${checksum_files[@]}" > seedsigner_os.${{ env.source_hash }}.sha256
+          else
+            echo "No image files found for checksums" >&2
+            exit 1
+          fi
 
       - name: upload checksums
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,29 +164,6 @@ jobs:
         run: |
           ls -la seedsigner-os/images
 
-      - name: normalize image archives for reproducibility
-        run: |
-          # The seedsigner-os build script stamps images with a fixed timestamp using
-          # "touch -d '2025-07-01 00:00:00'" before zipping. That call is interpreted in
-          # the host's local timezone, which shifts the stored mtime across systems and
-          # makes otherwise identical .img.zip files hash differently. Normalize here by
-          # re-zipping with a fixed UTC timestamp.
-          cd seedsigner-os/images
-          shopt -s nullglob
-          zip_files=(*.img.zip)
-
-          SOURCE_DATE_EPOCH=1751328000  # 2025-07-01 00:00:00 UTC
-          if ((${#zip_files[@]})); then
-            for zip in "${zip_files[@]}"; do
-              img_file="${zip%.zip}"
-              unzip -o "$zip"
-              TZ=UTC touch -d "@${SOURCE_DATE_EPOCH}" "$img_file"
-              rm -f "$zip"
-              TZ=UTC SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} zip -X -j "$zip" "$img_file"
-              TZ=UTC touch -d "@${SOURCE_DATE_EPOCH}" "$zip"
-            done
-          fi
-
       - name: print sha256sum
         run: |
           cd seedsigner-os/images


### PR DESCRIPTION
## Description
- Set DOCKER_DEFAULT_PLATFORM to linux/amd64 and drive builds through the seedsigner-os Docker Compose flow for reproducibility.
- Configure SS_ARGS from workflow inputs/commits and cache the compose ccache directories before uploading artifacts.

This pull request is categorized as a:
- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [x] Other

## Checklist
- [ ] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?
- [ ] No, I’m a fool
- [ ] Yes
- [x] N/A

I have tested this PR on the following platforms/os:
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cf310fa188322bf83666c80dd0883)