### PR TITLE
Fix build workflow app ref selection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,13 @@ jobs:
 
           APP_REF="${{ github.event_name == 'workflow_dispatch' && github.event.inputs['source-ref'] || github.sha }}"
 
-          SS_ARGS="--${{ matrix.target }} --app-repo=${APP_REPO_URL} --app-commit-id=${APP_REF}"
+          if [[ "${{ github.event_name }}" = "workflow_dispatch" ]] && ! [[ "${APP_REF}" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+            APP_REF_ARG="--app-branch=${APP_REF}"
+          else
+            APP_REF_ARG="--app-commit-id=${APP_REF}"
+          fi
+
+          SS_ARGS="--${{ matrix.target }} --app-repo=${APP_REPO_URL} ${APP_REF_ARG}"
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.dev }}" = "true" ]; then
             SS_ARGS+=" --dev"


### PR DESCRIPTION
### Motivation
- The build workflow always passed the user-supplied `source-ref` as a commit id which caused `git reset` in the build container to fail when the input was a branch or tag name. 
- That resulted in ambiguous revision errors like `unknown revision or path not in the working tree` during the docker build. 
- The workflow needs to distinguish between SHA commit IDs and branch/tag names so the correct `build.sh` flags (`--app-commit-id` vs `--app-branch`) are used. 

### Description
- Update `.github/workflows/build.yml` to inspect the `source-ref` input and choose between `--app-branch` and `--app-commit-id` based on a SHA regex check. 
- Introduce `APP_REF_ARG` and set it to `--app-branch=${APP_REF}` when `source-ref` is not a 7-40 hex SHA and otherwise to `--app-commit-id=${APP_REF}`. 
- Construct `SS_ARGS` using the new `APP_REF_ARG` instead of always using `--app-commit-id`. 

### Testing
- No automated tests were executed because this change is a workflow-only modification (no runtime/unit tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dfe09a3f08322ae403f0e20fdf158)