### PR TITLE
Retry smartcard test detection with short timeouts and pause

### DIFF
--- a/src/seedsigner/views/settings_views.py
+++ b/src/seedsigner/views/settings_views.py
@@ -476,7 +476,15 @@ class SCARDTestView(View):
                         time.sleep(0.5)
 
             if cardservice is None:
-                raise CardRequestTimeoutException("No Smartcard detected after retries")
+                self.loading_screen.stop()
+                self.run_screen(
+                        WarningScreen,
+                        title="Failure",
+                        status_headline=None,
+                        text=f"No Smartcard detected...",
+                        show_back_button=True,
+                    )
+                return Destination(BackStackView)
 
             self.loading_screen.stop()
 
@@ -508,17 +516,6 @@ class SCARDTestView(View):
                     title="PCSC Failure",
                     status_headline=None,
                     text=f"Unable to establish PCSC context(A restart may help, possibly faulty reader)",
-                    show_back_button=True,
-                )
-            return Destination(BackStackView)
-        
-        except CardRequestTimeoutException:
-            self.loading_screen.stop()
-            self.run_screen(
-                    WarningScreen,
-                    title="Failure",
-                    status_headline=None,
-                    text=f"No Smartcard detected...",
                     show_back_button=True,
                 )
             return Destination(BackStackView)

--- a/src/seedsigner/views/settings_views.py
+++ b/src/seedsigner/views/settings_views.py
@@ -465,8 +465,18 @@ class SCARDTestView(View):
         from smartcard.pcsc.PCSCExceptions import EstablishContextException
 
         try:
-            cardrequest = CardRequest(timeout=10, cardType=AnyCardType())
-            cardservice = cardrequest.waitforcard()
+            cardservice = None
+            for attempt in range(5):
+                try:
+                    cardrequest = CardRequest(timeout=2, cardType=AnyCardType())
+                    cardservice = cardrequest.waitforcard()
+                    break
+                except CardRequestTimeoutException:
+                    if attempt < 4:
+                        time.sleep(0.5)
+
+            if cardservice is None:
+                raise CardRequestTimeoutException("No Smartcard detected after retries")
 
             self.loading_screen.stop()
 


### PR DESCRIPTION
### Motivation
- Reduce wait time for the smartcard "simple test" by splitting detection into multiple short attempts to improve responsiveness.
- Allow the test to exit early when a card is detected instead of waiting a long single timeout.
- Handle the case where repeated short timeouts still find no card by raising the existing timeout exception.

### Description
- Replace the single `CardRequest(timeout=10)` call with a retry loop that runs 5 attempts using `CardRequest(timeout=2)` per attempt.
- Pause `0.5s` between attempts using `time.sleep(0.5)` and break out of the loop immediately on successful detection.
- If no card is found after retries, raise `CardRequestTimeoutException` to reuse the existing error handling path.
- Keep existing handling for `ListReadersException` and `EstablishContextException` and stop the loading screen on all failure paths.

### Testing
- No automated tests were executed for this change.
- The change compiles at commit time and the file was updated and committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b26cddec48322917b189f4d6192fc)