### PR TITLE
Bump version to B7

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -121,7 +121,7 @@ class Controller(Singleton):
         rather than at the top in order avoid circular imports.
     """
     
-    VERSION = "0.8.6+Satochip+ERT-B6"
+    VERSION = "0.8.6+Satochip+ERT-B7"
 
     # Declare class member vars with type hints to enable richer IDE support throughout
     # the code.


### PR DESCRIPTION
### Motivation
- Update the application build/release identifier to reflect the new suffix `B7` instead of `B6` for the Satochip ERT build. 
- Keep the in-app `VERSION` string accurate for diagnostics, packaging, and user-facing version display. 

### Description
- Changed the `VERSION` constant in `src/seedsigner/controller.py` from `"0.8.6+Satochip+ERT-B6"` to `"0.8.6+Satochip+ERT-B7"`. 

### Testing
- No automated tests were run for this change. 
- This is a non-functional string-only update so no runtime behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f04adc8d0832283eb4b463ddd38ca)