### PR TITLE
Add `debug-rootfs` workflow input and upload rootfs `.tar.gz` artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,11 @@ on:
         required: false
         default: 'false'
         type: boolean
+      debug-rootfs:
+        description: Build and export the rootfs debug archive
+        required: false
+        default: 'false'
+        type: boolean
 
 # Increment this number as part of a PR to trigger an image build for the PR
 # trigger = 0
@@ -124,6 +129,10 @@ jobs:
 
           if [ "${{ github.event_name }}" != "workflow_dispatch" ] || [ "${{ github.event.inputs.smartcard }}" = "true" ]; then
             SS_ARGS+=" --smartcard"
+          fi
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.debug-rootfs }}" = "true" ]; then
+            SS_ARGS+=" --debug-rootfs"
           fi
 
           echo "SS_ARGS=${SS_ARGS}" | tee -a "$GITHUB_ENV"
@@ -203,6 +212,15 @@ jobs:
           name: seedsigner_os_images-${{ matrix.target }}
           path: "seedsigner-os/images/*.img.zip"
           if-no-files-found: error
+          # maximum 90 days retention
+          retention-days: 90
+
+      - name: upload rootfs debug archives
+        uses: actions/upload-artifact@v4
+        with:
+          name: seedsigner_os_rootfs-${{ matrix.target }}
+          path: "seedsigner-os/images/*.tar.gz"
+          if-no-files-found: warn
           # maximum 90 days retention
           retention-days: 90
 


### PR DESCRIPTION
### Motivation
- Provide an opt-in way to produce a rootfs debug archive from the build process for troubleshooting and inspection.
- Keep debug-rootfs disabled by default to avoid increasing storage/use for normal CI runs.
- Ensure any produced `.tar.gz` rootfs debug archives are persisted as build artifacts for later download.

### Description
- Add a `workflow_dispatch` input `debug-rootfs` (boolean, default `false`) to the build workflow to control debug archive generation.
- Append `--debug-rootfs` to `SS_ARGS` when the `debug-rootfs` input is `true` so the build produces the rootfs archive.
- Add an `upload-artifact` step that uploads `seedsigner-os/images/*.tar.gz` as `seedsigner_os_rootfs-${{ matrix.target }}` with `if-no-files-found: warn`.
- Leave image upload behavior unchanged and retain artifacts for 90 days.

### Testing
- No automated tests were run because this is a workflow-only change and requires a `workflow_dispatch` run to exercise the new option.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f26c54c408322a832c5ded101329d)