### PR TITLE
Add DPI28 (2.8") touchscreen display and touch input support

### DIFF
--- a/src/seedsigner/gui/keyboard.py
+++ b/src/seedsigner/gui/keyboard.py
@@ -481,6 +481,36 @@ class Keyboard:
         return key.code
 
 
+    def get_key_at_screen_coords(self, screen_x: int, screen_y: int):
+        """
+        Find which key (if any) is at the given screen coordinates.
+
+        Args:
+            screen_x, screen_y: Screen coordinates in native space (240x240)
+
+        Returns:
+            Key object if found and active, None otherwise
+        """
+        # Check if within keyboard rect
+        if not (self.rect[0] <= screen_x <= self.rect[2] and
+                self.rect[1] <= screen_y <= self.rect[3]):
+            return None
+
+        # Find the key at these coordinates
+        for row_keys in self.keys:
+            for key in row_keys:
+                key_right = key.screen_x + self.key_width * key.size
+                key_bottom = key.screen_y + self.key_height
+                if (key.screen_x <= screen_x <= key_right and
+                    key.screen_y <= screen_y <= key_bottom):
+                    # Only return active keys - greyed out keys should be ignored
+                    if key.is_active:
+                        return key
+                    return None
+
+        return None
+
+
     def set_selected_key(self, selected_letter):
         # De-select the current selected_key
         self.get_selected_key().is_selected = False
@@ -646,4 +676,3 @@ class TextEntryDisplay(TextEntryDisplayConstants):
 
         # Paste the display onto the main canvas
         self.canvas.paste(image, (self.rect[0], self.rect[1]))
-

--- a/src/seedsigner/gui/renderer.py
+++ b/src/seedsigner/gui/renderer.py
@@ -1,3 +1,5 @@
+import os
+from typing import Optional
 from PIL import Image, ImageDraw
 from threading import Lock
 
@@ -8,11 +10,89 @@ from seedsigner.hardware.displays.display_driver import (
     DISPLAY_TYPE__ILI9486,
     DISPLAY_TYPE__ST7789,
     DISPLAY_TYPE__DESKTOP,
+    DISPLAY_TYPE__DPI28,
     DisplayDriver,
 )
 from seedsigner.models.settings import Settings
 from seedsigner.models.settings_definition import SettingsConstants
 from seedsigner.models.singleton import ConfigurableSingleton
+
+
+def _detect_display_type() -> Optional[str]:
+    """
+    Auto-detect display type based on hardware.
+
+    Returns 'dpi28' if Waveshare 2.8" DPI LCD is detected.
+    Can be overridden by SEEDSIGNER_DISPLAY environment variable.
+    """
+    # Allow manual override
+    env_display = os.environ.get('SEEDSIGNER_DISPLAY')
+    if env_display:
+        return env_display
+
+    # Auto-detect DPI LCD by checking framebuffer
+    try:
+        # Check if framebuffer exists with expected size for DPI LCD (480x640)
+        if os.path.exists('/dev/fb0'):
+            with open('/sys/class/graphics/fb0/virtual_size', 'r') as f:
+                size = f.read().strip()
+                if size == '480,640':
+                    print("[Display] Auto-detected DPI28 framebuffer (480x640)")
+                    return 'dpi28'
+    except (IOError, FileNotFoundError):
+        pass
+
+    return None  # Let Settings decide
+
+
+def _detect_touch_mode() -> bool:
+    """
+    Auto-detect if touch input is available.
+
+    Returns True if capacitive touch device is found, False otherwise.
+    Can be overridden by SEEDSIGNER_TOUCH environment variable.
+    """
+    # Allow manual override
+    env_touch = os.environ.get("SEEDSIGNER_TOUCH")
+    if env_touch:
+        return env_touch == "1"
+
+    # If DPI28 display is detected, assume touch is available
+    # (the DPI28 Waveshare display includes integrated touch)
+    if _detect_display_type() == "dpi28":
+        print("[Touch] DPI28 display detected - enabling touch mode")
+        return True
+
+    # Auto-detect touch input device via sysfs (no evdev needed)
+    try:
+        for i in range(10):
+            name_path = f"/sys/class/input/event{i}/device/name"
+            try:
+                with open(name_path, "r") as f:
+                    name = f.read().strip()
+                    # Look for common touch device names
+                    if any(keyword in name.lower() for keyword in ["touch", "goodix", "ft5", "edt-ft5"]):
+                        print(f"[Touch] Auto-detected touch device: {name}")
+                        return True
+            except (IOError, FileNotFoundError):
+                continue
+    except Exception:
+        pass
+
+    return False
+
+
+# Auto-detect touch mode
+TOUCH_MODE = _detect_touch_mode()
+
+# Set environment variable so other modules can check it
+if TOUCH_MODE and 'SEEDSIGNER_TOUCH' not in os.environ:
+    os.environ['SEEDSIGNER_TOUCH'] = '1'
+
+# Check for auto-detected DPI28 display
+_auto_detected_display = _detect_display_type()
+if _auto_detected_display == 'dpi28' and 'SEEDSIGNER_DISPLAY' not in os.environ:
+    os.environ['SEEDSIGNER_DISPLAY'] = 'dpi28'
 
 
 
@@ -24,6 +104,10 @@ class Renderer(ConfigurableSingleton):
     draw: ImageDraw.ImageDraw = None
     disp = None
     lock = Lock()
+
+    @property
+    def is_screenshot_generator(self) -> bool:
+        return False
 
 
     @classmethod
@@ -40,7 +124,13 @@ class Renderer(ConfigurableSingleton):
         # prevent any other screen writes while we're changing the display driver.
         self.lock.acquire()
 
-        display_config = Settings.get_instance().get_value(SettingsConstants.SETTING__DISPLAY_CONFIGURATION, default_if_none=True)
+        # Check for auto-detected display first
+        env_display = os.environ.get("SEEDSIGNER_DISPLAY")
+        if env_display == "dpi28":
+            display_config = "dpi28_240x240"
+            print("[Display] Using auto-detected DPI28 display")
+        else:
+            display_config = Settings.get_instance().get_value(SettingsConstants.SETTING__DISPLAY_CONFIGURATION, default_if_none=True)
         self.display_type = display_config.split("_")[0]
         if self.display_type not in ALL_DISPLAY_TYPES:
             raise Exception(f"Invalid display type: {self.display_type}")
@@ -51,7 +141,7 @@ class Renderer(ConfigurableSingleton):
         if Settings.get_instance().get_value(SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED, default_if_none=True) == SettingsConstants.OPTION__ENABLED:
             self.disp.invert()
 
-        if self.display_type in [DISPLAY_TYPE__ST7789, DISPLAY_TYPE__DESKTOP]:
+        if self.display_type in [DISPLAY_TYPE__ST7789, DISPLAY_TYPE__DESKTOP, DISPLAY_TYPE__DPI28]:
             self.canvas_width = self.disp.width
             self.canvas_height = self.disp.height
 
@@ -122,3 +212,14 @@ class Renderer(ConfigurableSingleton):
     def display_blank_screen(self):
         self.draw.rectangle((0, 0, self.canvas_width, self.canvas_height), outline=0, fill=0)
         self.show_image()
+
+
+    def set_touch_bar_labels(self, labels: tuple):
+        """
+        Set the touch bar labels for DPI28 display.
+
+        Args:
+            labels: Tuple from DPI28 touch bar presets (e.g., TOUCH_BAR_DEFAULT, TOUCH_BAR_KEYBOARD)
+        """
+        if self.display_type == DISPLAY_TYPE__DPI28 and hasattr(self.disp.display, 'set_touch_bar_labels'):
+            self.disp.display.set_touch_bar_labels(labels)

--- a/src/seedsigner/gui/renderer.py
+++ b/src/seedsigner/gui/renderer.py
@@ -136,6 +136,15 @@ class Renderer(ConfigurableSingleton):
             raise Exception(f"Invalid display type: {self.display_type}")
 
         width, height = display_config.split("_")[1].split("x")
+
+        # Fallback to DPI28 if SPI hardware is missing but a DPI framebuffer is present.
+        if self.display_type == DISPLAY_TYPE__ST7789:
+            spi_missing = not os.path.exists("/dev/spidev0.0")
+            if spi_missing and _detect_display_type() == "dpi28":
+                display_config = "dpi28_240x240"
+                self.display_type = DISPLAY_TYPE__DPI28
+                width, height = "240", "240"
+                print("[Display] SPI device missing; using DPI28 display instead")
         self.disp = DisplayDriver(self.display_type, width=int(width), height=int(height))
 
         if Settings.get_instance().get_value(SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED, default_if_none=True) == SettingsConstants.OPTION__ENABLED:

--- a/src/seedsigner/gui/renderer.py
+++ b/src/seedsigner/gui/renderer.py
@@ -57,27 +57,28 @@ def _detect_touch_mode() -> bool:
     if env_touch:
         return env_touch == "1"
 
-    # If DPI28 display is detected, assume touch is available
-    # (the DPI28 Waveshare display includes integrated touch)
-    if _detect_display_type() == "dpi28":
-        print("[Touch] DPI28 display detected - enabling touch mode")
-        return True
-
     # Auto-detect touch input device via sysfs (no evdev needed)
     try:
+        keywords = ["touch", "goodix", "ft5", "edt-ft5", "ft5406", "touchscreen", "stmpe", "raspberry pi"]
         for i in range(10):
             name_path = f"/sys/class/input/event{i}/device/name"
             try:
                 with open(name_path, "r") as f:
                     name = f.read().strip()
                     # Look for common touch device names
-                    if any(keyword in name.lower() for keyword in ["touch", "goodix", "ft5", "edt-ft5"]):
+                    if any(keyword in name.lower() for keyword in keywords):
                         print(f"[Touch] Auto-detected touch device: {name}")
                         return True
             except (IOError, FileNotFoundError):
                 continue
     except Exception:
         pass
+
+    # If DPI28 display is detected, assume touch is available
+    # (the DPI28 Waveshare display includes integrated touch)
+    if _detect_display_type() == "dpi28":
+        print("[Touch] DPI28 display detected - enabling touch mode")
+        return True
 
     return False
 

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -21,6 +21,15 @@ from seedsigner.models.threads import BaseThread, ThreadsafeCounter
 logger = logging.getLogger(__name__)
 
 
+def _get_input_handler():
+    """Get the appropriate input handler (touch or hardware buttons)"""
+    import os
+    if os.environ.get('SEEDSIGNER_TOUCH') == '1':
+        from seedsigner.hardware.touchbuttons import TouchButtons
+        return TouchButtons.get_instance()
+    return HardwareButtons.get_instance()
+
+
 # Must be huge numbers to avoid conflicting with the selected_button returned by the
 #   screens with buttons.
 RET_CODE__BACK_BUTTON = 1000
@@ -32,8 +41,8 @@ RET_CODE__POWER_BUTTON = 1001
 class BaseScreen(BaseComponent):
     def __post_init__(self):
         super().__post_init__()
-        
-        self.hw_inputs = HardwareButtons.get_instance()
+
+        self.hw_inputs = _get_input_handler()
 
         # Implementation classes can add their own BaseThread to run in parallel with the
         # main execution thread.
@@ -240,6 +249,12 @@ class BaseTopNavScreen(BaseScreen):
 
             user_input = self.hw_inputs.wait_for(HardwareButtonsConstants.ALL_KEYS)
 
+            # Check for direct back button tap (touchscreen)
+            if hasattr(self.hw_inputs, 'was_back_button_tapped'):
+                if self.hw_inputs.was_back_button_tapped():
+                    if self.top_nav.show_back_button:
+                        return RET_CODE__BACK_BUTTON
+
             with self.renderer.lock:
                 if not self.top_nav.is_selected and user_input in [
                         HardwareButtonsConstants.KEY_LEFT,
@@ -427,6 +442,35 @@ class ButtonListScreen(BaseTopNavScreen):
         cur_selected_button = self.buttons[self.selected_button]
         cur_selected_button.is_selected = True
 
+        # Reset touch bar to default (▲/SELECT/▼) for list screens
+        self._set_touch_bar_default()
+
+
+    def _set_touch_bar_default(self):
+        """Reset touch bar to default with scroll arrows"""
+        self._update_touch_bar_for_list_position()
+
+
+    def _update_touch_bar_for_list_position(self):
+        """Update touch bar based on current list scroll position"""
+        import os
+        if os.environ.get('SEEDSIGNER_TOUCH') == '1':
+            disp = self.renderer.disp
+            if hasattr(disp, 'display') and hasattr(disp.display, 'TOUCH_BAR_DEFAULT'):
+                # Check if we're at top or bottom of list
+                at_top = self.selected_button == 0
+                at_bottom = self.selected_button == len(self.buttons) - 1
+
+                if at_top and at_bottom:
+                    # Single item list - both disabled
+                    disp.display.set_touch_bar_labels(disp.display.TOUCH_BAR_SELECT_ONLY)
+                elif at_top:
+                    disp.display.set_touch_bar_labels(disp.display.TOUCH_BAR_UP_DISABLED)
+                elif at_bottom:
+                    disp.display.set_touch_bar_labels(disp.display.TOUCH_BAR_DOWN_DISABLED)
+                else:
+                    disp.display.set_touch_bar_labels(disp.display.TOUCH_BAR_DEFAULT)
+
 
     def get_threads(self) -> List[BaseThread]:
         threads = super().get_threads()
@@ -440,11 +484,22 @@ class ButtonListScreen(BaseTopNavScreen):
         super()._render()
         self._render_visible_buttons()
 
+        # Register buttons for direct touch tap detection
+        if hasattr(self.hw_inputs, 'register_buttons'):
+            self.hw_inputs.register_buttons(self.buttons)
+
         # Write the screen updates
         self.renderer.show_image()
 
 
-    def _render_visible_buttons(self):
+    def _render_visible_buttons(self, clear_first=False):
+        # Optionally clear the button area before re-rendering (for scroll operations)
+        if clear_first and self.has_scroll_arrows:
+            self.image_draw.rectangle(
+                (0, self.top_nav_height, self.canvas_width, self.canvas_height),
+                fill="black"
+            )
+
         if self.has_scroll_arrows:
             self._render_up_arrow()
             self._render_down_arrow()
@@ -454,8 +509,13 @@ class ButtonListScreen(BaseTopNavScreen):
                 button.render()
                 continue
 
-            button_position_y = button.screen_y - button.scroll_y
-            if button_position_y >= self.top_nav_height and button_position_y < self.down_arrow_img_y:
+            button_top = button.screen_y - button.scroll_y
+            button_bottom = button_top + button.height
+
+            # Check if any part of the button is visible (between top_nav and down_arrow)
+            is_visible = button_bottom > self.top_nav_height and button_top < self.down_arrow_img_y
+
+            if is_visible:
                 if i == 0:
                     # We rendered the top button; no more to scroll up for.
                     self._hide_up_arrow()
@@ -494,20 +554,30 @@ class ButtonListScreen(BaseTopNavScreen):
 
 
     def _run(self):
+        # Clear any pending touch input from previous screen
+        if hasattr(self.hw_inputs, 'clear_pending_input'):
+            self.hw_inputs.clear_pending_input()
+
         while True:
             ret = self._run_callback()
             if ret is not None:
                 logging.info("Exiting ButtonListScreen due to _run_callback")
                 return ret
 
-            user_input = self.hw_inputs.wait_for(
-                [
-                    HardwareButtonsConstants.KEY_UP,
-                    HardwareButtonsConstants.KEY_DOWN,
-                    HardwareButtonsConstants.KEY_LEFT,
-                    HardwareButtonsConstants.KEY_RIGHT,
-                ] + HardwareButtonsConstants.KEYS__ANYCLICK
-            )
+            import os
+            is_touch = os.environ.get('SEEDSIGNER_TOUCH') == '1'
+            input_keys = [
+                HardwareButtonsConstants.KEY_UP,
+                HardwareButtonsConstants.KEY_DOWN,
+                HardwareButtonsConstants.KEY_LEFT,
+                HardwareButtonsConstants.KEY_RIGHT,
+            ] + HardwareButtonsConstants.KEYS__ANYCLICK
+            if is_touch:
+                input_keys += [HardwareButtonsConstants.KEY1, HardwareButtonsConstants.KEY3]
+
+            user_input = self.hw_inputs.wait_for(input_keys)
+            up_keys = [HardwareButtonsConstants.KEY_UP, HardwareButtonsConstants.KEY1] if is_touch else [HardwareButtonsConstants.KEY_UP]
+            down_keys = [HardwareButtonsConstants.KEY_DOWN, HardwareButtonsConstants.KEY3] if is_touch else [HardwareButtonsConstants.KEY_DOWN]
 
             with self.renderer.lock:
                 if not self.top_nav.is_selected and (
@@ -526,9 +596,12 @@ class ButtonListScreen(BaseTopNavScreen):
                         self.top_nav.is_selected = True
                         self.top_nav.render_buttons()
 
-                elif user_input == HardwareButtonsConstants.KEY_UP:
+                elif user_input in up_keys:
                     if self.top_nav.is_selected:
                         # Can't go up any further
+                        pass
+                    elif self.selected_button == 0:
+                        # Already at top, can't go up (KEY1 shouldn't go to top_nav)
                         pass
                     else:
                         cur_selected_button: Button = self.buttons[self.selected_button]
@@ -541,12 +614,17 @@ class ButtonListScreen(BaseTopNavScreen):
                             frame_scroll = cur_selected_button.screen_y - next_selected_button.screen_y
                             for button in self.buttons:
                                 button.scroll_y -= frame_scroll
-                            self._render_visible_buttons()
+                            self._render_visible_buttons(clear_first=True)
+                            # Re-register buttons with updated positions
+                            if hasattr(self.hw_inputs, 'register_buttons'):
+                                self.hw_inputs.register_buttons(self.buttons)
                         else:
                             cur_selected_button.render()
                             next_selected_button.render()
+                        # Update touch bar to show which arrows are active
+                        self._update_touch_bar_for_list_position()
 
-                elif user_input == HardwareButtonsConstants.KEY_DOWN or (
+                elif user_input in down_keys or (
                         self.top_nav.is_selected and user_input == HardwareButtonsConstants.KEY_RIGHT
                     ):
                     if self.selected_button == len(self.buttons) - 1:
@@ -578,16 +656,84 @@ class ButtonListScreen(BaseTopNavScreen):
                         frame_scroll = next_selected_button.screen_y - cur_selected_button.screen_y
                         for button in self.buttons:
                             button.scroll_y += frame_scroll
-                        self._render_visible_buttons()
+                        self._render_visible_buttons(clear_first=True)
+                        # Re-register buttons with updated positions
+                        if hasattr(self.hw_inputs, 'register_buttons'):
+                            self.hw_inputs.register_buttons(self.buttons)
                     else:
                         if cur_selected_button:
                             cur_selected_button.render()
                         next_selected_button.render()
+                    # Update touch bar to show which arrows are active
+                    self._update_touch_bar_for_list_position()
 
-                elif user_input in HardwareButtonsConstants.KEYS__ANYCLICK:
+                elif user_input in [HardwareButtonsConstants.KEY2, HardwareButtonsConstants.KEY_PRESS]:
                     if self.top_nav.is_selected:
                         return self.top_nav.selected_button
+
+                    # Check for back button tap (touchscreen)
+                    if hasattr(self.hw_inputs, 'was_back_button_tapped'):
+                        if self.hw_inputs.was_back_button_tapped():
+                            if self.top_nav.show_back_button:
+                                return RET_CODE__BACK_BUTTON
+
+                    # Check for direct tap on a button (touchscreen)
+                    if hasattr(self.hw_inputs, 'get_tapped_button_index'):
+                        tapped_idx = self.hw_inputs.get_tapped_button_index()
+                        if tapped_idx >= 0 and tapped_idx < len(self.buttons):
+                            if tapped_idx == self.selected_button:
+                                # Tapped already-selected button - toggle/select it
+                                return tapped_idx
+                            else:
+                                # Tapped different button - move selection and scroll if needed
+                                cur_selected_button = self.buttons[self.selected_button]
+                                cur_selected_button.is_selected = False
+                                self.selected_button = tapped_idx
+                                next_selected_button = self.buttons[self.selected_button]
+                                next_selected_button.is_selected = True
+
+                                # Check if we need to scroll to show the tapped button
+                                if self.has_scroll_arrows:
+                                    button_top = next_selected_button.screen_y - next_selected_button.scroll_y
+                                    button_bottom = button_top + next_selected_button.height
+
+                                    if button_bottom > self.down_arrow_img_y:
+                                        # Button is below visible area - scroll down
+                                        scroll_amount = button_bottom - self.down_arrow_img_y + 8
+                                        for button in self.buttons:
+                                            button.scroll_y += scroll_amount
+                                        self._render_visible_buttons(clear_first=True)
+                                        # Re-register buttons with updated positions
+                                        if hasattr(self.hw_inputs, 'register_buttons'):
+                                            self.hw_inputs.register_buttons(self.buttons)
+                                    elif button_top < self.top_nav_height:
+                                        # Button is above visible area - scroll up
+                                        scroll_amount = self.top_nav_height - button_top + 8
+                                        for button in self.buttons:
+                                            button.scroll_y -= scroll_amount
+                                        self._render_visible_buttons(clear_first=True)
+                                        # Re-register buttons with updated positions
+                                        if hasattr(self.hw_inputs, 'register_buttons'):
+                                            self.hw_inputs.register_buttons(self.buttons)
+                                    else:
+                                        cur_selected_button.render()
+                                        next_selected_button.render()
+                                else:
+                                    cur_selected_button.render()
+                                    next_selected_button.render()
+
+                                self.renderer.show_image()
+                                continue
+                        elif user_input == HardwareButtonsConstants.KEY_PRESS:
+                            # KEY_PRESS but didn't tap a button - ignore (require tapping actual button)
+                            continue
+
+                    # KEY2 (SELECT on touch bar) or KEY_PRESS (non-touch) returns current selection
                     return self.selected_button
+
+                else:
+                    # Nothing to do with this input
+                    continue
 
                 # Write the screen updates
                 self.renderer.show_image()
@@ -677,8 +823,41 @@ class LargeButtonScreen(BaseTopNavScreen):
 
         self.buttons[self.selected_button].is_selected = True
 
+        # Register buttons for direct touch tap detection
+        if hasattr(self.hw_inputs, 'register_buttons'):
+            self.hw_inputs.register_buttons(self.buttons)
+
+        # Set touch bar based on screen type
+        # Hide touch bar for Reset/Power screen (all buttons are single-tap)
+        if self.title == "Reset / Power":
+            self._set_touch_bar_hidden()
+        else:
+            self._set_touch_bar_select_only()
+
+
+    def _set_touch_bar_select_only(self):
+        """Set touch bar to show only SELECT button (for grid layouts)"""
+        import os
+        if os.environ.get('SEEDSIGNER_TOUCH') == '1':
+            disp = self.renderer.disp
+            if hasattr(disp, 'display') and hasattr(disp.display, 'TOUCH_BAR_SELECT_ONLY'):
+                disp.display.set_touch_bar_labels(disp.display.TOUCH_BAR_SELECT_ONLY)
+
+
+    def _set_touch_bar_hidden(self):
+        """Hide all touch bar buttons"""
+        import os
+        if os.environ.get('SEEDSIGNER_TOUCH') == '1':
+            disp = self.renderer.disp
+            if hasattr(disp, 'display') and hasattr(disp.display, 'TOUCH_BAR_HIDDEN'):
+                disp.display.set_touch_bar_labels(disp.display.TOUCH_BAR_HIDDEN)
+
 
     def _run(self):
+        # Clear any pending touch input from previous screen
+        if hasattr(self.hw_inputs, 'clear_pending_input'):
+            self.hw_inputs.clear_pending_input()
+
         def swap_selected_button(new_selected_button: int):
             self.buttons[self.selected_button].is_selected = False
             self.buttons[self.selected_button].render()
@@ -754,6 +933,36 @@ class LargeButtonScreen(BaseTopNavScreen):
                 elif user_input in HardwareButtonsConstants.KEYS__ANYCLICK:
                     if self.top_nav.is_selected:
                         return self.top_nav.selected_button
+
+                    # Check for back button tap (touchscreen)
+                    if hasattr(self.hw_inputs, 'was_back_button_tapped'):
+                        if self.hw_inputs.was_back_button_tapped():
+                            if self.top_nav.show_back_button:
+                                return RET_CODE__BACK_BUTTON
+
+                    # Check for power button tap (touchscreen) - single tap
+                    if hasattr(self.hw_inputs, 'was_power_button_tapped'):
+                        if self.hw_inputs.was_power_button_tapped():
+                            if self.top_nav.show_power_button:
+                                return RET_CODE__POWER_BUTTON
+
+                    # Check for direct tap on a button (touchscreen)
+                    if hasattr(self.hw_inputs, 'get_tapped_button_index'):
+                        tapped_idx = self.hw_inputs.get_tapped_button_index()
+                        if tapped_idx >= 0 and tapped_idx < len(self.buttons):
+                            # Get button label to check for single-tap buttons
+                            button_label = self.buttons[tapped_idx].text.lower() if hasattr(self.buttons[tapped_idx], 'text') else ""
+                            # Power Off and Cancel have confirmation dialogs, so single-tap
+                            is_single_tap_button = button_label in ['power off', 'cancel']
+
+                            if tapped_idx == self.selected_button or is_single_tap_button:
+                                # Tapped already-selected button OR single-tap button - confirm
+                                return tapped_idx
+                            # Tapped different button - just move selection to it
+                            swap_selected_button(tapped_idx)
+                            self.renderer.show_image()
+                            continue
+
                     return self.selected_button
 
                 # Write the screen updates
@@ -1115,6 +1324,17 @@ class ResetScreen(BaseTopNavScreen):
             height=self.canvas_height - self.top_nav.height,
         ))
 
+        # Hide touch bar on reset screen
+        self._set_touch_bar_hidden()
+
+    def _set_touch_bar_hidden(self):
+        """Hide all touch bar buttons"""
+        import os
+        if os.environ.get('SEEDSIGNER_TOUCH') == '1':
+            disp = self.renderer.disp
+            if hasattr(disp, 'display') and hasattr(disp.display, 'TOUCH_BAR_HIDDEN'):
+                disp.display.set_touch_bar_labels(disp.display.TOUCH_BAR_HIDDEN)
+
 
 
 @dataclass
@@ -1130,6 +1350,17 @@ class PowerOffScreen(BaseTopNavScreen):
             height=self.canvas_height - self.top_nav.height,
         ))
 
+        # Hide touch bar on power off screen
+        self._set_touch_bar_hidden()
+
+    def _set_touch_bar_hidden(self):
+        """Hide all touch bar buttons"""
+        import os
+        if os.environ.get('SEEDSIGNER_TOUCH') == '1':
+            disp = self.renderer.disp
+            if hasattr(disp, 'display') and hasattr(disp.display, 'TOUCH_BAR_HIDDEN'):
+                disp.display.set_touch_bar_labels(disp.display.TOUCH_BAR_HIDDEN)
+
 
 
 @dataclass
@@ -1144,6 +1375,17 @@ class PowerOffNotRequiredScreen(BaseTopNavScreen):
             screen_y=self.top_nav.height,
             height=self.canvas_height - self.top_nav.height,
         ))
+
+        # Hide touch bar on power off screen
+        self._set_touch_bar_hidden()
+
+    def _set_touch_bar_hidden(self):
+        """Hide all touch bar buttons"""
+        import os
+        if os.environ.get('SEEDSIGNER_TOUCH') == '1':
+            disp = self.renderer.disp
+            if hasattr(disp, 'display') and hasattr(disp.display, 'TOUCH_BAR_HIDDEN'):
+                disp.display.set_touch_bar_labels(disp.display.TOUCH_BAR_HIDDEN)
 
 
 
@@ -1262,6 +1504,10 @@ class KeyboardScreen(BaseTopNavScreen):
 
 
     def _run(self):
+        # Clear any pending touch input from previous screen
+        if hasattr(self.hw_inputs, 'clear_pending_input'):
+            self.hw_inputs.clear_pending_input()
+
         self.cursor_position = len(self.user_input)
 
         # Start the interactive update loop
@@ -1271,6 +1517,8 @@ class KeyboardScreen(BaseTopNavScreen):
             )
 
             with self.renderer.lock:
+                # Track if we need to update the title after input changes
+                title_needs_update = False
                 # Check possible exit conditions   
                 if self.top_nav.is_selected and input == HardwareButtonsConstants.KEY_PRESS:
                     return RET_CODE__BACK_BUTTON
@@ -1316,6 +1564,7 @@ class KeyboardScreen(BaseTopNavScreen):
                         if len(self.user_input) > 0:
                             self.user_input = self.user_input[:-1]
                             self.cursor_position -= 1
+                            title_needs_update = True
 
                 elif input == HardwareButtonsConstants.KEY_PRESS and ret_val not in Keyboard.ADDITIONAL_KEYS:
                     # User has locked in the current letter
@@ -1324,19 +1573,20 @@ class KeyboardScreen(BaseTopNavScreen):
                         ret_val = self.keys_to_values[ret_val]
                     self.user_input += ret_val
                     self.cursor_position += 1
+                    title_needs_update = True
 
                     if self.cursor_position == self.return_after_n_chars:
                         return self.user_input
 
-                    # Render a new TextArea over the TopNav title bar
-                    if self.update_title():
-                        TextArea(
-                            text=self.title,
-                            font_name=GUIConstants.get_top_nav_title_font_name(),
-                            font_size=GUIConstants.get_top_nav_title_font_size(),
-                            height=self.top_nav.height,
-                        ).render()
-                        self.top_nav.render_buttons()
+                # Update the title if input changed (add or delete)
+                if title_needs_update and self.update_title():
+                    TextArea(
+                        text=self.title,
+                        font_name=GUIConstants.get_top_nav_title_font_name(),
+                        font_size=GUIConstants.get_top_nav_title_font_size(),
+                        height=self.top_nav.height,
+                    ).render()
+                    self.top_nav.render_buttons()
 
                 elif input in HardwareButtonsConstants.KEYS__LEFT_RIGHT_UP_DOWN:
                     # Live joystick movement; haven't locked this new letter in yet.

--- a/src/seedsigner/gui/screens/seed_screens.py
+++ b/src/seedsigner/gui/screens/seed_screens.py
@@ -247,17 +247,129 @@ class SeedMnemonicEntryScreen(BaseTopNavScreen):
         self.text_entry_display.render()
         self.render_possible_matches()
 
+        # Set touch bar to keyboard mode
+        self._update_touch_bar()
+
         self.renderer.show_image()
+
+    def _update_touch_bar(self):
+        """Update touch bar based on whether there's content to delete, words to select, and scroll position"""
+        disp = self.renderer.disp
+        if hasattr(disp, 'display') and hasattr(disp.display, 'set_touch_bar_labels'):
+            from seedsigner.hardware.DPI28 import DPI28
+            # DEL is active (orange) if there's content to delete (not just empty space)
+            has_content = len(self.letters) > 1 or (len(self.letters) == 1 and self.letters[0] != " ")
+            # WORD is active (orange) if there are possible words to select
+            has_words = hasattr(self, 'possible_words') and self.possible_words
+            # Down arrow is active (orange) if we can scroll down (not at bottom of word list)
+            can_scroll_down = has_words and hasattr(self, 'selected_possible_words_index') and self.selected_possible_words_index < len(self.possible_words) - 1
+
+            if has_words and has_content:
+                if can_scroll_down:
+                    disp.display.set_touch_bar_labels(DPI28.TOUCH_BAR_KEYBOARD_BOTH_ACTIVE)
+                else:
+                    disp.display.set_touch_bar_labels(DPI28.TOUCH_BAR_KEYBOARD_BOTH_ACTIVE_DOWN_DISABLED)
+            elif has_words:
+                if can_scroll_down:
+                    disp.display.set_touch_bar_labels(DPI28.TOUCH_BAR_KEYBOARD_WORD_ACTIVE)
+                else:
+                    # At bottom with words but no content - WORD active, down grey
+                    disp.display.set_touch_bar_labels(DPI28.TOUCH_BAR_KEYBOARD_BOTH_ACTIVE_DOWN_DISABLED)
+            elif has_content:
+                disp.display.set_touch_bar_labels(DPI28.TOUCH_BAR_KEYBOARD_DEL_ACTIVE)
+            else:
+                disp.display.set_touch_bar_labels(DPI28.TOUCH_BAR_KEYBOARD_DOWN_DISABLED)
+
+
+    def _reset_touch_bar(self):
+        """Reset touch bar to default labels when leaving keyboard screen"""
+        disp = self.renderer.disp
+        if hasattr(disp, 'display') and hasattr(disp.display, 'set_touch_bar_labels'):
+            from seedsigner.hardware.DPI28 import DPI28
+            disp.display.set_touch_bar_labels(DPI28.TOUCH_BAR_DEFAULT)
 
 
     def _run(self):
+        # Clear any stale input from previous screen
+        if hasattr(self.hw_inputs, 'clear_pending_input'):
+            self.hw_inputs.clear_pending_input()
+
+        import os
+        is_touch = os.environ.get('SEEDSIGNER_TOUCH') == '1'
+
         while True:
             input = self.hw_inputs.wait_for(HardwareButtonsConstants.ALL_KEYS)
+            # Check for direct back button tap (touchscreen - top left corner of screen)
+            if hasattr(self.hw_inputs, 'was_back_button_tapped'):
+                if self.hw_inputs.was_back_button_tapped():
+                    self._reset_touch_bar()
+                    return RET_CODE__BACK_BUTTON
+
+            # Check for touch bar DEL button tap (left side of touch bar = KEY1)
+            if hasattr(self.hw_inputs, 'was_touch_bar_back_tapped'):
+                if self.hw_inputs.was_touch_bar_back_tapped():
+                    # Left touch bar button is now DEL, not BACK
+                    input = HardwareButtonsConstants.KEY1
+
+            # Check for direct taps (touchscreen)
+            up_arrow_tapped = False
+            down_arrow_tapped = False
+            if hasattr(self.hw_inputs, 'get_last_tap_native_coords'):
+                tap_x, tap_y = self.hw_inputs.get_last_tap_native_coords()
+                if tap_x >= 0 and tap_y >= 0:
+                    # Check for up arrow button tap (scroll up word list)
+                    up_btn = self.matches_list_up_button
+                    if (up_btn.screen_x <= tap_x <= up_btn.screen_x + up_btn.width and
+                        up_btn.screen_y <= tap_y <= up_btn.screen_y + up_btn.height):
+                        up_arrow_tapped = True
+                    # Check for down arrow button tap (scroll down, not KEY3 which is now DEL)
+                    elif (self.matches_list_down_button.screen_x <= tap_x <= self.matches_list_down_button.screen_x + self.matches_list_down_button.width and
+                          self.matches_list_down_button.screen_y <= tap_y <= self.matches_list_down_button.screen_y + self.matches_list_down_button.height):
+                        down_arrow_tapped = True
+                    # Check for highlighted word tap (SELECT)
+                    elif (self.matches_list_highlight_button.screen_x <= tap_x <= self.matches_list_highlight_button.screen_x + self.matches_list_highlight_button.width and
+                          self.matches_list_highlight_button.screen_y <= tap_y <= self.matches_list_highlight_button.screen_y + self.matches_list_highlight_button.height):
+                        input = HardwareButtonsConstants.KEY2
+                    else:
+                        # Check for keyboard tap
+                        tapped_key = self.keyboard.get_key_at_screen_coords(tap_x, tap_y)
+                        if tapped_key is not None and tapped_key.is_active:
+                            # Select the tapped key and simulate KEY_PRESS
+                            self.keyboard.set_selected_key_indices(tapped_key.index_x, tapped_key.index_y)
+                            self.keyboard.render_keys()
+                            input = HardwareButtonsConstants.KEY_PRESS
+
+            # Handle up arrow tap separately (scroll word list up)
+            if up_arrow_tapped and self.possible_words:
+                self.selected_possible_words_index -= 1
+                if self.selected_possible_words_index < 0:
+                    self.selected_possible_words_index = 0
+                if not self.arrow_up_is_active:
+                    self.arrow_up_is_active = True
+                    self.matches_list_up_button.is_selected = True
+                self.render_possible_matches()
+                self._update_touch_bar()  # Update down arrow state based on position
+                self.renderer.show_image()
+                continue
+
+            # Handle down arrow tap separately (scroll word list down)
+            if down_arrow_tapped and self.possible_words:
+                self.selected_possible_words_index += 1
+                if self.selected_possible_words_index >= len(self.possible_words):
+                    self.selected_possible_words_index = len(self.possible_words) - 1
+                if not self.arrow_down_is_active:
+                    self.arrow_down_is_active = True
+                    self.matches_list_down_button.is_selected = True
+                self.render_possible_matches()
+                self._update_touch_bar()  # Update down arrow state based on position
+                self.renderer.show_image()
+                continue
 
             with self.renderer.lock:
                 if self.is_input_in_top_nav:
                     if input == HardwareButtonsConstants.KEY_PRESS:
                         # User clicked the "back" arrow
+                        self._reset_touch_bar()
                         return RET_CODE__BACK_BUTTON
 
                     elif input == HardwareButtonsConstants.KEY_UP:
@@ -297,6 +409,7 @@ class SeedMnemonicEntryScreen(BaseTopNavScreen):
                             
                         # Update the right-hand possible matches area
                         self.render_possible_matches()
+                        self._update_touch_bar()
 
                     elif ret_val == Keyboard.KEY_BACKSPACE["code"]:
                         # We're just hovering over DEL but haven't clicked. Show blank (" ")
@@ -306,16 +419,33 @@ class SeedMnemonicEntryScreen(BaseTopNavScreen):
 
                 # Has the user made a final selection of a candidate word?
                 final_selection = None
-                if input == HardwareButtonsConstants.KEY1 and self.possible_words:
-                    # Scroll the list up
-                    self.selected_possible_words_index -= 1
-                    if self.selected_possible_words_index < 0:
-                        self.selected_possible_words_index = 0
+                if input == HardwareButtonsConstants.KEY1:
+                    if is_touch:
+                        # KEY1 = DEL - delete the last letter
+                        if len(self.letters) > 2:
+                            self.letters = self.letters[:-2]
+                            self.letters.append(" ")
+                        elif len(self.letters) == 2:
+                            self.letters = [" "]
+                        elif len(self.letters) == 1 and self.letters[0] != " ":
+                            self.letters = [" "]
 
-                    if not self.arrow_up_is_active:
-                        # Flash the up arrow as selected
-                        self.arrow_up_is_active = True
-                        self.matches_list_up_button.is_selected = True
+                        if len(self.letters) >= 1:
+                            self.calc_possible_alphabet()
+                            self.keyboard.update_active_keys(active_keys=self.possible_alphabet)
+                            self.keyboard.render_keys()
+                            self.render_possible_matches()
+                            self._update_touch_bar()
+                    elif self.possible_words:
+                        # Scroll the list up
+                        self.selected_possible_words_index -= 1
+                        if self.selected_possible_words_index < 0:
+                            self.selected_possible_words_index = 0
+
+                        if not self.arrow_up_is_active:
+                            # Flash the up arrow as selected
+                            self.arrow_up_is_active = True
+                            self.matches_list_up_button.is_selected = True
 
                 elif input == HardwareButtonsConstants.KEY2:
                     if self.possible_words:
@@ -331,6 +461,8 @@ class SeedMnemonicEntryScreen(BaseTopNavScreen):
                         # Flash the down arrow as selected
                         self.arrow_down_is_active = True
                         self.matches_list_down_button.is_selected = True
+
+                    self._update_touch_bar()  # Update down arrow state based on position
 
                 if input is not HardwareButtonsConstants.KEY1 and self.arrow_up_is_active:
                     # Deactivate the UP arrow and redraw
@@ -407,6 +539,9 @@ class SeedMnemonicEntryScreen(BaseTopNavScreen):
 
                 # Update the right-hand possible matches area
                 self.render_possible_matches()
+
+                # Refresh touch bar state after updates
+                self._update_touch_bar()
 
                 # Now issue one call to send the pixels to the screen
                 self.renderer.show_image()
@@ -914,11 +1049,99 @@ class SeedAddPassphraseScreen(BaseTopNavScreen):
         cur_button1_text = self.KEYBOARD__UPPERCASE_BUTTON_TEXT
         cur_button2_text = self.KEYBOARD__DIGITS_BUTTON_TEXT
 
+        # Check for touch support
+        touch_buttons = None
+        if hasattr(self.hw_inputs, 'get_last_tap_native_coords'):
+            touch_buttons = self.hw_inputs
+            # Clear any pending input
+            if hasattr(touch_buttons, 'clear_pending_input'):
+                touch_buttons.clear_pending_input()
+
         # Start the interactive update loop
         while True:
             input = self.hw_inputs.wait_for(HardwareButtonsConstants.ALL_KEYS)
 
             keyboard_swap = False
+
+            # Handle touch-specific input
+            if touch_buttons:
+                # Check for back button tap (top-left corner)
+                if hasattr(touch_buttons, 'was_back_button_tapped') and touch_buttons.was_back_button_tapped():
+                    return dict(passphrase=self.passphrase, is_back_button=True)
+
+                # Check for touch bar taps
+                if hasattr(touch_buttons, 'was_touch_bar_back_tapped') and touch_buttons.was_touch_bar_back_tapped():
+                    # Touch bar left = KEY1 = switch abc/ABC keyboard
+                    input = HardwareButtonsConstants.KEY1
+
+                # Check for direct key tap on keyboard
+                # Note: taps on edges may return KEY_LEFT/KEY_RIGHT from _coords_to_nav_key,
+                # so we check tap coordinates regardless of what input was returned
+                x, y = touch_buttons.get_last_tap_native_coords()
+                if x >= 0 and y >= 0:
+                    key = cur_keyboard.get_key_at_screen_coords(x, y)
+                    if key:
+                        # Update keyboard selection to tapped key
+                        cur_keyboard.set_selected_key_indices(key.index_x, key.index_y)
+                        cur_keyboard.render_keys()
+                        # Process the key
+                        if key.code == Keyboard.KEY_BACKSPACE["code"]:
+                            if cursor_position > 0:
+                                if cursor_position == len(self.passphrase):
+                                    self.passphrase = self.passphrase[:-1]
+                                else:
+                                    self.passphrase = self.passphrase[:cursor_position - 1] + self.passphrase[cursor_position:]
+                                cursor_position -= 1
+                                self.text_entry_display.render(self.passphrase, cursor_position)
+                            self.renderer.show_image()
+                            continue
+                        elif key.code == Keyboard.KEY_CURSOR_LEFT["code"]:
+                            cursor_position = max(0, cursor_position - 1)
+                            self.text_entry_display.render(self.passphrase, cursor_position)
+                            self.renderer.show_image()
+                            continue
+                        elif key.code == Keyboard.KEY_CURSOR_RIGHT["code"]:
+                            cursor_position = min(len(self.passphrase), cursor_position + 1)
+                            self.text_entry_display.render(self.passphrase, cursor_position)
+                            self.renderer.show_image()
+                            continue
+                        elif key.code == Keyboard.KEY_SPACE["code"]:
+                            if cursor_position == len(self.passphrase):
+                                self.passphrase += " "
+                            else:
+                                self.passphrase = self.passphrase[:cursor_position] + " " + self.passphrase[cursor_position:]
+                            cursor_position += 1
+                            self.text_entry_display.render(self.passphrase, cursor_position)
+                            self.renderer.show_image()
+                            continue
+                        else:
+                            # Regular character
+                            if cursor_position == len(self.passphrase):
+                                self.passphrase += key.letter
+                            else:
+                                self.passphrase = self.passphrase[:cursor_position] + key.letter + self.passphrase[cursor_position:]
+                            cursor_position += 1
+                            self.text_entry_display.render(self.passphrase, cursor_position)
+                            self.renderer.show_image()
+                            continue
+                    else:
+                        # Tap was not on a key - check if it hit the right panel buttons
+                        # Coords are in native 240x240 space
+                        # hw_button1: ABC/abc toggle
+                        if (self.hw_button1.screen_x <= x <= self.hw_button1.screen_x + self.hw_button1.width and
+                            self.hw_button1.screen_y <= y <= self.hw_button1.screen_y + self.hw_button1.height):
+                            input = HardwareButtonsConstants.KEY1
+                        # hw_button2: 123/!@#/*[] toggle
+                        elif (self.hw_button2.screen_x <= x <= self.hw_button2.screen_x + self.hw_button2.width and
+                              self.hw_button2.screen_y <= y <= self.hw_button2.screen_y + self.hw_button2.height):
+                            input = HardwareButtonsConstants.KEY2
+                        # hw_button3: Confirm (checkmark)
+                        elif (self.hw_button3.screen_x <= x <= self.hw_button3.screen_x + self.hw_button3.width and
+                              self.hw_button3.screen_y <= y <= self.hw_button3.screen_y + self.hw_button3.height):
+                            input = HardwareButtonsConstants.KEY3
+                        else:
+                            # Didn't tap anything valid
+                            continue
 
             with self.renderer.lock:
                 # Check our two possible exit conditions
@@ -2486,4 +2709,3 @@ class SeedTranscribeEncryptedQRZoomedInScreen(BaseScreen):
                 )
                 cur_x = next_x
                 cur_y = next_y
-

--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -299,6 +299,94 @@ class ToolsDiceEntropyEntryScreen(KeyboardScreen):
         self.title = _("Dice Roll {}/{}").format(self.cursor_position + 1, self.return_after_n_chars)
         return True
 
+    def _run(self):
+        # Initialize cursor position (normally done in parent _run())
+        self.cursor_position = len(self.user_input)
+
+        # Check for touch support
+        touch_buttons = None
+        if hasattr(self, 'hw_inputs') and hasattr(self.hw_inputs, 'touch'):
+            touch_buttons = self.hw_inputs
+
+        if not touch_buttons:
+            # Non-touch fallback - use parent class behavior
+            return super()._run()
+
+        # Clear touch bar buttons and hide touch bar - dice screen doesn't use bottom bar
+        if hasattr(touch_buttons, 'clear_buttons'):
+            touch_buttons.clear_buttons()
+        disp = self.renderer.disp
+        if hasattr(disp, 'display') and hasattr(disp.display, 'set_touch_bar_labels'):
+            from seedsigner.hardware.DPI28 import DPI28
+            disp.display.set_touch_bar_labels(DPI28.TOUCH_BAR_HIDDEN)
+
+        while True:
+            # Handle touch input for dice - only KEY_PRESS for direct taps, not KEY1/2/3
+            input_result = touch_buttons.wait_for(
+                [HardwareButtonsConstants.KEY_PRESS] + [HardwareButtonsConstants.KEY_UP, HardwareButtonsConstants.KEY_DOWN, HardwareButtonsConstants.KEY_LEFT, HardwareButtonsConstants.KEY_RIGHT]
+            )
+
+            # Check for back button (top-left tap)
+            if hasattr(touch_buttons, 'was_back_button_tapped') and touch_buttons.was_back_button_tapped():
+                return RET_CODE__BACK_BUTTON
+
+            # Check if it was a touch and get coordinates for direct key tap
+            key = None
+            if hasattr(touch_buttons, 'get_last_tap_native_coords'):
+                x, y = touch_buttons.get_last_tap_native_coords()
+                if x >= 0 and y >= 0:
+                    key = self.keyboard.get_key_at_screen_coords(x, y)
+
+            # If no direct key tap, check if it was a press on selected key
+            if key is None and input_result == HardwareButtonsConstants.KEY_PRESS:
+                key = self.keyboard.get_selected_key()
+
+            # If we have a valid key, process it
+            if key:
+                # Select the key visually
+                self.keyboard.set_selected_key_indices(key.index_x, key.index_y)
+
+                # Check if it's the DEL/backspace key
+                if key.code == "DEL":
+                    if len(self.user_input) > 0:
+                        self.user_input = self.user_input[:-1]
+                        self.cursor_position -= 1
+                        if self.update_title():
+                            # Render new TextArea over title (like parent class does)
+                            TextArea(
+                                text=self.title,
+                                font_name=GUIConstants.get_top_nav_title_font_name(),
+                                font_size=GUIConstants.get_top_nav_title_font_size(),
+                                height=self.top_nav.height,
+                            ).render()
+                            self.top_nav.render_buttons()
+                        self.text_entry_display.render(self.user_input)
+                        self.renderer.show_image()
+                    continue
+
+                # Get the value and record it
+                char = key.letter
+                self.user_input += char
+                self.cursor_position += 1
+
+                # Update title
+                if self.update_title():
+                    TextArea(
+                        text=self.title,
+                        font_name=GUIConstants.get_top_nav_title_font_name(),
+                        font_size=GUIConstants.get_top_nav_title_font_size(),
+                        height=self.top_nav.height,
+                    ).render()
+                    self.top_nav.render_buttons()
+
+                # Update text entry display
+                self.text_entry_display.render(self.user_input)
+                self.renderer.show_image()
+
+                # Return if done
+                if self.cursor_position == self.return_after_n_chars:
+                    return self.user_input
+
 
 
 @dataclass
@@ -355,6 +443,94 @@ class ToolsCoinFlipEntryScreen(KeyboardScreen):
         # l10n_note already done.
         self.title = _("Coin Flip {}/{}").format(self.cursor_position + 1, self.return_after_n_chars)
         return True
+
+    def _run(self):
+        # Initialize cursor position (normally done in parent _run())
+        self.cursor_position = len(self.user_input)
+
+        # Check for touch support
+        touch_buttons = None
+        if hasattr(self, 'hw_inputs') and hasattr(self.hw_inputs, 'touch'):
+            touch_buttons = self.hw_inputs
+
+        if not touch_buttons:
+            # Non-touch fallback - use parent class behavior
+            return super()._run()
+
+        # Clear touch bar buttons and hide touch bar - coin flip screen doesn't use bottom bar
+        if hasattr(touch_buttons, 'clear_buttons'):
+            touch_buttons.clear_buttons()
+        disp = self.renderer.disp
+        if hasattr(disp, 'display') and hasattr(disp.display, 'set_touch_bar_labels'):
+            from seedsigner.hardware.DPI28 import DPI28
+            disp.display.set_touch_bar_labels(DPI28.TOUCH_BAR_HIDDEN)
+
+        while True:
+            # Handle touch input for coin flip - only KEY_PRESS for direct taps, not KEY1/2/3
+            input_result = touch_buttons.wait_for(
+                [HardwareButtonsConstants.KEY_PRESS] + [HardwareButtonsConstants.KEY_UP, HardwareButtonsConstants.KEY_DOWN, HardwareButtonsConstants.KEY_LEFT, HardwareButtonsConstants.KEY_RIGHT]
+            )
+
+            # Check for back button (top-left tap)
+            if hasattr(touch_buttons, 'was_back_button_tapped') and touch_buttons.was_back_button_tapped():
+                return RET_CODE__BACK_BUTTON
+
+            # Check if it was a touch and get coordinates for direct key tap
+            key = None
+            if hasattr(touch_buttons, 'get_last_tap_native_coords'):
+                x, y = touch_buttons.get_last_tap_native_coords()
+                if x >= 0 and y >= 0:
+                    key = self.keyboard.get_key_at_screen_coords(x, y)
+
+            # If no direct key tap, check if it was a press on selected key
+            if key is None and input_result == HardwareButtonsConstants.KEY_PRESS:
+                key = self.keyboard.get_selected_key()
+
+            # If we have a key, process it
+            if key:
+                # Select the key visually
+                self.keyboard.set_selected_key_indices(key.index_x, key.index_y)
+
+                # Check if it's the DEL/backspace key
+                if key.code == "DEL":
+                    if len(self.user_input) > 0:
+                        self.user_input = self.user_input[:-1]
+                        self.cursor_position -= 1
+                        if self.update_title():
+                            # Render new TextArea over title (like parent class does)
+                            TextArea(
+                                text=self.title,
+                                font_name=GUIConstants.get_top_nav_title_font_name(),
+                                font_size=GUIConstants.get_top_nav_title_font_size(),
+                                height=self.top_nav.height,
+                            ).render()
+                            self.top_nav.render_buttons()
+                        self.text_entry_display.render(self.user_input)
+                        self.renderer.show_image()
+                    continue
+
+                # Get the value and record it
+                char = key.letter
+                self.user_input += char
+                self.cursor_position += 1
+
+                # Update title
+                if self.update_title():
+                    TextArea(
+                        text=self.title,
+                        font_name=GUIConstants.get_top_nav_title_font_name(),
+                        font_size=GUIConstants.get_top_nav_title_font_size(),
+                        height=self.top_nav.height,
+                    ).render()
+                    self.top_nav.render_buttons()
+
+                # Update text entry display
+                self.text_entry_display.render(self.user_input)
+                self.renderer.show_image()
+
+                # Return if done
+                if self.cursor_position == self.return_after_n_chars:
+                    return self.user_input
 
 
 

--- a/src/seedsigner/gui/toast.py
+++ b/src/seedsigner/gui/toast.py
@@ -105,7 +105,6 @@ class BaseToastOverlayManagerThread(BaseThread):
                  ):
         from seedsigner.controller import Controller
         from seedsigner.gui.renderer import Renderer
-        from seedsigner.hardware.buttons import HardwareButtons
         super().__init__()
         self.activation_delay: int = activation_delay
         self.duration: int = duration
@@ -113,7 +112,14 @@ class BaseToastOverlayManagerThread(BaseThread):
 
         self.renderer = Renderer.get_instance()
         self.controller = Controller.get_instance()
-        self.hw_inputs = HardwareButtons.get_instance()
+        # Get input handler (touch or hardware buttons)
+        import os
+        if os.environ.get('SEEDSIGNER_TOUCH') == '1':
+            from seedsigner.hardware.touchbuttons import TouchButtons
+            self.hw_inputs = TouchButtons.get_instance()
+        else:
+            from seedsigner.hardware.buttons import HardwareButtons
+            self.hw_inputs = HardwareButtons.get_instance()
 
         # Special case when screensaver is running
         self.hw_inputs.override_ind = True

--- a/src/seedsigner/hardware/DPI28.py
+++ b/src/seedsigner/hardware/DPI28.py
@@ -1,0 +1,425 @@
+"""
+DPI28 - Framebuffer display driver for Waveshare 2.8" DPI LCD.
+
+Display specs:
+- 480x640 resolution (portrait)
+- DPI interface (uses GPIO, not SPI)
+- Directly writes to /dev/fb0 framebuffer
+- 32-bit BGRA format (requires RGB→BGR swap)
+
+Layout:
+- Top 480x480: UI area (240x240 scaled 2x)
+- Bottom 480x160: Touch bar (KEY1, KEY2, KEY3)
+
+Based on mutatrum's fast-pillow-fb approach:
+https://github.com/mutatrum/fast-pillow-fb
+
+On PC/Emulator: This module is replaced by EmulatedDPI28 in run_emulator.py
+"""
+
+import os
+import mmap
+import fcntl
+from PIL import Image, ImageDraw, ImageFont
+
+# Linux console mode constants for hiding tty text on framebuffer
+KD_TEXT = 0x00
+KD_GRAPHICS = 0x01
+KDSETMODE = 0x4B3A
+
+# Try to import numpy for faster conversion (~7 fps vs ~1 fps pure Python)
+try:
+    import numpy as np
+    HAS_NUMPY = True
+except ImportError:
+    HAS_NUMPY = False
+    print("[DPI28] numpy not available, using slow Python conversion")
+
+# Cython disabled - pyximport hangs on Pi Zero
+HAS_CYTHON = False
+
+
+# Icon constants from SeedSigner icon fonts (language-agnostic)
+class TouchBarIcons:
+    # From seedsigner-icons.otf
+    CHEVRON_UP = "\ue90b"
+    CHEVRON_DOWN = "\ue908"
+    CHECK = "\ue905"
+    DELETE = "\ue922"
+    # From FontAwesome
+    KEYBOARD = "\uf11c"
+
+
+class DPI28:
+    """
+    Framebuffer display driver for Waveshare 2.8" DPI LCD.
+
+    Accepts 240x240 images (SeedSigner native), scales to 480x480,
+    and adds a 160px touch bar at the bottom.
+    
+    Uses mmap for fast framebuffer writes and handles RGB→BGR conversion
+    required by the Raspberry Pi framebuffer.
+    """
+
+    # Native UI size (what SeedSigner renders)
+    NATIVE_WIDTH = 240
+    NATIVE_HEIGHT = 240
+
+    # Physical display size
+    DISPLAY_WIDTH = 480
+    DISPLAY_HEIGHT = 640
+
+    # Scaled UI area
+    UI_WIDTH = 480
+    UI_HEIGHT = 480
+
+    # Touch bar
+    TOUCH_BAR_HEIGHT = 160
+
+    # Touch bar label presets: (icons_tuple, colors_tuple, font_types_tuple)
+    _UP = TouchBarIcons.CHEVRON_UP
+    _DOWN = TouchBarIcons.CHEVRON_DOWN
+    _SELECT = TouchBarIcons.CHECK
+    _DEL = TouchBarIcons.DELETE
+    _WORD = TouchBarIcons.KEYBOARD
+
+    TOUCH_BAR_DEFAULT = ((_UP, _SELECT, _DOWN), ('#ff9416', '#ff9416', '#ff9416'), ('seedsigner', 'seedsigner', 'seedsigner'))
+    TOUCH_BAR_UP_DISABLED = ((_UP, _SELECT, _DOWN), ('#444444', '#ff9416', '#ff9416'), ('seedsigner', 'seedsigner', 'seedsigner'))
+    TOUCH_BAR_DOWN_DISABLED = ((_UP, _SELECT, _DOWN), ('#ff9416', '#ff9416', '#444444'), ('seedsigner', 'seedsigner', 'seedsigner'))
+    TOUCH_BAR_SELECT_ONLY = (('', _SELECT, ''), ('#1a1a1a', '#ff9416', '#1a1a1a'), ('seedsigner', 'seedsigner', 'seedsigner'))
+    TOUCH_BAR_KEYBOARD = ((_DEL, _WORD, _DOWN), ('#444444', '#444444', '#ff9416'), ('seedsigner', 'fontawesome', 'seedsigner'))
+    TOUCH_BAR_KEYBOARD_DOWN_DISABLED = ((_DEL, _WORD, _DOWN), ('#444444', '#444444', '#444444'), ('seedsigner', 'fontawesome', 'seedsigner'))
+    TOUCH_BAR_KEYBOARD_WORD_ACTIVE = ((_DEL, _WORD, _DOWN), ('#444444', '#ff9416', '#ff9416'), ('seedsigner', 'fontawesome', 'seedsigner'))
+    TOUCH_BAR_KEYBOARD_DEL_ACTIVE = ((_DEL, _WORD, _DOWN), ('#ff9416', '#444444', '#ff9416'), ('seedsigner', 'fontawesome', 'seedsigner'))
+    TOUCH_BAR_KEYBOARD_BOTH_ACTIVE = ((_DEL, _WORD, _DOWN), ('#ff9416', '#ff9416', '#ff9416'), ('seedsigner', 'fontawesome', 'seedsigner'))
+    TOUCH_BAR_KEYBOARD_BOTH_ACTIVE_DOWN_DISABLED = ((_DEL, _WORD, _DOWN), ('#ff9416', '#ff9416', '#444444'), ('seedsigner', 'fontawesome', 'seedsigner'))
+    TOUCH_BAR_HIDDEN = (('', '', ''), ('#1a1a1a', '#1a1a1a', '#1a1a1a'), ('seedsigner', 'seedsigner', 'seedsigner'))
+
+    def __init__(self, device_no: int = 0):
+        """
+        Initialize the framebuffer display.
+
+        Args:
+            device_no: Framebuffer device number (0 for /dev/fb0)
+        """
+        # Report 240x240 to SeedSigner (native rendering size)
+        self.width = self.NATIVE_WIDTH
+        self.height = self.NATIVE_HEIGHT
+
+        self.device_no = device_no
+        self.fb_path = f"/dev/fb{device_no}"
+        self.config_dir = f"/sys/class/graphics/fb{device_no}/"
+        
+        self.fb = None
+        self.fb_file = None
+        self.fb_size = None
+        self.bits_per_pixel = None
+        self.stride = None
+        self.length = None
+        self.tty_fd = None  # For console mode control
+
+        # Current touch bar labels
+        self._current_labels = self.TOUCH_BAR_DEFAULT
+
+        # Cache touch bars for different label sets
+        self._touch_bar_cache = {}
+        self._touch_bar = self._get_touch_bar(self.TOUCH_BAR_DEFAULT)
+
+        # Initialize framebuffer
+        self._init_framebuffer()
+
+    def _read_config(self, filename: str) -> list:
+        """Read framebuffer config from sysfs"""
+        try:
+            with open(filename, "r") as fp:
+                content = fp.readline()
+                tokens = content.strip().split(",")
+                return [int(t) for t in tokens if t]
+        except Exception as e:
+            print(f"[DPI28] Could not read {filename}: {e}")
+            return []
+
+    def _init_framebuffer(self):
+        """Initialize framebuffer with mmap for fast access"""
+        try:
+            # Read framebuffer configuration
+            size_config = self._read_config(self.config_dir + "virtual_size")
+            if len(size_config) >= 2:
+                self.fb_size = (size_config[0], size_config[1])
+            else:
+                # Fallback to expected size
+                self.fb_size = (self.DISPLAY_WIDTH, self.DISPLAY_HEIGHT)
+            
+            bpp_config = self._read_config(self.config_dir + "bits_per_pixel")
+            self.bits_per_pixel = bpp_config[0] if bpp_config else 32
+            
+            stride_config = self._read_config(self.config_dir + "stride")
+            self.stride = stride_config[0] if stride_config else (self.bits_per_pixel // 8 * self.fb_size[0])
+            
+            # Calculate buffer length
+            self.length = self.fb_size[0] * self.fb_size[1] * (self.bits_per_pixel // 8)
+            
+            print(f"[DPI28] Framebuffer: {self.fb_path}")
+            print(f"[DPI28] Size: {self.fb_size}, BPP: {self.bits_per_pixel}, Stride: {self.stride}")
+            print(f"[DPI28] Using: {'Cython' if HAS_CYTHON else 'numpy' if HAS_NUMPY else 'Python'} conversion")
+            
+            # Open and mmap the framebuffer
+            self.fb_file = open(self.fb_path, "r+b")
+            self.fb = mmap.mmap(self.fb_file.fileno(), length=self.length, access=mmap.ACCESS_WRITE)
+
+            # Switch console to graphics mode to hide tty text (login prompt, etc.)
+            self._hide_console_text()
+
+        except Exception as e:
+            print(f"[DPI28] Could not initialize framebuffer: {e}")
+            self.close()
+            self.fb = None
+
+    def _hide_console_text(self):
+        """
+        Switch the console to graphics mode to hide tty text on the framebuffer.
+
+        This prevents the Linux login prompt and other console text from appearing
+        over the SeedSigner graphics. Uses KDSETMODE ioctl to switch tty0 to KD_GRAPHICS mode.
+        """
+        try:
+            self.tty_fd = os.open("/dev/tty0", os.O_RDWR)
+            fcntl.ioctl(self.tty_fd, KDSETMODE, KD_GRAPHICS)
+            print("[DPI28] Console switched to graphics mode")
+        except (OSError, IOError) as e:
+            print(f"[DPI28] Could not switch console to graphics mode: {e}")
+            if self.tty_fd is not None:
+                try:
+                    os.close(self.tty_fd)
+                except OSError:
+                    pass
+                self.tty_fd = None
+
+    def _restore_console_text(self):
+        """Restore console to text mode (called on cleanup)."""
+        if self.tty_fd is not None:
+            try:
+                fcntl.ioctl(self.tty_fd, KDSETMODE, KD_TEXT)
+                os.close(self.tty_fd)
+                print("[DPI28] Console restored to text mode")
+            except (OSError, IOError) as e:
+                print(f"[DPI28] Could not restore console mode: {e}")
+            self.tty_fd = None
+
+    def _get_touch_bar(self, labels: tuple) -> Image.Image:
+        """Get touch bar from cache or create new one"""
+        if labels not in self._touch_bar_cache:
+            self._touch_bar_cache[labels] = self._create_touch_bar(labels)
+        return self._touch_bar_cache[labels]
+
+    def set_touch_bar_labels(self, labels: tuple):
+        """
+        Set the touch bar labels.
+
+        Args:
+            labels: Tuple of 3 strings for (KEY1, KEY2, KEY3)
+                    Use TOUCH_BAR_DEFAULT or TOUCH_BAR_KEYBOARD presets
+        """
+        if labels != self._current_labels:
+            self._current_labels = labels
+            self._touch_bar = self._get_touch_bar(labels)
+
+    def _get_font_path(self, font_type: str) -> str:
+        """Get the path to the icon font file"""
+        this_dir = os.path.dirname(os.path.abspath(__file__))
+        resources_dir = os.path.join(this_dir, '..', 'resources', 'fonts')
+
+        if font_type == 'seedsigner':
+            return os.path.join(resources_dir, 'seedsigner-icons.otf')
+        if font_type == 'fontawesome':
+            return os.path.join(resources_dir, 'Font_Awesome_6_Free-Solid-900.otf')
+        return None
+
+    def _create_touch_bar(self, preset: tuple = None) -> Image.Image:
+        """Create the touch bar with icons and colors"""
+        if preset is None:
+            preset = self.TOUCH_BAR_DEFAULT
+
+        icons, colors, font_types = preset
+
+        bar = Image.new('RGB', (self.UI_WIDTH, self.TOUCH_BAR_HEIGHT), '#1a1a1a')
+        draw = ImageDraw.Draw(bar)
+
+        btn_width = self.UI_WIDTH // 3
+        btn_height = 100
+        btn_y = (self.TOUCH_BAR_HEIGHT - btn_height) // 2
+
+        icon_fonts = {}
+
+        for i, (icon, color, font_type) in enumerate(zip(icons, colors, font_types)):
+            x = i * btn_width
+            draw.rounded_rectangle(
+                [x + 10, btn_y, x + btn_width - 10, btn_y + btn_height],
+                radius=15,
+                fill=color
+            )
+
+            if not icon:
+                continue
+
+            icon_color = 'black' if color == '#ff9416' else 'white'
+
+            if font_type not in icon_fonts:
+                font_path = self._get_font_path(font_type)
+                try:
+                    icon_fonts[font_type] = ImageFont.truetype(font_path, 40)
+                except OSError:
+                    icon_fonts[font_type] = ImageFont.load_default()
+
+            font = icon_fonts[font_type]
+
+            bbox = draw.textbbox((0, 0), icon, font=font)
+            icon_w = bbox[2] - bbox[0]
+            icon_h = bbox[3] - bbox[1]
+            icon_x = x + (btn_width - icon_w) // 2
+            icon_y = btn_y + (btn_height - icon_h) // 2
+            draw.text((icon_x, icon_y), icon, fill=icon_color, font=font)
+
+        return bar
+
+    def show_image(self, image: Image.Image, x: int = 0, y: int = 0):
+        """
+        Display a PIL Image on the screen.
+
+        Accepts 240x240 image, scales to 480x480, adds touch bar.
+
+        Args:
+            image: PIL Image (240x240) to display
+            x: X offset (ignored for now)
+            y: Y offset (ignored for now)
+        """
+        if not self.fb:
+            return
+
+        # Scale 240x240 -> 480x480 using nearest neighbor (sharp pixels)
+        scaled = image.resize((self.UI_WIDTH, self.UI_HEIGHT), Image.NEAREST)
+
+        # Create full display image
+        display = Image.new('RGB', (self.DISPLAY_WIDTH, self.DISPLAY_HEIGHT))
+        display.paste(scaled, (0, 0))
+        display.paste(self._touch_bar, (0, self.UI_HEIGHT))
+
+        # Write to framebuffer
+        self._write_to_fb(display)
+
+    def _write_to_fb(self, image: Image.Image):
+        """
+        Write image to framebuffer with RGB→BGR conversion.
+        
+        Uses fastest available method:
+        1. Cython (~17 fps)
+        2. Numpy (~7 fps)
+        3. Pure Python (~1 fps)
+        """
+        if not self.fb:
+            return
+
+        if image.mode != 'RGB':
+            image = image.convert('RGB')
+
+        if self.bits_per_pixel == 32:
+            self._write_32bit(image)
+        elif self.bits_per_pixel == 16:
+            self._write_16bit(image)
+        else:
+            print(f"[DPI28] Unsupported bits_per_pixel: {self.bits_per_pixel}")
+
+    def _write_32bit(self, image: Image.Image):
+        """Write 32-bit BGRA to framebuffer"""
+        if HAS_CYTHON:
+            # Fastest: Cython (~17 fps)
+            rgb_data = image.tobytes()
+            num_pixels = image.width * image.height
+            RGBtoBGR.rgbtobgr(rgb_data, self.fb, num_pixels)
+        elif HAS_NUMPY:
+            # Fast: Numpy (~7 fps)
+            # Convert PIL to numpy array
+            arr = np.array(image)
+            # Swap R and B channels: RGB -> BGR
+            bgr = arr[:, :, ::-1]
+            # Add alpha channel (BGRA)
+            bgra = np.dstack((bgr, np.full((image.height, image.width), 255, dtype=np.uint8)))
+            # Write to framebuffer
+            self.fb.seek(0)
+            self.fb.write(bgra.tobytes())
+        else:
+            # Slow: Pure Python (~1 fps)
+            self._write_32bit_python(image)
+
+    def _write_32bit_python(self, image: Image.Image):
+        """Fallback pure Python 32-bit write (slow!)"""
+        pixels = image.load()
+        bgra_data = bytearray(self.length)
+        
+        idx = 0
+        for row in range(image.height):
+            for col in range(image.width):
+                r, g, b = pixels[col, row]
+                # BGRA format (swap R and B)
+                bgra_data[idx] = b
+                bgra_data[idx + 1] = g
+                bgra_data[idx + 2] = r
+                bgra_data[idx + 3] = 255  # Alpha
+                idx += 4
+        
+        self.fb.seek(0)
+        self.fb.write(bgra_data)
+
+    def _write_16bit(self, image: Image.Image):
+        """Write 16-bit RGB565 to framebuffer (if needed)"""
+        if HAS_NUMPY:
+            arr = np.array(image)
+            r = (arr[:, :, 0] >> 3).astype(np.uint16)
+            g = (arr[:, :, 1] >> 2).astype(np.uint16)
+            b = (arr[:, :, 2] >> 3).astype(np.uint16)
+            rgb565 = (r << 11) | (g << 5) | b
+            self.fb.seek(0)
+            self.fb.write(rgb565.tobytes())
+        else:
+            self._write_16bit_python(image)
+
+    def _write_16bit_python(self, image: Image.Image):
+        """Fallback pure Python 16-bit write (slow!)"""
+        pixels = image.load()
+        rgb565_data = bytearray(image.width * image.height * 2)
+
+        idx = 0
+        for row in range(image.height):
+            for col in range(image.width):
+                r, g, b = pixels[col, row]
+                rgb565 = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3)
+                rgb565_data[idx] = rgb565 & 0xFF
+                rgb565_data[idx + 1] = (rgb565 >> 8) & 0xFF
+                idx += 2
+
+        self.fb.seek(0)
+        self.fb.write(rgb565_data)
+
+    def clear(self):
+        """Clear the display to black"""
+        if not self.fb:
+            return
+
+        try:
+            self.fb.seek(0)
+            self.fb.write(bytearray(self.length))
+        except Exception as e:
+            print(f"[DPI28] Clear error: {e}")
+
+    def close(self):
+        """Close the framebuffer device and restore console mode"""
+        self._restore_console_text()
+        if self.fb:
+            self.fb.close()
+            self.fb = None
+        if self.fb_file:
+            self.fb_file.close()
+            self.fb_file = None
+
+    def __del__(self):
+        self.close()

--- a/src/seedsigner/hardware/DPI28.py
+++ b/src/seedsigner/hardware/DPI28.py
@@ -117,6 +117,7 @@ class DPI28:
         self.stride = None
         self.length = None
         self.tty_fd = None  # For console mode control
+        self.color_order = "bgr"
 
         # Current touch bar labels
         self._current_labels = self.TOUCH_BAR_DEFAULT
@@ -139,6 +140,23 @@ class DPI28:
             print(f"[DPI28] Could not read {filename}: {e}")
             return []
 
+    def _detect_color_order(self):
+        """Detect framebuffer color channel order (rgb vs bgr)."""
+        format_path = os.path.join(self.config_dir, "format")
+        if not os.path.exists(format_path):
+            return
+
+        try:
+            with open(format_path, "r") as fp:
+                fmt = fp.read().strip().lower()
+        except OSError:
+            return
+
+        if "bgr" in fmt:
+            self.color_order = "bgr"
+        elif "rgb" in fmt:
+            self.color_order = "rgb"
+
     def _init_framebuffer(self):
         """Initialize framebuffer with mmap for fast access"""
         try:
@@ -158,10 +176,14 @@ class DPI28:
             
             # Calculate buffer length
             self.length = self.fb_size[0] * self.fb_size[1] * (self.bits_per_pixel // 8)
+
+            # Detect color order (rgb vs bgr) if available
+            self._detect_color_order()
             
             print(f"[DPI28] Framebuffer: {self.fb_path}")
             print(f"[DPI28] Size: {self.fb_size}, BPP: {self.bits_per_pixel}, Stride: {self.stride}")
             print(f"[DPI28] Using: {'Cython' if HAS_CYTHON else 'numpy' if HAS_NUMPY else 'Python'} conversion")
+            print(f"[DPI28] Color order: {self.color_order}")
             
             # Open and mmap the framebuffer
             self.fb_file = open(self.fb_path, "r+b")
@@ -331,7 +353,7 @@ class DPI28:
 
     def _write_32bit(self, image: Image.Image):
         """Write 32-bit BGRA to framebuffer"""
-        if HAS_CYTHON:
+        if HAS_CYTHON and self.color_order == "bgr":
             # Fastest: Cython (~17 fps)
             rgb_data = image.tobytes()
             num_pixels = image.width * image.height
@@ -340,8 +362,11 @@ class DPI28:
             # Fast: Numpy (~7 fps)
             # Convert PIL to numpy array
             arr = np.array(image)
-            # Swap R and B channels: RGB -> BGR
-            bgr = arr[:, :, ::-1]
+            if self.color_order == "bgr":
+                # Swap R and B channels: RGB -> BGR
+                bgr = arr[:, :, ::-1]
+            else:
+                bgr = arr
             # Add alpha channel (BGRA)
             bgra = np.dstack((bgr, np.full((image.height, image.width), 255, dtype=np.uint8)))
             # Write to framebuffer
@@ -361,10 +386,15 @@ class DPI28:
         for row in range(image.height):
             for col in range(image.width):
                 r, g, b = pixels[col, row]
-                # BGRA format (swap R and B)
-                bgra_data[idx] = b
-                bgra_data[idx + 1] = g
-                bgra_data[idx + 2] = r
+                if self.color_order == "bgr":
+                    # BGRA format (swap R and B)
+                    bgra_data[idx] = b
+                    bgra_data[idx + 1] = g
+                    bgra_data[idx + 2] = r
+                else:
+                    bgra_data[idx] = r
+                    bgra_data[idx + 1] = g
+                    bgra_data[idx + 2] = b
                 bgra_data[idx + 3] = 255  # Alpha
                 idx += 4
         
@@ -376,9 +406,14 @@ class DPI28:
         """Write 16-bit RGB565 to framebuffer (if needed)"""
         if HAS_NUMPY:
             arr = np.array(image)
-            r = (arr[:, :, 0] >> 3).astype(np.uint16)
-            g = (arr[:, :, 1] >> 2).astype(np.uint16)
-            b = (arr[:, :, 2] >> 3).astype(np.uint16)
+            if self.color_order == "bgr":
+                b = (arr[:, :, 0] >> 3).astype(np.uint16)
+                g = (arr[:, :, 1] >> 2).astype(np.uint16)
+                r = (arr[:, :, 2] >> 3).astype(np.uint16)
+            else:
+                r = (arr[:, :, 0] >> 3).astype(np.uint16)
+                g = (arr[:, :, 1] >> 2).astype(np.uint16)
+                b = (arr[:, :, 2] >> 3).astype(np.uint16)
             rgb565 = (r << 11) | (g << 5) | b
             self.fb.seek(0)
             self.fb.write(rgb565.tobytes())
@@ -395,6 +430,8 @@ class DPI28:
         for row in range(image.height):
             for col in range(image.width):
                 r, g, b = pixels[col, row]
+                if self.color_order == "bgr":
+                    r, b = b, r
                 rgb565 = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3)
                 rgb565_data[idx] = rgb565 & 0xFF
                 rgb565_data[idx + 1] = (rgb565 >> 8) & 0xFF

--- a/src/seedsigner/hardware/DPI28.py
+++ b/src/seedsigner/hardware/DPI28.py
@@ -347,6 +347,7 @@ class DPI28:
             # Write to framebuffer
             self.fb.seek(0)
             self.fb.write(bgra.tobytes())
+            self.fb.flush()
         else:
             # Slow: Pure Python (~1 fps)
             self._write_32bit_python(image)
@@ -369,6 +370,7 @@ class DPI28:
         
         self.fb.seek(0)
         self.fb.write(bgra_data)
+        self.fb.flush()
 
     def _write_16bit(self, image: Image.Image):
         """Write 16-bit RGB565 to framebuffer (if needed)"""
@@ -380,6 +382,7 @@ class DPI28:
             rgb565 = (r << 11) | (g << 5) | b
             self.fb.seek(0)
             self.fb.write(rgb565.tobytes())
+            self.fb.flush()
         else:
             self._write_16bit_python(image)
 
@@ -399,6 +402,7 @@ class DPI28:
 
         self.fb.seek(0)
         self.fb.write(rgb565_data)
+        self.fb.flush()
 
     def clear(self):
         """Clear the display to black"""

--- a/src/seedsigner/hardware/displays/display_driver.py
+++ b/src/seedsigner/hardware/displays/display_driver.py
@@ -4,12 +4,14 @@ DISPLAY_TYPE__ST7789 = "st7789"
 DISPLAY_TYPE__ILI9341 = "ili9341"
 DISPLAY_TYPE__ILI9486 = "ili9486"
 DISPLAY_TYPE__DESKTOP = "desktop"
+DISPLAY_TYPE__DPI28 = "dpi28"
 
 ALL_DISPLAY_TYPES = [
     DISPLAY_TYPE__ST7789,
     DISPLAY_TYPE__ILI9341,
     DISPLAY_TYPE__ILI9486,
     DISPLAY_TYPE__DESKTOP,
+    DISPLAY_TYPE__DPI28,
 ]
 
 
@@ -56,6 +58,10 @@ class DisplayDriver:
 
             # Desktop display can support arbitrary sizes; defaults are handled by caller
             self.display = DesktopDisplay(width=width, height=height)
+
+        elif self.display_type == DISPLAY_TYPE__DPI28:
+            from seedsigner.hardware.DPI28 import DPI28
+            self.display = DPI28()
     
 
     def __str__(self):

--- a/src/seedsigner/hardware/touch.py
+++ b/src/seedsigner/hardware/touch.py
@@ -47,13 +47,15 @@ class TouchInput:
 
     def _find_touch_device(self) -> Optional[str]:
         """Find touch input device by scanning /dev/input/"""
+        keywords = ["goodix", "touch", "ft5", "edt-ft5", "ft5406", "touchscreen", "stmpe", "raspberry pi"]
         for i in range(10):
             name_path = f"/sys/class/input/event{i}/device/name"
             if os.path.exists(name_path):
                 try:
                     with open(name_path, "r") as f:
                         name = f.read().strip()
-                        if "Goodix" in name or "touch" in name.lower():
+                        name_lower = name.lower()
+                        if any(keyword in name_lower for keyword in keywords):
                             return f"/dev/input/event{i}"
                 except OSError:
                     pass

--- a/src/seedsigner/hardware/touch.py
+++ b/src/seedsigner/hardware/touch.py
@@ -1,0 +1,162 @@
+"""
+Touch input handler for capacitive touchscreen.
+
+On Raspberry Pi: Reads raw Linux input events from /dev/input/
+On PC/Emulator: Uses injected mock that translates pygame mouse events
+"""
+
+import struct
+import select
+import os
+from typing import Optional, Tuple
+
+
+# Linux input event codes (from linux/input-event-codes.h)
+EV_SYN = 0x00
+EV_ABS = 0x03
+ABS_MT_TRACKING_ID = 0x39
+ABS_MT_POSITION_X = 0x35
+ABS_MT_POSITION_Y = 0x36
+
+# Touch panel native resolution (Waveshare 2.8" DPI LCD)
+TOUCH_WIDTH = 640
+TOUCH_HEIGHT = 480
+
+
+class TouchInput:
+    """
+    Handles touch input from capacitive touchscreen.
+    Reads raw Linux input events - no external dependencies required.
+    """
+
+    def __init__(self, device_path: str = None,
+                 screen_width: int = 480, screen_height: int = 640,
+                 swap_xy: bool = False, invert_x: bool = False, invert_y: bool = False):
+        self.screen_width = screen_width
+        self.screen_height = screen_height
+        self.swap_xy = swap_xy
+        self.invert_x = invert_x
+        self.invert_y = invert_y
+
+        self.x = 0
+        self.y = 0
+        self.touching = False
+        self.fd = None
+
+        self._init_device(device_path)
+
+    def _find_touch_device(self) -> Optional[str]:
+        """Find touch input device by scanning /dev/input/"""
+        for i in range(10):
+            name_path = f"/sys/class/input/event{i}/device/name"
+            if os.path.exists(name_path):
+                try:
+                    with open(name_path, "r") as f:
+                        name = f.read().strip()
+                        if "Goodix" in name or "touch" in name.lower():
+                            return f"/dev/input/event{i}"
+                except OSError:
+                    pass
+        return None
+
+    def _init_device(self, device_path: str = None):
+        """Initialize raw input device access"""
+        path = device_path or self._find_touch_device()
+
+        if path and os.path.exists(path):
+            try:
+                self.fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+                print(f"[Touch] Opened: {path}")
+            except Exception as e:
+                print(f"[Touch] Failed to open {path}: {e}")
+                self.fd = None
+        else:
+            print("[Touch] No touch device found")
+
+    def poll(self) -> Optional[Tuple[str, int, int]]:
+        """Poll for touch events (non-blocking)."""
+        if self.fd is None:
+            return None
+
+        try:
+            r, _, _ = select.select([self.fd], [], [], 0)
+            if not r:
+                return None
+
+            # input_event struct on 32-bit ARM (Pi Zero):
+            # tv_sec(4) + tv_usec(4) + type(2) + code(2) + value(4) = 16 bytes
+            EVENT_SIZE = 16
+
+            result = None
+            pending_down = False
+            pending_up = False
+
+            while True:
+                try:
+                    data = os.read(self.fd, EVENT_SIZE)
+                    if len(data) < EVENT_SIZE:
+                        break
+
+                    ev_type, ev_code, ev_value = struct.unpack("HHi", data[8:16])
+
+                    if ev_type == EV_ABS:
+                        if ev_code == ABS_MT_POSITION_X:
+                            self.x = ev_value
+                        elif ev_code == ABS_MT_POSITION_Y:
+                            self.y = ev_value
+                        elif ev_code == ABS_MT_TRACKING_ID:
+                            if ev_value >= 0:
+                                self.touching = True
+                                pending_down = True
+                            else:
+                                self.touching = False
+                                pending_up = True
+
+                    elif ev_type == EV_SYN:
+                        # SYN marks end of event packet - coordinates now complete
+                        x, y = self._transform(self.x, self.y)
+                        if pending_down:
+                            result = ("down", x, y)
+                            pending_down = False
+                        elif pending_up:
+                            result = ("up", x, y)
+                            pending_up = False
+                        elif self.touching:
+                            result = ("move", x, y)
+
+                except BlockingIOError:
+                    break
+                except OSError:
+                    break
+
+            return result
+
+        except OSError:
+            return None
+
+    def _transform(self, raw_x: int, raw_y: int) -> Tuple[int, int]:
+        """Transform raw touch coordinates to screen coordinates."""
+        # Scale from touch panel resolution to screen resolution
+        screen_x = raw_x * self.screen_width // TOUCH_WIDTH
+        screen_y = raw_y * self.screen_height // TOUCH_HEIGHT
+
+        if self.swap_xy:
+            screen_x, screen_y = screen_y, screen_x
+
+        if self.invert_x:
+            screen_x = self.screen_width - 1 - screen_x
+
+        if self.invert_y:
+            screen_y = self.screen_height - 1 - screen_y
+
+        # Clamp to screen bounds
+        screen_x = max(0, min(self.screen_width - 1, screen_x))
+        screen_y = max(0, min(self.screen_height - 1, screen_y))
+
+        return screen_x, screen_y
+
+    def close(self):
+        """Close the device"""
+        if self.fd is not None:
+            os.close(self.fd)
+            self.fd = None

--- a/src/seedsigner/hardware/touchbuttons.py
+++ b/src/seedsigner/hardware/touchbuttons.py
@@ -1,0 +1,470 @@
+"""
+TouchButtons - Touch input adapter for SeedSigner.
+
+Provides the same interface as HardwareButtons but uses touchscreen input.
+Supports direct tap detection on UI buttons.
+"""
+
+import time
+from typing import List, Tuple
+
+from seedsigner.models.singleton import Singleton
+from seedsigner.hardware.buttons import HardwareButtonsConstants as BaseHardwareButtonsConstants
+
+
+if not hasattr(BaseHardwareButtonsConstants, "release_lock"):
+    BaseHardwareButtonsConstants.release_lock = True
+
+
+class TouchButtons(Singleton):
+    """
+    Touch-based input that provides HardwareButtons-compatible interface.
+
+    Key features:
+    - Direct tap: Screens register button positions, taps return button index
+    - Fallback navigation: Touch regions map to UP/DOWN/LEFT/RIGHT for screens
+      that don't support direct tap
+    """
+
+    # Screen layout for 480x640 display
+    # UI area: 480x480 (top), scaled 2x from 240x240
+    # Touch bar: 480x160 (bottom) - KEY1, KEY2, KEY3
+    SCREEN_WIDTH = 480
+    SCREEN_HEIGHT = 640
+    UI_HEIGHT = 480
+    TOUCH_BAR_TOP = 480
+
+    # Re-export constants
+    KEY_UP = BaseHardwareButtonsConstants.KEY_UP
+    KEY_DOWN = BaseHardwareButtonsConstants.KEY_DOWN
+    KEY_LEFT = BaseHardwareButtonsConstants.KEY_LEFT
+    KEY_RIGHT = BaseHardwareButtonsConstants.KEY_RIGHT
+    KEY_PRESS = BaseHardwareButtonsConstants.KEY_PRESS
+    KEY1 = BaseHardwareButtonsConstants.KEY1
+    KEY2 = BaseHardwareButtonsConstants.KEY2
+    KEY3 = BaseHardwareButtonsConstants.KEY3
+
+    @classmethod
+    def get_instance(cls):
+        if cls._instance is None:
+            cls._instance = cls.__new__(cls)
+            cls._instance._initialize()
+        return cls._instance
+
+    def _initialize(self):
+        """Initialize touch input"""
+        from seedsigner.hardware.touch import TouchInput
+        self.touch = TouchInput()
+
+        self.override_ind = False
+
+        # Timing for input handling
+        self.cur_input = None
+        self.cur_input_started = None
+        self.last_input_time = int(time.time() * 1000)
+        self.first_repeat_threshold = 225
+        self.next_repeat_threshold = 250
+
+        # Touch state
+        self.last_touch_x = 0
+        self.last_touch_y = 0
+        self.touch_down = False
+
+        # Direct tap support
+        # List of (x, y, width, height, index) in NATIVE coords (240x240)
+        self.button_rects: List[Tuple[int, int, int, int, int]] = []
+        self._tapped_button_index = -1
+        self._back_button_tapped = False
+        self._power_button_tapped = False
+        self._touch_bar_back_tapped = False  # Touch bar left button (BACK in keyboard mode)
+
+        # Last tap coordinates in native space (240x240) for keyboard detection
+        self._last_tap_native_x = -1
+        self._last_tap_native_y = -1
+
+    def register_buttons(self, buttons: list):
+        """
+        Register button positions for direct tap detection.
+
+        Args:
+            buttons: List of Button objects with screen_x, screen_y, width, height.
+                     Coordinates are in native 240x240 space.
+        """
+        self.button_rects = []
+        for i, btn in enumerate(buttons):
+            if hasattr(btn, 'screen_y') and hasattr(btn, 'height'):
+                x = getattr(btn, 'screen_x', 0)
+                y = btn.screen_y - getattr(btn, 'scroll_y', 0)  # Account for scroll
+                w = getattr(btn, 'width', 240)
+                h = btn.height
+                self.button_rects.append((x, y, w, h, i))
+
+    def clear_buttons(self):
+        """Clear registered button positions"""
+        self.button_rects = []
+        self._tapped_button_index = -1
+
+    def get_tapped_button_index(self) -> int:
+        """
+        Get index of directly tapped button, or -1 if none.
+        Resets after reading.
+        """
+        idx = self._tapped_button_index
+        self._tapped_button_index = -1
+        return idx
+
+    def was_back_button_tapped(self) -> bool:
+        """
+        Check if back button was tapped.
+        Resets after reading.
+        """
+        result = self._back_button_tapped
+        self._back_button_tapped = False
+        return result
+
+    def was_power_button_tapped(self) -> bool:
+        """
+        Check if power button was tapped.
+        Resets after reading.
+        """
+        result = self._power_button_tapped
+        self._power_button_tapped = False
+        return result
+
+    def was_touch_bar_back_tapped(self) -> bool:
+        """
+        Check if touch bar left button (BACK) was tapped.
+        Resets after reading.
+        """
+        result = self._touch_bar_back_tapped
+        self._touch_bar_back_tapped = False
+        return result
+
+    def get_last_tap_native_coords(self) -> Tuple[int, int]:
+        """
+        Get the last tap coordinates in native space (240x240).
+        Resets after reading.
+
+        Returns:
+            (x, y) tuple in native coords, or (-1, -1) if no tap
+        """
+        x, y = self._last_tap_native_x, self._last_tap_native_y
+        self._last_tap_native_x = -1
+        self._last_tap_native_y = -1
+        return (x, y)
+
+    def clear_pending_input(self):
+        """
+        Clear all pending input state.
+        Call this when entering a new screen to avoid stale tap data.
+        """
+        self._last_tap_native_x = -1
+        self._last_tap_native_y = -1
+        self._tapped_button_index = -1
+        self._back_button_tapped = False
+        self._power_button_tapped = False
+        self._touch_bar_back_tapped = False
+        self.touch_down = False
+        # Drain any pending touch events
+        while self.touch.poll():
+            pass
+
+    def _check_back_button_tap(self, touch_x: int, touch_y: int) -> bool:
+        """
+        Check if touch hit the back button area (top-left corner).
+
+        Args:
+            touch_x, touch_y: Touch coordinates in screen space (480x640)
+
+        Returns:
+            True if back button was tapped
+        """
+        # Back button is roughly in the top-left 60x60 area (native coords)
+        # In screen coords that's 120x120
+        native_x = touch_x // 2
+        native_y = touch_y // 2
+
+        # Check if in top nav area (top ~48 pixels in native coords)
+        # and in the left side (left ~48 pixels)
+        return native_y < 48 and native_x < 48
+
+    def _check_power_button_tap(self, touch_x: int, touch_y: int) -> bool:
+        """
+        Check if touch hit the power button area (top-right corner).
+
+        Args:
+            touch_x, touch_y: Touch coordinates in screen space (480x640)
+
+        Returns:
+            True if power button was tapped
+        """
+        native_x = touch_x // 2
+        native_y = touch_y // 2
+
+        # Check if in top nav area (top ~48 pixels in native coords)
+        # and in the right side (right ~48 pixels, so x > 192 for 240 width)
+        return native_y < 48 and native_x > 192
+
+    def _check_button_tap(self, touch_x: int, touch_y: int) -> int:
+        """
+        Check if touch hit a registered button.
+
+        Args:
+            touch_x, touch_y: Touch coordinates in screen space (480x640)
+
+        Returns:
+            Button index or -1 if no hit
+        """
+        if not self.button_rects:
+            return -1
+
+        # Only check UI area, not touch bar
+        if touch_y >= self.TOUCH_BAR_TOP:
+            return -1
+
+        # Convert screen coords (480x480) to native coords (240x240)
+        native_x = touch_x // 2
+        native_y = touch_y // 2
+
+        # Exclude scroll indicator zones - these are visual only, not tappable
+        # Up arrow indicator: y < 48 (below top_nav header area)
+        # Down arrow indicator: y > 226 (bottom 14px of 240px UI)
+        # Only exclude center area where arrows are drawn (not full width)
+        if 80 <= native_x <= 160:  # Center third of screen
+            if native_y < 48 or native_y > 226:
+                return -1  # In scroll indicator zone, don't detect button
+
+        for x, y, w, h, index in self.button_rects:
+            if x <= native_x <= x + w and y <= native_y <= y + h:
+                return index
+
+        return -1
+
+    def _coords_to_nav_key(self, x: int, y: int) -> int:
+        """
+        Map touch coordinates to navigation key (fallback for non-button areas).
+
+        Args:
+            x, y: Touch coordinates in screen space (480x640)
+
+        Returns:
+            Key code (KEY_UP, KEY_DOWN, etc.)
+        """
+        # Touch bar - KEY1, KEY2, KEY3
+        if y >= self.TOUCH_BAR_TOP:
+            third = self.SCREEN_WIDTH // 3
+            if x < third:
+                return self.KEY1
+            if x < 2 * third:
+                return self.KEY2
+            return self.KEY3
+
+        # UI area - map to D-pad style navigation
+        px = x / self.SCREEN_WIDTH  # 0-1 horizontal
+        py = y / self.UI_HEIGHT      # 0-1 vertical within UI area
+
+        # Top 20% = UP
+        if py < 0.20:
+            return self.KEY_UP
+
+        # Bottom 40% = DOWN in center, LEFT/RIGHT on edges
+        if py > 0.60:
+            if 0.25 < px < 0.75:
+                return self.KEY_DOWN
+            if px < 0.25:
+                return self.KEY_LEFT
+            return self.KEY_RIGHT
+
+        # Middle 40% - LEFT/RIGHT on edges, CENTER for select
+        if px < 0.25:
+            return self.KEY_LEFT
+        if px > 0.75:
+            return self.KEY_RIGHT
+        return self.KEY_PRESS
+
+    def wait_for(self, keys=None, check_release=True, release_keys=None) -> int:
+        """
+        Wait for touch input matching requested keys.
+
+        This is the main input method called by SeedSigner screens.
+
+        Args:
+            keys: List of key codes to listen for
+            check_release: Whether to wait for touch release
+            release_keys: Keys that require release detection
+
+        Returns:
+            Key code that was activated
+        """
+        from seedsigner.controller import Controller
+        controller = Controller.get_instance()
+
+        if keys is None:
+            keys = []
+        if release_keys is None:
+            release_keys = keys
+
+        self.override_ind = False
+        pending_key = None  # Key waiting for release
+
+        while True:
+            cur_time = int(time.time() * 1000)
+
+            # Screensaver check
+            if cur_time - self.last_input_time > controller.screensaver_activation_ms and not controller.is_screensaver_running:
+                controller.start_screensaver()
+                self.update_last_input_time()
+                time.sleep(self.next_repeat_threshold / 1000.0)
+                continue
+
+            # Override handling (for toast/notifications)
+            if self.override_ind:
+                self.override_ind = False
+                return BaseHardwareButtonsConstants.OVERRIDE
+
+            # Poll for touch events
+            event = self.touch.poll()
+            if event:
+                event_type, x, y = event
+                print(f"[Touch] {event_type} at ({x}, {y})")
+
+                if event_type == 'down':
+                    self.touch_down = True
+                    self.last_touch_x = x
+                    self.last_touch_y = y
+
+                    # Store native coords for keyboard tap detection (only in UI area)
+                    if y < self.TOUCH_BAR_TOP:
+                        self._last_tap_native_x = x // 2
+                        self._last_tap_native_y = y // 2
+
+                    # Check for back button tap (top-left corner)
+                    if self._check_back_button_tap(x, y):
+                        print("[Touch] Back button tapped!")
+                        self._back_button_tapped = True
+                        pending_key = self.KEY_PRESS
+                        self.cur_input = self.KEY_PRESS
+                        self.cur_input_started = cur_time
+                        self.last_input_time = cur_time
+                        if not check_release or self.KEY_PRESS not in release_keys:
+                            return self.KEY_PRESS
+                        continue
+
+                    # Check for power button tap (top-right corner)
+                    if self._check_power_button_tap(x, y):
+                        print("[Touch] Power button tapped!")
+                        self._power_button_tapped = True
+                        pending_key = self.KEY_PRESS
+                        self.cur_input = self.KEY_PRESS
+                        self.cur_input_started = cur_time
+                        self.last_input_time = cur_time
+                        if not check_release or self.KEY_PRESS not in release_keys:
+                            return self.KEY_PRESS
+                        continue
+
+                    # Check for direct button tap
+                    if self.KEY_PRESS in keys:
+                        btn_idx = self._check_button_tap(x, y)
+                        print(f"[Touch] Button check: {btn_idx}, registered: {len(self.button_rects)}")
+                        if btn_idx >= 0:
+                            self._tapped_button_index = btn_idx
+                            pending_key = self.KEY_PRESS
+                            self.cur_input = self.KEY_PRESS
+                            self.cur_input_started = cur_time
+                            self.last_input_time = cur_time
+                            print(f"[Touch] Direct tap on button {btn_idx}, waiting for release...")
+                            # If not checking release, return immediately
+                            if not check_release or self.KEY_PRESS not in release_keys:
+                                return self.KEY_PRESS
+                            continue
+
+                    # Fall back to navigation key mapping
+                    key = self._coords_to_nav_key(x, y)
+                    print(f"[Touch] Nav key: {key}, in keys: {key in keys}")
+
+                    # Track if touch bar BACK (left button) was tapped
+                    if key == self.KEY1 and y >= self.TOUCH_BAR_TOP:
+                        print("[Touch] Touch bar BACK tapped!")
+                        self._touch_bar_back_tapped = True
+
+                    if key in keys:
+                        pending_key = key
+                        self.cur_input = key
+                        self.cur_input_started = cur_time
+                        self.last_input_time = cur_time
+                        # If not checking release, return immediately
+                        if not check_release or key not in release_keys:
+                            return key
+                        # Otherwise wait for release
+                        continue
+
+                elif event_type == 'up':
+                    self.touch_down = False
+                    print(f"[Touch] Release, pending_key: {pending_key}")
+                    # Return the pending key on release
+                    if pending_key is not None:
+                        key = pending_key
+                        pending_key = None
+                        self.cur_input = None
+                        BaseHardwareButtonsConstants.release_lock = True
+                        print(f"[Touch] Returning key: {key}")
+                        return key
+
+            time.sleep(0.01)  # Small delay to avoid busy loop
+
+    def update_last_input_time(self):
+        """Update timestamp of last input"""
+        self.last_input_time = int(time.time() * 1000)
+
+    def add_events(self, keys):
+        """Compatibility method - no-op for touch"""
+        pass
+
+    def trigger_override(self):
+        """Trigger override input (for notifications)"""
+        self.override_ind = True
+
+    def has_any_input(self) -> bool:
+        """Check if there's any touch input (polls for events)"""
+        # Poll for touch events to update state
+        event = self.touch.poll()
+        if event:
+            event_type, _, _ = event
+            if event_type == 'down':
+                self.touch_down = True
+                return True
+            if event_type == 'up':
+                self.touch_down = False
+                return True  # Return True on release too to wake from screensaver
+        return self.touch_down
+
+    def check_for_low(self, key: int = None, keys: list = None) -> bool:
+        """
+        Check if specified key(s) are pressed.
+        For touch: checks if screen is currently being touched.
+        """
+        # For touch input, we check if there is an active touch
+        event = self.touch.poll()
+        if event:
+            event_type, _, _ = event
+            if event_type == "down":
+                self.touch_down = True
+                self.update_last_input_time()
+                return True
+            if event_type == "up":
+                self.touch_down = False
+        return self.touch_down
+
+
+# Factory function to get appropriate input handler
+def get_buttons():
+    """
+    Get the appropriate button handler based on environment.
+
+    Returns TouchButtons for touchscreen, HardwareButtons for GPIO.
+    """
+    import os
+    if os.environ.get('SEEDSIGNER_TOUCH') == '1':
+        return TouchButtons.get_instance()
+    from seedsigner.hardware.buttons import HardwareButtons
+    return HardwareButtons.get_instance()

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -475,6 +475,7 @@ class SettingsConstants:
     DISPLAY_CONFIGURATION__ST7789__320x240 = "st7789_320x240"    # natively portrait dimensions; we apply a 90° rotation
     DISPLAY_CONFIGURATION__ILI9341__320x240 = "ili9341_320x240"  # natively portrait dimensions; we apply a 90° rotation
     DISPLAY_CONFIGURATION__ILI9486__480x320 = "ili9486_480x320"  # natively portrait dimensions; we apply a 90° rotation
+    DISPLAY_CONFIGURATION__DPI28__240x240 = "dpi28_240x240"  # Waveshare 2.8" DPI touchscreen (480x640 physical, 240x240 native)
     DISPLAY_CONFIGURATION__DESKTOP__240x240 = "desktop_240x240"  # pygame-based desktop simulation
     DISPLAY_CONFIGURATION__DESKTOP__320x240 = "desktop_320x240"
     if USING_MOCK_GPIO:
@@ -482,6 +483,7 @@ class SettingsConstants:
             (DISPLAY_CONFIGURATION__ST7789__240x240, "st7789 240x240"),
             (DISPLAY_CONFIGURATION__ST7789__320x240, "st7789 320x240"),
             (DISPLAY_CONFIGURATION__ILI9341__320x240, "ili9341 320x240 (beta)"),
+            (DISPLAY_CONFIGURATION__DPI28__240x240, "dpi28 240x240 touch"),
             (DISPLAY_CONFIGURATION__DESKTOP__240x240, "desktop 240x240"),
             (DISPLAY_CONFIGURATION__DESKTOP__320x240, "desktop 320x240"),
             # (DISPLAY_CONFIGURATION__ILI9486__320x480, "ili9486 480x320"),  # TODO: Enable when ili9486 driver performance is improved
@@ -491,6 +493,7 @@ class SettingsConstants:
             (DISPLAY_CONFIGURATION__ST7789__240x240, "st7789 240x240"),
             (DISPLAY_CONFIGURATION__ST7789__320x240, "st7789 320x240"),
             (DISPLAY_CONFIGURATION__ILI9341__320x240, "ili9341 320x240 (beta)"),
+            (DISPLAY_CONFIGURATION__DPI28__240x240, "dpi28 240x240 touch"),
             # (DISPLAY_CONFIGURATION__ILI9486__320x480, "ili9486 480x320"),  # TODO: Enable when ili9486 driver performance is improved
         ]
 


### PR DESCRIPTION
### Motivation
- Enable support for the Waveshare 2.8" DPI framebuffer touchscreen so the device can use the physical 480x640 DPI display with a 240x240 native UI and a bottom touch bar. 
- Provide direct touchscreen input (taps, touch-bar buttons, and navigation fallback) so screens can accept taps on UI elements and the touch bar. 
- Auto-detect hardware and expose a selectable `dpi28_240x240` display configuration to simplify switching between desktop and touchscreen modes.

### Description
- Added a framebuffer display driver `src/seedsigner/hardware/DPI28.py` that scales 240x240 UI images to the 480x480 UI region, composes a 160px touch bar, and writes BGRA/RGB565 to `/dev/fb0` (with `numpy`-accelerated and pure-Python fallbacks). 
- Added raw touch input reader `src/seedsigner/hardware/touch.py` and a touch adapter `src/seedsigner/hardware/touchbuttons.py` that expose a `HardwareButtons`-compatible interface plus tap detection, touch-bar events, and helpers like `get_last_tap_native_coords()` and `register_buttons()`. 
- Integrated DPI28/touch into the app: `src/seedsigner/hardware/displays/display_driver.py` now supports `dpi28`, `src/seedsigner/models/settings_definition.py` adds `dpi28_240x240` to available display options, and `src/seedsigner/gui/renderer.py` auto-detects framebuffer/touch hardware and sets `SEEDSIGNER_DISPLAY`/`SEEDSIGNER_TOUCH`. 
- Wired touch behavior into the UI: `src/seedsigner/gui/screens/screen.py`, `seed_screens.py`, and `tools_screens.py` now select the input handler (touch vs GPIO), register button hit boxes, handle direct taps, manage touch-bar label updates via `Renderer.set_touch_bar_labels()`, and hide/show the touch bar on screens where appropriate. 
- Keyboard and helper updates include `src/seedsigner/gui/keyboard.py` adding `get_key_at_screen_coords()` to support direct keyboard taps, and `src/seedsigner/gui/toast.py` uses the correct input handler for dismiss/cancel behavior.

### Testing
- No automated tests were executed as part of this change set; the patch adds the new drivers and touch integration but no CI/test runs were performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69782c9d3f7483228980e8cad367e5d5)