### PR TITLE
Add battery discharge calibration workflow and curve support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS instructions for /workspace/seedsigner
+
+## UI copy length guidance
+
+For TextArea-based informational screens (especially ButtonListScreen flows), keep body copy to a **maximum of ~120 characters total**, split across **no more than 2 lines** (roughly **~60 characters per line**). This aligns with existing info screens such as the restart/power-off messages, which fit cleanly on the display.
+
+If additional detail is needed, prefer a second screen instead of longer text.

--- a/docs/battery.md
+++ b/docs/battery.md
@@ -1,0 +1,15 @@
+# Battery calibration (UPS HAT)
+
+## Hardware
+
+SeedSigner works out of the box with the [Waveshare UPS HAT (C)](https://www.waveshare.com/ups-hat-c.htm). The stock 1000mAh battery provides about 4 hours of runtime.
+
+The battery meter will also work with any hardware that uses an INA219 battery meter connected over I2C at address `0x43`.
+
+## Battery curves and calibration
+
+Calibration runs the discharge test from **Tools → Battery Calibration**, logging a voltage sample every minute while the device discharges. That log is converted into a voltage-to-percent curve in 5% steps and written to the microSD card as `custom_battery_discharge_curve.json` (in the MicroSD directory).
+
+By default, the battery meter assumes a standard 3.7V LiPo cell.
+
+On boot, SeedSigner loads the custom curve when it exists; otherwise it falls back to the built-in default curve.

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -221,8 +221,9 @@ class Controller(Singleton):
         controller.microsd.start_detection()
 
         controller.battery_hat = BatteryHat.get_instance()
-        controller.battery_hat.start()
         controller.battery_hat.process_discharge_log()
+        controller.battery_hat.load_discharge_curve()
+        controller.battery_hat.start()
 
         # Store one working psbt in memory
         controller.psbt = None

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -222,6 +222,7 @@ class Controller(Singleton):
 
         controller.battery_hat = BatteryHat.get_instance()
         controller.battery_hat.start()
+        controller.battery_hat.process_discharge_log()
 
         # Store one working psbt in memory
         controller.psbt = None

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -198,6 +198,7 @@ class FontAwesomeIconConstants:
     BATTERY_HALF = "\uf242"
     BATTERY_QUARTER = "\uf243"
     BATTERY_EMPTY = "\uf244"
+    BATTERY_CHARGING = "\uf0e7"
 
 
 
@@ -1796,6 +1797,7 @@ class TopNav(BaseComponent):
 class BatteryIndicator(BaseComponent):
     """Simple battery indicator component."""
     percent: float = 0
+    charging: bool = False
     screen_x: int = 0
     screen_y: int = 0
     icon_size: int = GUIConstants.ICON_FONT_SIZE
@@ -1804,6 +1806,7 @@ class BatteryIndicator(BaseComponent):
     def __post_init__(self):
         super().__post_init__()
         self.font = Fonts.get_font(GUIConstants.ICON_FONT_NAME__FONT_AWESOME, self.icon_size)
+        self.charging_font = Fonts.get_font(GUIConstants.ICON_FONT_NAME__FONT_AWESOME, max(10, self.icon_size - 6))
         self.text_font = Fonts.get_font(GUIConstants.get_body_font_name(), self.font_size)
         # Pre-calc height from icon/text
         (left, top, right, bottom) = self.font.getbbox(FontAwesomeIconConstants.BATTERY_FULL, anchor="ls")
@@ -1835,27 +1838,41 @@ class BatteryIndicator(BaseComponent):
         )
 
         icon = self._icon_from_percent()
+        icon_color = GUIConstants.BODY_FONT_COLOR
+        if self.percent is not None and self.percent < 20:
+            icon_color = GUIConstants.ERROR_COLOR
         self.image_draw.text(
             (self.screen_x, self.screen_y + self.height),
             text=icon,
             font=self.font,
-            fill=GUIConstants.BODY_FONT_COLOR,
+            fill=icon_color,
             anchor="ls",
         )
 
-        if self.percent is not None:
-            pct_text = f"{int(self.percent)}%"
+        if self.charging:
+            charging_icon = FontAwesomeIconConstants.BATTERY_CHARGING
+            text_x = self.screen_x + self.font.getlength(icon) + GUIConstants.COMPONENT_PADDING
+            self.image_draw.text(
+                (text_x, self.screen_y + self.height),
+                text=charging_icon,
+                font=self.charging_font,
+                fill=GUIConstants.BODY_FONT_COLOR,
+                anchor="ls",
+            )
         else:
-            pct_text = "--%"
+            if self.percent is not None:
+                pct_text = f"{int(self.percent)}%"
+            else:
+                pct_text = "--%"
 
-        text_x = self.screen_x + self.font.getlength(icon) + GUIConstants.COMPONENT_PADDING
-        self.image_draw.text(
-            (text_x, self.screen_y + self.height),
-            text=pct_text,
-            font=self.text_font,
-            fill=GUIConstants.BODY_FONT_COLOR,
-            anchor="ls",
-        )
+            text_x = self.screen_x + self.font.getlength(icon) + GUIConstants.COMPONENT_PADDING
+            self.image_draw.text(
+                (text_x, self.screen_y + self.height),
+                text=pct_text,
+                font=self.text_font,
+                fill=GUIConstants.BODY_FONT_COLOR,
+                anchor="ls",
+            )
 
 
 

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1376,20 +1376,47 @@ class MainMenuScreen(LargeButtonScreen):
         self.battery_indicator = BatteryIndicator()
         self.battery_indicator.screen_x = GUIConstants.EDGE_PADDING
         self.battery_indicator.screen_y = GUIConstants.EDGE_PADDING
-        self.last_battery_update = 0
         if self.battery_hat.detected:
             self.components.append(self.battery_indicator)
+        self.threads.append(MainMenuScreen.UpdateThread(self))
 
     def _run_callback(self):
-        if self.battery_hat.detected:
-            if self.battery_indicator not in self.components:
-                self.components.append(self.battery_indicator)
-            cur_time = time.time()
-            if cur_time - self.last_battery_update > 60:
-                percent = self.battery_hat.get_percent()
-                if percent is not None:
-                    with self.renderer.lock:
-                        self.battery_indicator.percent = percent
-                        self.battery_indicator.render()
-                        self.renderer.show_image()
-                self.last_battery_update = cur_time
+        return None
+
+    class UpdateThread(BaseThread):
+        def __init__(self, screen):
+            super().__init__()
+            self.screen = screen
+            self.battery_hat = screen.battery_hat
+            self.last_percent = None
+            self.last_charging = None
+
+        def run(self):
+            while self.keep_running:
+                if not self.battery_hat.detected:
+                    self.battery_hat.detected = self.battery_hat.detect_hat()
+
+                if self.battery_hat.detected and self.screen.battery_indicator not in self.screen.components:
+                    with self.screen.renderer.lock:
+                        self.screen.components.append(self.screen.battery_indicator)
+                        self.screen.battery_indicator.render()
+                        self.screen.renderer.show_image()
+
+                percent = None
+                current = None
+                if self.battery_hat.detected:
+                    percent = self.battery_hat.get_percent()
+                    current = self.battery_hat.get_current()
+                charging = current is not None and current > 0
+                percent_display = int(percent) if percent is not None else None
+
+                if percent_display != self.last_percent or charging != self.last_charging:
+                    self.last_percent = percent_display
+                    self.last_charging = charging
+                    with self.screen.renderer.lock:
+                        self.screen.battery_indicator.percent = percent
+                        self.screen.battery_indicator.charging = charging
+                        self.screen.battery_indicator.render()
+                        self.screen.renderer.show_image()
+
+                time.sleep(1)

--- a/src/seedsigner/gui/screens/settings_screens.py
+++ b/src/seedsigner/gui/screens/settings_screens.py
@@ -386,6 +386,15 @@ class BatteryInfoScreen(BaseTopNavScreen):
         )
         self.components.append(self.percent_text)
 
+        start_y += self.percent_text.height + GUIConstants.COMPONENT_PADDING
+        self.curve_text = TextArea(
+            text="Curve: --",
+            is_text_centered=True,
+            screen_y=start_y,
+            font_size=self.info_font_size,
+        )
+        self.components.append(self.curve_text)
+
         self.threads.append(BatteryInfoScreen.UpdateThread(self))
 
     def _replace_info_text(self, attribute: str, text: str) -> None:
@@ -443,10 +452,16 @@ class BatteryInfoScreen(BaseTopNavScreen):
                         percent_text = f"Percent: {percent:.1f}%"
                     else:
                         percent_text = "Percent: --%"
+                    curve_label = self.battery_hat.get_curve_label()
+                    if curve_label:
+                        curve_text = f"Curve: {curve_label}"
+                    else:
+                        curve_text = "Curve: default"
                     self.screen._replace_info_text("voltage_text", voltage_text)
                     self.screen._replace_info_text("current_text", current_text)
                     self.screen._replace_info_text("power_text", power_text)
                     self.screen._replace_info_text("percent_text", percent_text)
+                    self.screen._replace_info_text("curve_text", curve_text)
                     self.screen.renderer.show_image()
                 time.sleep(5)
 

--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -1,5 +1,4 @@
 import math
-import random
 import time
 
 from dataclasses import dataclass
@@ -106,33 +105,16 @@ class ToolsBatteryCalibrationRunningScreen(BaseScreen):
 
     def __post_init__(self):
         super().__post_init__()
-        self.logo = load_image("logo_black_240.png")
-        self.image = Image.new(
-            "RGB",
-            (self.renderer.canvas_width + self.logo.width, self.renderer.canvas_height + self.logo.height),
-            (0, 0, 0),
-        )
-        logo_x = int((self.image.width - self.logo.width) / 2)
-        logo_y = int((self.image.height - self.logo.height) / 2)
-        self.image.paste(self.logo, (logo_x, logo_y))
-        self.min_coords = (0, 0)
-        self.max_coords = (self.renderer.canvas_width, self.renderer.canvas_height)
-        self.cur_x = int(self.logo.width / 2)
-        self.cur_y = int(self.logo.height / 2)
-        self.increment_x = self._rand_increment()
-        self.increment_y = self._rand_increment()
+        self.status_font = Fonts.get_font(GUIConstants.get_body_font_name(), GUIConstants.get_body_font_size())
         self.camera = Camera.get_instance()
 
-    def _rand_increment(self) -> float:
-        max_increment = 10.0
-        min_increment = 1.0
-        increment = random.uniform(min_increment, max_increment)
-        if random.uniform(-1.0, 1.0) < 0.0:
-            return -1.0 * increment
-        return increment
+    def _format_elapsed(self, elapsed_seconds: int) -> str:
+        hours = elapsed_seconds // 3600
+        minutes = (elapsed_seconds % 3600) // 60
+        seconds = elapsed_seconds % 60
+        return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
 
-    def _write_log_line(self, handle, timestamp: int) -> None:
-        voltage = self.battery_hat.get_voltage()
+    def _write_log_line(self, handle, timestamp: int, voltage: float | None) -> None:
         if voltage is None:
             handle.write(f"{timestamp},\n")
         else:
@@ -147,51 +129,68 @@ class ToolsBatteryCalibrationRunningScreen(BaseScreen):
             camera_started = True
         except Exception:
             camera_started = False
+        start_time = time.monotonic()
+        last_render_time = 0.0
+        charging_start_time = None
         next_log_time = time.monotonic()
         try:
             with self.log_path.open("w", encoding="utf-8") as handle:
-                with self.renderer.lock:
-                    while True:
-                        if self.hw_inputs.has_any_input() or self.hw_inputs.override_ind:
+                while True:
+                    if self.hw_inputs.has_any_input() or self.hw_inputs.override_ind:
+                        if self.log_path.exists():
+                            self.log_path.unlink()
+                        return RET_CODE__BACK_BUTTON
+
+                    now = time.monotonic()
+                    voltage = self.battery_hat.get_voltage()
+                    current = self.battery_hat.get_current()
+
+                    if current is not None and current < 0:
+                        if charging_start_time is None:
+                            charging_start_time = now
+                        elif now - charging_start_time >= 30:
                             if self.log_path.exists():
                                 self.log_path.unlink()
                             return RET_CODE__BACK_BUTTON
+                    else:
+                        charging_start_time = None
 
-                        now = time.monotonic()
-                        if now >= next_log_time:
-                            self._write_log_line(handle, int(time.time()))
-                            next_log_time = now + 60
+                    if now >= next_log_time:
+                        if current is None or current >= 0:
+                            self._write_log_line(handle, int(time.time()), voltage)
+                        next_log_time = now + 60
 
-                        crop = self.image.crop((
-                            self.cur_x, self.cur_y,
-                            self.cur_x + self.renderer.canvas_width, self.cur_y + self.renderer.canvas_height,
-                        ))
-                        self.renderer.disp.show_image(crop, 0, 0)
+                    if now - last_render_time >= 0.5:
+                        elapsed_text = self._format_elapsed(int(now - start_time))
+                        voltage_text = "--" if voltage is None else f"{voltage:.2f} V"
+                        current_text = "--" if current is None else f"{current:.0f} mA"
+                        status_text = _("Charging detected") if current is not None and current < 0 else _("Discharging")
 
-                        self.cur_x += self.increment_x
-                        self.cur_y += self.increment_y
+                        with self.renderer.lock:
+                            self.renderer.draw.rectangle(
+                                (0, 0, self.renderer.canvas_width, self.renderer.canvas_height),
+                                fill=GUIConstants.BACKGROUND_COLOR,
+                            )
+                            y = GUIConstants.EDGE_PADDING
+                            line_spacing = self.status_font.size + GUIConstants.COMPONENT_PADDING
+                            for line in (
+                                _("Elapsed: ") + elapsed_text,
+                                _("Voltage: ") + voltage_text,
+                                _("Current: ") + current_text,
+                                _("Status: ") + status_text,
+                            ):
+                                self.renderer.draw.text(
+                                    (GUIConstants.EDGE_PADDING, y),
+                                    text=line,
+                                    fill=GUIConstants.BODY_FONT_COLOR,
+                                    font=self.status_font,
+                                    anchor="lt",
+                                )
+                                y += line_spacing
+                            self.renderer.show_image()
+                        last_render_time = now
 
-                        if self.cur_x < self.min_coords[0]:
-                            self.cur_x = self.min_coords[0]
-                            self.increment_x = self._rand_increment()
-                            if self.increment_x < 0.0:
-                                self.increment_x *= -1.0
-                        elif self.cur_x > self.max_coords[0]:
-                            self.cur_x = self.max_coords[0]
-                            self.increment_x = self._rand_increment()
-                            if self.increment_x > 0.0:
-                                self.increment_x *= -1.0
-
-                        if self.cur_y < self.min_coords[1]:
-                            self.cur_y = self.min_coords[1]
-                            self.increment_y = self._rand_increment()
-                            if self.increment_y < 0.0:
-                                self.increment_y *= -1.0
-                        elif self.cur_y > self.max_coords[1]:
-                            self.cur_y = self.max_coords[1]
-                            self.increment_y = self._rand_increment()
-                            if self.increment_y > 0.0:
-                                self.increment_y *= -1.0
+                    time.sleep(0.1)
         finally:
             if camera_started:
                 self.camera.stop_video_stream_mode()

--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -79,7 +79,7 @@ class ToolsBatteryCalibrationIntroScreen(ButtonListScreen):
         super().__post_init__()
 
         self.components.append(TextArea(
-            text=_("Charge the battery until it is full, then select Next to begin the discharge test."),
+            text=_("Charge the battery fully. Select Next to start the discharge test."),
             screen_y=self.top_nav.height + int(GUIConstants.COMPONENT_PADDING / 2),
         ))
 
@@ -94,15 +94,15 @@ class ToolsBatteryCalibrationStartScreen(ButtonListScreen):
         super().__post_init__()
 
         self.components.append(TextArea(
-            text=_("This test will run until the battery is flat. Leave the device connected to nothing and allow it to fully discharge."),
+            text=_("Test runs until empty. Leave the device unplugged."),
             screen_y=self.top_nav.height + int(GUIConstants.COMPONENT_PADDING / 2),
         ))
 
 
 @dataclass
 class ToolsBatteryCalibrationRunningScreen(BaseScreen):
-    log_path: Path
-    battery_hat: Any
+    log_path: Path = None
+    battery_hat: Any = None
 
     def __post_init__(self):
         super().__post_init__()

--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -1,15 +1,17 @@
 import math
+import random
 import time
 
 from dataclasses import dataclass
 from gettext import gettext as _
+from pathlib import Path
 from typing import Any, List
 from PIL import Image, ImageDraw
 from seedsigner.helpers import mnemonic_generation
 from seedsigner.gui.renderer import Renderer
 from seedsigner.hardware.camera import Camera
 from seedsigner.helpers.qr import QR
-from seedsigner.gui.components import FontAwesomeIconConstants, Fonts, GUIConstants, IconTextLine, SeedSignerIconConstants, TextArea, Button, IconButton, CheckboxButton
+from seedsigner.gui.components import FontAwesomeIconConstants, Fonts, GUIConstants, IconTextLine, SeedSignerIconConstants, TextArea, Button, IconButton, CheckboxButton, load_image
 from seedsigner.gui.keyboard import Keyboard, TextEntryDisplay
 from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, BaseScreen, BaseTopNavScreen, ButtonListScreen, KeyboardScreen, WarningEdgesMixin, ButtonOption
 from seedsigner.hardware.buttons import HardwareButtonsConstants
@@ -66,6 +68,133 @@ class ToolsNetworkInfoScreen(ButtonListScreen):
         )
         self.components.append(message_display)
 
+
+@dataclass
+class ToolsBatteryCalibrationIntroScreen(ButtonListScreen):
+    def __post_init__(self):
+        self.title = _("Battery Calibration")
+        self.is_bottom_list = True
+        self.is_button_text_centered = True
+        self.button_data = [ButtonOption(_("Next"))]
+        super().__post_init__()
+
+        self.components.append(TextArea(
+            text=_("Charge the battery until it is full, then select Next to begin the discharge test."),
+            screen_y=self.top_nav.height + int(GUIConstants.COMPONENT_PADDING / 2),
+        ))
+
+
+@dataclass
+class ToolsBatteryCalibrationStartScreen(ButtonListScreen):
+    def __post_init__(self):
+        self.title = _("Battery Calibration")
+        self.is_bottom_list = True
+        self.is_button_text_centered = True
+        self.button_data = [ButtonOption(_("Start"))]
+        super().__post_init__()
+
+        self.components.append(TextArea(
+            text=_("This test will run until the battery is flat. Leave the device connected to nothing and allow it to fully discharge."),
+            screen_y=self.top_nav.height + int(GUIConstants.COMPONENT_PADDING / 2),
+        ))
+
+
+@dataclass
+class ToolsBatteryCalibrationRunningScreen(BaseScreen):
+    log_path: Path
+    battery_hat: Any
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.logo = load_image("logo_black_240.png")
+        self.image = Image.new(
+            "RGB",
+            (self.renderer.canvas_width + self.logo.width, self.renderer.canvas_height + self.logo.height),
+            (0, 0, 0),
+        )
+        logo_x = int((self.image.width - self.logo.width) / 2)
+        logo_y = int((self.image.height - self.logo.height) / 2)
+        self.image.paste(self.logo, (logo_x, logo_y))
+        self.min_coords = (0, 0)
+        self.max_coords = (self.renderer.canvas_width, self.renderer.canvas_height)
+        self.cur_x = int(self.logo.width / 2)
+        self.cur_y = int(self.logo.height / 2)
+        self.increment_x = self._rand_increment()
+        self.increment_y = self._rand_increment()
+        self.camera = Camera.get_instance()
+
+    def _rand_increment(self) -> float:
+        max_increment = 10.0
+        min_increment = 1.0
+        increment = random.uniform(min_increment, max_increment)
+        if random.uniform(-1.0, 1.0) < 0.0:
+            return -1.0 * increment
+        return increment
+
+    def _write_log_line(self, handle, timestamp: int) -> None:
+        voltage = self.battery_hat.get_voltage()
+        if voltage is None:
+            handle.write(f"{timestamp},\n")
+        else:
+            handle.write(f"{timestamp},{voltage:.4f}\n")
+        handle.flush()
+
+    def _run(self):
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        camera_started = False
+        try:
+            self.camera.start_video_stream_mode(resolution=(320, 240), framerate=30, format="rgb")
+            camera_started = True
+        except Exception:
+            camera_started = False
+        next_log_time = time.monotonic()
+        try:
+            with self.log_path.open("w", encoding="utf-8") as handle:
+                with self.renderer.lock:
+                    while True:
+                        if self.hw_inputs.has_any_input() or self.hw_inputs.override_ind:
+                            if self.log_path.exists():
+                                self.log_path.unlink()
+                            return RET_CODE__BACK_BUTTON
+
+                        now = time.monotonic()
+                        if now >= next_log_time:
+                            self._write_log_line(handle, int(time.time()))
+                            next_log_time = now + 60
+
+                        crop = self.image.crop((
+                            self.cur_x, self.cur_y,
+                            self.cur_x + self.renderer.canvas_width, self.cur_y + self.renderer.canvas_height,
+                        ))
+                        self.renderer.disp.show_image(crop, 0, 0)
+
+                        self.cur_x += self.increment_x
+                        self.cur_y += self.increment_y
+
+                        if self.cur_x < self.min_coords[0]:
+                            self.cur_x = self.min_coords[0]
+                            self.increment_x = self._rand_increment()
+                            if self.increment_x < 0.0:
+                                self.increment_x *= -1.0
+                        elif self.cur_x > self.max_coords[0]:
+                            self.cur_x = self.max_coords[0]
+                            self.increment_x = self._rand_increment()
+                            if self.increment_x > 0.0:
+                                self.increment_x *= -1.0
+
+                        if self.cur_y < self.min_coords[1]:
+                            self.cur_y = self.min_coords[1]
+                            self.increment_y = self._rand_increment()
+                            if self.increment_y < 0.0:
+                                self.increment_y *= -1.0
+                        elif self.cur_y > self.max_coords[1]:
+                            self.cur_y = self.max_coords[1]
+                            self.increment_y = self._rand_increment()
+                            if self.increment_y > 0.0:
+                                self.increment_y *= -1.0
+        finally:
+            if camera_started:
+                self.camera.stop_video_stream_mode()
 
 @dataclass
 class ToolsImageEntropyLivePreviewScreen(BaseScreen):

--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -145,7 +145,7 @@ class ToolsBatteryCalibrationRunningScreen(BaseScreen):
                     voltage = self.battery_hat.get_voltage()
                     current = self.battery_hat.get_current()
 
-                    if current is not None and current < 0:
+                    if current is not None and current > 0:
                         if charging_start_time is None:
                             charging_start_time = now
                         elif now - charging_start_time >= 30:
@@ -156,7 +156,7 @@ class ToolsBatteryCalibrationRunningScreen(BaseScreen):
                         charging_start_time = None
 
                     if now >= next_log_time:
-                        if current is None or current >= 0:
+                        if current is None or current <= 0:
                             self._write_log_line(handle, int(time.time()), voltage)
                         next_log_time = now + 60
 
@@ -164,7 +164,7 @@ class ToolsBatteryCalibrationRunningScreen(BaseScreen):
                         elapsed_text = self._format_elapsed(int(now - start_time))
                         voltage_text = "--" if voltage is None else f"{voltage:.2f} V"
                         current_text = "--" if current is None else f"{current:.0f} mA"
-                        status_text = _("Charging detected") if current is not None and current < 0 else _("Discharging")
+                        status_text = _("Charging detected") if current is not None and current > 0 else _("Discharging")
 
                         with self.renderer.lock:
                             self.renderer.draw.rectangle(

--- a/src/seedsigner/hardware/battery_hat.py
+++ b/src/seedsigner/hardware/battery_hat.py
@@ -333,7 +333,6 @@ class BatteryHat(Singleton, BaseThread):
         curve_path = self.get_discharge_curve_path()
         curve_path.parent.mkdir(parents=True, exist_ok=True)
         payload = {
-            "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "source_log": log_path.name,
             "curve": curve,
         }

--- a/src/seedsigner/hardware/battery_hat.py
+++ b/src/seedsigner/hardware/battery_hat.py
@@ -68,6 +68,29 @@ class BatteryHat(Singleton, BaseThread):
     MAX_VOLTAGE = 4.2
 
     UPDATE_PERIOD = 60  # seconds
+    DEFAULT_DISCHARGE_CURVE = [
+        {"percent": 100, "voltage": 4.032},
+        {"percent": 95, "voltage": 3.9804},
+        {"percent": 90, "voltage": 3.9676},
+        {"percent": 85, "voltage": 3.952},
+        {"percent": 80, "voltage": 3.936},
+        {"percent": 75, "voltage": 3.905},
+        {"percent": 70, "voltage": 3.8652},
+        {"percent": 65, "voltage": 3.8334},
+        {"percent": 60, "voltage": 3.8136},
+        {"percent": 55, "voltage": 3.7858},
+        {"percent": 50, "voltage": 3.7619},
+        {"percent": 45, "voltage": 3.732},
+        {"percent": 40, "voltage": 3.6927},
+        {"percent": 35, "voltage": 3.6356},
+        {"percent": 30, "voltage": 3.5775},
+        {"percent": 25, "voltage": 3.531},
+        {"percent": 20, "voltage": 3.4904},
+        {"percent": 15, "voltage": 3.4433},
+        {"percent": 10, "voltage": 3.3991},
+        {"percent": 5, "voltage": 3.3313},
+        {"percent": 0, "voltage": 2.98},
+    ]
 
     @classmethod
     def reset_instance(cls):
@@ -90,7 +113,7 @@ class BatteryHat(Singleton, BaseThread):
             instance.percent = None
             instance.detected = False
             instance._curve_data = None
-            instance._curve_mtime = None
+            instance._curve_label = None
         return cls._instance
 
     @classmethod
@@ -103,7 +126,7 @@ class BatteryHat(Singleton, BaseThread):
     def get_discharge_curve_path(cls):
         from seedsigner.hardware.microsd import MicroSD
 
-        return MicroSD.get_microsd_dir() / "battery_discharge_curve.json"
+        return MicroSD.get_microsd_dir() / "custom_battery_discharge_curve.json"
 
     def _open_bus(self):
         if self._bus is None:
@@ -218,18 +241,16 @@ class BatteryHat(Singleton, BaseThread):
         pct = (voltage - self.MIN_VOLTAGE) / (self.MAX_VOLTAGE - self.MIN_VOLTAGE) * 100
         return max(0, min(100, pct))
 
-    def _load_discharge_curve(self) -> list[dict] | None:
-        curve_path = self.get_discharge_curve_path()
+    def load_discharge_curve(self) -> None:
+        curve = self._load_curve_from_path(self.get_discharge_curve_path())
+        if curve:
+            return
+        self._curve_data = list(self.DEFAULT_DISCHARGE_CURVE)
+        self._curve_label = "default"
+
+    def _load_curve_from_path(self, curve_path: Path) -> list[dict] | None:
         if not curve_path.exists():
-            self._curve_data = None
-            self._curve_mtime = None
             return None
-        try:
-            mtime = curve_path.stat().st_mtime
-        except OSError:
-            return None
-        if self._curve_data is not None and self._curve_mtime == mtime:
-            return self._curve_data
         try:
             with curve_path.open("r", encoding="utf-8") as handle:
                 data = json.load(handle)
@@ -240,8 +261,13 @@ class BatteryHat(Singleton, BaseThread):
         if not isinstance(curve, list):
             return None
         self._curve_data = curve
-        self._curve_mtime = mtime
+        self._curve_label = curve_path.name
         return curve
+
+    def _load_discharge_curve(self) -> list[dict] | None:
+        if self._curve_data is None:
+            self.load_discharge_curve()
+        return self._curve_data
 
     def _percent_from_curve(self, voltage: float, curve: list[dict]) -> float | None:
         points = []
@@ -268,10 +294,7 @@ class BatteryHat(Singleton, BaseThread):
         return None
 
     def get_curve_label(self) -> str | None:
-        curve_path = self.get_discharge_curve_path()
-        if curve_path.exists():
-            return curve_path.name
-        return None
+        return self._curve_label
 
     def _load_discharge_log_entries(self, log_path: Path) -> list[tuple[float, float]]:
         entries: list[tuple[float, float]] = []

--- a/src/seedsigner/hardware/battery_hat.py
+++ b/src/seedsigner/hardware/battery_hat.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from pathlib import Path
 
 try:
     from smbus2 import SMBus  # type: ignore
@@ -271,6 +272,79 @@ class BatteryHat(Singleton, BaseThread):
         if curve_path.exists():
             return curve_path.name
         return None
+
+    def _load_discharge_log_entries(self, log_path: Path) -> list[tuple[float, float]]:
+        entries: list[tuple[float, float]] = []
+        try:
+            with log_path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    parts = line.strip().split(",")
+                    if len(parts) < 2:
+                        continue
+                    try:
+                        timestamp = float(parts[0])
+                        voltage = float(parts[1])
+                    except ValueError:
+                        continue
+                    entries.append((timestamp, voltage))
+        except OSError as exc:
+            logger.warning(f"Failed to read battery discharge log: {exc}")
+        return entries
+
+    def _generate_discharge_curve(self, entries: list[tuple[float, float]], step: int) -> list[dict]:
+        entries.sort(key=lambda item: item[0])
+        start_time = entries[0][0]
+        end_time = entries[-1][0]
+        duration = end_time - start_time
+        if duration <= 0:
+            return []
+
+        curve: list[dict] = []
+        idx = 0
+        for percent in range(100, -1, -step):
+            target_time = start_time + (1 - percent / 100) * duration
+            while idx < len(entries) - 2 and entries[idx + 1][0] < target_time:
+                idx += 1
+            low_t, low_v = entries[idx]
+            high_t, high_v = entries[min(idx + 1, len(entries) - 1)]
+            if high_t == low_t:
+                voltage = low_v
+            else:
+                t = (target_time - low_t) / (high_t - low_t)
+                voltage = low_v + t * (high_v - low_v)
+            curve.append({"percent": percent, "voltage": round(voltage, 4)})
+        return curve
+
+    def process_discharge_log(self, step: int = 5) -> bool:
+        log_path = self.get_discharge_log_path()
+        if not log_path.exists():
+            return False
+
+        entries = self._load_discharge_log_entries(log_path)
+        if len(entries) < 2:
+            log_path.unlink(missing_ok=True)
+            return False
+
+        curve = self._generate_discharge_curve(entries, step)
+        if not curve:
+            log_path.unlink(missing_ok=True)
+            return False
+
+        curve_path = self.get_discharge_curve_path()
+        curve_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "source_log": log_path.name,
+            "curve": curve,
+        }
+        try:
+            with curve_path.open("w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2)
+        except OSError as exc:
+            logger.warning(f"Failed to write discharge curve: {exc}")
+            return False
+        log_path.unlink(missing_ok=True)
+        return True
 
     def run(self):
         while self.keep_running:

--- a/src/seedsigner/hardware/battery_hat.py
+++ b/src/seedsigner/hardware/battery_hat.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 
@@ -87,7 +88,21 @@ class BatteryHat(Singleton, BaseThread):
             instance._bus = None
             instance.percent = None
             instance.detected = False
+            instance._curve_data = None
+            instance._curve_mtime = None
         return cls._instance
+
+    @classmethod
+    def get_discharge_log_path(cls):
+        from seedsigner.hardware.microsd import MicroSD
+
+        return MicroSD.get_microsd_dir() / "battery_discharge_log.csv"
+
+    @classmethod
+    def get_discharge_curve_path(cls):
+        from seedsigner.hardware.microsd import MicroSD
+
+        return MicroSD.get_microsd_dir() / "battery_discharge_curve.json"
 
     def _open_bus(self):
         if self._bus is None:
@@ -194,9 +209,68 @@ class BatteryHat(Singleton, BaseThread):
         voltage = self.read_voltage()
         if voltage is None:
             return None
+        curve = self._load_discharge_curve()
+        if curve:
+            pct = self._percent_from_curve(voltage, curve)
+            if pct is not None:
+                return max(0, min(100, pct))
         pct = (voltage - self.MIN_VOLTAGE) / (self.MAX_VOLTAGE - self.MIN_VOLTAGE) * 100
-        pct = max(0, min(100, pct))
-        return pct
+        return max(0, min(100, pct))
+
+    def _load_discharge_curve(self) -> list[dict] | None:
+        curve_path = self.get_discharge_curve_path()
+        if not curve_path.exists():
+            self._curve_data = None
+            self._curve_mtime = None
+            return None
+        try:
+            mtime = curve_path.stat().st_mtime
+        except OSError:
+            return None
+        if self._curve_data is not None and self._curve_mtime == mtime:
+            return self._curve_data
+        try:
+            with curve_path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(f"Failed to load discharge curve: {exc}")
+            return None
+        curve = data.get("curve")
+        if not isinstance(curve, list):
+            return None
+        self._curve_data = curve
+        self._curve_mtime = mtime
+        return curve
+
+    def _percent_from_curve(self, voltage: float, curve: list[dict]) -> float | None:
+        points = []
+        for entry in curve:
+            try:
+                points.append((float(entry["voltage"]), float(entry["percent"])))
+            except (KeyError, TypeError, ValueError):
+                continue
+        if len(points) < 2:
+            return None
+        points.sort(key=lambda item: item[0])
+        if voltage <= points[0][0]:
+            return points[0][1]
+        if voltage >= points[-1][0]:
+            return points[-1][1]
+        for idx in range(1, len(points)):
+            low_v, low_p = points[idx - 1]
+            high_v, high_p = points[idx]
+            if voltage <= high_v:
+                if high_v == low_v:
+                    return low_p
+                t = (voltage - low_v) / (high_v - low_v)
+                return low_p + t * (high_p - low_p)
+        return None
+
+    def get_curve_label(self) -> str | None:
+        curve_path = self.get_discharge_curve_path()
+        if curve_path.exists():
+            return curve_path.name
+        return None
 
     def run(self):
         while self.keep_running:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 import os
 import time
@@ -31,7 +32,8 @@ from seedsigner.gui.screens.tools_screens import (ToolsCalcFinalWordDoneScreen, 
     ToolsCalcFinalWordScreen, ToolsCoinFlipEntryScreen, ToolsDiceEntropyEntryScreen, ToolsImageEntropyFinalImageScreen,
     ToolsImageEntropyLivePreviewScreen, ToolsAddressExplorerAddressTypeScreen, ToolsTextQRTextEntryScreen, ToolsTextQRReviewTextScreen,
     ToolsTextQRTranscribeModePromptScreen, ToolsTranscribeTextQRWholeQRScreen, ToolsTranscribeTextQRZoomedInScreen,
-    ToolsTranscribeTextQRConfirmQRPromptScreen, ToolsCommonFilterScreen, ToolsNetworkInfoScreen)
+    ToolsTranscribeTextQRConfirmQRPromptScreen, ToolsCommonFilterScreen, ToolsNetworkInfoScreen,
+    ToolsBatteryCalibrationIntroScreen, ToolsBatteryCalibrationStartScreen, ToolsBatteryCalibrationRunningScreen)
 from seedsigner.helpers import embit_utils, mnemonic_generation
 from seedsigner.helpers.iso7816 import format_sw_error
 from seedsigner.models.decode_qr import DecodeQR
@@ -84,6 +86,7 @@ class ToolsMenuView(View):
     TEXTQRCODE = ButtonOption("Text QR Code")
     SMARTCARD = ButtonOption("Smartcard Tools", FontAwesomeIconConstants.LOCK)
     MICROSD = ButtonOption("MicroSD Tools")
+    BATTERY_CALIBRATION = ButtonOption("Battery Calibration")
     GPG = ButtonOption("GPG Tools")
     CLEAR_DESCRIPTOR = ButtonOption("Clear Multisig Descriptor")
     NETWORK_INFO = ButtonOption("Network Info")
@@ -103,6 +106,7 @@ class ToolsMenuView(View):
             self.VERIFY_ADDRESS,
             self.TEXTQRCODE,
             self.MICROSD,
+            self.BATTERY_CALIBRATION,
             self.NETWORK_INFO if Path("/usr/bin/network-info").is_file() else None,
             self.GPG,
             self.CLEAR_DESCRIPTOR,
@@ -152,6 +156,9 @@ class ToolsMenuView(View):
         elif button_data[selected_menu_num] == self.MICROSD:
             return Destination(ToolsMicroSDMenuView)
 
+        elif button_data[selected_menu_num] == self.BATTERY_CALIBRATION:
+            return Destination(ToolsBatteryCalibrationView)
+
         elif button_data[selected_menu_num] == self.NETWORK_INFO:
             return Destination(ToolsNetworkInfoView)
 
@@ -169,6 +176,118 @@ class ToolsMenuView(View):
             )
             return Destination(BackStackView)
 
+
+
+class ToolsBatteryCalibrationView(View):
+    CALIBRATION_STEP = 5
+
+    def _load_log_entries(self, log_path: Path) -> list[tuple[float, float]]:
+        entries: list[tuple[float, float]] = []
+        try:
+            with log_path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    parts = line.strip().split(",")
+                    if len(parts) < 2:
+                        continue
+                    try:
+                        timestamp = float(parts[0])
+                        voltage = float(parts[1])
+                    except ValueError:
+                        continue
+                    entries.append((timestamp, voltage))
+        except OSError as exc:
+            logger.warning(f"Failed to read battery discharge log: {exc}")
+        return entries
+
+    def _generate_curve(self, entries: list[tuple[float, float]]) -> list[dict]:
+        entries.sort(key=lambda item: item[0])
+        start_time = entries[0][0]
+        end_time = entries[-1][0]
+        duration = end_time - start_time
+        if duration <= 0:
+            return []
+
+        curve: list[dict] = []
+        idx = 0
+        for percent in range(100, -1, -self.CALIBRATION_STEP):
+            target_time = start_time + (1 - percent / 100) * duration
+            while idx < len(entries) - 2 and entries[idx + 1][0] < target_time:
+                idx += 1
+            low_t, low_v = entries[idx]
+            high_t, high_v = entries[min(idx + 1, len(entries) - 1)]
+            if high_t == low_t:
+                voltage = low_v
+            else:
+                t = (target_time - low_t) / (high_t - low_t)
+                voltage = low_v + t * (high_v - low_v)
+            curve.append({"percent": percent, "voltage": round(voltage, 4)})
+        return curve
+
+    def _process_existing_log(self) -> None:
+        from seedsigner.hardware.battery_hat import BatteryHat
+
+        battery_hat = BatteryHat.get_instance()
+        log_path = battery_hat.get_discharge_log_path()
+        if not log_path.exists():
+            return
+
+        entries = self._load_log_entries(log_path)
+        if len(entries) < 2:
+            log_path.unlink(missing_ok=True)
+            return
+
+        curve = self._generate_curve(entries)
+        if not curve:
+            log_path.unlink(missing_ok=True)
+            return
+
+        curve_path = battery_hat.get_discharge_curve_path()
+        curve_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "source_log": log_path.name,
+            "curve": curve,
+        }
+        try:
+            with curve_path.open("w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2)
+        except OSError as exc:
+            logger.warning(f"Failed to write discharge curve: {exc}")
+        log_path.unlink(missing_ok=True)
+
+    def run(self):
+        self._process_existing_log()
+
+        microsd = MicroSD.get_instance()
+        if not microsd.is_inserted:
+            self.run_screen(
+                WarningScreen,
+                title=_("microSD card not detected"),
+                text=_("Insert a microSD card to save the discharge log."),
+                button_data=[ButtonOption(_("Back"))],
+            )
+            return Destination(BackStackView)
+
+        ret = self.run_screen(ToolsBatteryCalibrationIntroScreen)
+        if ret == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        ret = self.run_screen(ToolsBatteryCalibrationStartScreen)
+        if ret == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        from seedsigner.hardware.battery_hat import BatteryHat
+
+        battery_hat = BatteryHat.get_instance()
+        log_path = battery_hat.get_discharge_log_path()
+        ret = ToolsBatteryCalibrationRunningScreen(
+            log_path=log_path,
+            battery_hat=battery_hat,
+        ).display()
+
+        if ret == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+        return Destination(BackStackView)
 
 
 class ToolsNetworkInfoView(View):

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -181,82 +181,10 @@ class ToolsMenuView(View):
 class ToolsBatteryCalibrationView(View):
     CALIBRATION_STEP = 5
 
-    def _load_log_entries(self, log_path: Path) -> list[tuple[float, float]]:
-        entries: list[tuple[float, float]] = []
-        try:
-            with log_path.open("r", encoding="utf-8") as handle:
-                for line in handle:
-                    parts = line.strip().split(",")
-                    if len(parts) < 2:
-                        continue
-                    try:
-                        timestamp = float(parts[0])
-                        voltage = float(parts[1])
-                    except ValueError:
-                        continue
-                    entries.append((timestamp, voltage))
-        except OSError as exc:
-            logger.warning(f"Failed to read battery discharge log: {exc}")
-        return entries
-
-    def _generate_curve(self, entries: list[tuple[float, float]]) -> list[dict]:
-        entries.sort(key=lambda item: item[0])
-        start_time = entries[0][0]
-        end_time = entries[-1][0]
-        duration = end_time - start_time
-        if duration <= 0:
-            return []
-
-        curve: list[dict] = []
-        idx = 0
-        for percent in range(100, -1, -self.CALIBRATION_STEP):
-            target_time = start_time + (1 - percent / 100) * duration
-            while idx < len(entries) - 2 and entries[idx + 1][0] < target_time:
-                idx += 1
-            low_t, low_v = entries[idx]
-            high_t, high_v = entries[min(idx + 1, len(entries) - 1)]
-            if high_t == low_t:
-                voltage = low_v
-            else:
-                t = (target_time - low_t) / (high_t - low_t)
-                voltage = low_v + t * (high_v - low_v)
-            curve.append({"percent": percent, "voltage": round(voltage, 4)})
-        return curve
-
-    def _process_existing_log(self) -> None:
+    def run(self):
         from seedsigner.hardware.battery_hat import BatteryHat
 
-        battery_hat = BatteryHat.get_instance()
-        log_path = battery_hat.get_discharge_log_path()
-        if not log_path.exists():
-            return
-
-        entries = self._load_log_entries(log_path)
-        if len(entries) < 2:
-            log_path.unlink(missing_ok=True)
-            return
-
-        curve = self._generate_curve(entries)
-        if not curve:
-            log_path.unlink(missing_ok=True)
-            return
-
-        curve_path = battery_hat.get_discharge_curve_path()
-        curve_path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {
-            "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-            "source_log": log_path.name,
-            "curve": curve,
-        }
-        try:
-            with curve_path.open("w", encoding="utf-8") as handle:
-                json.dump(payload, handle, indent=2)
-        except OSError as exc:
-            logger.warning(f"Failed to write discharge curve: {exc}")
-        log_path.unlink(missing_ok=True)
-
-    def run(self):
-        self._process_existing_log()
+        BatteryHat.get_instance().process_discharge_log(step=self.CALIBRATION_STEP)
 
         microsd = MicroSD.get_instance()
         if not microsd.is_inserted:


### PR DESCRIPTION
### Motivation

- Provide a user-accessible Tools workflow to run a battery discharge calibration that logs voltage samples to microSD and produces a usable discharge curve.  
- Use the recorded discharge curve to map measured voltages to battery percentage for more accurate battery reporting.  
- Surface which calibration curve is active on the Battery Info screen so users can see what is being used.

### Description

- Added a multi-step Tools workflow with UI screens to `Tools -> Battery Calibration`: `ToolsBatteryCalibrationIntroScreen`, `ToolsBatteryCalibrationStartScreen`, and `ToolsBatteryCalibrationRunningScreen` in `src/seedsigner/gui/screens/tools_screens.py`, plus a `ToolsBatteryCalibrationView` in `src/seedsigner/views/tools_views.py` to orchestrate the flow and process existing logs.  
- The running screen logs timestamped voltage samples once per minute to a microSD file `battery_discharge_log.csv`, runs the screensaver-like moving logo loop and starts the camera video stream (no preview displayed) to maximize power draw, and cancels on any button press while deleting the log file.  
- Added processing logic in `ToolsBatteryCalibrationView` to detect an existing log on entry, convert it to a discharge curve sampled at 5% increments, and write `battery_discharge_curve.json` to the microSD; the source log is removed after processing.  
- Extended `BatteryHat` in `src/seedsigner/hardware/battery_hat.py` with `get_discharge_log_path()` and `get_discharge_curve_path()`, logic to load the JSON curve, and interpolation (`_percent_from_curve`) so `read_percentage()` uses the custom curve when available.  
- Updated the Battery Info screen (`src/seedsigner/gui/screens/settings_screens.py`) to display the name of the active curve file (or default) next to the other live battery metrics.  
- Integrated the new Tools menu item and view by adding `BATTERY_CALIBRATION` to `ToolsMenuView` and routing selection to `ToolsBatteryCalibrationView` in `src/seedsigner/views/tools_views.py`.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e89c9975483228cb6b67ecc19d5fa)