### PR TITLE
Battery: charging icon, low-battery red, and persistent discharge curve loading

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -221,8 +221,9 @@ class Controller(Singleton):
         controller.microsd.start_detection()
 
         controller.battery_hat = BatteryHat.get_instance()
-        controller.battery_hat.start()
         controller.battery_hat.process_discharge_log()
+        controller.battery_hat.load_discharge_curve()
+        controller.battery_hat.start()
 
         # Store one working psbt in memory
         controller.psbt = None

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -1806,6 +1806,7 @@ class BatteryIndicator(BaseComponent):
     def __post_init__(self):
         super().__post_init__()
         self.font = Fonts.get_font(GUIConstants.ICON_FONT_NAME__FONT_AWESOME, self.icon_size)
+        self.charging_font = Fonts.get_font(GUIConstants.ICON_FONT_NAME__FONT_AWESOME, max(10, self.icon_size - 6))
         self.text_font = Fonts.get_font(GUIConstants.get_body_font_name(), self.font_size)
         # Pre-calc height from icon/text
         (left, top, right, bottom) = self.font.getbbox(FontAwesomeIconConstants.BATTERY_FULL, anchor="ls")
@@ -1836,7 +1837,7 @@ class BatteryIndicator(BaseComponent):
             fill=GUIConstants.BACKGROUND_COLOR,
         )
 
-        icon = FontAwesomeIconConstants.BATTERY_CHARGING if self.charging else self._icon_from_percent()
+        icon = self._icon_from_percent()
         icon_color = GUIConstants.BODY_FONT_COLOR
         if self.percent is not None and self.percent < 20:
             icon_color = GUIConstants.ERROR_COLOR
@@ -1848,7 +1849,19 @@ class BatteryIndicator(BaseComponent):
             anchor="ls",
         )
 
-        if not self.charging:
+        if self.charging:
+            charging_icon = FontAwesomeIconConstants.BATTERY_CHARGING
+            icon_width = self.font.getlength(icon)
+            charging_width = self.charging_font.getlength(charging_icon)
+            overlay_x = self.screen_x + (icon_width - charging_width) / 2
+            self.image_draw.text(
+                (overlay_x, self.screen_y + self.height),
+                text=charging_icon,
+                font=self.charging_font,
+                fill=GUIConstants.BODY_FONT_COLOR,
+                anchor="ls",
+            )
+        else:
             if self.percent is not None:
                 pct_text = f"{int(self.percent)}%"
             else:

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -198,6 +198,7 @@ class FontAwesomeIconConstants:
     BATTERY_HALF = "\uf242"
     BATTERY_QUARTER = "\uf243"
     BATTERY_EMPTY = "\uf244"
+    BATTERY_CHARGING = "\uf0e7"
 
 
 
@@ -1796,6 +1797,7 @@ class TopNav(BaseComponent):
 class BatteryIndicator(BaseComponent):
     """Simple battery indicator component."""
     percent: float = 0
+    charging: bool = False
     screen_x: int = 0
     screen_y: int = 0
     icon_size: int = GUIConstants.ICON_FONT_SIZE
@@ -1834,28 +1836,32 @@ class BatteryIndicator(BaseComponent):
             fill=GUIConstants.BACKGROUND_COLOR,
         )
 
-        icon = self._icon_from_percent()
+        icon = FontAwesomeIconConstants.BATTERY_CHARGING if self.charging else self._icon_from_percent()
+        icon_color = GUIConstants.BODY_FONT_COLOR
+        if self.percent is not None and self.percent < 20:
+            icon_color = GUIConstants.ERROR_COLOR
         self.image_draw.text(
             (self.screen_x, self.screen_y + self.height),
             text=icon,
             font=self.font,
-            fill=GUIConstants.BODY_FONT_COLOR,
+            fill=icon_color,
             anchor="ls",
         )
 
-        if self.percent is not None:
-            pct_text = f"{int(self.percent)}%"
-        else:
-            pct_text = "--%"
+        if not self.charging:
+            if self.percent is not None:
+                pct_text = f"{int(self.percent)}%"
+            else:
+                pct_text = "--%"
 
-        text_x = self.screen_x + self.font.getlength(icon) + GUIConstants.COMPONENT_PADDING
-        self.image_draw.text(
-            (text_x, self.screen_y + self.height),
-            text=pct_text,
-            font=self.text_font,
-            fill=GUIConstants.BODY_FONT_COLOR,
-            anchor="ls",
-        )
+            text_x = self.screen_x + self.font.getlength(icon) + GUIConstants.COMPONENT_PADDING
+            self.image_draw.text(
+                (text_x, self.screen_y + self.height),
+                text=pct_text,
+                font=self.text_font,
+                fill=GUIConstants.BODY_FONT_COLOR,
+                anchor="ls",
+            )
 
 
 

--- a/src/seedsigner/gui/components.py
+++ b/src/seedsigner/gui/components.py
@@ -1851,11 +1851,9 @@ class BatteryIndicator(BaseComponent):
 
         if self.charging:
             charging_icon = FontAwesomeIconConstants.BATTERY_CHARGING
-            icon_width = self.font.getlength(icon)
-            charging_width = self.charging_font.getlength(charging_icon)
-            overlay_x = self.screen_x + (icon_width - charging_width) / 2
+            text_x = self.screen_x + self.font.getlength(icon) + GUIConstants.COMPONENT_PADDING
             self.image_draw.text(
-                (overlay_x, self.screen_y + self.height),
+                (text_x, self.screen_y + self.height),
                 text=charging_icon,
                 font=self.charging_font,
                 fill=GUIConstants.BODY_FONT_COLOR,

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1385,7 +1385,7 @@ class MainMenuScreen(LargeButtonScreen):
             if self.battery_indicator not in self.components:
                 self.components.append(self.battery_indicator)
             cur_time = time.time()
-            if cur_time - self.last_battery_update > 5:
+            if cur_time - self.last_battery_update > 1:
                 percent = self.battery_hat.get_percent()
                 current = self.battery_hat.get_current()
                 charging = current is not None and current > 0

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1387,9 +1387,12 @@ class MainMenuScreen(LargeButtonScreen):
             cur_time = time.time()
             if cur_time - self.last_battery_update > 60:
                 percent = self.battery_hat.get_percent()
-                if percent is not None:
+                current = self.battery_hat.get_current()
+                charging = current is not None and current > 0
+                if percent is not None or current is not None:
                     with self.renderer.lock:
                         self.battery_indicator.percent = percent
+                        self.battery_indicator.charging = charging
                         self.battery_indicator.render()
                         self.renderer.show_image()
                 self.last_battery_update = cur_time

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1376,23 +1376,47 @@ class MainMenuScreen(LargeButtonScreen):
         self.battery_indicator = BatteryIndicator()
         self.battery_indicator.screen_x = GUIConstants.EDGE_PADDING
         self.battery_indicator.screen_y = GUIConstants.EDGE_PADDING
-        self.last_battery_update = 0
         if self.battery_hat.detected:
             self.components.append(self.battery_indicator)
+        self.threads.append(MainMenuScreen.UpdateThread(self))
 
     def _run_callback(self):
-        if self.battery_hat.detected:
-            if self.battery_indicator not in self.components:
-                self.components.append(self.battery_indicator)
-            cur_time = time.time()
-            if cur_time - self.last_battery_update > 1:
-                percent = self.battery_hat.get_percent()
-                current = self.battery_hat.get_current()
+        return None
+
+    class UpdateThread(BaseThread):
+        def __init__(self, screen):
+            super().__init__()
+            self.screen = screen
+            self.battery_hat = screen.battery_hat
+            self.last_percent = None
+            self.last_charging = None
+
+        def run(self):
+            while self.keep_running:
+                if not self.battery_hat.detected:
+                    self.battery_hat.detected = self.battery_hat.detect_hat()
+
+                if self.battery_hat.detected and self.screen.battery_indicator not in self.screen.components:
+                    with self.screen.renderer.lock:
+                        self.screen.components.append(self.screen.battery_indicator)
+                        self.screen.battery_indicator.render()
+                        self.screen.renderer.show_image()
+
+                percent = None
+                current = None
+                if self.battery_hat.detected:
+                    percent = self.battery_hat.get_percent()
+                    current = self.battery_hat.get_current()
                 charging = current is not None and current > 0
-                if percent is not None or current is not None:
-                    with self.renderer.lock:
-                        self.battery_indicator.percent = percent
-                        self.battery_indicator.charging = charging
-                        self.battery_indicator.render()
-                        self.renderer.show_image()
-                self.last_battery_update = cur_time
+                percent_display = int(percent) if percent is not None else None
+
+                if percent_display != self.last_percent or charging != self.last_charging:
+                    self.last_percent = percent_display
+                    self.last_charging = charging
+                    with self.screen.renderer.lock:
+                        self.screen.battery_indicator.percent = percent
+                        self.screen.battery_indicator.charging = charging
+                        self.screen.battery_indicator.render()
+                        self.screen.renderer.show_image()
+
+                time.sleep(1)

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1385,7 +1385,7 @@ class MainMenuScreen(LargeButtonScreen):
             if self.battery_indicator not in self.components:
                 self.components.append(self.battery_indicator)
             cur_time = time.time()
-            if cur_time - self.last_battery_update > 60:
+            if cur_time - self.last_battery_update > 5:
                 percent = self.battery_hat.get_percent()
                 current = self.battery_hat.get_current()
                 charging = current is not None and current > 0

--- a/src/seedsigner/hardware/battery_hat.py
+++ b/src/seedsigner/hardware/battery_hat.py
@@ -68,6 +68,29 @@ class BatteryHat(Singleton, BaseThread):
     MAX_VOLTAGE = 4.2
 
     UPDATE_PERIOD = 60  # seconds
+    DEFAULT_DISCHARGE_CURVE = [
+        {"percent": 100, "voltage": 4.032},
+        {"percent": 95, "voltage": 3.9804},
+        {"percent": 90, "voltage": 3.9676},
+        {"percent": 85, "voltage": 3.952},
+        {"percent": 80, "voltage": 3.936},
+        {"percent": 75, "voltage": 3.905},
+        {"percent": 70, "voltage": 3.8652},
+        {"percent": 65, "voltage": 3.8334},
+        {"percent": 60, "voltage": 3.8136},
+        {"percent": 55, "voltage": 3.7858},
+        {"percent": 50, "voltage": 3.7619},
+        {"percent": 45, "voltage": 3.732},
+        {"percent": 40, "voltage": 3.6927},
+        {"percent": 35, "voltage": 3.6356},
+        {"percent": 30, "voltage": 3.5775},
+        {"percent": 25, "voltage": 3.531},
+        {"percent": 20, "voltage": 3.4904},
+        {"percent": 15, "voltage": 3.4433},
+        {"percent": 10, "voltage": 3.3991},
+        {"percent": 5, "voltage": 3.3313},
+        {"percent": 0, "voltage": 2.98},
+    ]
 
     @classmethod
     def reset_instance(cls):
@@ -90,7 +113,7 @@ class BatteryHat(Singleton, BaseThread):
             instance.percent = None
             instance.detected = False
             instance._curve_data = None
-            instance._curve_mtime = None
+            instance._curve_label = None
         return cls._instance
 
     @classmethod
@@ -103,7 +126,7 @@ class BatteryHat(Singleton, BaseThread):
     def get_discharge_curve_path(cls):
         from seedsigner.hardware.microsd import MicroSD
 
-        return MicroSD.get_microsd_dir() / "battery_discharge_curve.json"
+        return MicroSD.get_microsd_dir() / "custom_battery_discharge_curve.json"
 
     def _open_bus(self):
         if self._bus is None:
@@ -218,18 +241,16 @@ class BatteryHat(Singleton, BaseThread):
         pct = (voltage - self.MIN_VOLTAGE) / (self.MAX_VOLTAGE - self.MIN_VOLTAGE) * 100
         return max(0, min(100, pct))
 
-    def _load_discharge_curve(self) -> list[dict] | None:
-        curve_path = self.get_discharge_curve_path()
+    def load_discharge_curve(self) -> None:
+        curve = self._load_curve_from_path(self.get_discharge_curve_path())
+        if curve:
+            return
+        self._curve_data = list(self.DEFAULT_DISCHARGE_CURVE)
+        self._curve_label = "default"
+
+    def _load_curve_from_path(self, curve_path: Path) -> list[dict] | None:
         if not curve_path.exists():
-            self._curve_data = None
-            self._curve_mtime = None
             return None
-        try:
-            mtime = curve_path.stat().st_mtime
-        except OSError:
-            return None
-        if self._curve_data is not None and self._curve_mtime == mtime:
-            return self._curve_data
         try:
             with curve_path.open("r", encoding="utf-8") as handle:
                 data = json.load(handle)
@@ -240,8 +261,13 @@ class BatteryHat(Singleton, BaseThread):
         if not isinstance(curve, list):
             return None
         self._curve_data = curve
-        self._curve_mtime = mtime
+        self._curve_label = curve_path.name
         return curve
+
+    def _load_discharge_curve(self) -> list[dict] | None:
+        if self._curve_data is None:
+            self.load_discharge_curve()
+        return self._curve_data
 
     def _percent_from_curve(self, voltage: float, curve: list[dict]) -> float | None:
         points = []
@@ -268,10 +294,7 @@ class BatteryHat(Singleton, BaseThread):
         return None
 
     def get_curve_label(self) -> str | None:
-        curve_path = self.get_discharge_curve_path()
-        if curve_path.exists():
-            return curve_path.name
-        return None
+        return self._curve_label
 
     def _load_discharge_log_entries(self, log_path: Path) -> list[tuple[float, float]]:
         entries: list[tuple[float, float]] = []


### PR DESCRIPTION
### Motivation
- Improve battery UI to show charging state clearly and highlight dangerously low battery levels.
- Make discharge curve loading resilient to MicroSD removal by caching a loaded curve at boot rather than re-reading from the card continuously.
- Allow a custom curve file name and provide a sensible default LiPo curve when no custom curve is present.

### Description
- Added a default LiPo discharge curve constant `DEFAULT_DISCHARGE_CURVE` and a cache label `_curve_label` to `BatteryHat`, and implemented `load_discharge_curve()` and `_load_curve_from_path()` to load a custom curve file called `custom_battery_discharge_curve.json` or fall back to the default; cached data is kept in memory so it survives MicroSD removal (`src/seedsigner/hardware/battery_hat.py`).
- Reworked `_load_discharge_curve()` to return the cached curve if present and updated `get_curve_label()` to return the cached label rather than probing the filesystem (`src/seedsigner/hardware/battery_hat.py`).
- Adjusted controller startup order to call `process_discharge_log()` then `load_discharge_curve()` before starting the `BatteryHat` thread to ensure the curve is generated/loaded at boot after any logs are processed (`src/seedsigner/controller.py`).
- Updated UI components to show a charging icon (`BATTERY_CHARGING`) and a `charging` flag on `BatteryIndicator`, to hide the numeric percentage while charging, and to tint the icon red when `percent < 20` using `GUIConstants.ERROR_COLOR` (`src/seedsigner/gui/components.py`).
- Updated the main menu update loop to query `get_current()` and set `battery_indicator.charging` when current > 0 so the charging icon is shown on the home screen (`src/seedsigner/gui/screens/screen.py`).

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f9f3d389883229ae3305cad9def2b)