### PR TITLE
Always show Battery info menu with unavailable warning

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -221,9 +221,10 @@ class Controller(Singleton):
         controller.microsd.start_detection()
 
         controller.battery_hat = BatteryHat.get_instance()
-        controller.battery_hat.process_discharge_log()
-        controller.battery_hat.load_discharge_curve()
-        controller.battery_hat.start()
+        if controller.battery_hat.initialize():
+            controller.battery_hat.process_discharge_log()
+            controller.battery_hat.load_discharge_curve()
+            controller.battery_hat.start()
 
         # Store one working psbt in memory
         controller.psbt = None

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -1376,7 +1376,7 @@ class MainMenuScreen(LargeButtonScreen):
         self.battery_indicator = BatteryIndicator()
         self.battery_indicator.screen_x = GUIConstants.EDGE_PADDING
         self.battery_indicator.screen_y = GUIConstants.EDGE_PADDING
-        if self.battery_hat.detected:
+        if self.battery_hat.is_enabled() and self.battery_hat.detected:
             self.components.append(self.battery_indicator)
         self.threads.append(MainMenuScreen.UpdateThread(self))
 
@@ -1393,8 +1393,9 @@ class MainMenuScreen(LargeButtonScreen):
 
         def run(self):
             while self.keep_running:
-                if not self.battery_hat.detected:
-                    self.battery_hat.detected = self.battery_hat.detect_hat()
+                if not self.battery_hat.is_enabled():
+                    time.sleep(1)
+                    continue
 
                 if self.battery_hat.detected and self.screen.battery_indicator not in self.screen.components:
                     with self.screen.renderer.lock:

--- a/src/seedsigner/gui/screens/settings_screens.py
+++ b/src/seedsigner/gui/screens/settings_screens.py
@@ -424,8 +424,9 @@ class BatteryInfoScreen(BaseTopNavScreen):
 
         def run(self):
             while self.keep_running:
-                if not self.battery_hat.detected:
-                    self.battery_hat.detected = self.battery_hat.detect_hat()
+                if not self.battery_hat.is_enabled():
+                    time.sleep(5)
+                    continue
                 voltage = None
                 current = None
                 power = None

--- a/src/seedsigner/hardware/battery_hat.py
+++ b/src/seedsigner/hardware/battery_hat.py
@@ -112,9 +112,21 @@ class BatteryHat(Singleton, BaseThread):
             instance._bus = None
             instance.percent = None
             instance.detected = False
+            instance.enabled = SMBus is not None
             instance._curve_data = None
             instance._curve_label = None
         return cls._instance
+
+    def initialize(self) -> bool:
+        if not self.enabled:
+            return False
+        self.detected = self.detect_hat()
+        if not self.detected:
+            self.enabled = False
+        return self.enabled
+
+    def is_enabled(self) -> bool:
+        return self.enabled
 
     @classmethod
     def get_discharge_log_path(cls):
@@ -129,15 +141,19 @@ class BatteryHat(Singleton, BaseThread):
         return MicroSD.get_microsd_dir() / "custom_battery_discharge_curve.json"
 
     def _open_bus(self):
+        if not self.enabled:
+            return
         if self._bus is None:
             if SMBus is None:
                 logger.warning("smbus2 not available")
+                self.enabled = False
                 return
             try:
                 self._bus = SMBus(self.I2C_BUS)
             except FileNotFoundError:
                 logger.warning("I2C bus not available")
                 self._bus = None
+                self.enabled = False
 
     def _read_register(self, reg: int) -> int:
         self._open_bus()
@@ -176,6 +192,7 @@ class BatteryHat(Singleton, BaseThread):
             self._bus.read_word_data(self.I2C_ADDR, self.REG_CONFIG)
             return True
         except Exception:
+            self.enabled = False
             return False
 
     def read_voltage(self) -> float:

--- a/src/seedsigner/views/settings_views.py
+++ b/src/seedsigner/views/settings_views.py
@@ -711,6 +711,8 @@ class BatteryInfoView(View):
             self.run_screen(
                 WarningScreen,
                 title=_("Battery Info"),
+                status_icon_size=0,
+                status_headline=None,
                 text=_("No compatible battery monitor detected"),
                 button_data=[ButtonOption(_("Back"))],
             )

--- a/src/seedsigner/views/settings_views.py
+++ b/src/seedsigner/views/settings_views.py
@@ -81,9 +81,7 @@ class SettingsMenuView(View):
 
         elif self.visibility == SettingsConstants.VISIBILITY__HARDWARE:
             title = "Hardware"
-            from seedsigner.hardware.battery_hat import BatteryHat
-            if BatteryHat.get_instance().detect_hat():
-                button_data.append(self.BATTERY_INFO)
+            button_data.append(self.BATTERY_INFO)
             button_data.append(self.IO_TEST)
             if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
                 button_data.append(self.LIST_READERS)
@@ -707,6 +705,17 @@ class DonateView(View):
 
 class BatteryInfoView(View):
     def run(self):
+        from seedsigner.hardware.battery_hat import BatteryHat
+
+        if not BatteryHat.get_instance().is_enabled():
+            self.run_screen(
+                WarningScreen,
+                title=_("Battery Info"),
+                text=_("No compatible battery monitor detected"),
+                button_data=[ButtonOption(_("Back"))],
+            )
+            return Destination(SettingsMenuView, view_args={"visibility": SettingsConstants.VISIBILITY__HARDWARE})
+
         self.run_screen(settings_screens.BatteryInfoScreen)
 
         return Destination(SettingsMenuView, view_args={"visibility": SettingsConstants.VISIBILITY__HARDWARE})

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -100,13 +100,16 @@ class ToolsMenuView(View):
         if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.SMARTCARD)
         
+        from seedsigner.hardware.battery_hat import BatteryHat
+        battery_calibration_button = self.BATTERY_CALIBRATION if BatteryHat.get_instance().is_enabled() else None
+
         button_data.extend([
             self.KEYBOARD,
             self.ADDRESS_EXPLORER,
             self.VERIFY_ADDRESS,
             self.TEXTQRCODE,
             self.MICROSD,
-            self.BATTERY_CALIBRATION,
+            battery_calibration_button,
             self.NETWORK_INFO if Path("/usr/bin/network-info").is_file() else None,
             self.GPG,
             self.CLEAR_DESCRIPTOR,
@@ -184,7 +187,11 @@ class ToolsBatteryCalibrationView(View):
     def run(self):
         from seedsigner.hardware.battery_hat import BatteryHat
 
-        BatteryHat.get_instance().process_discharge_log(step=self.CALIBRATION_STEP)
+        battery_hat = BatteryHat.get_instance()
+        if not battery_hat.is_enabled():
+            return Destination(BackStackView)
+
+        battery_hat.process_discharge_log(step=self.CALIBRATION_STEP)
 
         microsd = MicroSD.get_instance()
         if not microsd.is_inserted:
@@ -204,9 +211,6 @@ class ToolsBatteryCalibrationView(View):
         if ret == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        from seedsigner.hardware.battery_hat import BatteryHat
-
-        battery_hat = BatteryHat.get_instance()
         log_path = battery_hat.get_discharge_log_path()
         ret = ToolsBatteryCalibrationRunningScreen(
             log_path=log_path,

--- a/tests/base.py
+++ b/tests/base.py
@@ -38,6 +38,12 @@ class DummyBatteryHat(MagicMock):
     def reset_instance(cls):
         cls._instance = None
 
+    def initialize(self):
+        return True
+
+    def is_enabled(self):
+        return True
+
     def start(self):
         pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,12 @@ class DummyBatteryHat(MagicMock):
     def reset_instance(cls):
         cls._instance = None
 
+    def initialize(self):
+        return True
+
+    def is_enabled(self):
+        return True
+
     def start(self):
         pass
     def stop(self):

--- a/tests/test_flows_settings.py
+++ b/tests/test_flows_settings.py
@@ -62,6 +62,20 @@ class TestSettingsFlows(FlowTest):
             FlowStep(settings_views.SettingsMenuView),
         ])
 
+
+    def test_battery_info_unavailable(self):
+        """Battery info should show an unavailable message when no monitor is detected."""
+        with patch("seedsigner.hardware.battery_hat.BatteryHat") as battery_hat:
+            battery_hat.get_instance.return_value.is_enabled.return_value = False
+
+            self.run_sequence([
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SETTINGS),
+                FlowStep(settings_views.SettingsMenuView, button_data_selection=settings_views.SettingsMenuView.HARDWARE),
+                FlowStep(settings_views.SettingsMenuView, button_data_selection=settings_views.SettingsMenuView.BATTERY_INFO),
+                FlowStep(settings_views.BatteryInfoView),
+                FlowStep(settings_views.SettingsMenuView),
+            ])
+
     def test_hardware_menu_back_returns_to_main(self):
         """Ensure BACK from Hardware settings returns to main Settings menu."""
         def assert_general(view: settings_views.SettingsMenuView):


### PR DESCRIPTION
### Motivation
- Make the `Battery info` entry visible in Hardware settings even when no INA219/battery monitor is detected so users can see a clear explanation instead of a missing menu item.
- Prevent background battery threads and UI components from operating when battery support is not available.

### Description
- Always append the `BATTERY_INFO` item in `SettingsMenuView` by removing the detection gating and keep `IO_TEST` in the Hardware menu.
- Update `BatteryInfoView` to call `BatteryHat.get_instance().is_enabled()` and show a `WarningScreen` with the text `"No compatible battery monitor detected"` and a Back button when battery support is disabled, otherwise run the existing `BatteryInfoScreen`.
- Guard runtime battery UI and threads by checking `BatteryHat.is_enabled()` in `MainMenuScreen` and `BatteryInfoScreen.UpdateThread` so battery components do not run when disabled.
- Make `ToolsMenuView` only include the `BATTERY_CALIBRATION` button when `BatteryHat.is_enabled()` and short-circuit `ToolsBatteryCalibrationView.run()` to return immediately if battery support is disabled.
- Add `initialize()` / `is_enabled()` stubs to the test `DummyBatteryHat` and add a new flow test `test_battery_info_unavailable` to verify navigation shows the unavailable message.

### Testing
- Ran `pytest -q tests/test_flows_settings.py tests/test_flows_tools.py` which completed successfully with `17 passed` (run time ~17.9s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986323e7c448322aef8536552a8503e)