### PR TITLE
Fix Xprv equality so multiple xprvs can be imported and add CI tests for multi-seed imports

### DIFF
--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -467,3 +467,8 @@ class XprvSeed(Seed):
 
     def get_bip85_child_mnemonic(self, bip85_index: int, bip85_num_words: int, network: str = SettingsConstants.MAINNET):
         raise InvalidSeedException("BIP85 is not supported for xprv seeds")
+
+    def __eq__(self, other):
+        if isinstance(other, XprvSeed):
+            return self._xprv == other._xprv
+        return False

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,6 +1,7 @@
 import os
 import json
 import pytest
+from unittest.mock import patch
 from seedsigner.models.seed import InvalidSeedException, Seed, ElectrumSeed, Slip39Seed, SeedWordsUnavailableException, XprvSeed
 from seedsigner.models.decode_qr import DecodeQR, DecodeQRStatus
 import shamir_mnemonic
@@ -340,3 +341,66 @@ class TestSlip39ExtendableSetting(BaseTest):
         assert isinstance(seed, Slip39Seed)
         assert not seed.extendable
 
+
+
+def test_seed_storage_allows_multiple_xprvs():
+    from seedsigner.models.seed_storage import SeedStorage
+
+    storage = SeedStorage()
+
+    xprv_a = XprvSeed("xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb")
+    xprv_b = XprvSeed("xprv9s21ZrQH143K4QViKpwKCpS2zVbz8GrZgpEchMDg6KME9HZtjfL7iThE9w5muQA4YPHKN1u5VM1w8D4pvnjxa2BmpGMfXr7hnRrRHZ93awZ")
+
+    storage.set_pending_seed(xprv_a)
+    first_index = storage.finalize_pending_seed()
+
+    storage.set_pending_seed(xprv_b)
+    second_index = storage.finalize_pending_seed()
+
+    assert first_index == 0
+    assert second_index == 1
+    assert storage.num_seeds() == 2
+    assert storage.seeds[0] == xprv_a
+    assert storage.seeds[1] == xprv_b
+
+
+def test_seed_storage_import_multiple_seed_types_mix_and_match():
+    from seedsigner.models.seed_storage import SeedStorage
+
+    with patch("seedsigner.gui.screens.screen.LoadingScreenThread"):
+        storage = SeedStorage()
+
+        bip39_a = Seed(mnemonic="abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split())
+        bip39_b = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split())
+
+        electrum_a = ElectrumSeed(mnemonic="regular reject rare profit once math fringe chase until ketchup century escape".split())
+        electrum_b = ElectrumSeed(mnemonic="basket print toy noodle betray weird filter ticket insect copy force machine".split())
+
+        secret1 = bytes.fromhex("11" * 16)
+        shares1 = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret1)[0]
+        slip39_a = Slip39Seed(mnemonics=[shares1[0], shares1[1]])
+
+        secret2 = bytes.fromhex("22" * 16)
+        shares2 = shamir_mnemonic.generate_mnemonics(1, [(2, 3)], secret2)[0]
+        slip39_b = Slip39Seed(mnemonics=[shares2[0], shares2[1]])
+
+        xprv_a = XprvSeed("xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb")
+        xprv_b = XprvSeed("xprv9s21ZrQH143K4QViKpwKCpS2zVbz8GrZgpEchMDg6KME9HZtjfL7iThE9w5muQA4YPHKN1u5VM1w8D4pvnjxa2BmpGMfXr7hnRrRHZ93awZ")
+
+        seeds_in_order = [
+            bip39_a,
+            xprv_a,
+            electrum_a,
+            slip39_a,
+            bip39_b,
+            xprv_b,
+            electrum_b,
+            slip39_b,
+        ]
+
+        for expected_index, seed in enumerate(seeds_in_order):
+            storage.set_pending_seed(seed)
+            assert storage.finalize_pending_seed() == expected_index
+
+        assert storage.num_seeds() == len(seeds_in_order)
+        assert storage.seeds == seeds_in_order


### PR DESCRIPTION
### Motivation
- Importing a second xprv appeared to finalize but then reverted because xprv seeds were compared using `Seed.__eq__` which compares `seed_bytes` (which is `None` for xprv seeds), causing them to be treated as equal. 
- Ensure the app can persist multiple distinct xprv seeds and add automated coverage for importing multiple seeds of different supported types. 

### Description
- Implemented `XprvSeed.__eq__` to compare normalized `_xprv` strings so distinct xprv seeds are treated as different objects (`src/seedsigner/models/seed.py`).
- Added two tests to validate storage behavior: `test_seed_storage_allows_multiple_xprvs` and `test_seed_storage_import_multiple_seed_types_mix_and_match` (`tests/test_seed.py`).
- Added `patch` import and mocked `LoadingScreenThread` in the mixed-types test to avoid GUI loading-screen side effects during test execution.

### Testing
- Ran `pytest -q tests/test_seed.py -k "multiple_xprvs or mix_and_match"` and both new tests passed.
- Ran `pytest -q tests/test_flows_seed.py -k "scan_xprv_flow"` and the related flow test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876d099c8c8322ad46d7caf98f1892)