### PR TITLE
Show seed type labels on In-Memory Seeds screen

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -60,8 +60,19 @@ class SeedsMenuView(View):
         self.seeds = []
         for seed in self.controller.storage.seeds:
             self.seeds.append({
-                "fingerprint": seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
+                "fingerprint": seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK)),
+                "seed_type": self.get_seed_type_label(seed),
             })
+
+    @staticmethod
+    def get_seed_type_label(seed: Seed) -> str:
+        if isinstance(seed, Slip39Seed):
+            return "SLIP39"
+        if isinstance(seed, XprvSeed):
+            return "XPRV"
+        if isinstance(seed, ElectrumSeed):
+            return "ELEC"
+        return "BIP39"
 
 
     def run(self):
@@ -71,7 +82,12 @@ class SeedsMenuView(View):
 
         button_data = []
         for seed in self.seeds:
-            button_data.append(ButtonOption(seed["fingerprint"], SeedSignerIconConstants.FINGERPRINT))
+            button_data.append(
+                ButtonOption(
+                    f"{seed['fingerprint']} ({seed['seed_type']})",
+                    SeedSignerIconConstants.FINGERPRINT,
+                )
+            )
         button_data.append(self.LOAD)
 
         selected_menu_num = self.run_screen(


### PR DESCRIPTION
### Motivation
- Make it easier to identify loaded seeds by showing the seed type next to each fingerprint in the In-Memory Seeds menu.

### Description
- Append a seed-type tag in parentheses after each fingerprint in the In-Memory Seeds `ButtonList` and add `SeedsMenuView.get_seed_type_label` to map loaded seed instances to labels (`BIP39`, `SLIP39`, `XPRV`, `ELEC`).

### Testing
- Compiled the modified file with `python -m compileall -q src/seedsigner/views/seed_views.py` which succeeded; an automated Playwright screenshot attempt targeting `http://127.0.0.1:3000` failed because no UI server was reachable in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876f6e69bc8322bab427a796513c1f)