### PR TITLE
Re-export battery_hat from seedsigner.hardware package

### DIFF
--- a/src/seedsigner/hardware/__init__.py
+++ b/src/seedsigner/hardware/__init__.py
@@ -1,0 +1,9 @@
+"""Hardware package exports.
+
+This package intentionally re-exports selected hardware submodules so callers
+can patch/import via ``seedsigner.hardware.<module>`` attributes.
+"""
+
+from . import battery_hat
+
+__all__ = ["battery_hat"]


### PR DESCRIPTION
### Motivation
- Tests and runtime code patch against `seedsigner.hardware.battery_hat` and encountered `AttributeError` because the package did not expose the submodule.

### Description
- Added `src/seedsigner/hardware/__init__.py` to re-export the `battery_hat` submodule, included a short docstring, and defined `__all__ = ["battery_hat"]` so `seedsigner.hardware.battery_hat` is reliably available.

### Testing
- Ran `pytest -q tests/test_flows_settings.py` which completed successfully (`8 passed`).
- Ran `pytest -q tests/test_controller.py` which completed successfully (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69877262550883229f3ab871323358e3)