### PR TITLE
Fix BIP85 Diceware entropy handling in password generator

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -14426,8 +14426,6 @@ class ToolsPasswordBIP85GenerateView(View):
                 sides = 6
                 rolls = _diceware_word_count(self.password_type, self.strength_bits) * 5
             entropy = bip85.derive_entropy(root, BIP85_APP_DICE, [sides, rolls, index])
-            drng = bip85_drng.BIP85DRNG.new(entropy)
-            seed_bytes = drng.read(64)
             _cache_password_entropy(
                 self.controller,
                 password_type=self.password_type,
@@ -14435,7 +14433,7 @@ class ToolsPasswordBIP85GenerateView(View):
                 entropy_source=PASSWORD_ENTROPY_BIP85,
                 word_count=_diceware_word_count(self.password_type, self.strength_bits),
                 roll_data=None,
-                entropy_bytes=seed_bytes,
+                entropy_bytes=entropy,
             )
             return Destination(
                 ToolsPasswordWordSeparatorView,

--- a/tests/test_password_generator_views.py
+++ b/tests/test_password_generator_views.py
@@ -459,6 +459,65 @@ def test_bip85_dice_rolls_uses_seed_root_not_seed_bytes_none(monkeypatch):
     assert review_dest.view_args["password"] == "1,0,0,2,0,1,5,5,2,4"
 
 
+def test_bip85_diceware_short_uses_bip85_entropy_directly(monkeypatch):
+    master_xprv = "xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb"
+
+    view = object.__new__(tools_views.ToolsPasswordBIP85GenerateView)
+    view.password_type = tools_views.PASSWORD_TYPE_DICEWARE_EFF_SHORT
+    view.strength_bits = 32
+    view.random_options = {}
+    view.controller = None
+
+    class SeedObj:
+        @staticmethod
+        def get_root(_network=None):
+            return embit_bip32.HDKey.from_string(master_xprv)
+
+    class Storage:
+        seeds = [SeedObj()]
+
+    class Controller:
+        storage = Storage()
+
+        @staticmethod
+        def get_seed(_idx):
+            return SeedObj()
+
+    view.controller = Controller()
+
+    class S:
+        @staticmethod
+        def get_value(_key):
+            return "M"
+
+    view.settings = S()
+
+    class FakeIndexScreen:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def display(self):
+            return "0"
+
+    monkeypatch.setattr(
+        tools_views.seed_screens,
+        "SeedBIP85SelectChildIndexScreen",
+        FakeIndexScreen,
+    )
+
+    dest = tools_views.ToolsPasswordBIP85GenerateView.run(view)
+
+    assert dest.View_cls is tools_views.ToolsPasswordWordSeparatorView
+
+    cached = view.controller.password_generator_entropy_cache
+    assert cached["word_count"] == 4
+    assert cached["entropy_bytes"] == embit_bip85.derive_entropy(
+        embit_bip32.HDKey.from_string(master_xprv),
+        tools_views.BIP85_APP_DICE,
+        [6, 16, 0],
+    )
+
+
 def test_entropy_source_for_dice_rolls_excludes_dice_option(monkeypatch):
     view = object.__new__(tools_views.ToolsPasswordEntropySourceView)
     view.password_type = tools_views.PASSWORD_TYPE_DICE_ROLLS


### PR DESCRIPTION
### Motivation
- Diceware word generation for BIP85-derived entropy was being produced from an expanded DRNG stream instead of the raw BIP85 `derive_entropy(...)` bytes, causing mismatch with expected Diceware vectors for the EFF short/long wordlists.
- The change aligns the implementation with the expected BIP85 Diceware flow where the derived entropy is used directly to generate dice rolls/words.

### Description
- Stop expanding the BIP85 output through `BIP85DRNG.new(...).read(64)` for diceware word generation and instead cache/use the `derive_entropy(...)` bytes directly by setting `entropy_bytes=entropy` in the password entropy cache in `ToolsPasswordBIP85GenerateView`.
- Add a regression test `test_bip85_diceware_short_uses_bip85_entropy_directly` in `tests/test_password_generator_views.py` that verifies `Diceware-EFF Short` (32-bit) caches the exact `derive_entropy(root, BIP85_APP_DICE, [6, 16, 0])` output for the provided test xprv vector.
- Keep existing Dice Rolls behavior unchanged (Dice Rolls path still uses the DRNG semantics as before).

### Testing
- Ran the focused test selection with `pytest -q tests/test_password_generator_views.py -k "bip85_diceware_short_uses_bip85_entropy_directly or matches_bip85_dice_spec_vector_output or bip85_dice_rolls_uses_seed_root_not_seed_bytes_none"` and all selected tests passed.
- Result: `3 passed, 14 deselected` for the invoked test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69879877232c83229ae9e9da4b5a97f3)