### PR TITLE
Align BIP85 password generation with BIP-0085

### DIFF
--- a/src/seedsigner/helpers/password_generation.py
+++ b/src/seedsigner/helpers/password_generation.py
@@ -56,6 +56,32 @@ def base85_password_from_seed(seed: bytes, length: int) -> str:
     return encoded[:length]
 
 
+def bip85_hex_password(entropy: bytes, num_bytes: int) -> str:
+    if len(entropy) != 64:
+        raise ValueError("Entropy must be exactly 64 bytes")
+    if num_bytes < 16 or num_bytes > 64:
+        raise ValueError("num_bytes must be in [16, 64]")
+    return entropy[:num_bytes].hex()
+
+
+def bip85_base64_password(entropy: bytes, length: int) -> str:
+    if len(entropy) != 64:
+        raise ValueError("Entropy must be exactly 64 bytes")
+    if length < 20 or length > 86:
+        raise ValueError("length must be in [20, 86]")
+    encoded = base64.b64encode(entropy).decode("ascii").replace("=", "")
+    return encoded[:length]
+
+
+def bip85_base85_password(entropy: bytes, length: int) -> str:
+    if len(entropy) != 64:
+        raise ValueError("Entropy must be exactly 64 bytes")
+    if length < 10 or length > 80:
+        raise ValueError("length must be in [10, 80]")
+    encoded = base64.b85encode(entropy).decode("ascii")
+    return encoded[:length]
+
+
 def dice_roll_entropy_bits(roll_count: int) -> float:
     return roll_count * math.log2(6)
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -14283,25 +14283,45 @@ class ToolsPasswordGenerateView(View):
             elif self.password_type == PASSWORD_TYPE_HEX:
                 if self.entropy_source == PASSWORD_ENTROPY_DICE:
                     length = self._dice_length_for_charset(16)
+                    password = password_generation.hex_password_from_seed(entropy_bytes, length)
+                elif self.entropy_source == PASSWORD_ENTROPY_BIP85:
+                    num_bytes = _strength_to_length(self.strength_bits, 256)
+                    password = password_generation.bip85_hex_password(entropy_bytes, num_bytes)
                 else:
                     length = _strength_to_length(self.strength_bits, 16)
-                password = password_generation.hex_password_from_seed(entropy_bytes, length)
+                    password = password_generation.hex_password_from_seed(entropy_bytes, length)
             elif self.password_type == PASSWORD_TYPE_BASE64:
                 if self.entropy_source == PASSWORD_ENTROPY_DICE:
                     length = self._dice_length_for_charset(64)
+                    password = password_generation.base64_password_from_seed(
+                        entropy_bytes, length
+                    )
+                elif self.entropy_source == PASSWORD_ENTROPY_BIP85:
+                    length = _strength_to_length(self.strength_bits, 64)
+                    password = password_generation.bip85_base64_password(
+                        entropy_bytes, length
+                    )
                 else:
                     length = _strength_to_length(self.strength_bits, 64)
-                password = password_generation.base64_password_from_seed(
-                    entropy_bytes, length
-                )
+                    password = password_generation.base64_password_from_seed(
+                        entropy_bytes, length
+                    )
             else:
                 if self.entropy_source == PASSWORD_ENTROPY_DICE:
                     length = self._dice_length_for_charset(85)
+                    password = password_generation.base85_password_from_seed(
+                        entropy_bytes, length
+                    )
+                elif self.entropy_source == PASSWORD_ENTROPY_BIP85:
+                    length = _strength_to_length(self.strength_bits, 85)
+                    password = password_generation.bip85_base85_password(
+                        entropy_bytes, length
+                    )
                 else:
                     length = _strength_to_length(self.strength_bits, 85)
-                password = password_generation.base85_password_from_seed(
-                    entropy_bytes, length
-                )
+                    password = password_generation.base85_password_from_seed(
+                        entropy_bytes, length
+                    )
         except ValueError as exc:
             self.run_screen(
                 WarningScreen,
@@ -14505,7 +14525,7 @@ class ToolsPasswordBIP85GenerateView(View):
                     entropy_source=PASSWORD_ENTROPY_BIP85,
                     strength_bits=self.strength_bits,
                     random_options=self.random_options,
-                    roll_data=entropy[:num_bytes],
+                    roll_data=entropy,
                 ),
             )
         elif self.password_type == PASSWORD_TYPE_BASE64:

--- a/tests/test_bip85_vectors.py
+++ b/tests/test_bip85_vectors.py
@@ -1,7 +1,13 @@
 from embit import bip32, bip85
 
 from seedsigner.helpers.bip85_drng import BIP85DRNG
-from seedsigner.helpers.password_generation import dice_rolls_from_seed, dice_roll_values_from_seed
+from seedsigner.helpers.password_generation import (
+    bip85_base64_password,
+    bip85_base85_password,
+    bip85_hex_password,
+    dice_rolls_from_seed,
+    dice_roll_values_from_seed,
+)
 
 MASTER_XPRV = "xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb"
 
@@ -31,6 +37,39 @@ def test_bip85_dice_vector_matches_spec():
 
     assert dice_rolls_from_seed(entropy, sides=6, roll_count=10, base=0) == "1002015524"
     assert dice_roll_values_from_seed(entropy, sides=6, roll_count=10, base=0) == [1, 0, 0, 2, 0, 1, 5, 5, 2, 4]
+
+
+def test_bip85_hex_vector_matches_spec():
+    root = bip32.HDKey.from_string(MASTER_XPRV)
+    entropy = bip85.derive_entropy(root, 128169, [64, 0])
+    assert (
+        entropy.hex()
+        == "492db4698cf3b73a5a24998aa3e9d7fa96275d85724a91e71aa2d645442f878555d078fd1f1f67e368976f04137b1f7a0d19232136ca50c44614af72b5582a5c"
+    )
+    assert (
+        bip85_hex_password(entropy, 64)
+        == "492db4698cf3b73a5a24998aa3e9d7fa96275d85724a91e71aa2d645442f878555d078fd1f1f67e368976f04137b1f7a0d19232136ca50c44614af72b5582a5c"
+    )
+
+
+def test_bip85_base64_vector_matches_spec():
+    root = bip32.HDKey.from_string(MASTER_XPRV)
+    entropy = bip85.derive_entropy(root, 707764, [21, 0])
+    assert (
+        entropy.hex()
+        == "74a2e87a9ba0cdd549bdd2f9ea880d554c6c355b08ed25088cfa88f3f1c4f74632b652fd4a8f5fda43074c6f6964a3753b08bb5210c8f5e75c07a4c2a20bf6e9"
+    )
+    assert bip85_base64_password(entropy, 21) == "dKLoepugzdVJvdL56ogNV"
+
+
+def test_bip85_base85_vector_matches_spec():
+    root = bip32.HDKey.from_string(MASTER_XPRV)
+    entropy = bip85.derive_entropy(root, 707785, [12, 0])
+    assert (
+        entropy.hex()
+        == "f7cfe56f63dca2490f65fcbf9ee63dcd85d18f751b6b5e1c1b8733af6459c904a75e82b4a22efff9b9e69de2144b293aa8714319a054b6cb55826a8e51425209"
+    )
+    assert bip85_base85_password(entropy, 12) == "_s`{TW89)i4`"
 
 
 def test_bip85_xprv_vector_matches_spec():

--- a/tests/test_password_generator_views.py
+++ b/tests/test_password_generator_views.py
@@ -41,9 +41,9 @@ def test_password_generate_view_skips_itself_for_review_destination():
     view = object.__new__(tools_views.ToolsPasswordGenerateView)
     view.password_type = tools_views.PASSWORD_TYPE_HEX
     view.entropy_source = tools_views.PASSWORD_ENTROPY_BIP85
-    view.strength_bits = 64
+    view.strength_bits = 128
     view.random_options = {}
-    view.roll_data = b"\x01" * 32
+    view.roll_data = b"\x01" * 64
     view.roll_count = 0
     view.word_count = None
     view.word_separator = tools_views.PASSWORD_WORD_SEPARATOR_NONE


### PR DESCRIPTION
### Motivation
- Ensure password outputs derived via BIP85 follow the BIP-0085 specification for HEX, Base64 and Base85 which require operating on the full 64-byte BIP85 entropy and specific length constraints.
- Provide explicit BIP85-specific helpers and tighten validation to avoid ambiguities when deriving passwords from BIP85 entropy.

### Description
- Added BIP85-specific helpers in `src/seedsigner/helpers/password_generation.py`: `bip85_hex_password`, `bip85_base64_password`, and `bip85_base85_password` which validate a 64-byte entropy input and enforce BIP-0085 length ranges. 
- Updated password generation flow in `src/seedsigner/views/tools_views.py` so HEX/Base64/Base85 use the new BIP85 helpers when the entropy source is BIP85, and the HEX handoff now keeps the full 64-byte entropy in view args for correct downstream truncation. 
- Kept existing non-BIP85 behavior (dice or generic RNG) unchanged by calling the original seed-based helpers where appropriate. 
- Added and updated tests in `tests/test_bip85_vectors.py` to assert HEX/Base64/Base85/Dice outputs against the published BIP-0085 vectors, and adjusted a view test fixture in `tests/test_password_generator_views.py` to provide valid 64-byte BIP85 entropy for HEX path tests.

### Testing
- Ran `pytest -q tests/test_bip85_vectors.py tests/test_password_generator_views.py -q` and all tests passed. 
- Ran `pytest -q tests/test_password_generation.py -q` and all tests passed. 
- The new vector tests validate outputs match the BIP-0085 examples for HEX, Base64, Base85 and Dice flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a24e15408322be4cee96ce1c5699)