### PR TITLE
Remove 32-bit password strength option and make 128-bit the default

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -13501,7 +13501,6 @@ class ToolsPasswordStrengthView(View):
 
     def run(self):
         options = [
-            ButtonOption("32 bits", return_data=32),
             ButtonOption("64 bits", return_data=64),
             ButtonOption("128 bits", return_data=128),
             ButtonOption("256 bits", return_data=256),


### PR DESCRIPTION
### Motivation
- Remove a low-entropy `32 bits` option from the password generator and make `128 bits` the default selection for stronger, safer passwords.

### Description
- Deleted the `ButtonOption("32 bits", return_data=32)` entry in `ToolsPasswordStrengthView` in `src/seedsigner/views/tools_views.py`, leaving `64`, `128`, and `256` bit options and keeping `selected_button=1` so `128 bits` is the default.

### Testing
- Ran `python -m py_compile src/seedsigner/views/tools_views.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698801703b6c832294e54a971dec06fd)