### PR TITLE
Fix tools back navigation regression in password flow

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -373,16 +373,7 @@ class ToolsMenuView(View):
         )
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
-            _clear_password_entropy_cache(self.controller)
-            return Destination(
-                ToolsPasswordEntropySourceView,
-                view_args=dict(
-                    password_type=self.password_type,
-                    strength_bits=self.strength_bits,
-                    random_options=self.random_options,
-                ),
-                skip_current_view=True,
-            )
+            return Destination(BackStackView)
 
         elif button_data[selected_menu_num] == self.IMAGE:
             return Destination(ToolsImageEntropyLivePreviewView)
@@ -549,16 +540,7 @@ class ToolsNetworkInfoView(View):
         )
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
-            _clear_password_entropy_cache(self.controller)
-            return Destination(
-                ToolsPasswordEntropySourceView,
-                view_args=dict(
-                    password_type=self.password_type,
-                    strength_bits=self.strength_bits,
-                    random_options=self.random_options,
-                ),
-                skip_current_view=True,
-            )
+            return Destination(BackStackView)
 
         if self.page_num >= len(self.paged_info) - 1:
             return Destination(BackStackView)

--- a/tests/test_password_generator_views.py
+++ b/tests/test_password_generator_views.py
@@ -579,3 +579,40 @@ def test_entropy_source_for_dice_rolls_excludes_dice_option(monkeypatch):
     assert dest.view_args["entropy_source"] == tools_views.PASSWORD_ENTROPY_HARDWARE_RNG
     assert dest.view_args["dice_sides"] == 6
     assert dest.view_args["roll_count"] == 10
+
+
+def test_tools_menu_back_returns_back_stack(monkeypatch):
+    view = object.__new__(tools_views.ToolsMenuView)
+
+    class Settings:
+        @staticmethod
+        def get_value(_key):
+            return tools_views.SettingsConstants.OPTION__DISABLED
+
+    view.settings = Settings()
+
+    monkeypatch.setattr(
+        tools_views.ToolsMenuView,
+        "run_screen",
+        lambda self, *_args, **_kwargs: tools_views.RET_CODE__BACK_BUTTON,
+    )
+
+    dest = tools_views.ToolsMenuView.run(view)
+
+    assert dest.View_cls is tools_views.BackStackView
+
+
+def test_network_info_back_returns_back_stack(monkeypatch):
+    view = object.__new__(tools_views.ToolsNetworkInfoView)
+    view.page_num = 0
+    view.paged_info = ["page"]
+
+    monkeypatch.setattr(
+        tools_views.ToolsNetworkInfoView,
+        "run_screen",
+        lambda self, *_args, **_kwargs: tools_views.RET_CODE__BACK_BUTTON,
+    )
+
+    dest = tools_views.ToolsNetworkInfoView.run(view)
+
+    assert dest.View_cls is tools_views.BackStackView


### PR DESCRIPTION
### Motivation
- Back from general Tools screens could incorrectly attempt to resume the password-generator flow, causing an `AttributeError` due to missing `password_type`/password flow state when returning to Home.

### Description
- Change `ToolsMenuView` to return `BackStackView` when Back is selected instead of routing into `ToolsPasswordEntropySourceView` with password-specific state.
- Change `ToolsNetworkInfoView` to return `BackStackView` when Back is selected for the same reason.
- Remove the password-entropy cache clear + resume-path in those back handlers to avoid referencing undefined attributes.
- Add two regression tests in `tests/test_password_generator_views.py`: `test_tools_menu_back_returns_back_stack` and `test_network_info_back_returns_back_stack` to prevent reintroducing the crash.

### Testing
- Ran `pytest -q tests/test_password_generator_views.py` and all tests passed (`20 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69880255a2188322bf52afcf1eca1fd9)