### PR TITLE
Avoid reusing cached PIN when smartcard UID changes on genuine-check retry

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -1550,6 +1550,7 @@ class ToolsSmartcardGenuineCheckView(View):
             return Destination(BackStackView)
 
         try:
+            initial_uid = getattr(Satochip_Connector, "UID_SHA1", None)
             is_genuine, _, _, _, txt_error = Satochip_Connector.card_verify_authenticity()
 
             # Workaround for occasional incorrect UID calculation in pysatochip
@@ -1564,8 +1565,15 @@ class ToolsSmartcardGenuineCheckView(View):
                         init_card_filter=card_filter,
                         require_pin=False,
                     )
-                    Satochip_Connector.set_pin(0, temp_pin)
-                    if Satochip_Connector:
+                    retry_uid = getattr(Satochip_Connector, "UID_SHA1", None)
+                    can_retry_authenticity = True
+                    if temp_pin and initial_uid == retry_uid:
+                        Satochip_Connector.set_pin(0, temp_pin)
+                    elif temp_pin:
+                        can_retry_authenticity = False
+                        txt_error = "Card changed during retry; re-enter PIN for this card."
+
+                    if Satochip_Connector and can_retry_authenticity:
                         is_genuine, _, _, _, txt_error = (
                             Satochip_Connector.card_verify_authenticity()
                         )


### PR DESCRIPTION
### Motivation
- Prevent a previously-entered cached PIN from being applied to a different smartcard when the card UID changes between the initial genuine-check and a retry, which can cause confusing failures.
- Preserve the existing retry workaround for transient UID/read issues when the same card is reconnected.

### Description
- Capture the initial card UID before the first authenticity check with `initial_uid = getattr(Satochip_Connector, "UID_SHA1", None)`.
- On retry, read `retry_uid` and compare it to `initial_uid`, and only call `Satochip_Connector.set_pin(0, temp_pin)` when the UIDs match.
- If the UID changed, set `txt_error = "Card changed during retry; re-enter PIN for this card."` and skip retrying the authenticity verification with the cached PIN.
- Implemented the logic in `ToolsSmartcardGenuineCheckView.run` in `src/seedsigner/views/tools_views.py`.

### Testing
- Ran `python -m py_compile src/seedsigner/views/tools_views.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988866c1f8c83229781ebcdae979da0)