### PR TITLE
Move sensitive settings and descriptor logging to debug level

### DIFF
--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -163,10 +163,6 @@ class Settings(Singleton):
 
 
     def update(self, new_settings: dict, persist: bool = True):
-        print("Updating Settings")
-        print("Existing Settings:", self._data) 
-        print()
-        print("New Settings:", new_settings)
         """
             Replaces the current settings with the incoming dict.
 
@@ -218,13 +214,13 @@ class Settings(Singleton):
         """
         if attr_name not in self._data:
             # Outdated settings
-            print(f"Setting {attr_name} not recognized. Ignoring.")
+            logger.debug("Setting %s not recognized. Ignoring.", attr_name)
             return
 
         settings_entry = SettingsDefinition.get_settings_entry(attr_name)
         if not settings_entry:
             # Settings entry may be unavailable on this platform
-            print(f"Setting {attr_name} not found. Ignoring.")
+            logger.debug("Setting %s not found. Ignoring.", attr_name)
             return
 
         if settings_entry.type == SettingsConstants.TYPE__MULTISELECT:
@@ -257,8 +253,8 @@ class Settings(Singleton):
             import seedsigner
             #from seedsigner.gui.screens.screen import LoadingScreenThread, WarningScreen
             
-            print("Smartcard Interface Changed")
-            print("Value:", value)
+            logger.debug("Smartcard Interface Changed")
+            logger.debug("Value: %s", value)
             # Update PCSC ignore list (Needed for IFD-NFC, but also add ability to disable SEC1210 or other readers if required)
             pcscd_ignore_devices = []
             if 'pn532' not in value:
@@ -270,7 +266,7 @@ class Settings(Singleton):
 
             # PCSC supports filtering unwanted devices, but this is done through an environment variable
             # and also requires a restart of PCSC (So it's pretty simple to just edit the init.d file)
-            print("Updating PCSC Ignore List to:", ':'.join(pcscd_ignore_devices))
+            logger.debug("Updating PCSC Ignore List to: %s", ':'.join(pcscd_ignore_devices))
 
             # Only do this on SeedSignerOS, not on dev environment
             if self.HOSTNAME == self.SEEDSIGNER_OS:
@@ -280,7 +276,7 @@ class Settings(Singleton):
 
             # Basically just check through a a bunch of possible USB hubs and ports and enable/disable them all (Should cover all RPi models, RPi4 has lots of USB ports...)
             if not any('usb' in d for d in value) and any('usb' in d for d in self._data[attr_name]):
-                print("Disabling USB")
+                logger.debug("Disabling USB")
                 try:
                     self.loading_screen = seedsigner.gui.screens.screen.LoadingScreenThread(text="Disabling USB Ports")
                     self.loading_screen.start()
@@ -307,7 +303,7 @@ class Settings(Singleton):
                     pass
 
             if any('usb' in d for d in value) and not any('usb' in d for d in self._data[attr_name]):
-                print("Enabling USB")
+                logger.debug("Enabling USB")
                 try:
                     self.loading_screen = seedsigner.gui.screens.screen.LoadingScreenThread(text="Enabling USB Ports")
                     self.loading_screen.start()
@@ -359,7 +355,7 @@ class Settings(Singleton):
 
             # Execution order matters here if swithing from Phoenix to PN532, basically we want to disable phoenix first and then enable PN532
             if "phoenix-usb" in value and "phoenix-usb" not in self._data[attr_name]:
-                print("Phoenix Enabled")
+                logger.debug("Phoenix Enabled")
                 try:
                     self.loading_screen = seedsigner.gui.screens.screen.LoadingScreenThread(text="Starting OpenCT")
                     self.loading_screen.start()
@@ -375,7 +371,7 @@ class Settings(Singleton):
                     pass
 
             if "phoenix-usb" not in value and "phoenix-usb" in self._data[attr_name]:
-                print("Phoenix Disabled")
+                logger.debug("Phoenix Disabled")
                 try:
                     self.loading_screen = seedsigner.gui.screens.screen.LoadingScreenThread(text="Stopping OpenCT")
                     self.loading_screen.start()
@@ -396,7 +392,7 @@ class Settings(Singleton):
                     self.loading_screen.start()
                 except:
                     pass
-                print("PN532 Enabled")
+                logger.debug("PN532 Enabled")
                 os.system("ifdnfc-activate yes")
                 try:
                     self.loading_screen.stop()
@@ -409,7 +405,7 @@ class Settings(Singleton):
                     self.loading_screen.start()
                 except:
                     pass
-                print("PN532 Disabled")
+                logger.debug("PN532 Disabled")
                 os.system("ifdnfc-activate no")
                 try:
                     self.loading_screen.stop()
@@ -491,7 +487,7 @@ class Settings(Singleton):
         with open(path, "w") as f:
             f.write(content)
 
-        print(f"Environment variable set in 'start()' and 'restart()', and removed from global scope.")
+        logger.debug("Environment variable set in 'start()' and 'restart()', and removed from global scope.")
 
     def get_value(self, attr_name: str, default_if_none: bool = None):
         """
@@ -550,7 +546,7 @@ class Settings(Singleton):
         os.environ['LANGUAGE'] = locale
 
         # Re-initialize with the new locale
-        print(f"Set LANGUAGE locale to {os.environ['LANGUAGE']}")
+        logger.debug("Set LANGUAGE locale to %s", os.environ.get('LANGUAGE', ''))
 
 
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2967,7 +2967,7 @@ class ToolsSeedkeeperSaveDescriptorView(View):
 
                 multisig_descriptor_templates.append(secret_dict['secret'])
 
-            logger.debug("multisig_descriptor_templates: %s", multisig_descriptor_templates)
+            logger.debug("Loaded %d multisig descriptor templates from Seedkeeper", len(multisig_descriptor_templates))
 
             logger.debug("Key Strings: %s", key_strings)
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2794,8 +2794,8 @@ class ToolsSeedkeeperLoadDescriptorView(View):
                         multisig_descriptor_secrets.append((sid, label))
                         button_data.append(ButtonOption(label))
 
-            logger.debug("Multisig Descriptor Secrets: %s", multisig_descriptor_secrets)
-            logger.debug("Xpub Secrets: %s", xpub_secrets)
+            logger.debug("Found %d multisig descriptor secrets", len(multisig_descriptor_secrets))
+            logger.debug("Found %d xpub secrets", len(xpub_secrets))
 
             self.loading_screen.stop()
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2972,9 +2972,10 @@ class ToolsSeedkeeperSaveDescriptorView(View):
             logger.debug("Key Strings: %s", key_strings)
 
             # Add required secrets to seedkeeper
-            for secret_label, secret_text in key_strings:
+            for idx, (secret_label, secret_text) in enumerate(key_strings):
                 if secret_text in multisig_descriptor_templates or secret_label in xpub_labels:
-                    logger.debug("Matched Existing Secret, skipping: %s", secret_label)
+                    # Do not log secret labels directly, as they may contain sensitive information
+                    logger.debug("Matched existing secret at index %d; skipping import", idx)
                     secrets_skipped += 1
                     continue
                 header = Satochip_Connector.make_header(secret_type, "Plaintext export allowed", secret_label)

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2955,8 +2955,8 @@ class ToolsSeedkeeperSaveDescriptorView(View):
                     if stype == "Descriptor": 
                         multisig_descriptor_secrets.append((sid, label))
 
-            logger.debug("Multisig Descriptor Secrets: %s", multisig_descriptor_secrets)
-            logger.debug("Xpub Secrets: %s", xpub_labels)
+            logger.debug("Found %d multisig descriptor secrets", len(multisig_descriptor_secrets))
+            logger.debug("Found %d xpub labels", len(xpub_labels))
 
             multisig_descriptor_templates = []
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2969,7 +2969,8 @@ class ToolsSeedkeeperSaveDescriptorView(View):
 
             logger.debug("Loaded %d multisig descriptor templates from Seedkeeper", len(multisig_descriptor_templates))
 
-            logger.debug("Key Strings: %s", key_strings)
+            # Do not log key_strings directly, as it may contain sensitive descriptor labels or passphrases
+            logger.debug("Prepared %d key strings for Seedkeeper import", len(key_strings))
 
             # Add required secrets to seedkeeper
             for idx, (secret_label, secret_text) in enumerate(key_strings):

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2833,9 +2833,9 @@ class ToolsSeedkeeperLoadDescriptorView(View):
                 secret_dict['secret'] = unhexlify(secret_dict['secret'])[1:].decode()
                 secret_template = secret_dict['secret']
 
-                for xpub_secret_id, xpub_secret_label in xpub_secrets: 
+                for idx, (xpub_secret_id, xpub_secret_label) in enumerate(xpub_secrets):
                     if xpub_secret_label in secret_template:
-                        logger.debug("Matched on: %s", xpub_secret_label)
+                        logger.debug("Matched on an xpub secret label at index %d", idx)
                         secret_dict = Satochip_Connector.seedkeeper_export_secret(xpub_secret_id, None)
                         secret_dict['secret'] = unhexlify(secret_dict['secret'])[1:].decode()
                         secret_template = secret_template.replace(xpub_secret_label, secret_dict['secret'])

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2384,7 +2384,7 @@ class ToolsSeedkeeperViewSecretsView(View):
                     headers_parsed.append((sid, label))
                     button_data.append(ButtonOption(label))
 
-            logger.info(headers_parsed)
+            logger.debug("headers_parsed: %s", headers_parsed)
             if len(headers_parsed) < 1:
                 self.run_screen(
                 WarningScreen,
@@ -2693,7 +2693,7 @@ class ToolsSeedkeeperDeleteSecretView(View):
                     headers_parsed.append((sid, label))
                     button_data.append(ButtonOption(label))
 
-            logger.info(headers_parsed)
+            logger.debug("headers_parsed: %s", headers_parsed)
             if len(headers_parsed) < 1:
                 self.run_screen(
                 WarningScreen,
@@ -2794,8 +2794,8 @@ class ToolsSeedkeeperLoadDescriptorView(View):
                         multisig_descriptor_secrets.append((sid, label))
                         button_data.append(ButtonOption(label))
 
-            logger.info("Multisig Descriptor Secrets:", multisig_descriptor_secrets)
-            logger.info("Xpub Secrets:",xpub_secrets)
+            logger.debug("Multisig Descriptor Secrets: %s", multisig_descriptor_secrets)
+            logger.debug("Xpub Secrets: %s", xpub_secrets)
 
             self.loading_screen.stop()
 
@@ -2835,7 +2835,7 @@ class ToolsSeedkeeperLoadDescriptorView(View):
 
                 for xpub_secret_id, xpub_secret_label in xpub_secrets: 
                     if xpub_secret_label in secret_template:
-                        logger.info("Matched on:", xpub_secret_label)
+                        logger.debug("Matched on: %s", xpub_secret_label)
                         secret_dict = Satochip_Connector.seedkeeper_export_secret(xpub_secret_id, None)
                         secret_dict['secret'] = unhexlify(secret_dict['secret'])[1:].decode()
                         secret_template = secret_template.replace(xpub_secret_label, secret_dict['secret'])
@@ -2885,7 +2885,7 @@ class ToolsSeedkeeperSaveDescriptorView(View):
             # Break up the descriptor for efficient storage on SeedKeeper Cards
             descriptor_string = descriptor.to_string()
 
-            logger.info(descriptor_string)
+            logger.debug("descriptor_string: %s", descriptor_string)
 
             # Prompt for Descriptor Name
             ret = seed_screens.SeedAddPassphraseScreen(title="Descriptor Label").display()
@@ -2955,8 +2955,8 @@ class ToolsSeedkeeperSaveDescriptorView(View):
                     if stype == "Descriptor": 
                         multisig_descriptor_secrets.append((sid, label))
 
-            logger.info("Multisig Descriptor Secrets:", multisig_descriptor_secrets)
-            logger.info("Xpub Secrets:",xpub_labels)
+            logger.debug("Multisig Descriptor Secrets: %s", multisig_descriptor_secrets)
+            logger.debug("Xpub Secrets: %s", xpub_labels)
 
             multisig_descriptor_templates = []
 
@@ -2967,14 +2967,14 @@ class ToolsSeedkeeperSaveDescriptorView(View):
 
                 multisig_descriptor_templates.append(secret_dict['secret'])
 
-            logger.info(multisig_descriptor_templates)
+            logger.debug("multisig_descriptor_templates: %s", multisig_descriptor_templates)
 
-            logger.info("Key Strings:", key_strings)
+            logger.debug("Key Strings: %s", key_strings)
 
             # Add required secrets to seedkeeper
             for secret_label, secret_text in key_strings:
                 if secret_text in multisig_descriptor_templates or secret_label in xpub_labels:
-                    logger.info("Mached Existing Secret, skipping:", secret_label)
+                    logger.debug("Matched Existing Secret, skipping: %s", secret_label)
                     secrets_skipped += 1
                     continue
                 header = Satochip_Connector.make_header(secret_type, "Plaintext export allowed", secret_label)


### PR DESCRIPTION
## Summary
- Remove `print()` statements in `settings.py` that dump full settings dictionaries to stdout on every update
- Convert all remaining `print()` in `settings.py` to `logger.debug()`
- Downgrade `logger.info()` calls in `tools_views.py` that expose wallet descriptors, xpub data, Seedkeeper secret headers, and key strings to `logger.debug()`

## Context

**C-2 (settings.py):** `update()` printed the entire `self._data` and `new_settings`
to stdout on every settings change, exposing configuration including encryption
iteration counts and PIN attempt limits.

**C-3 (tools_views.py):** `logger.info()` calls logged descriptor strings with
extended public keys and Seedkeeper secret metadata. Xpub exposure enables full
wallet balance enumeration.

Both are now `logger.debug()`, silent at the default INFO log level. Debug output
only appears with `--loglevel DEBUG`.

## Test plan
- [ ] Verify settings changes still work correctly
- [ ] Verify descriptor/xpub operations still work
- [ ] Verify default log output no longer contains descriptor or settings data