### PR TITLE
Potential fix for code scanning alert no. 27: Clear-text logging of sensitive information

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -10836,7 +10836,9 @@ def bip85_verify_existing(
     from datetime import datetime, timezone
 
     logger.info(
-        "bip85_verify_existing: fpr=%s index=%s", fingerprint, key_index
+        "bip85_verify_existing: fpr(last8)=%s index=%s",
+        fingerprint[-8:] if fingerprint else "None",
+        key_index,
     )
     if hasattr(seed, "get_root"):
         root = seed.get_root()


### PR DESCRIPTION
Potential fix for [https://github.com/3rdIteration/seedsigner/security/code-scanning/27](https://github.com/3rdIteration/seedsigner/security/code-scanning/27)

To fix this, avoid logging the full secret key fingerprint in clear text. The simplest way, without changing functionality, is to either (a) remove the fingerprint from the log message, or (b) only log a truncated/redacted version (e.g., last 8 hex characters), which is already how the UI labels keys when no UID is present. This maintains debuggability (you can still correlate which key was used) while reducing exposure of the full fingerprint.

The best minimal change is to keep the log line but change the message to log only a short, non-sensitive portion of the fingerprint such as the last 8 characters, and clearly indicate it is truncated. That means editing line 10838–10840 in `src/seedsigner/views/tools_views.py` where `bip85_verify_existing` logs the fingerprint. We do not need new imports or helper functions; we can slice the string inline: `fingerprint[-8:] if fingerprint else "None"`. The rest of the function remains untouched.

Concretely:
- In `bip85_verify_existing`, replace `logger.info("bip85_verify_existing: fpr=%s index=%s", fingerprint, key_index)` with something like `logger.info("bip85_verify_existing: fpr(last8)=%s index=%s", fingerprint[-8:] if fingerprint else "None", key_index)`.
- No other files/lines need modification, and no new dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
