### PR TITLE
Potential fix for code scanning alert no. 36: Clear-text logging of sensitive information

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -10837,7 +10837,7 @@ def bip85_verify_existing(
 
     logger.info(
         "bip85_verify_existing: fpr(last8)=%s index=%s",
-        fingerprint[-8:] if fingerprint else "None",
+        "redacted" if fingerprint else "None",
         key_index,
     )
     if hasattr(seed, "get_root"):


### PR DESCRIPTION
Potential fix for [https://github.com/3rdIteration/seedsigner/security/code-scanning/36](https://github.com/3rdIteration/seedsigner/security/code-scanning/36)

In general, the fix is to avoid logging sensitive key-identifying material. Here, instead of logging even the last 8 characters of the GPG fingerprint, we can log a non-sensitive placeholder (e.g., `"redacted"`) or omit that part altogether, while still logging non-sensitive context like the key index. This keeps functionality unchanged: `bip85_verify_existing` uses `fingerprint` for derivation and verification but does not rely on the log content. The best minimal fix is therefore to change the `logger.info` call to stop interpolating the fingerprint value.

Concretely, in `src/seedsigner/views/tools_views.py` around lines 10838–10842, update the `logger.info` call inside `bip85_verify_existing` so that it no longer logs any portion of `fingerprint`. For example, change the format string to only include the index, or keep the label but replace the fingerprint value with a static, non-sensitive string like `"redacted"`. No new imports or helper methods are needed; only the arguments to `logger.info` change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
