### PR TITLE
Potential fix for code scanning alert no. 19: Clear-text logging of sensitive information

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -11713,9 +11713,10 @@ class ToolsGPGAddSubkeysView(View):
                 primary_curve,
                 subkeys,
             ):
+                fingerprint_suffix = fingerprint[-8:] if fingerprint else "unknown"
                 logger.warning(
-                    "Selected seed/index failed validation for fingerprint %s",
-                    fingerprint,
+                    "Selected seed/index failed validation for fingerprint ending with %s",
+                    fingerprint_suffix,
                 )
                 corrected = None
                 for i in range(base_index - 1, -1, -1):


### PR DESCRIPTION
Potential fix for [https://github.com/3rdIteration/seedsigner/security/code-scanning/19](https://github.com/3rdIteration/seedsigner/security/code-scanning/19)

In general, to fix clear-text logging of sensitive information, avoid logging the sensitive value directly; either remove it from logs, replace it with a non-sensitive surrogate (e.g., a truncated or hashed form), or log only non-sensitive metadata (like an index or generic status message).

For this specific case, the concern is logging the full `fingerprint` when validation fails. We can preserve debugging value by logging only a redacted form of the fingerprint, such as the last 8 characters, which is already used elsewhere in this function for display (`key["fpr"][-8:]`). This avoids dumping the entire fingerprint while still letting developers correlate which key caused a problem. Implementation-wise, we only need to change the two logger.warning calls around lines 11716–11748 in `src/seedsigner/views/tools_views.py` to avoid including the full `fingerprint`. A minimal change is to compute a local variable like `fingerprint_suffix = fingerprint[-8:]` and log that instead of `fingerprint`. No new imports or helper methods are necessary; slicing is built-in.

Concretely:
- In the `if not bip85_verify_existing(...):` block:
  - Before the first `logger.warning`, compute a redacted string (e.g., last 8 chars).
  - Change the format string to refer to a “redacted fingerprint” and pass the redacted value.
- Leave all functional logic unchanged (no changes to how `fingerprint` is used for actual cryptographic or lookup purposes).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
