### PR TITLE
Potential fix for code scanning alert no. 18: Clear-text logging of sensitive information

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -11663,9 +11663,10 @@ class ToolsGPGAddSubkeysView(View):
         created_ts = keys[selected]["created"]
         entry = BIP85_DATA.get(fingerprint)
         bip85 = entry is not None
+        fingerprint_suffix = fingerprint[-8:] if isinstance(fingerprint, str) and len(fingerprint) >= 8 else fingerprint
         logger.info(
-            "AddSubkeysView: fpr=%s bip85=%s start_index=%s",
-            fingerprint,
+            "AddSubkeysView: fpr_suffix=%s bip85=%s start_index=%s",
+            fingerprint_suffix,
             bip85,
             start_index,
         )


### PR DESCRIPTION
Potential fix for [https://github.com/3rdIteration/seedsigner/security/code-scanning/18](https://github.com/3rdIteration/seedsigner/security/code-scanning/18)

In general, to fix clear-text logging of sensitive information, either stop logging the sensitive value or replace it with a non-sensitive substitute (e.g., a truncated form, a generic tag, or a one-time internal correlation ID). The key is to preserve enough logging for diagnostics without exposing secret or user-identifying data.

For this specific case, the `logger.info` call logs `fingerprint`, which comes from the list of secret keys. We do not need the full fingerprint in logs to preserve behavior; at most, truncated information or an index is sufficient for debugging. The best minimal-change fix is to log a non-sensitive representation instead of the full fingerprint—for example, the last 8 characters, or to drop it entirely. The function already uses `key["fpr"][-8:]` for display when no UID is present, so logging an 8-character suffix is consistent with existing behavior and gives enough context for debugging without writing the full fingerprint to logs.

Concretely:
- In `src/seedsigner/views/tools_views.py`, around lines 11666–11671, modify the `logger.info` call so that it does not log the full `fingerprint`.
- Introduce a local variable (e.g., `fingerprint_suffix = fingerprint[-8:] if len(fingerprint) >= 8 else fingerprint`) and log only that, or remove the fingerprint from the log line entirely.
- No new imports or helper methods are needed; this is a simple string slicing operation in the same block where `fingerprint` is defined.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
