### PR TITLE
Potential fix for code scanning alert no. 17: Clear-text logging of sensitive information

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -10981,9 +10981,11 @@ def bip85_add_subkeys(
     from pgpy.packet.types import MPI
     from Cryptodome.PublicKey import RSA
 
+    # Log only a shortened version of the fingerprint to avoid exposing the full value
+    fpr_short = fingerprint[-8:] if fingerprint else ""
     logger.info(
-        "bip85_add_subkeys: fpr=%s alg=%s key_index=%s start_index=%s",
-        fingerprint,
+        "bip85_add_subkeys: fpr_suffix=%s alg=%s key_index=%s start_index=%s",
+        fpr_short,
         alg,
         key_index,
         start_index,


### PR DESCRIPTION
Potential fix for [https://github.com/3rdIteration/seedsigner/security/code-scanning/17](https://github.com/3rdIteration/seedsigner/security/code-scanning/17)

In general, to fix clear-text logging of sensitive information, either remove sensitive fields from log messages entirely or sanitize them (e.g., mask, hash, or truncate them so they are no longer directly usable) before logging. For cryptographic identifiers like key fingerprints, logging only a short suffix or a hash can often provide enough diagnostic value without exposing the full value.

In this specific case, the problematic sink is the `logger.info` call inside `bip85_add_subkeys` (around line 10984). The easiest and safest fix that preserves behavior is to stop logging the full `fingerprint`. We can either remove the fingerprint from the log or replace it with a masked version. Since elsewhere the UI uses the last 8 characters (`key["fpr"][-8:]`) as a short identifier, we can be consistent and only log a short suffix instead of the full fingerprint. We will introduce a local variable (e.g., `fpr_short = fingerprint[-8:] if fingerprint else ""`) and use that in the log message, and also adjust the log message text so it’s clear that this is a shortened fingerprint. No changes are needed to other code paths or function signatures; the change remains purely in logging.

Concretely:
- In `src/seedsigner/views/tools_views.py`, locate `def bip85_add_subkeys(...)` and its `logger.info` call.
- Above the `logger.info` call, compute a shortened fingerprint string.
- Update the `logger.info` format string to indicate it logs a short fingerprint and use the shortened variable instead of `fingerprint`.
- No new imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
