### PR TITLE
Potential fix for code scanning alert no. 16: Clear-text logging of sensitive information

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -10890,9 +10890,7 @@ def bip85_verify_existing(
     primary._key = pk
     if primary.fingerprint != fingerprint:
         logger.warning(
-            "Primary key fingerprint mismatch: expected %s got %s",
-            fingerprint,
-            primary.fingerprint,
+            "Primary key fingerprint mismatch during BIP85 verification"
         )
         return False
 


### PR DESCRIPTION
Potential fix for [https://github.com/3rdIteration/seedsigner/security/code-scanning/16](https://github.com/3rdIteration/seedsigner/security/code-scanning/16)

In general, to fix clear‑text logging of sensitive information, either (a) stop logging the sensitive field entirely, or (b) log only non‑sensitive derivatives (e.g., truncated values or opaque identifiers) that preserve debugging usefulness without exposing the full secret or directly identifying data.

Here, the problematic log is:

```python
logger.warning(
    "Primary key fingerprint mismatch: expected %s got %s",
    fingerprint,
    primary.fingerprint,
)
```

To keep functionality but avoid logging sensitive key identifiers, the best fix is to remove the actual fingerprint values from the log message. We can still report that a mismatch occurred, and if needed, provide a generic context (e.g., index or that it’s a BIP85 check) without revealing the specific fingerprints. Since the rest of the function and its callers do not depend on the log contents, this change does not affect behavior aside from safer logging.

Concretely:

- In `src/seedsigner/views/tools_views.py`, in function `bip85_verify_existing`, replace the above `logger.warning` call with one that does not interpolate `fingerprint` values, such as:

  ```python
  logger.warning("Primary key fingerprint mismatch during BIP85 verification")
  ```

- No additional imports or helper methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
