### PR TITLE
Potential fix for code scanning alert no. 14: Clear-text logging of sensitive information

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -5844,8 +5844,7 @@ def parse_uid_list(colon_output: str):
 def filter_deletable_subkeys(primary_fpr: str, subkeys):
     bip85 = primary_fpr in BIP85_DATA
     logger.info(
-        "filter_deletable_subkeys: fpr=%s bip85=%s subkey_count=%s",
-        primary_fpr,
+        "filter_deletable_subkeys: bip85=%s subkey_count=%s",
         bip85,
         len(subkeys),
     )


### PR DESCRIPTION
Potential fix for [https://github.com/3rdIteration/seedsigner/security/code-scanning/14](https://github.com/3rdIteration/seedsigner/security/code-scanning/14)

In general, the fix is to avoid writing sensitive key material or identifiers to logs in clear text. For this specific case, we only need the fingerprint in memory to determine BIP85 status and filter subkeys; it does not need to be logged. We can either remove it from the log message entirely or replace it with a redacted/truncated form that does not expose the full value.

The minimal, non-functional-impact change is to modify the `logger.info` call inside `filter_deletable_subkeys` so that it no longer logs `primary_fpr`. We can keep the log message for debugging by logging only whether the key is BIP85 and the subkey count. Alternatively, we can log an anonymized identifier (e.g., last 8 chars), but to be conservative, the safest is to remove the fingerprint from the log. That involves changing the format string and the arguments list at lines 5846–5851. No new imports or helper functions are necessary.

Concretely, in `src/seedsigner/views/tools_views.py`, update the `logger.info` in `filter_deletable_subkeys` so it looks like:

```python
logger.info(
    "filter_deletable_subkeys: bip85=%s subkey_count=%s",
    bip85,
    len(subkeys),
)
```

leaving the rest of the function unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
