### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -2685,8 +2685,8 @@ class ToolsSeedkeeperViewSecretsView(View):
                 wordlist_byte = secret_raw_bytes[offset]
                 offset+=1
                 wordlist = BIP39_WORDLIST_DIC.get(wordlist_byte)
-                if wordlist == None:
-                    logger.info(f"Error: wordlist byte {wordlist_byte} unsupported!")
+                if wordlist is None:
+                    logger.info("Error: unsupported BIP39 wordlist identifier encountered")
                     exit()
                 
                 entropy_size = secret_raw_bytes[offset]


### PR DESCRIPTION
Potential fix for [https://github.com/3rdIteration/seedsigner/security/code-scanning/6](https://github.com/3rdIteration/seedsigner/security/code-scanning/6)

To fix the problem, we should stop logging the tainted byte value directly. We still want an error log to help debugging, but it should not include the potentially sensitive, taint-tracked `wordlist_byte` value. The best low-impact fix is to log a generic error message without the byte content, or at most to log that an “unsupported wordlist identifier” was encountered, without including the actual identifier value. This preserves behavior (an error is logged, and the code still exits) while removing clear-text logging of data derived from the secret.

Concretely, in `src/seedsigner/views/tools_views.py` around line 2688–2690, we will replace:

```python
if wordlist == None:
    logger.info(f"Error: wordlist byte {wordlist_byte} unsupported!")
    exit()
```

with something like:

```python
if wordlist is None:
    logger.info("Error: unsupported BIP39 wordlist identifier encountered")
    exit()
```

This change keeps logging at the same level and keeps the control flow (`exit()`) intact, but no longer logs the tainted byte value. No new imports or helper functions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
