### PR TITLE
Fix camera entropy fallback and clear image entropy on wipe

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -399,6 +399,11 @@ class Controller(Singleton):
                     self.psbt_sign_with_satochip = False
                     self.sign_message_with_satochip = False
 
+                    # Clear camera entropy data so it cannot be used to
+                    # reconstruct seeds after the flow completes.
+                    self.image_entropy_preview_frames = None
+                    self.image_entropy_final_image = None
+
                     # Clear the whole Smartcard session if caching PIN is disabled (Same as removing the card)
                     if Settings.get_instance().get_value(SettingsConstants.SETTING__CACHE_SCARD_PIN) != "E":
                         self.Satochip_PIN = None
@@ -566,6 +571,8 @@ class Controller(Singleton):
         self.Satochip_Last_UID_SHA1 = None
         self.Satochip_Connector = None
         self.GPG_Admin_PIN = None
+        self.image_entropy_preview_frames = None
+        self.image_entropy_final_image = None
 
         # Return to main menu
         self.clear_back_stack()

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -231,14 +231,16 @@ def _derive_hardware_rng_entropy_bytes() -> bytes:
 def _derive_camera_entropy_bytes(preview_images, final_image) -> bytes | None:
     # Build in some hardware-level uniqueness via CPU unique Serial num
     try:
-        stream = os.popen("cat /proc/cpuinfo | grep Serial")
-        output = stream.read()
-        serial_num = output.split(":")[-1].strip().encode("utf-8")
+        with open("/proc/cpuinfo", "r", encoding="utf-8") as f:
+            serial_line = next(
+                (line for line in f if line.startswith("Serial")), ""
+            )
+        serial_num = serial_line.split(":")[-1].strip().encode("utf-8")
         serial_hash = hashlib.sha256(serial_num)
         hash_bytes = serial_hash.digest()
     except Exception as e:
         logger.info(repr(e), exc_info=True)
-        hash_bytes = b"0"
+        hash_bytes = hashlib.sha256(os.urandom(32)).digest()
 
     # Build in modest entropy via millis since power on
     millis_hash = hashlib.sha256(hash_bytes + str(time.time()).encode("utf-8"))


### PR DESCRIPTION
## Summary
- Replace constant `b"0"` fallback in camera entropy derivation with `os.urandom(32)` hashed through SHA-256
- Replace `os.popen()` shell pipeline with direct file read for CPU serial
- Clear `image_entropy_preview_frames` and `image_entropy_final_image` on wipe timeout and home navigation

## Context

**C-1:** When reading the CPU serial from `/proc/cpuinfo` fails, camera entropy derivation fell back to the literal byte string `b"0"`, making the device-binding entropy component identical across all affected devices. Now falls back to `os.urandom(32)` to maintain strong randomness. The `os.popen("cat /proc/cpuinfo | grep Serial")` shell pipeline was also replaced with a direct file read.

**C-4:** The wipe timer (`handle_wipe_timeout()`) and home navigation reset wiped seeds, PINs, and PSBT data but left raw camera pixel data in memory. An attacker with physical access could extract these frames and reconstruct the entropy chain used to generate the now-wiped seed. Both code paths now clear the image entropy fields.

## Test plan
- [ ] Verify camera-based seed generation works on Raspberry Pi (normal path reads CPU serial)
- [ ] Verify camera-based seed generation works without `/proc/cpuinfo` (fallback uses `os.urandom`)
- [ ] Verify wipe timer clears image entropy (inspect controller state after timeout)
- [ ] Verify returning to home screen clears image entropy

https://claude.ai/code/session_0172zHJQXdNVqvzsQ76MynQd