### PR TITLE
Add explicit least-privilege permissions to GitHub workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,9 @@ on:
 # Increment this number as part of a PR to trigger an image build for the PR
 # trigger = 0
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: >-

--- a/.github/workflows/telegram.yml
+++ b/.github/workflows/telegram.yml
@@ -6,6 +6,10 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   if_merged:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   # Concurrency group that uses the workflow name and PR number if available
   # or commit SHA as a fallback. If a new build is triggered under that


### PR DESCRIPTION
### Motivation
- CodeQL flagged workflows missing explicit `permissions` (`actions/missing-workflow-permissions`), so workflows relied on repository/org defaults instead of least-privilege defaults.
- The intent is to document and enforce minimal permissions at workflow scope while preserving job-level write privileges where required.

### Description
- Added top-level `permissions: contents: read` to `tests.yml` so CI jobs no longer inherit broad repo permissions.
- Added top-level `permissions: contents: read` to `build.yml` so build jobs default to read-only access.
- Added top-level `permissions: contents: read` and `pull-requests: read` to `telegram.yml` to match the notifier's needs.
- Preserved the existing `upload_release` job-level `permissions: contents: write` in `build.yml` so only that job can write release assets.

### Testing
- Ran `git diff --check` and there were no whitespace or formatting errors (passed).
- Ran a small validation script that ensured every `.github/workflows/*.yml` file contains a `permissions` key and it completed successfully.
- Verified the changes are staged and committed (3 files changed: `build.yml`, `tests.yml`, `telegram.yml`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69894f99551883228e127d14e09c2685)