### PR TITLE
Potential fix for code scanning alert no. 20: Use of weak cryptographic key

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -10637,6 +10637,10 @@ def bip85_rsa_from_root(root, bits: int, index: int, sub_index: int | None = Non
     from Cryptodome.PublicKey import RSA
     from seedsigner.helpers.bip85_drng import BIP85DRNG
 
+    # Enforce a minimum RSA key size of 2048 bits to avoid weak keys.
+    if bits < 2048:
+        bits = 2048
+
     path = [bits, index]
     if sub_index is not None:
         path.append(sub_index)


### PR DESCRIPTION
Potential fix for [https://github.com/3rdIteration/seedsigner/security/code-scanning/20](https://github.com/3rdIteration/seedsigner/security/code-scanning/20)

In general, the fix is to ensure that RSA keys are never generated with fewer than 2048 bits. This can be done either by validating and constraining the `bits` parameter at call sites or by enforcing a minimum inside the RSA key generation helper. The safest and least invasive is to clamp the `bits` value inside `bip85_rsa_from_root`, which is the centralized helper that actually calls `RSA.generate`. That way, even if other callers are added later or existing validation is incomplete elsewhere, no weak key is ever generated.

Concretely, in `src/seedsigner/views/tools_views.py`, we should update `bip85_rsa_from_root` to enforce a minimum key size, e.g., 2048 bits. We do this by computing `bits = max(bits, 2048)` (or similar) before using it to build the BIP85 path and before calling `RSA.generate`. This preserves existing semantics for any request ≥ 2048 bits and automatically upgrades any smaller or default (`0`) requests to 2048 bits, without changing the rest of the functionality. The BIP85 path currently includes the raw `bits` value, which is intended to deterministically bind the derived key material to the requested size; to keep this property aligned with the actual RSA key size, we should use the clamped `bits` value both in the path and in the call to `RSA.generate`. No new imports or external dependencies are required, as we only introduce a simple integer max operation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
