### PR TITLE
Potential fix for code scanning alert no. 20: Use of weak cryptographic key

### DIFF
--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -75,6 +75,9 @@ from seedsigner.helpers.satochip_signer import (
 from seedsigner.gui.screens import seed_screens
 logger = logging.getLogger(__name__)
 
+# Minimum RSA key size in bits to avoid weak keys.
+MIN_RSA_KEY_BITS = 2048
+
 from pysatochip.JCconstants import SEEDKEEPER_DIC_TYPE, SEEDKEEPER_DIC_ORIGIN, SEEDKEEPER_DIC_EXPORT_RIGHTS, BIP39_WORDLIST_DIC
 from pysatochip.CardConnector import CardConnector, UnexpectedSW12Error
 from binascii import unhexlify, hexlify
@@ -10637,9 +10640,9 @@ def bip85_rsa_from_root(root, bits: int, index: int, sub_index: int | None = Non
     from Cryptodome.PublicKey import RSA
     from seedsigner.helpers.bip85_drng import BIP85DRNG
 
-    # Enforce a minimum RSA key size of 2048 bits to avoid weak keys.
-    if bits < 2048:
-        bits = 2048
+    # Enforce a minimum RSA key size to avoid weak keys.
+    if bits < MIN_RSA_KEY_BITS:
+        bits = MIN_RSA_KEY_BITS
 
     path = [bits, index]
     if sub_index is not None:
@@ -10866,7 +10869,12 @@ def bip85_verify_existing(
     pk = PrivKeyV4()
     if primary_algo in ("1", "2", "3"):
         pk.pkalg = PubKeyAlgorithm.RSAEncryptOrSign
-        bits = int(primary_bits) if primary_bits else 0
+        try:
+            bits = int(primary_bits) if primary_bits else MIN_RSA_KEY_BITS
+        except (TypeError, ValueError):
+            bits = MIN_RSA_KEY_BITS
+        if bits < MIN_RSA_KEY_BITS:
+            bits = MIN_RSA_KEY_BITS
         rsa_main = bip85_rsa_from_root(root, bits, key_index)
         pk.keymaterial = rsa_to_privpacket(rsa_main)
     elif primary_curve == "secp256k1":


### PR DESCRIPTION
Potential fix for [https://github.com/3rdIteration/seedsigner/security/code-scanning/20](https://github.com/3rdIteration/seedsigner/security/code-scanning/20)

In general, the problem is addressed by ensuring RSA keys are never generated with fewer than 2048 bits, and by validating any external or user‑supplied key size before it influences cryptographic operations. Instead of silently converting arbitrary or missing input to 2048 in a helper, we should (a) define a clear minimum key size constant, (b) clamp or reject invalid values at the point where the bits value is computed, and (c) keep `bip85_rsa_from_root` strictly using validated values.

The best fix here, without changing visible functionality, is:

1. Introduce a module‑level constant for the minimum RSA key size (2048).
2. In `bip85_rsa_from_root`, keep a guard but make it reference that constant.
3. At the call site in the GPG key generation logic (around line 10869), normalize `primary_bits` so that if it is missing, non‑numeric, or too small, we use the minimum safe size instead of 0, and ensure the value passed into `bip85_rsa_from_root` is always at least 2048.
4. Optionally, for additional robustness, handle non‑integer `primary_bits` with a `try/except`.

Because we can only modify `src/seedsigner/views/tools_views.py` within the shown snippets, the changes will be:

- Add a constant like `MIN_RSA_KEY_BITS = 2048` near the other top‑level definitions (immediately after the logger definition for clear scope).
- Update the guard in `bip85_rsa_from_root` to refer to `MIN_RSA_KEY_BITS` instead of a magic literal and keep the enforcement.
- Replace the assignment `bits = int(primary_bits) if primary_bits else 0` at line 10869 with logic that parses `primary_bits` safely and ensures the resulting `bits` is at least `MIN_RSA_KEY_BITS`.

No new imports or external libraries are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
