### PR TITLE
docs: add security-first guidance for entropy and key handling to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,45 @@
 For TextArea-based informational screens (especially ButtonListScreen flows), keep body copy to a **maximum of ~120 characters total**, split across **no more than 2 lines** (roughly **~60 characters per line**). This aligns with existing info screens such as the restart/power-off messages, which fit cleanly on the display.
 
 If additional detail is needed, prefer a second screen instead of longer text.
+
+## Security-first development guidance
+
+Because this project handles private key material for an air-gapped signer, **security takes precedence over convenience**. Treat all entropy and key-handling paths as high-risk code.
+
+### Entropy generation and handling
+- Use only cryptographically secure RNG sources/APIs; never use non-CSPRNG functions for seed/key generation.
+- Mix entropy sources conservatively (never reduce effective entropy via lossy transforms or truncation).
+- Do not log, print, serialize, or persist raw entropy, seed bytes, or private keys—even in debug mode.
+- Prefer deterministic, reviewed key-derivation standards (e.g., BIP39/BIP32 flows already used in repo) over custom schemes.
+- Add explicit comments when code assumes a minimum entropy size/security level.
+
+### Private key safety
+- Keep secret material in memory for the shortest time possible.
+- Avoid copies of secret data (including implicit copies via string conversions, repr/debug formatting, or temporary buffers).
+- Zeroize/wipe secret buffers as soon as they are no longer needed.
+- Store secrets in mutable byte buffers when possible (so they can be wiped), not immutable strings.
+- Ensure error paths and early returns also wipe sensitive intermediates.
+
+### Cleanup and lifecycle controls
+- On screen transitions, cancellations, exceptions, and shutdown/restart flows, clear in-memory seed/key state.
+- Ensure temporary files are never used for entropy/key material; if unavoidable, they must be securely deleted immediately.
+- Verify object caches/singletons do not retain secret state longer than required.
+
+### Input, command, and script hardening
+- Treat all external input (QR payloads, SD card files, settings imports) as untrusted.
+- Validate and constrain input using strict allowlists, length checks, and format checks before processing.
+- Never build shell commands by string concatenation with untrusted input.
+- Prefer `subprocess.run([...], shell=False, check=True)` patterns over shell invocation.
+- If shell scripts are required, quote variables defensively and avoid eval-like constructs.
+- Do not execute dynamic code from user-provided payloads, descriptors, labels, or metadata.
+
+### Dependency and crypto hygiene
+- Prefer standard-library or well-reviewed cryptographic primitives already used by the project.
+- Do not introduce new crypto dependencies or algorithms without explicit justification in the PR description.
+- Keep reproducibility and deterministic builds in mind for security-sensitive changes.
+
+### Code review expectations for sensitive changes
+For changes touching entropy, seed generation/import, key derivation, signing, or secret storage:
+- Add/extend tests for both success and failure/cleanup paths.
+- Document threat assumptions and failure modes in code comments or PR notes.
+- Call out any remaining risk tradeoffs explicitly.


### PR DESCRIPTION
### Motivation
- This repository targets an air-gapped Bitcoin signer and thus requires explicit contributor guidance so security outweighs convenience for entropy and key handling. 
- The change aims to reduce risk of weak entropy, accidental leakage of secrets, unsafe lifecycle management, and injection vectors from scripts or untrusted input.

### Description
- Add a new `Security-first development guidance` section to `AGENTS.md` that centralizes secure practices for this project. 
- Add entropy-generation guidance requiring CSPRNGs, conservative entropy mixing, and prohibition on logging or persisting raw entropy or seeds. 
- Add private-key safety and lifecycle controls covering minimal in-memory lifetime, avoidance of secret copies, use of mutable buffers where possible, zeroization/wiping, and cleanup on errors and UI transitions. 
- Add input/script hardening guidance, dependency/crypto hygiene, and explicit code-review expectations for changes touching entropy, derivation, signing, or secret storage.

### Testing
- Verified the new content by printing the file with `sed -n '1,260p' AGENTS.md`, which succeeded. 
- Verified the diff and staged change with `git status --short && git diff -- AGENTS.md`, which succeeded. 
- Verified the commit with `git rev-parse --abbrev-ref HEAD && git show --stat --oneline -1`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698957e9c2988322b29ef49ece32ec46)