### PR TITLE
Add secure memory wiping for sensitive seed data (H-3)

### DIFF
--- a/src/seedsigner/helpers/secure_delete.py
+++ b/src/seedsigner/helpers/secure_delete.py
@@ -1,0 +1,73 @@
+"""Best-effort secure memory clearing for sensitive Python objects.
+
+Python does not guarantee secure deletion of string or bytes data.
+These helpers use ctypes to overwrite the internal buffer of bytearray
+and (where possible) bytes objects before they are garbage-collected.
+
+Limitations:
+    - Immutable ``str`` and ``bytes`` objects may have been copied by the
+      interpreter (interning, concatenation) so zeroing the original does
+      not guarantee all copies are erased.
+    - Only CPython is supported; other interpreters may lay out objects
+      differently.
+    - This is a *mitigation*, not a guarantee. A sufficiently privileged
+      attacker with access to the process memory may still recover data.
+"""
+
+import ctypes
+import sys
+
+
+def _wipe_buffer(obj, length: int) -> None:
+    """Overwrite *length* bytes starting at the object's buffer address."""
+    if length <= 0:
+        return
+    # id(obj) is the CPython memory address of the PyObject struct.
+    # For bytes the buffer starts at an offset past the ob_refcnt,
+    # ob_type, ob_size, and ob_shash fields.  The offset is
+    # platform-dependent but sys.getsizeof gives us the total
+    # allocation; the last *length* bytes are the data + NUL.
+    buf_start = id(obj) + sys.getsizeof(obj) - length - 1
+    ctypes.memset(buf_start, 0, length)
+
+
+def wipe_bytes(b: bytes | bytearray | None) -> None:
+    """Zero out the contents of a bytes or bytearray object in place."""
+    if b is None:
+        return
+    if isinstance(b, bytearray):
+        for i in range(len(b)):
+            b[i] = 0
+        return
+    if isinstance(b, bytes) and len(b) > 0:
+        _wipe_buffer(b, len(b))
+
+
+def wipe_string(s: str | None) -> None:
+    """Best-effort zeroing of a str object's internal buffer.
+
+    Only works for ASCII/Latin-1 compact strings on CPython where each
+    character occupies one byte.  For wider encodings the internal
+    layout differs and this may not fully clear the data, but it will
+    still overwrite a significant portion.
+    """
+    if s is None or len(s) == 0:
+        return
+    # CPython compact ASCII strings store data right after the
+    # PyASCIIObject struct.  sys.getsizeof includes the NUL terminator.
+    buf_size = sys.getsizeof(s) - sys.getsizeof("")
+    if buf_size > 0:
+        buf_start = id(s) + sys.getsizeof("") - 1
+        ctypes.memset(buf_start, 0, buf_size)
+
+
+def wipe_list(lst: list | None) -> None:
+    """Wipe all str/bytes elements of a list, then clear it."""
+    if lst is None:
+        return
+    for item in lst:
+        if isinstance(item, (bytes, bytearray)):
+            wipe_bytes(item)
+        elif isinstance(item, str):
+            wipe_string(item)
+    lst.clear()

--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -9,6 +9,7 @@ import shamir_mnemonic
 from embit.networks import NETWORKS
 from typing import List
 
+from seedsigner.helpers.secure_delete import wipe_bytes, wipe_string, wipe_list
 from seedsigner.models.settings import SettingsConstants
 
 logger = logging.getLogger(__name__)
@@ -187,7 +188,18 @@ class Seed:
         return
         
 
-    ### override operators    
+    def wipe(self):
+        """Best-effort secure clearing of all sensitive fields."""
+        wipe_bytes(self.seed_bytes)
+        self.seed_bytes = None
+        wipe_bytes(self.master_secret)
+        self.master_secret = None
+        wipe_list(self._mnemonic)
+        self._mnemonic = []
+        wipe_string(self._passphrase)
+        self._passphrase = ""
+
+    ### override operators
     def __eq__(self, other):
         if isinstance(other, Seed):
             return self.seed_bytes == other.seed_bytes
@@ -380,6 +392,18 @@ class Slip39Seed(Seed):
     def bip85_supported(self) -> bool:
         return True
 
+    def wipe(self):
+        """Securely clear SLIP-39-specific fields, then delegate to parent."""
+        wipe_list(self._shares)
+        self._shares = []
+        wipe_string(self._slip39_passphrase)
+        self._slip39_passphrase = ""
+        wipe_bytes(self._initial_master_secret)
+        self._initial_master_secret = None
+        wipe_string(self._creation_passphrase)
+        self._creation_passphrase = ""
+        super().wipe()
+
     def regenerate_shares(self, threshold: int, num_shares: int) -> List[str]:
         """Generate new SLIP-39 shares from the original master secret."""
         if not self.extendable:
@@ -468,6 +492,13 @@ class XprvSeed(Seed):
     def get_bip85_child_mnemonic(self, bip85_index: int, bip85_num_words: int, network: str = SettingsConstants.MAINNET):
         # TODO: Support other BIP-39 wordlist languages!
         return bip85.derive_mnemonic(self.get_root(network), bip85_num_words, bip85_index)
+
+    def wipe(self):
+        """Securely clear xprv-specific fields, then delegate to parent."""
+        wipe_string(self._xprv)
+        self._xprv = ""
+        self._root = None
+        super().wipe()
 
     def __eq__(self, other):
         if isinstance(other, XprvSeed):

--- a/src/seedsigner/models/seed_storage.py
+++ b/src/seedsigner/models/seed_storage.py
@@ -1,4 +1,5 @@
 from typing import List
+from seedsigner.helpers.secure_delete import wipe_bytes, wipe_list
 from seedsigner.models.seed import Seed, ElectrumSeed, Slip39Seed, InvalidSeedException
 from seedsigner.models.settings_definition import SettingsConstants
 
@@ -37,6 +38,8 @@ class SeedStorage:
 
 
     def clear_pending_seed(self):
+        if self.pending_seed is not None:
+            self.pending_seed.wipe()
         self.pending_seed = None
 
 
@@ -106,6 +109,7 @@ class SeedStorage:
     
 
     def discard_pending_mnemonic(self):
+        wipe_list(self._pending_mnemonic)
         self._pending_mnemonic = []
         self._pending_is_electrum = False
 
@@ -169,6 +173,9 @@ class SeedStorage:
         self.discard_pending_slip39_shares()
 
     def discard_pending_slip39_shares(self):
+        wipe_list(self._pending_slip39_share)
+        for share in self._pending_slip39_shares:
+            wipe_list(share)
         self._pending_slip39_share = []
         self._pending_slip39_shares = []
         self._pending_is_slip39 = False


### PR DESCRIPTION
## Summary
- Adds new `secure_delete.py` helper module with `ctypes.memset`-based memory wiping for `bytes`, `bytearray`, `str`, and `list` objects
- Adds `wipe()` methods to `Seed`, `Slip39Seed`, and `XprvSeed` classes that zero out seed bytes, mnemonic words, passphrases, and master secrets
- Integrates secure wiping into `SeedStorage` when discarding pending seeds, mnemonics, and SLIP-39 shares
- Best-effort mitigation for CPython; documented limitations for immutable object copies and non-CPython interpreters

## Test plan
- [ ] Verify seed creation and usage still works normally
- [ ] Verify discarding a pending seed properly clears sensitive data
- [ ] Verify SLIP-39 share discard wipes share data
- [ ] Test on Raspberry Pi Zero to ensure no performance regression

https://claude.ai/code/session_0172zHJQXdNVqvzsQ76MynQd