### PR TITLE
Sanitize exception logging in seed generation (M-1)

### DIFF
--- a/src/seedsigner/models/seed.py
+++ b/src/seedsigner/models/seed.py
@@ -54,8 +54,8 @@ class Seed:
         try:
             self.seed_bytes = bip39.mnemonic_to_seed(self.mnemonic_str, password=self._passphrase, wordlist=self.wordlist)
         except Exception as e:
-            logger.info(repr(e), exc_info=True)
-            raise InvalidSeedException(repr(e))
+            logger.info("BIP-39 mnemonic_to_seed failed: %s", type(e).__name__)
+            raise InvalidSeedException(type(e).__name__)
 
 
     @property
@@ -332,8 +332,8 @@ class Slip39Seed(Seed):
                 self._initial_master_secret = secret
             self.seed_bytes = secret
         except Exception as e:
-            logger.info(repr(e), exc_info=True)
-            raise InvalidSeedException(repr(e))
+            logger.info("SLIP-39 secret recovery failed: %s", type(e).__name__)
+            raise InvalidSeedException(type(e).__name__)
         finally:
             self.loading_screen.stop()
 


### PR DESCRIPTION
## Summary
- Replaces `logger.info(repr(e), exc_info=True)` with `logger.info("... failed: %s", type(e).__name__)` in both BIP-39 and SLIP-39 seed generation paths
- Replaces `raise InvalidSeedException(repr(e))` with `raise InvalidSeedException(type(e).__name__)` to prevent mnemonic/passphrase data from leaking into exception messages or log output
- Addresses security audit finding M-1: exception `repr()` could include sensitive seed material

## Test plan
- [ ] Verify invalid BIP-39 mnemonic still raises `InvalidSeedException` with sanitized message
- [ ] Verify invalid SLIP-39 shares still raise `InvalidSeedException` with sanitized message
- [ ] Check log output contains only exception type name, not seed data

https://claude.ai/code/session_0172zHJQXdNVqvzsQ76MynQd