### PR TITLE
Add System info screen to Hardware settings

### DIFF
--- a/src/seedsigner/gui/screens/settings_screens.py
+++ b/src/seedsigner/gui/screens/settings_screens.py
@@ -469,6 +469,38 @@ class BatteryInfoScreen(BaseTopNavScreen):
 
 
 @dataclass
+class SystemInfoScreen(BaseTopNavScreen):
+    pi_version: str = ""
+    system_serial: str = ""
+    microsd_serial: str = ""
+
+    def __post_init__(self):
+        self.title = _("System Info")
+        super().__post_init__()
+
+        info_lines = [
+            _("Pi: {pi_version}").format(pi_version=self.pi_version),
+            _("System: {system_serial}").format(system_serial=self.system_serial),
+            _("MicroSD: {microsd_serial}").format(microsd_serial=self.microsd_serial),
+        ]
+
+        start_y = self.top_nav.height + 2 * GUIConstants.COMPONENT_PADDING
+        line_spacing = GUIConstants.COMPONENT_PADDING
+
+        for line in info_lines:
+            text_area = TextArea(
+                text=line,
+                screen_x=GUIConstants.EDGE_PADDING,
+                width=self.canvas_width - 2 * GUIConstants.EDGE_PADDING,
+                is_text_centered=False,
+                auto_line_break=True,
+                screen_y=start_y,
+            )
+            self.components.append(text_area)
+            start_y += text_area.height + line_spacing
+
+
+@dataclass
 class SettingsQRConfirmationScreen(ButtonListScreen):
     config_name: str = None
     title: str = _mft("Settings QR")

--- a/src/seedsigner/views/settings_views.py
+++ b/src/seedsigner/views/settings_views.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import re
 from gettext import gettext as _
 
 #from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen, WarningScreen, settings_screens)
@@ -24,6 +26,7 @@ class SettingsMenuView(View):
     DONATE = ButtonOption("Donate")
     RESTART_PCSC = ButtonOption("Restart PCSC")
     BATTERY_INFO = ButtonOption("Battery info")
+    SYSTEM_INFO = ButtonOption("System info")
     LOAD_BACKUP_FILES = ButtonOption("Load Backup Files", right_icon_name=SeedSignerIconConstants.CHEVRON_RIGHT)
 
     def __init__(self, visibility: str = SettingsConstants.VISIBILITY__GENERAL, selected_attr: str = None, initial_scroll: int = 0):
@@ -83,6 +86,7 @@ class SettingsMenuView(View):
 
         elif self.visibility == SettingsConstants.VISIBILITY__HARDWARE:
             title = "Hardware"
+            button_data.append(self.SYSTEM_INFO)
             button_data.append(self.BATTERY_INFO)
             button_data.append(self.IO_TEST)
             if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
@@ -144,6 +148,9 @@ class SettingsMenuView(View):
 
         elif button_data[selected_menu_num] == self.BATTERY_INFO:
             return Destination(BatteryInfoView)
+
+        elif button_data[selected_menu_num] == self.SYSTEM_INFO:
+            return Destination(SystemInfoView)
 
         elif settings_entries[selected_menu_num].attr_name == SettingsConstants.SETTING__ENCRYPTION_ITER:
             return Destination(SettingPBKDF2IterationsView, view_args=dict(attr_name=settings_entries[selected_menu_num].attr_name, parent_initial_scroll=initial_scroll))
@@ -756,5 +763,75 @@ class BatteryInfoView(View):
             return Destination(SettingsMenuView, view_args={"visibility": SettingsConstants.VISIBILITY__HARDWARE})
 
         self.run_screen(settings_screens.BatteryInfoScreen)
+
+        return Destination(SettingsMenuView, view_args={"visibility": SettingsConstants.VISIBILITY__HARDWARE})
+
+
+class SystemInfoView(View):
+    def _read_text_file(self, path: str) -> str | None:
+        try:
+            with open(path, "r", encoding="utf-8") as file:
+                value = file.read().strip().replace("\x00", "")
+            return value or None
+        except Exception:
+            return None
+
+    def _get_pi_version(self) -> str:
+        model = self._read_text_file("/proc/device-tree/model")
+        if model:
+            return model
+
+        try:
+            with open("/proc/cpuinfo", "r", encoding="utf-8") as file:
+                for line in file:
+                    if line.startswith("Model"):
+                        return line.split(":", 1)[-1].strip()
+        except Exception:
+            pass
+
+        return _("Unavailable")
+
+    def _get_system_serial(self) -> str:
+        try:
+            with open("/proc/cpuinfo", "r", encoding="utf-8") as file:
+                for line in file:
+                    if line.startswith("Serial"):
+                        serial = line.split(":", 1)[-1].strip()
+                        return serial or _("Unavailable")
+        except Exception:
+            pass
+
+        return _("Unavailable")
+
+    def _get_microsd_serial(self) -> str:
+        from seedsigner.hardware.microsd import MicroSD
+
+        mount_device = None
+        try:
+            with open("/proc/mounts", "r", encoding="utf-8") as file:
+                for line in file:
+                    parts = line.split()
+                    if len(parts) >= 2 and parts[1] == MicroSD.MOUNT_POINT:
+                        mount_device = parts[0]
+                        break
+        except Exception:
+            return _("Unavailable")
+
+        if not mount_device:
+            return _("Unavailable")
+
+        block_device = os.path.basename(mount_device)
+        parent_device = re.sub(r"p?\d+$", "", block_device)
+        serial_path = f"/sys/class/block/{parent_device}/device/serial"
+        serial = self._read_text_file(serial_path)
+        return serial if serial else _("Unavailable")
+
+    def run(self):
+        self.run_screen(
+            settings_screens.SystemInfoScreen,
+            pi_version=self._get_pi_version(),
+            system_serial=self._get_system_serial(),
+            microsd_serial=self._get_microsd_serial(),
+        )
 
         return Destination(SettingsMenuView, view_args={"visibility": SettingsConstants.VISIBILITY__HARDWARE})

--- a/tests/test_flows_settings.py
+++ b/tests/test_flows_settings.py
@@ -76,6 +76,17 @@ class TestSettingsFlows(FlowTest):
                 FlowStep(settings_views.SettingsMenuView),
             ])
 
+    def test_system_info(self):
+        """Basic flow from MainMenuView to System Info View."""
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SETTINGS),
+            FlowStep(settings_views.SettingsMenuView, button_data_selection=settings_views.SettingsMenuView.HARDWARE),
+            FlowStep(settings_views.SettingsMenuView, button_data_selection=settings_views.SettingsMenuView.SYSTEM_INFO),
+            FlowStep(settings_views.SystemInfoView),
+            FlowStep(settings_views.SettingsMenuView),
+        ])
+
+
     def test_hardware_menu_back_returns_to_main(self):
         """Ensure BACK from Hardware settings returns to main Settings menu."""
         def assert_general(view: settings_views.SettingsMenuView):


### PR DESCRIPTION
### Motivation

- Provide an easy way for users to view device identification details from the Hardware settings menu.
- Surface Raspberry Pi model/version, system serial, and MicroSD serial information for troubleshooting and inventory.

### Description

- Add a new `SYSTEM_INFO` `ButtonOption` in the Hardware settings and wire navigation to a new `SystemInfoView`.
- Implement `SystemInfoView` which gathers information from `/proc/device-tree/model` and `/proc/cpuinfo` for Pi version and system serial, and resolves the MicroSD serial via `/proc/mounts` -> block device -> `/sys/class/block/<device>/device/serial`, with safe fallbacks to `"Unavailable"` when data is missing.
- Add `SystemInfoScreen` (UI) to `settings_screens.py` to render the three info lines using the existing `BaseTopNavScreen`/`TextArea` components and existing layout constants.
- Add a flow test `test_system_info` to `tests/test_flows_settings.py` to validate navigation into and out of the new screen.

### Testing

- Ran `pytest -q tests/test_flows_settings.py::TestSettingsFlows::test_system_info tests/test_flows_settings.py::TestSettingsFlows::test_io_test tests/test_flows_settings.py::TestSettingsFlows::test_battery_info_unavailable` and all 3 tests passed (`3 passed`).
- No new dependencies were introduced and the change uses safe file reads with exception handling to avoid crashes when files are absent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989ed4a38888322b27311ee37b4c963)