### PR TITLE
Harden seed wipe, secret handling, and command execution paths

### DIFF
--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -17,12 +17,28 @@ from seedsigner.models.settings import Settings
 from seedsigner.models.singleton import Singleton
 from seedsigner.models.threads import BaseThread
 from seedsigner.models.settings_definition import SettingsConstants
+from seedsigner.helpers.secure_delete import wipe_string, wipe_bytes
 from seedsigner.views.screensaver import ScreensaverScreen
 from seedsigner.views.view import Destination
 from seedsigner.hardware.rng_monitor import HardwareRngHealthMonitor, HardwareRngMonitorThread
 
 
 logger = logging.getLogger(__name__)
+
+
+def _wipe_controller_secret(value):
+    if isinstance(value, (bytes, bytearray)):
+        wipe_bytes(value)
+    elif isinstance(value, str):
+        wipe_string(value)
+
+
+def _clear_password_entropy_cache(controller):
+    cache = getattr(controller, "password_generator_entropy_cache", None)
+    if isinstance(cache, dict):
+        for key in ("roll_data", "entropy_bytes"):
+            _wipe_controller_secret(cache.get(key))
+    controller.password_generator_entropy_cache = None
 
 
 
@@ -406,12 +422,15 @@ class Controller(Singleton):
 
                     # Clear the whole Smartcard session if caching PIN is disabled (Same as removing the card)
                     if Settings.get_instance().get_value(SettingsConstants.SETTING__CACHE_SCARD_PIN) != "E":
+                        _wipe_controller_secret(self.Satochip_PIN)
                         self.Satochip_PIN = None
                         self.Satochip_Last_UID_SHA1 = None
                         self.Satochip_Connector = None
 
                     # Always drop any cached OpenPGP admin PIN when returning home
+                    _wipe_controller_secret(self.GPG_Admin_PIN)
                     self.GPG_Admin_PIN = None
+                    _clear_password_entropy_cache(self)
                 
                 logger.info(f"\nback_stack: {self.back_stack}")
 
@@ -552,6 +571,8 @@ class Controller(Singleton):
         logger.info("Controller: wipe timer triggered; wiping data")
 
         # Wipe sensitive in-memory data
+        for seed in self.storage.seeds:
+            seed.wipe()
         self.storage.seeds = []
         self.storage.clear_pending_seed()
         if self._storage2:
@@ -567,12 +588,15 @@ class Controller(Singleton):
         self.address_explorer_data = None
         self.sign_message_data = None
         self.resume_main_flow = None
+        _wipe_controller_secret(self.Satochip_PIN)
         self.Satochip_PIN = None
         self.Satochip_Last_UID_SHA1 = None
         self.Satochip_Connector = None
+        _wipe_controller_secret(self.GPG_Admin_PIN)
         self.GPG_Admin_PIN = None
         self.image_entropy_preview_frames = None
         self.image_entropy_final_image = None
+        _clear_password_entropy_cache(self)
 
         # Return to main menu
         self.clear_back_stack()

--- a/src/seedsigner/helpers/seedkeeper_utils.py
+++ b/src/seedsigner/helpers/seedkeeper_utils.py
@@ -427,9 +427,8 @@ def init_satochip(parentObject, init_card_filter=None, require_pin=True):
 
 
 def run_globalplatform(
-    parentObject, command, loadingText="Loading", successtext="Success"
+    parentObject, command_args, loadingText="Loading", successtext="Success"
 ):
-    import shlex
     from subprocess import run
     from seedsigner.models.settings import (
         Settings,
@@ -449,7 +448,7 @@ def run_globalplatform(
         # Assume gp.jar is available in the current working directory
         base_cmd = ["java", "-jar", "gp.jar"]
 
-    data = run(base_cmd + shlex.split(command), capture_output=True, text=True)
+    data = run(base_cmd + command_args, capture_output=True, text=True)
 
     # This process often kills IFD-NFC, so restart it if required
     scinterface = parentObject.settings.get_value(
@@ -537,7 +536,7 @@ def run_globalplatform(
         )
 
         if uninstall_required:
-            command = command.replace("--install", "--uninstall")
+            command = ["--uninstall" if arg == "--install" else arg for arg in command_args]
             data = run_globalplatform(
                 parentObject,
                 command,

--- a/src/seedsigner/models/encryptedqr.py
+++ b/src/seedsigner/models/encryptedqr.py
@@ -1,4 +1,5 @@
 from seedsigner.models.encryption import EncryptedQRCode
+from seedsigner.helpers.secure_delete import wipe_string
 
 class EncryptedQR:
     def __init__(self, encrypted_qr: EncryptedQRCode=None, public_data: str=None):
@@ -26,6 +27,10 @@ class EncryptedQR:
         self._encryption_key = encryption_key
 
 
+    def wipe(self):
+        wipe_string(self._encryption_key)
+        self._encryption_key = None
+
 
 class EncryptedQRStorage:
     def __init__(self):
@@ -42,6 +47,8 @@ class EncryptedQRStorage:
 
 
     def clear_encryptedqr(self):
+        if self._encryptedqr:
+            self._encryptedqr.wipe()
         self._encryptedqr = None
 
 

--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -4,6 +4,7 @@ import json
 import os
 import pathlib
 import platform
+import subprocess
 
 from typing import List
 
@@ -32,6 +33,13 @@ from seedsigner.models.settings_definition import SettingsConstants, SettingsDef
 from seedsigner.models.singleton import Singleton
 
 logger = logging.getLogger(__name__)
+
+
+def _run_cmd(command: list[str], use_sudo_prefix: bool = False) -> None:
+    cmd = command
+    if use_sudo_prefix:
+        cmd = ["sudo", *command]
+    subprocess.run(cmd, check=False)
 
 
 class InvalidSettingsQRData(Exception):
@@ -286,16 +294,16 @@ class Settings(Singleton):
                 # Different Raspberry Pi models have different port config, see
                 # https://github.com/mvp/uhubctl?tab=readme-ov-file#raspberry-pi-b2b3b
                 if "Zero" in GPIO.RPI_INFO['TYPE']: # For RPi0, 02w
-                    os.system(self.SU_COMMAND_PREFIX + "uhubctl -l 1 -a 0")
+                    _run_cmd(["uhubctl", "-l", "1", "-a", "0"], use_sudo_prefix=(self.SU_COMMAND_PREFIX == "sudo "))
                     
                 elif "Pi 4" in GPIO.RPI_INFO['TYPE']: # For RPi4 
-                    os.system(self.SU_COMMAND_PREFIX + "uhubctl -l 2 -a 0")
-                    os.system(self.SU_COMMAND_PREFIX + "uhubctl -l 3 -a 0")
-                    os.system(self.SU_COMMAND_PREFIX + "uhubctl -l 1-1 -a 0")
+                    _run_cmd(["uhubctl", "-l", "2", "-a", "0"], use_sudo_prefix=(self.SU_COMMAND_PREFIX == "sudo "))
+                    _run_cmd(["uhubctl", "-l", "3", "-a", "0"], use_sudo_prefix=(self.SU_COMMAND_PREFIX == "sudo "))
+                    _run_cmd(["uhubctl", "-l", "1-1", "-a", "0"], use_sudo_prefix=(self.SU_COMMAND_PREFIX == "sudo "))
                 
                 else:
                     # For Raspberry Pi B+,2B,3B, 3B+
-                    os.system(self.SU_COMMAND_PREFIX + "uhubctl -l 1-1 -p 2 -a 0")
+                    _run_cmd(["uhubctl", "-l", "1-1", "-p", "2", "-a", "0"], use_sudo_prefix=(self.SU_COMMAND_PREFIX == "sudo "))
                 
                 try:
                     self.loading_screen.stop()
@@ -314,16 +322,16 @@ class Settings(Singleton):
                 # https://github.com/mvp/uhubctl?tab=readme-ov-file#raspberry-pi-b2b3b
                  
                 if "Zero" in GPIO.RPI_INFO['TYPE']: # For RPi0, 02w
-                    os.system(self.SU_COMMAND_PREFIX + "uhubctl -l 1 -a 1")
+                    _run_cmd(["uhubctl", "-l", "1", "-a", "1"], use_sudo_prefix=(self.SU_COMMAND_PREFIX == "sudo "))
                     
                 elif "Pi 4" in GPIO.RPI_INFO['TYPE']: # For RPi4 
-                    os.system(self.SU_COMMAND_PREFIX + "uhubctl -l 2 -a 1")
-                    os.system(self.SU_COMMAND_PREFIX + "uhubctl -l 3 -a 1")
-                    os.system(self.SU_COMMAND_PREFIX + "uhubctl -l 1-1 -a 1")
+                    _run_cmd(["uhubctl", "-l", "2", "-a", "1"], use_sudo_prefix=(self.SU_COMMAND_PREFIX == "sudo "))
+                    _run_cmd(["uhubctl", "-l", "3", "-a", "1"], use_sudo_prefix=(self.SU_COMMAND_PREFIX == "sudo "))
+                    _run_cmd(["uhubctl", "-l", "1-1", "-a", "1"], use_sudo_prefix=(self.SU_COMMAND_PREFIX == "sudo "))
                 
                 else:
                     # For Raspberry Pi B+,2B,3B, 3B+
-                    os.system(self.SU_COMMAND_PREFIX + "uhubctl -l 1-1 -p 2 -a 1")
+                    _run_cmd(["uhubctl", "-l", "1-1", "-p", "2", "-a", "1"], use_sudo_prefix=(self.SU_COMMAND_PREFIX == "sudo "))
 
                 time.sleep(1)
                 # Restart PCSC at the end
@@ -362,7 +370,7 @@ class Settings(Singleton):
                 except:
                     pass
 
-                os.system(self.SU_COMMAND_PREFIX + "openct-control init") # OpenCT needs a bit of time to get going before restarting PCSCD (At least two seconds) to work reliabily
+                _run_cmd(["openct-control", "init"], use_sudo_prefix=(self.SU_COMMAND_PREFIX == "sudo ")) # OpenCT needs a bit of time to get going before restarting PCSCD (At least two seconds) to work reliabily
                 time.sleep(3)
 
                 try:
@@ -378,7 +386,7 @@ class Settings(Singleton):
                 except:
                     pass
                 
-                os.system(self.SU_COMMAND_PREFIX + "openct-control shutdown")
+                _run_cmd(["openct-control", "shutdown"], use_sudo_prefix=(self.SU_COMMAND_PREFIX == "sudo "))
                 time.sleep(3)
 
                 try:
@@ -393,7 +401,7 @@ class Settings(Singleton):
                 except:
                     pass
                 logger.debug("PN532 Enabled")
-                os.system("ifdnfc-activate yes")
+                _run_cmd(["ifdnfc-activate", "yes"])
                 try:
                     self.loading_screen.stop()
                 except:
@@ -406,7 +414,7 @@ class Settings(Singleton):
                 except:
                     pass
                 logger.debug("PN532 Disabled")
-                os.system("ifdnfc-activate no")
+                _run_cmd(["ifdnfc-activate", "no"])
                 try:
                     self.loading_screen.stop()
                 except:
@@ -419,13 +427,13 @@ class Settings(Singleton):
             except:
                 pass
             if self.HOSTNAME == self.SEEDSIGNER_OS:
-                os.system("/etc/init.d/S01pcscd stop")
+                _run_cmd(["/etc/init.d/S01pcscd", "stop"])
                 time.sleep(1)
-                os.system("/etc/init.d/S01pcscd start")
+                _run_cmd(["/etc/init.d/S01pcscd", "start"])
             else:
-                os.system("sudo service pcscd stop")
+                _run_cmd(["sudo", "service", "pcscd", "stop"])
                 time.sleep(1)
-                os.system("sudo service pcscd start")
+                _run_cmd(["sudo", "service", "pcscd", "start"])
             try:
                 self.loading_screen.stop()
             except:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -37,6 +37,7 @@ from seedsigner.gui.screens.tools_screens import (ToolsCalcFinalWordDoneScreen, 
     ToolsTranscribeTextQRConfirmQRPromptScreen, ToolsCommonFilterScreen, ToolsNetworkInfoScreen,
     ToolsBatteryCalibrationIntroScreen, ToolsBatteryCalibrationStartScreen, ToolsBatteryCalibrationRunningScreen)
 from seedsigner.helpers import embit_utils, mnemonic_generation
+from seedsigner.helpers.secure_delete import wipe_bytes, wipe_string
 from seedsigner.helpers import bip85_drng, diceware, password_generation
 from seedsigner.helpers.iso7816 import format_sw_error
 from seedsigner.models.decode_qr import DecodeQR
@@ -108,6 +109,14 @@ BIP85_APP_DICE = 89101
 
 
 def _clear_password_entropy_cache(controller) -> None:
+    cache = getattr(controller, "password_generator_entropy_cache", None)
+    if isinstance(cache, dict):
+        wipe_bytes(cache.get("entropy_bytes"))
+        roll_data = cache.get("roll_data")
+        if isinstance(roll_data, str):
+            wipe_string(roll_data)
+        else:
+            wipe_bytes(roll_data)
     controller.password_generator_entropy_cache = None
 
 
@@ -2704,7 +2713,7 @@ class ToolsSeedkeeperViewSecretsView(View):
 
                 except Exception as ex:
                     logger.info(f"Error during entropy conversion: {ex}")
-                    bip39_mnemonic = f"failed to convert entropy: {entropy_bytes.hex()}"
+                    bip39_mnemonic = "Unable to decode mnemonic"
 
                 passphrase_size= secret_raw_bytes[offset]
                 offset+=1
@@ -2715,9 +2724,12 @@ class ToolsSeedkeeperViewSecretsView(View):
                     passphrase = passphrase_bytes.decode("utf-8")
                 except Exception as ex:
                     logger.info(f"Error during passphrase decoding: {ex}")
-                    passphrase = f"failed to decode passphrase bytes: {passphrase_bytes.hex()}"
+                    passphrase = "Unable to decode passphrase"
 
-                secret_dict['secret']= f'BIP39 mnemonic: "{bip39_mnemonic}" \nPassphrase: "{passphrase}"'  
+                secret_dict['secret']= f'BIP39 mnemonic: "{bip39_mnemonic}" \nPassphrase: "{passphrase}"'
+                wipe_bytes(entropy_bytes)
+                wipe_bytes(passphrase_bytes)
+                wipe_bytes(secret_raw_bytes)
 
             elif stype == 'Password':
                 
@@ -4469,14 +4481,18 @@ def _format_javacard_keys(keys: dict) -> str:
     return f"ENC={keys['enc']}\nMAC={keys['mac']}\nDEK={keys['dek']}\n"
 
 
-def _format_gp_key_args(keys: dict, flag: str) -> str:
+def _format_gp_key_args(keys: dict, flag: str) -> list[str]:
     if keys["type"] == "single":
-        return f"{flag} {keys['key']}"
-    return (
-        f"{flag}-enc {keys['enc']} "
-        f"{flag}-mac {keys['mac']} "
-        f"{flag}-dek {keys['dek']}"
-    )
+        return [flag, keys["key"]]
+    return [
+        f"{flag}-enc", keys["enc"],
+        f"{flag}-mac", keys["mac"],
+        f"{flag}-dek", keys["dek"],
+    ]
+
+
+def _run_ifdnfc_activate(enabled: bool) -> None:
+    subprocess.run(["ifdnfc-activate", "yes" if enabled else "no"], check=False)
 
 
 def _decode_seedkeeper_text(secret_dict: dict) -> str:
@@ -4913,7 +4929,7 @@ class ToolsJavacardUnlockCardView(View):
         if confirm == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        command = f"{_format_gp_key_args(keys, '--key')} --unlock"
+        command = _format_gp_key_args(keys, "--key") + ["--unlock"]
         seedkeeper_utils.run_globalplatform(
             self,
             command,
@@ -4948,7 +4964,7 @@ class ToolsJavacardLockCardView(View):
         if confirm == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        command = f"--key default {_format_gp_key_args(keys, '--lock')}"
+        command = ["--key", "default"] + _format_gp_key_args(keys, "--lock")
         seedkeeper_utils.run_globalplatform(
             self,
             command,
@@ -5011,7 +5027,7 @@ class ToolsDIYBuildAppletsView(View):
 
         if Settings.HOSTNAME == Settings.SEEDSIGNER_OS:
             if not os.path.exists(microsd_dir / "javacard-build.xml"):
-                os.system(f"cp /opt/tools/javacard-build.xml.seedsigneros {microsd_dir}/javacard-build.xml")
+                run(["cp", "/opt/tools/javacard-build.xml.seedsigneros", str(microsd_dir / "javacard-build.xml")], check=False)
 
             if not os.path.exists(microsd_dir / "javacard-cap/"):
                 os.makedirs(microsd_dir / "javacard-cap/", exist_ok=True)
@@ -5097,7 +5113,7 @@ class ToolsDIYInstallAppletView(View):
             logger.info("SmartPGP AID: %s", aid)
             installed_applets = seedkeeper_utils.run_globalplatform(
                 self,
-                f"--install {cap_dir}/{applet_file} --create {aid}",
+                ["--install", f"{cap_dir}/{applet_file}", "--create", aid],
                 "Installing Applet",
                 f"Applet Installed\nSerial: {serial_hex}",
             )
@@ -5126,14 +5142,14 @@ class ToolsDIYInstallAppletView(View):
 
             installed_applets = seedkeeper_utils.run_globalplatform(
                 self,
-                f"--install {cap_dir}/{applet_file} --params {storage_param}",
+                ["--install", f"{cap_dir}/{applet_file}", "--params", storage_param],
                 "Installing Applet",
                 "Applet Installed",
             )
         else:
             installed_applets = seedkeeper_utils.run_globalplatform(
                 self,
-                f"--install {cap_dir}/{applet_file}",
+                ["--install", f"{cap_dir}/{applet_file}"],
                 "Installing Applet",
                 "Applet Installed",
             )
@@ -5141,9 +5157,9 @@ class ToolsDIYInstallAppletView(View):
         # This process often kills IFD-NFC, so restart it if required
         scinterface = self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_INTERFACES)
         if "pn532" in scinterface:
-            os.system("ifdnfc-activate no")
+            _run_ifdnfc_activate(False)
             time.sleep(1)
-            os.system("ifdnfc-activate yes")
+            _run_ifdnfc_activate(True)
 
         return Destination(MainMenuView)
 
@@ -5164,7 +5180,7 @@ class ToolsDIYUninstallAppletView(View):
         if ret == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        installed_applets = seedkeeper_utils.run_globalplatform(self,"-l -v", "Checking Installed Applets", None)
+        installed_applets = seedkeeper_utils.run_globalplatform(self,["-l", "-v"], "Checking Installed Applets", None)
 
         if installed_applets:
             installed_applets = installed_applets.split('\n')
@@ -5201,7 +5217,7 @@ class ToolsDIYUninstallAppletView(View):
 
                 applet_aid = installed_applets_aids[selected_applet_num]
 
-                seedkeeper_utils.run_globalplatform(self,"--delete " + applet_aid + " -force", "Uninstalling Applet", "Applet Uninstalled")
+                seedkeeper_utils.run_globalplatform(self,["--delete", applet_aid, "-force"], "Uninstalling Applet", "Applet Uninstalled")
 
             else:
                 self.run_screen(
@@ -5216,9 +5232,9 @@ class ToolsDIYUninstallAppletView(View):
                 # This process often kills IFD-NFC, so restart it if required
         scinterface = self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_INTERFACES)
         if "pn532" in scinterface:
-            os.system("ifdnfc-activate no")
+            _run_ifdnfc_activate(False)
             time.sleep(1)
-            os.system("ifdnfc-activate yes")
+            _run_ifdnfc_activate(True)
 
         return Destination(MainMenuView)
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -114,3 +114,39 @@ class TestController(BaseTest):
         # Hidden Settings defaults
         assert controller.settings.get_value(SettingsConstants.SETTING__QR_BRIGHTNESS) == 62
 
+
+
+    def test_handle_wipe_timeout_wipes_loaded_seeds_and_secret_caches(self, monkeypatch):
+        from unittest.mock import patch
+        from seedsigner.models.seed import Seed
+        from seedsigner.models.encryptedqr import EncryptedQR
+
+        controller = Controller.get_instance()
+        seed = Seed([
+            "abandon", "abandon", "abandon", "abandon", "abandon", "abandon",
+            "abandon", "abandon", "abandon", "abandon", "abandon", "about",
+        ])
+        controller.storage.seeds = [seed]
+        controller.storage2.set_encryptedqr(EncryptedQR())
+        controller.storage2.encryptedqr.set_encryption_key("top-secret")
+        controller.Satochip_PIN = "123456"
+        controller.GPG_Admin_PIN = "654321"
+        controller.password_generator_entropy_cache = {"roll_data": "1234512345", "entropy_bytes": b"A" * 32}
+
+        monkeypatch.setattr(controller, "activate_toast", lambda *_args, **_kwargs: None)
+
+        class _Buttons:
+            def trigger_override(self):
+                return None
+
+        with patch("seedsigner.hardware.buttons.HardwareButtons.get_instance", return_value=_Buttons()):
+            controller.handle_wipe_timeout()
+
+        assert controller.storage.seeds == []
+        assert seed.seed_bytes is None
+        assert seed.mnemonic_list == []
+        assert seed.passphrase == ""
+        assert controller.storage2.encryptedqr is None
+        assert controller.password_generator_entropy_cache is None
+        assert controller.Satochip_PIN is None
+        assert controller.GPG_Admin_PIN is None

--- a/tests/test_seedkeeper_install.py
+++ b/tests/test_seedkeeper_install.py
@@ -43,7 +43,7 @@ def test_seedkeeper_install_defaults_to_8k(monkeypatch, tmp_path):
 
     view.run()
 
-    assert "--params 1FFF" in captured["cmd"]
+    assert captured["cmd"][-2:] == ["--params", "1FFF"]
     assert storage_screen_kwargs.get("selected_button") == 1
 
     storage_labels = [option.button_label for option in storage_screen_kwargs.get("button_data", [])]
@@ -82,7 +82,7 @@ def test_seedkeeper_install_respects_selected_storage(monkeypatch, tmp_path):
 
     view.run()
 
-    assert "--params 7FFF" in captured["cmd"]
+    assert captured["cmd"][-2:] == ["--params", "7FFF"]
 
 
 def test_seedkeeper_install_supports_largest_storage(monkeypatch, tmp_path):
@@ -116,5 +116,5 @@ def test_seedkeeper_install_supports_largest_storage(monkeypatch, tmp_path):
 
     view.run()
 
-    assert "--params FFFF" in captured["cmd"]
+    assert captured["cmd"][-2:] == ["--params", "FFFF"]
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -117,7 +117,7 @@ class TestSettings(BaseTest):
         """Updating from old list-of-lists format should normalize to list of values"""
         legacy = [[opt[0], opt[1]] for opt in SettingsConstants.ALL_SMARTCARD_INTERFACES]
 
-        with patch("os.system"), patch("time.sleep"):
+        with patch("subprocess.run"), patch("time.sleep"):
             self.settings.update({
                 SettingsConstants.SETTING__SMARTCARD_INTERFACES: legacy
             })
@@ -128,12 +128,12 @@ class TestSettings(BaseTest):
     def test_update_skips_unchanged_smartcard_interfaces(self):
         """Updating with identical smartcard interfaces should not restart pcscd"""
         current = self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_INTERFACES)
-        with patch("os.system") as mock_system, patch("time.sleep"):
+        with patch("subprocess.run") as mock_run, patch("time.sleep"):
             self.settings.update({
                 SettingsConstants.SETTING__SMARTCARD_INTERFACES: current
             })
 
-        mock_system.assert_not_called()
+        mock_run.assert_not_called()
 
     def test_update_can_skip_persist(self):
         """Updating with persist=False should not trigger a save to disk"""


### PR DESCRIPTION
### Motivation
- Reduce secret leakage and improve memory-hygiene by ensuring auto-wipe actively zeroizes in-memory secrets (loaded seeds, cached PINs, entropy caches, and encrypted-QR keys) rather than merely dropping references.
- Eliminate places that embed raw secret bytes into UI/log strings and reduce command-injection surface by removing string-assembled commands and `os.system` uses.

### Description
- Actively wipe all loaded `Seed` objects during inactivity auto-wipe by calling `seed.wipe()` before clearing `storage.seeds`, and zeroize controller-level secret fields such as cached PINs and password entropy cache via secure-delete helpers. (`src/seedsigner/controller.py`)
- Add `wipe()` semantics to `EncryptedQR` and ensure `EncryptedQRStorage.clear_encryptedqr()` zeroizes the encryption key before dropping the object. (`src/seedsigner/models/encryptedqr.py`)
- Sanitize SeedKeeper fallback messages to avoid including raw entropy/passphrase hex in UI text and zeroize temporary parsed buffers on success/failure paths. (`src/seedsigner/views/tools_views.py`)
- Replace string-based command assembly / `shlex.split` in `run_globalplatform()` with explicit argument lists and update callers to pass `list[str]` argv arrays, preventing ambiguous splitting/parsing. (`src/seedsigner/helpers/seedkeeper_utils.py`, `src/seedsigner/views/tools_views.py`)
- Replace targeted `os.system(...)` uses with `subprocess.run([...], shell=False)` via a small helper `_run_cmd()` that optionally prefixes `sudo` when needed, reducing runtime injection risk in settings and tool flows. (`src/seedsigner/models/settings.py`, `src/seedsigner/views/tools_views.py`)
- Add a controller-level helper to zeroize cached entropy/roll buffers and update password-entropy cache helpers to wipe stored buffers. (`src/seedsigner/controller.py`, `src/seedsigner/views/tools_views.py`)
- Updated and added focused unit tests to cover wipe-timeout behavior and adjusted tests that relied on prior command string expectations. (`tests/test_controller.py`, `tests/test_seedkeeper_install.py`, `tests/test_settings.py`)

### Testing
- Ran the focused test set: `pytest -q tests/test_controller.py tests/test_seedkeeper_install.py tests/test_settings.py`, all tests passed (20 passed).
- Verified targeted behavioral changes with grep checks for removed `os.system` and `shlex.split` usages in updated files and validated callers were updated to use argv lists.
- No new crypto primitives or external dependencies were introduced; secure-delete helpers (existing) were reused for zeroization.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989f57bcb1c8322abe601589f7f5782)