### PR TITLE
Auto-detect Luckfox Pico Mini/Max and apply variant hardware profiles

### DIFF
--- a/src/seedsigner/gui/screens/scan_screens.py
+++ b/src/seedsigner/gui/screens/scan_screens.py
@@ -10,6 +10,7 @@ from seedsigner.gui import renderer
 from seedsigner.gui.keyboard import Keyboard, TextEntryDisplay
 from seedsigner.hardware.buttons import HardwareButtonsConstants
 from seedsigner.hardware.camera import Camera
+from seedsigner.hardware.platform import is_luckfox
 from seedsigner.models.decode_qr import DecodeQR, DecodeQRStatus
 from seedsigner.models.threads import BaseThread, ThreadsafeCounter
 
@@ -54,8 +55,8 @@ class ScanScreen(BaseScreen):
     """
     decoder: DecodeQR = None
     instructions_text: str = None
-    resolution: tuple[int,int] = (480, 480)
-    framerate: int = 6  # TODO: alternate optimization for Pi Zero 2W?
+    resolution: tuple[int,int] = (240, 240) if is_luckfox() else (480, 480)
+    framerate: int = 2 if is_luckfox() else 6  # tuned lower for Luckfox CPU/camera path
     render_rect: tuple[int,int,int,int] = None
 
     FRAME__ADDED_PART = 1

--- a/src/seedsigner/hardware/buttons.py
+++ b/src/seedsigner/hardware/buttons.py
@@ -16,16 +16,35 @@ import logging
 import time
 from typing import Dict, List, Tuple
 
+from seedsigner.hardware.platform import get_luckfox_profile, is_luckfox
+
 try:
     import RPi.GPIO as GPIO
-    USING_GPIO = True
+    GPIO_BACKEND = "rpi"
 except ModuleNotFoundError:
-    USING_GPIO = False
     GPIO = None
+    if is_luckfox():
+        try:
+            from periphery import GPIO as PeripheryGPIO  # type: ignore
+
+            GPIO_BACKEND = "periphery"
+        except ModuleNotFoundError:
+            GPIO_BACKEND = "desktop"
+            PeripheryGPIO = None
+    else:
+        GPIO_BACKEND = "desktop"
+        PeripheryGPIO = None
+
+if GPIO_BACKEND == "desktop":
     try:
         import pygame  # type: ignore
     except ModuleNotFoundError:
         pygame = None
+else:
+    pygame = None
+
+USING_GPIO = GPIO_BACKEND in {"rpi", "periphery"}
+LUCKFOX_PROFILE = get_luckfox_profile() if GPIO_BACKEND == "periphery" else None
 
 from seedsigner.models.singleton import Singleton
 
@@ -57,7 +76,19 @@ class HardwareButtons(Singleton):
     events.
     """
 
-    if USING_GPIO and GPIO.RPI_INFO['P1_REVISION'] == 3:  # RPi with 40-pin GPIO
+    if GPIO_BACKEND == "periphery":
+        logger.info(f"Using Luckfox GPIO mapping for variant: {LUCKFOX_PROFILE.variant}")
+        KEY_UP_PIN = LUCKFOX_PROFILE.key_up_pin
+        KEY_DOWN_PIN = LUCKFOX_PROFILE.key_down_pin
+        KEY_LEFT_PIN = LUCKFOX_PROFILE.key_left_pin
+        KEY_RIGHT_PIN = LUCKFOX_PROFILE.key_right_pin
+        KEY_PRESS_PIN = LUCKFOX_PROFILE.key_press_pin
+
+        KEY1_PIN = LUCKFOX_PROFILE.key1_pin
+        KEY2_PIN = LUCKFOX_PROFILE.key2_pin
+        KEY3_PIN = LUCKFOX_PROFILE.key3_pin
+
+    elif GPIO_BACKEND == "rpi" and GPIO.RPI_INFO['P1_REVISION'] == 3:  # RPi with 40-pin GPIO
         # Raspberry Pi 2 and newer models share the same pin layout.
         logger.info("Detected 40pin GPIO (Rasbperry Pi 2 and above)")
         KEY_UP_PIN = 31
@@ -135,7 +166,7 @@ class HardwareButtons(Singleton):
         if cls._instance is None:
             cls._instance = cls.__new__(cls)
 
-            if USING_GPIO:
+            if GPIO_BACKEND == "rpi":
                 # Initialise the Raspberry Pi GPIO pins.
                 GPIO.setmode(GPIO.BOARD)
                 GPIO.setup(HardwareButtons.KEY_UP_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
@@ -148,6 +179,20 @@ class HardwareButtons(Singleton):
                 GPIO.setup(HardwareButtons.KEY3_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 
                 cls._instance.GPIO = GPIO
+            elif GPIO_BACKEND == "periphery":
+                cls._instance.GPIO = {
+                    pin: PeripheryGPIO(pin, "in")
+                    for pin in (
+                        HardwareButtons.KEY_UP_PIN,
+                        HardwareButtons.KEY_DOWN_PIN,
+                        HardwareButtons.KEY_LEFT_PIN,
+                        HardwareButtons.KEY_RIGHT_PIN,
+                        HardwareButtons.KEY_PRESS_PIN,
+                        HardwareButtons.KEY1_PIN,
+                        HardwareButtons.KEY2_PIN,
+                        HardwareButtons.KEY3_PIN,
+                    )
+                }
             else:
                 if pygame is None:
                     raise ModuleNotFoundError(
@@ -223,7 +268,7 @@ class HardwareButtons(Singleton):
 
             if USING_GPIO:
                 for key in keys:
-                    if self.GPIO.input(key) == GPIO.LOW:
+                    if self._is_pressed(key):
                         if self.cur_input != key:
                             self.cur_input = key
                             self.cur_input_started = cur_time
@@ -285,7 +330,7 @@ class HardwareButtons(Singleton):
 
         if USING_GPIO:
             for key in keys:
-                if self.GPIO.input(key) == self.GPIO.LOW:
+                if self._is_pressed(key):
                     self.update_last_input_time()
                     return True
             return False
@@ -304,7 +349,7 @@ class HardwareButtons(Singleton):
         """Return ``True`` if any button is currently pressed."""
         if USING_GPIO:
             for key in HardwareButtonsConstants.ALL_KEYS:
-                if self.GPIO.input(key) == GPIO.LOW:
+                if self._is_pressed(key):
                     return True
             return False
         else:
@@ -315,6 +360,13 @@ class HardwareButtons(Singleton):
                 if pg_key and pressed[pg_key]:
                     return True
             return False
+
+
+    def _is_pressed(self, key: int) -> bool:
+        if GPIO_BACKEND == "rpi":
+            return self.GPIO.input(key) == GPIO.LOW
+        # Periphery ``read`` returns boolean high/low.
+        return self.GPIO[key].read() is False
 
 
 # Coordinates for clickable desktop buttons (unscaled)
@@ -389,7 +441,16 @@ _recalc_desktop_layout()
 class HardwareButtonsConstants:
     """Numeric codes representing each physical or simulated button."""
 
-    if USING_GPIO and GPIO.RPI_INFO['P1_REVISION'] == 3:
+    if GPIO_BACKEND == "periphery":
+        KEY_UP = HardwareButtons.KEY_UP_PIN
+        KEY_DOWN = HardwareButtons.KEY_DOWN_PIN
+        KEY_LEFT = HardwareButtons.KEY_LEFT_PIN
+        KEY_RIGHT = HardwareButtons.KEY_RIGHT_PIN
+        KEY_PRESS = HardwareButtons.KEY_PRESS_PIN
+        KEY1 = HardwareButtons.KEY1_PIN
+        KEY2 = HardwareButtons.KEY2_PIN
+        KEY3 = HardwareButtons.KEY3_PIN
+    elif GPIO_BACKEND == "rpi" and GPIO.RPI_INFO['P1_REVISION'] == 3:
         KEY_UP = 31
         KEY_DOWN = 35
         KEY_LEFT = 29
@@ -399,7 +460,7 @@ class HardwareButtonsConstants:
         KEY1 = 40
         KEY2 = 38
         KEY3 = 36
-    elif USING_GPIO:
+    elif GPIO_BACKEND == "rpi":
         KEY_UP = 5
         KEY_DOWN = 11
         KEY_LEFT = 3

--- a/src/seedsigner/hardware/camera.py
+++ b/src/seedsigner/hardware/camera.py
@@ -9,6 +9,7 @@ import io
 from PIL import Image
 from seedsigner.models.settings import Settings, SettingsConstants
 from seedsigner.models.singleton import Singleton
+from seedsigner.hardware.platform import is_luckfox
 
 
 class Camera(Singleton):
@@ -16,6 +17,7 @@ class Camera(Singleton):
 
     _video_stream = None
     _picamera = None
+    _single_frame_stream = None
     _camera_rotation = None
     _camera_index = 0
 
@@ -116,6 +118,9 @@ class Camera(Singleton):
                 self._picamera.close()
             else:
                 self._picamera.release()
+        if self._single_frame_stream is not None:
+            self._single_frame_stream.stop()
+            self._single_frame_stream = None
 
         try:
             from picamera import PiCamera
@@ -125,17 +130,28 @@ class Camera(Singleton):
         except Exception:
             try:
                 import cv2  # type: ignore
-            except Exception as e:
-                raise ModuleNotFoundError(
-                    "OpenCV is required for desktop camera support; install requirements-desktop.txt",
-                ) from e
-            self._picamera = cv2.VideoCapture(self._camera_index)
-            self._picamera.set(cv2.CAP_PROP_FRAME_WIDTH, resolution[0])
-            self._picamera.set(cv2.CAP_PROP_FRAME_HEIGHT, resolution[1])
+
+                self._picamera = cv2.VideoCapture(self._camera_index)
+                self._picamera.set(cv2.CAP_PROP_FRAME_WIDTH, resolution[0])
+                self._picamera.set(cv2.CAP_PROP_FRAME_HEIGHT, resolution[1])
+            except Exception:
+                if not is_luckfox():
+                    raise ModuleNotFoundError(
+                        "OpenCV is required for desktop camera support; install requirements-desktop.txt",
+                    )
+
+                from seedsigner.hardware.pivideostream import PiVideoStream
+
+                self._single_frame_stream = PiVideoStream(
+                    resolution=resolution,
+                    framerate=2,
+                    format="rgb",
+                    device_index=self._camera_index,
+                ).start()
 
     def capture_frame(self):
         """Capture a single frame from the camera as a PIL image."""
-        if self._picamera is None:
+        if self._picamera is None and self._single_frame_stream is None:
             raise Exception("Must call start_single_frame_mode first.")
 
         if hasattr(self._picamera, "capture"):
@@ -150,7 +166,8 @@ class Camera(Singleton):
             self._picamera.capture(stream, format="jpeg")
             stream.seek(0)
             return Image.open(stream).rotate(90 + self._camera_rotation)
-        else:
+
+        if self._picamera is not None:
             # OpenCV path
             ret, frame = self._picamera.read()
             if not ret:
@@ -158,6 +175,17 @@ class Camera(Singleton):
             return Image.fromarray(frame.astype("uint8"), "RGB").rotate(
                 90 + self._camera_rotation
             )
+
+        if self._single_frame_stream is not None:
+            for _ in range(20):
+                frame = self._single_frame_stream.read()
+                if frame is not None:
+                    return Image.fromarray(frame.astype("uint8"), "RGB").rotate(
+                        90 + self._camera_rotation
+                    )
+            return None
+
+        return None
 
     def stop_single_frame_mode(self):
         """Release any resources used for single-frame capture."""
@@ -167,4 +195,8 @@ class Camera(Singleton):
             else:
                 self._picamera.release()
             self._picamera = None
+
+        if self._single_frame_stream is not None:
+            self._single_frame_stream.stop()
+            self._single_frame_stream = None
 

--- a/src/seedsigner/hardware/displays/ST7789.py
+++ b/src/seedsigner/hardware/displays/ST7789.py
@@ -1,7 +1,17 @@
 import spidev
-import RPi.GPIO as GPIO
 import time
 import array
+
+from seedsigner.hardware.platform import get_luckfox_profile, is_luckfox
+
+if is_luckfox():
+    from periphery import GPIO as PeripheryGPIO  # type: ignore
+
+    GPIO = None
+    LUCKFOX_PROFILE = get_luckfox_profile()
+else:
+    import RPi.GPIO as GPIO
+    PeripheryGPIO = None
 
 
 
@@ -13,16 +23,24 @@ class ST7789(object):
         self.height = 240
 
         #Initialize DC RST pin
-        self._dc = 22
-        self._rst = 13
-        self._bl = 18
+        if is_luckfox():
+            # Luckfox Pico Pro Max GPIO numbering via libgpiod character device.
+            self._dc = PeripheryGPIO(LUCKFOX_PROFILE.st7789_dc_pin, "out")
+            self._rst = PeripheryGPIO(LUCKFOX_PROFILE.st7789_rst_pin, "out")
+            self._bl = None
+            self._use_periphery = True
+        else:
+            self._dc = 22
+            self._rst = 13
+            self._bl = 18
 
-        GPIO.setmode(GPIO.BOARD)
-        GPIO.setwarnings(False)
-        GPIO.setup(self._dc,GPIO.OUT)
-        GPIO.setup(self._rst,GPIO.OUT)
-        GPIO.setup(self._bl,GPIO.OUT)
-        GPIO.output(self._bl, GPIO.HIGH)
+            GPIO.setmode(GPIO.BOARD)
+            GPIO.setwarnings(False)
+            GPIO.setup(self._dc,GPIO.OUT)
+            GPIO.setup(self._rst,GPIO.OUT)
+            GPIO.setup(self._bl,GPIO.OUT)
+            GPIO.output(self._bl, GPIO.HIGH)
+            self._use_periphery = False
 
         #Initialize SPI
         self._spi = spidev.SpiDev(0, 0)
@@ -33,11 +51,11 @@ class ST7789(object):
 
     """    Write register address and data     """
     def command(self, cmd):
-        GPIO.output(self._dc, GPIO.LOW)
+        self._gpio_write(self._dc, False)
         self._spi.writebytes([cmd])
 
     def data(self, val):
-        GPIO.output(self._dc, GPIO.HIGH)
+        self._gpio_write(self._dc, True)
         self._spi.writebytes([val])
 
     def init(self):
@@ -122,11 +140,11 @@ class ST7789(object):
 
     def reset(self):
         """Reset the display"""
-        GPIO.output(self._rst,GPIO.HIGH)
+        self._gpio_write(self._rst, True)
         time.sleep(0.01)
-        GPIO.output(self._rst,GPIO.LOW)
+        self._gpio_write(self._rst, False)
         time.sleep(0.01)
-        GPIO.output(self._rst,GPIO.HIGH)
+        self._gpio_write(self._rst, True)
         time.sleep(0.01)
         
     def SetWindows(self, Xstart, Ystart, Xend, Yend):
@@ -158,15 +176,21 @@ class ST7789(object):
         arr.byteswap()
         pix = arr.tobytes()
         self.SetWindows ( 0, 0, self.width, self.height)
-        GPIO.output(self._dc,GPIO.HIGH)
+        self._gpio_write(self._dc, True)
         self._spi.writebytes2(pix)	
         
     def clear(self):
         """Clear contents of image buffer"""
         _buffer = [0xff]*(self.width * self.height * 2)
         self.SetWindows ( 0, 0, self.width, self.height)
-        GPIO.output(self._dc,GPIO.HIGH)
+        self._gpio_write(self._dc, True)
         self._spi.writebytes2(_buffer)
+
+    def _gpio_write(self, channel, value: bool):
+        if self._use_periphery:
+            channel.write(value)
+            return
+        GPIO.output(channel, GPIO.HIGH if value else GPIO.LOW)
 
     def invert(self, enabled: bool = True):
         """Invert how the display interprets colors"""

--- a/src/seedsigner/hardware/pivideostream.py
+++ b/src/seedsigner/hardware/pivideostream.py
@@ -1,14 +1,21 @@
-"""Threaded video capture that works with both PiCamera and OpenCV webcams."""
+"""Threaded video capture for PiCamera, OpenCV, and Luckfox v4l2 backends."""
 
 import logging
+import os
+import shutil
+import subprocess
 import time
 from threading import Thread
+
+
+from seedsigner.hardware.platform import get_luckfox_profile, is_luckfox
 
 logger = logging.getLogger(__name__)
 
 try:
     from picamera.array import PiRGBArray
     from picamera import PiCamera
+
     PICAMERA_AVAILABLE = True
 except Exception:  # ModuleNotFoundError, ImportError, etc.
     PICAMERA_AVAILABLE = False
@@ -22,36 +29,41 @@ class PiVideoStream:
     """Continuously capture frames in a background thread."""
 
     def __init__(self, resolution=(320, 240), framerate=32, format="bgr", device_index=0, **kwargs):
-        """Initialize the video stream.
-
-        When running on a Pi with the ``picamera`` library available we use that;
-        otherwise we fall back to OpenCV's ``VideoCapture`` on the given
-        ``device_index``.
-        """
         self.should_stop = False
         self.is_stopped = True
         self.frame = None
         self.device_index = device_index
+        self.width, self.height = resolution
+        self.v4l2_process = None
 
         if PICAMERA_AVAILABLE:
+            self.backend = "picamera"
             self.camera = PiCamera(resolution=resolution, framerate=framerate, **kwargs)
             self.rawCapture = PiRGBArray(self.camera, size=resolution)
             self.stream = self.camera.capture_continuous(
                 self.rawCapture, format=format, use_video_port=True
             )
-            self.use_picamera = True
-        else:
-            if cv2 is None:
-                raise ModuleNotFoundError(
-                    "OpenCV is required for desktop camera support; install requirements-desktop.txt"
-                )
-            self.camera = cv2.VideoCapture(self.device_index)
-            self.camera.set(cv2.CAP_PROP_FRAME_WIDTH, resolution[0])
-            self.camera.set(cv2.CAP_PROP_FRAME_HEIGHT, resolution[1])
-            self.use_picamera = False
+            return
+
+        if is_luckfox() and self._v4l2_available():
+            self.backend = "v4l2"
+            self.luckfox_profile = get_luckfox_profile()
+            self.device = self._select_v4l2_device(device_index)
+            self.frame_size = self.width * self.height
+            self.camera = None
+            return
+
+        if cv2 is None:
+            raise ModuleNotFoundError(
+                "No supported camera backend found. Install OpenCV for desktop mode."
+            )
+
+        self.backend = "opencv"
+        self.camera = cv2.VideoCapture(self.device_index)
+        self.camera.set(cv2.CAP_PROP_FRAME_WIDTH, resolution[0])
+        self.camera.set(cv2.CAP_PROP_FRAME_HEIGHT, resolution[1])
 
     def start(self):
-        """Start the capture thread."""
         t = Thread(target=self.update, args=())
         t.daemon = True
         t.start()
@@ -59,33 +71,85 @@ class PiVideoStream:
         return self
 
     def update(self):
-        """Continuously read frames until :meth:`stop` is called."""
-        if self.use_picamera:
-            for f in self.stream:
-                self.frame = f.array
-                self.rawCapture.truncate(0)
-                if self.should_stop:
-                    logger.info("PiVideoStream: closing everything")
-                    self.stream.close()
-                    self.rawCapture.close()
-                    self.camera.close()
-                    self.should_stop = False
-                    self.is_stopped = True
-                    return
+        if self.backend == "picamera":
+            self._update_picamera()
+        elif self.backend == "v4l2":
+            self._update_v4l2()
         else:
-            while not self.should_stop:
-                ret, frame = self.camera.read()
-                if ret:
-                    self.frame = frame
-            self.camera.release()
-            self.is_stopped = True
+            self._update_opencv()
+
+    def _update_picamera(self):
+        for f in self.stream:
+            self.frame = f.array
+            self.rawCapture.truncate(0)
+            if self.should_stop:
+                logger.info("PiVideoStream: closing picamera stream")
+                self.stream.close()
+                self.rawCapture.close()
+                self.camera.close()
+                self.should_stop = False
+                self.is_stopped = True
+                return
+
+    def _update_opencv(self):
+        while not self.should_stop:
+            ret, frame = self.camera.read()
+            if ret:
+                self.frame = frame
+        self.camera.release()
+        self.is_stopped = True
+
+    def _update_v4l2(self):
+        try:
+            import numpy as np  # type: ignore
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError("Luckfox v4l2 backend requires numpy") from e
+
+        cmd = [
+            "v4l2-ctl",
+            f"--device={self.device}",
+            f"--set-fmt-video=width={self.width},height={self.height},pixelformat=GREY",
+            "--stream-mmap",
+            "--stream-to=-",
+            "--stream-count=0",
+        ]
+        self.v4l2_process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            bufsize=self.frame_size * 4,
+        )
+
+        while not self.should_stop:
+            if self.v4l2_process.stdout is None:
+                break
+            frame_data = self.v4l2_process.stdout.read(self.frame_size)
+            if len(frame_data) < self.frame_size:
+                break
+            grey = np.frombuffer(frame_data, dtype=np.uint8).reshape((self.height, self.width))
+            self.frame = np.stack((grey, grey, grey), axis=-1)
+
+        if self.v4l2_process and self.v4l2_process.poll() is None:
+            self.v4l2_process.terminate()
+            self.v4l2_process.wait(timeout=1)
+        self.is_stopped = True
 
     def read(self):
-        """Return the most recently captured frame."""
         return self.frame
 
     def stop(self):
-        """Signal the capture thread to stop and wait for it to finish."""
         self.should_stop = True
         while not self.is_stopped:
             time.sleep(0.01)
+
+    def _v4l2_available(self) -> bool:
+        return shutil.which("v4l2-ctl") is not None
+
+    def _select_v4l2_device(self, preferred_index: int) -> str:
+        preferred = f"/dev/video{preferred_index}"
+        if os.path.exists(preferred):
+            return preferred
+        for candidate in self.luckfox_profile.video_devices:
+            if os.path.exists(candidate):
+                return candidate
+        return preferred

--- a/src/seedsigner/hardware/platform.py
+++ b/src/seedsigner/hardware/platform.py
@@ -1,0 +1,158 @@
+"""Hardware platform and board-profile detection helpers.
+
+The project primarily targets Raspberry Pi devices but can also run on desktop
+or alternative ARM boards like the Luckfox Pico line. This module centralizes
+platform/variant detection so hardware backends can adapt automatically.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+
+PLATFORM__RASPBERRY_PI = "raspberry_pi"
+PLATFORM__LUCKFOX = "luckfox"
+PLATFORM__DESKTOP = "desktop"
+
+LUCKFOX_VARIANT__UNKNOWN = "unknown"
+LUCKFOX_VARIANT__PICO_MINI = "pico-mini"
+LUCKFOX_VARIANT__PICO_MAX = "pico-max"
+
+
+@dataclass(frozen=True)
+class LuckfoxHardwareProfile:
+    """Luckfox board profile used by hardware backends."""
+
+    variant: str
+    # libgpiod global GPIO numbers for button matrix
+    key_up_pin: int
+    key_down_pin: int
+    key_left_pin: int
+    key_right_pin: int
+    key_press_pin: int
+    key1_pin: int
+    key2_pin: int
+    key3_pin: int
+    # libgpiod global GPIO numbers for display lines
+    st7789_dc_pin: int
+    st7789_rst_pin: int
+    # preferred camera device candidates
+    video_devices: tuple[str, ...]
+
+
+# Both SeedSigner Luckfox carrier PCBs currently use the same wiring map.
+# Keep profiles split so per-variant pinouts can diverge later without changing
+# each backend module.
+_LUCKFOX_PROFILE_PICO_MINI = LuckfoxHardwareProfile(
+    variant=LUCKFOX_VARIANT__PICO_MINI,
+    key_up_pin=58,
+    key_down_pin=53,
+    key_left_pin=59,
+    key_right_pin=54,
+    key_press_pin=52,
+    key1_pin=55,
+    key2_pin=43,
+    key3_pin=42,
+    st7789_dc_pin=56,
+    st7789_rst_pin=57,
+    video_devices=("/dev/video11", "/dev/video12", "/dev/video0"),
+)
+
+_LUCKFOX_PROFILE_PICO_MAX = LuckfoxHardwareProfile(
+    variant=LUCKFOX_VARIANT__PICO_MAX,
+    key_up_pin=58,
+    key_down_pin=53,
+    key_left_pin=59,
+    key_right_pin=54,
+    key_press_pin=52,
+    key1_pin=55,
+    key2_pin=43,
+    key3_pin=42,
+    st7789_dc_pin=56,
+    st7789_rst_pin=57,
+    video_devices=("/dev/video12", "/dev/video11", "/dev/video0"),
+)
+
+
+def _read_first_existing(paths: list[str]) -> str:
+    for path in paths:
+        try:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                value = f.read().strip("\x00\n ")
+                if value:
+                    return value
+        except OSError:
+            continue
+    return ""
+
+
+def _device_model_blob() -> str:
+    model = _read_first_existing([
+        "/proc/device-tree/model",
+        "/sys/firmware/devicetree/base/model",
+    ])
+    compatible = _read_first_existing([
+        "/proc/device-tree/compatible",
+        "/sys/firmware/devicetree/base/compatible",
+    ])
+    return f"{model}\n{compatible}".lower()
+
+
+@lru_cache(maxsize=1)
+def detect_platform() -> str:
+    """Return one of the ``PLATFORM__*`` constants for this runtime."""
+    forced = os.getenv("SEEDSIGNER_PLATFORM", "").strip().lower()
+    if forced in {PLATFORM__RASPBERRY_PI, PLATFORM__LUCKFOX, PLATFORM__DESKTOP}:
+        return forced
+
+    model_blob = _device_model_blob()
+    if "luckfox" in model_blob or "rv110" in model_blob:
+        return PLATFORM__LUCKFOX
+
+    try:
+        with open("/proc/cpuinfo", "r", encoding="utf-8", errors="ignore") as f:
+            cpuinfo = f.read().lower()
+        if "raspberry pi" in cpuinfo or "bcm27" in cpuinfo:
+            return PLATFORM__RASPBERRY_PI
+    except OSError:
+        pass
+
+    return PLATFORM__DESKTOP
+
+
+@lru_cache(maxsize=1)
+def detect_luckfox_variant() -> str:
+    """Return detected Luckfox board variant when running on Luckfox."""
+    forced = os.getenv("SEEDSIGNER_LUCKFOX_VARIANT", "").strip().lower()
+    if forced in {LUCKFOX_VARIANT__PICO_MINI, LUCKFOX_VARIANT__PICO_MAX}:
+        return forced
+
+    if detect_platform() != PLATFORM__LUCKFOX:
+        return LUCKFOX_VARIANT__UNKNOWN
+
+    model_blob = _device_model_blob()
+    if "mini" in model_blob:
+        return LUCKFOX_VARIANT__PICO_MINI
+    if "max" in model_blob:
+        return LUCKFOX_VARIANT__PICO_MAX
+
+    # Conservative default: preserve current behavior if exact model text differs.
+    return LUCKFOX_VARIANT__PICO_MAX
+
+
+@lru_cache(maxsize=1)
+def get_luckfox_profile() -> LuckfoxHardwareProfile:
+    """Return hardware profile for the currently detected Luckfox variant."""
+    variant = detect_luckfox_variant()
+    if variant == LUCKFOX_VARIANT__PICO_MINI:
+        return _LUCKFOX_PROFILE_PICO_MINI
+    return _LUCKFOX_PROFILE_PICO_MAX
+
+
+def is_luckfox() -> bool:
+    return detect_platform() == PLATFORM__LUCKFOX
+
+
+def is_raspberry_pi() -> bool:
+    return detect_platform() == PLATFORM__RASPBERRY_PI

--- a/src/seedsigner/hardware/platform.py
+++ b/src/seedsigner/hardware/platform.py
@@ -16,8 +16,8 @@ PLATFORM__LUCKFOX = "luckfox"
 PLATFORM__DESKTOP = "desktop"
 
 LUCKFOX_VARIANT__UNKNOWN = "unknown"
-LUCKFOX_VARIANT__PICO_MINI = "pico-mini"
-LUCKFOX_VARIANT__PICO_MAX = "pico-max"
+LUCKFOX_VARIANT__PICO_MINI = "luckfox-22"
+LUCKFOX_VARIANT__PICO_MAX = "luckfox-40"
 
 
 @dataclass(frozen=True)
@@ -42,10 +42,8 @@ class LuckfoxHardwareProfile:
 
 
 # Both SeedSigner Luckfox carrier PCBs currently use the same wiring map.
-# Keep profiles split so per-variant pinouts can diverge later without changing
-# each backend module.
-_LUCKFOX_PROFILE_PICO_MINI = LuckfoxHardwareProfile(
-    variant=LUCKFOX_VARIANT__PICO_MINI,
+# Keep profiles split so per-variant values can diverge later.
+_LUCKFOX_BASE_PINS = dict(
     key_up_pin=58,
     key_down_pin=53,
     key_left_pin=59,
@@ -56,22 +54,19 @@ _LUCKFOX_PROFILE_PICO_MINI = LuckfoxHardwareProfile(
     key3_pin=42,
     st7789_dc_pin=56,
     st7789_rst_pin=57,
+)
+
+
+_LUCKFOX_PROFILE_PICO_MINI = LuckfoxHardwareProfile(
+    variant=LUCKFOX_VARIANT__PICO_MINI,
     video_devices=("/dev/video11", "/dev/video12", "/dev/video0"),
+    **_LUCKFOX_BASE_PINS,
 )
 
 _LUCKFOX_PROFILE_PICO_MAX = LuckfoxHardwareProfile(
     variant=LUCKFOX_VARIANT__PICO_MAX,
-    key_up_pin=58,
-    key_down_pin=53,
-    key_left_pin=59,
-    key_right_pin=54,
-    key_press_pin=52,
-    key1_pin=55,
-    key2_pin=43,
-    key3_pin=42,
-    st7789_dc_pin=56,
-    st7789_rst_pin=57,
     video_devices=("/dev/video12", "/dev/video11", "/dev/video0"),
+    **_LUCKFOX_BASE_PINS,
 )
 
 
@@ -125,6 +120,12 @@ def detect_platform() -> str:
 def detect_luckfox_variant() -> str:
     """Return detected Luckfox board variant when running on Luckfox."""
     forced = os.getenv("SEEDSIGNER_LUCKFOX_VARIANT", "").strip().lower()
+    # Backward-compat aliases.
+    if forced == "pico-mini":
+        forced = LUCKFOX_VARIANT__PICO_MINI
+    elif forced == "pico-max":
+        forced = LUCKFOX_VARIANT__PICO_MAX
+
     if forced in {LUCKFOX_VARIANT__PICO_MINI, LUCKFOX_VARIANT__PICO_MAX}:
         return forced
 

--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -7,6 +7,8 @@ import platform
 
 from typing import List
 
+from seedsigner.hardware.platform import is_luckfox
+
 try:
     import RPi.GPIO as GPIO
     USING_MOCK_GPIO = False
@@ -75,7 +77,7 @@ class Settings(Singleton):
             # Load default/persistent locale setting
             settings.load_locale()
 
-            if USING_MOCK_GPIO:
+            if USING_MOCK_GPIO and not is_luckfox():
                 settings._data[SettingsConstants.SETTING__DISPLAY_CONFIGURATION] = (
                     SettingsConstants.DISPLAY_CONFIGURATION__DESKTOP__240x240
                 )

--- a/tests/test_hardware_platform.py
+++ b/tests/test_hardware_platform.py
@@ -1,0 +1,56 @@
+from seedsigner.hardware import platform as hw_platform
+
+
+def _clear_caches():
+    hw_platform.detect_platform.cache_clear()
+    hw_platform.detect_luckfox_variant.cache_clear()
+    hw_platform.get_luckfox_profile.cache_clear()
+
+
+def test_detect_platform_from_env(monkeypatch):
+    _clear_caches()
+    monkeypatch.setenv("SEEDSIGNER_PLATFORM", hw_platform.PLATFORM__LUCKFOX)
+    assert hw_platform.detect_platform() == hw_platform.PLATFORM__LUCKFOX
+
+
+def test_detect_platform_luckfox_from_model(monkeypatch):
+    _clear_caches()
+    monkeypatch.delenv("SEEDSIGNER_PLATFORM", raising=False)
+
+    def fake_read(paths):
+        if "model" in paths[0]:
+            return "Luckfox Pico"
+        return ""
+
+    monkeypatch.setattr(hw_platform, "_read_first_existing", fake_read)
+    assert hw_platform.detect_platform() == hw_platform.PLATFORM__LUCKFOX
+
+
+def test_detect_luckfox_variant_from_model(monkeypatch):
+    _clear_caches()
+    monkeypatch.setenv("SEEDSIGNER_PLATFORM", hw_platform.PLATFORM__LUCKFOX)
+    monkeypatch.delenv("SEEDSIGNER_LUCKFOX_VARIANT", raising=False)
+
+    monkeypatch.setattr(hw_platform, "_device_model_blob", lambda: "luckfox pico mini")
+    assert hw_platform.detect_luckfox_variant() == hw_platform.LUCKFOX_VARIANT__PICO_MINI
+
+
+def test_luckfox_profile_can_be_forced_to_max(monkeypatch):
+    _clear_caches()
+    monkeypatch.setenv("SEEDSIGNER_PLATFORM", hw_platform.PLATFORM__LUCKFOX)
+    monkeypatch.setenv("SEEDSIGNER_LUCKFOX_VARIANT", hw_platform.LUCKFOX_VARIANT__PICO_MAX)
+
+    profile = hw_platform.get_luckfox_profile()
+    assert profile.variant == hw_platform.LUCKFOX_VARIANT__PICO_MAX
+    assert "/dev/video12" in profile.video_devices
+
+
+def test_luckfox_profiles_have_valid_pin_maps():
+    _clear_caches()
+    mini = hw_platform._LUCKFOX_PROFILE_PICO_MINI
+    max_profile = hw_platform._LUCKFOX_PROFILE_PICO_MAX
+
+    for profile in (mini, max_profile):
+        assert profile.key_up_pin > 0
+        assert profile.st7789_dc_pin > 0
+        assert profile.video_devices

--- a/tests/test_hardware_platform.py
+++ b/tests/test_hardware_platform.py
@@ -54,3 +54,12 @@ def test_luckfox_profiles_have_valid_pin_maps():
         assert profile.key_up_pin > 0
         assert profile.st7789_dc_pin > 0
         assert profile.video_devices
+
+
+def test_luckfox_profile_alias_is_supported(monkeypatch):
+    _clear_caches()
+    monkeypatch.setenv("SEEDSIGNER_PLATFORM", hw_platform.PLATFORM__LUCKFOX)
+    monkeypatch.setenv("SEEDSIGNER_LUCKFOX_VARIANT", "pico-mini")
+
+    profile = hw_platform.get_luckfox_profile()
+    assert profile.variant == hw_platform.LUCKFOX_VARIANT__PICO_MINI


### PR DESCRIPTION
### Motivation
- Add explicit board-variant detection and profiles so the code can automatically handle both Luckfox Pico Mini and Pico Max variants without hardcoded assumptions.
- Centralize per-variant pin/device choices so future wiring differences between Mini/Max can be addressed in one place.

### Description
- Add `src/seedsigner/hardware/platform.py` with platform detection, Luckfox variant detection (`pico-mini`/`pico-max`), and `LuckfoxHardwareProfile` objects that list button GPIOs, ST7789 DC/RST pins, and preferred camera device candidates.
- Wire button handling to use the detected Luckfox profile by updating `src/seedsigner/hardware/buttons.py` to select periphery pins when `periphery` GPIO backend is active and add a `_is_pressed` helper to unify `rpi`/`periphery` input checks.
- Update ST7789 display backend in `src/seedsigner/hardware/displays/ST7789.py` to use profile-provided DC/RST pins and a `_gpio_write` shim to support libgpiod `PeripheryGPIO` and RPi GPIO paths.
- Improve camera backends: enhance `src/seedsigner/hardware/pivideostream.py` to support a Luckfox `v4l2` backend that tries profile-ordered `/dev/video*` candidates and use `shutil.which` for probing `v4l2-ctl`, and update `src/seedsigner/hardware/camera.py` to use a short-lived `PiVideoStream` single-frame capture path on Luckfox when OpenCV is not present.
- Small settings tweak in `src/seedsigner/models/settings.py` to avoid overriding display configuration for actual Luckfox hardware when `USING_MOCK_GPIO` is detected.
- Add tests in `tests/test_hardware_platform.py` to validate platform detection, variant detection, profile forcing, and profile pin/device sanity.

### Testing
- Run Python compilation check: `python -m py_compile src/seedsigner/hardware/platform.py src/seedsigner/hardware/buttons.py src/seedsigner/hardware/displays/ST7789.py src/seedsigner/hardware/pivideostream.py tests/test_hardware_platform.py` which completed successfully.
- Run unit tests: `pytest -q tests/test_hardware_platform.py tests/test_settings_definition.py` which passed (8 passed).
- Added test file `tests/test_hardware_platform.py` to cover detection and profile behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b44871d188322b321c56188dce761)