### PR TITLE
Remove 'v' prefix from splash version and update attribution text

### DIFF
--- a/src/seedsigner/views/screensaver.py
+++ b/src/seedsigner/views/screensaver.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import random
 import time
 
@@ -22,22 +21,11 @@ class LogoScreen(BaseScreen):
         super().__init__()
         self.logo = load_image("logo_black_240.png")
 
-        self.partners = [
-            "hrf",
-        ]
-
-        self.partner_logos: dict = {}
-        for partner in self.partners:
-            logo_url = os.path.join("partners", f"{partner}_logo.png")
-            self.partner_logos[partner] = load_image(logo_url)
 
 
     def _run(self):
         pass
 
-
-    def get_random_partner(self) -> str:
-        return self.partners[random.randrange(len(self.partners))]
 
 
 
@@ -100,7 +88,7 @@ class OpeningSplashScreen(LogoScreen):
 
         # Display version num below SeedSigner logo
         font = Fonts.get_font(GUIConstants.get_body_font_name(), GUIConstants.get_top_nav_title_font_size())
-        version = f"v{controller.VERSION}"
+        version = controller.VERSION
 
         # The logo png is 240x240, but the actual logo is 70px tall, vertically centered
         logo_height = 70
@@ -116,23 +104,14 @@ class OpeningSplashScreen(LogoScreen):
                 # Hold on the version num for a moment
                 time.sleep(1)
 
-            # Set up the partner logo
-            partner_logo: Image.Image = self.partner_logos[self.get_random_partner()]
             font = Fonts.get_font(GUIConstants.get_top_nav_title_font_name(), GUIConstants.get_body_font_size())
-            # TRANSLATOR_NOTE: This is on the opening splash screen, displayed above the HRF logo
-            sponsor_text = _("With support from:")
+            # TRANSLATOR_NOTE: This is on the opening splash screen under the version number.
+            sponsor_text = _("An Unofficial Fork of")
             (left, top, tw, th) = font.getbbox(sponsor_text, anchor="lt")
 
             x = int((self.renderer.canvas_width) / 2)
-            y = self.canvas_height - GUIConstants.COMPONENT_PADDING - partner_logo.height - int(GUIConstants.COMPONENT_PADDING/2) - th
+            y = self.canvas_height - GUIConstants.COMPONENT_PADDING - th
             self.renderer.draw.text(xy=(x, y), text=sponsor_text, font=font, fill="#ccc", anchor="mt")
-            self.renderer.canvas.paste(
-                partner_logo,
-                (
-                    int((self.renderer.canvas_width - partner_logo.width) / 2),
-                    y + th + int(GUIConstants.COMPONENT_PADDING/2)
-                )
-            )
 
             self.renderer.show_image()
 
@@ -254,5 +233,4 @@ class ScreensaverScreen(LogoScreen):
 
     def stop(self):
         self._is_running = False
-
 


### PR DESCRIPTION
### Motivation
- The splash screen should display the raw version string without a leading `v` prefix and replace the partner attribution block with a simple text line reading "An Unofficial Fork of" for the build being shipped.
- The partner logo plumbing is no longer used for the splash attribution, so remove the unused partner-logo wiring to simplify the splash code.

### Description
- Display version text using `controller.VERSION` instead of `f"v{controller.VERSION}"` in `src/seedsigner/views/screensaver.py` so the `v` prefix is removed.
- Replace the localized sponsor line from `"With support from:"` (and the HRF logo paste) to the single-line `"An Unofficial Fork of"` and adjust vertical positioning accordingly in `OpeningSplashScreen`.
- Remove now-unused partner-logo initialization and the `get_random_partner` helper, and drop the unused `os` usage while ensuring `random` remains imported.

### Testing
- Ran `python -m py_compile src/seedsigner/views/screensaver.py`, which completed successfully.
- Attempted a Playwright screenshot capture against `http://localhost:3000` for visual validation, but it failed with `ERR_EMPTY_RESPONSE` because no web server was running in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e0e7a42688322addfa095035447ba)