### PR TITLE
Store SeedKeeper xprv exports as Data secrets and load them safely

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -348,6 +348,45 @@ class SeedKeeperSelectView(View):
 
         return mnemonic # str
 
+    @staticmethod
+    def _decode_seedkeeper_text(secret_hex: str) -> str:
+        """Decode a Seedkeeper UTF-8 payload with optional 1/2-byte length prefix."""
+        raw = bytes.fromhex(secret_hex)
+        if len(raw) >= 2 and int.from_bytes(raw[:2], "big") == len(raw[2:]):
+            return raw[2:].decode("utf-8")
+        if len(raw) >= 1 and raw[0] == len(raw[1:]):
+            return raw[1:].decode("utf-8")
+        return raw.decode("utf-8")
+
+    @staticmethod
+    def _extract_xprv_from_masterseed_secret(secret_hex: str) -> str:
+        """Load legacy xprv payloads stored in a Masterseed subtype 0 secret."""
+        secret_raw_bytes = bytes.fromhex(secret_hex)
+
+        candidates: list[str] = []
+        if secret_raw_bytes:
+            size = secret_raw_bytes[0]
+            if len(secret_raw_bytes) >= 1 + size:
+                try:
+                    candidates.append(secret_raw_bytes[1:1 + size].decode("utf-8"))
+                except UnicodeDecodeError:
+                    pass
+
+        for decode_attempt in (
+            lambda: SeedKeeperSelectView._decode_seedkeeper_text(secret_hex),
+            lambda: secret_raw_bytes.decode("utf-8"),
+        ):
+            try:
+                candidates.append(decode_attempt())
+            except UnicodeDecodeError:
+                continue
+
+        for candidate in candidates:
+            if candidate.startswith(("xprv", "tprv")):
+                return candidate
+
+        raise ValueError("Unsupported Masterseed subtype 0 payload")
+
 
     def run(self):
         from seedsigner.gui.screens.screen import LoadingScreenThread
@@ -376,6 +415,7 @@ class SeedKeeperSelectView(View):
                 if ((stype == "BIP39 mnemonic" and export_rights == 'Plaintext export allowed') or
                         (stype == 'Masterseed' and subtype == 0x01) or
                         (stype == 'Masterseed' and subtype == 0x00) or
+                        (stype == 'Data' and label.startswith('XPRV:') and export_rights == 'Plaintext export allowed') or
                         (stype == 'Electrum mnemonic' and export_rights == 'Plaintext export allowed')):
 
                     if not label:
@@ -453,9 +493,14 @@ class SeedKeeperSelectView(View):
                 secret_passphrase = passphrase
 
             elif stype == 'Masterseed' and subtype == 0x00:
-                secret_raw_bytes = bytes.fromhex(secret_dict['secret'])
-                xprv_size = secret_raw_bytes[0]
-                xprv = secret_raw_bytes[1:1 + xprv_size].decode("utf-8")
+                xprv = self._extract_xprv_from_masterseed_secret(secret_dict['secret'])
+                self.controller.storage.set_pending_seed(XprvSeed(xprv))
+                return Destination(SeedFinalizeView)
+
+            elif stype == 'Data':
+                xprv = self._decode_seedkeeper_text(secret_dict['secret']).strip()
+                if not xprv.startswith(("xprv", "tprv")):
+                    raise ValueError("Selected Seedkeeper data entry is not an xprv")
                 self.controller.storage.set_pending_seed(XprvSeed(xprv))
                 return Destination(SeedFinalizeView)
 
@@ -4557,10 +4602,10 @@ class SaveToSeedkeeperView(View):
                         label = ret['passphrase']
                         export_rights = "Plaintext export allowed"
                         if isinstance(seed, XprvSeed):
-                            type = "Masterseed"
-                            subtype = 0x00
+                            type = "Data"
+                            label = f"XPRV:{label}"
                             xprv_list = list(bytes(seed.get_root().to_base58(), 'utf-8'))
-                            secret_list = [len(xprv_list)] + xprv_list
+                            secret_list = list(len(xprv_list).to_bytes(2, "big")) + xprv_list
                         else:
                             type = "Masterseed"
                             subtype = 0x01
@@ -4578,7 +4623,10 @@ class SaveToSeedkeeperView(View):
                                            [len(bip39_passphrase_list)] +
                                            bip39_passphrase_list
                                            )
-                    header = Satochip_Connector.make_header(type, export_rights, label, subtype=subtype)
+                    if type == "Data":
+                        header = Satochip_Connector.make_header(type, export_rights, label)
+                    else:
+                        header = Satochip_Connector.make_header(type, export_rights, label, subtype=subtype)
                     secret_dic = {'header': header, 'secret_list': secret_list}
 
             try:

--- a/tests/test_seedkeeper_xprv_storage.py
+++ b/tests/test_seedkeeper_xprv_storage.py
@@ -1,0 +1,15 @@
+from seedsigner.views.seed_views import SeedKeeperSelectView
+
+
+def test_decode_seedkeeper_text_supports_v2_two_byte_length_prefix():
+    xprv = "xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb"
+    payload = len(xprv.encode("utf-8")).to_bytes(2, "big") + xprv.encode("utf-8")
+
+    assert SeedKeeperSelectView._decode_seedkeeper_text(payload.hex()) == xprv
+
+
+def test_extract_xprv_from_legacy_masterseed_subtype_zero_payload():
+    xprv = "xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb"
+    payload = bytes([len(xprv.encode("utf-8"))]) + xprv.encode("utf-8")
+
+    assert SeedKeeperSelectView._extract_xprv_from_masterseed_secret(payload.hex()) == xprv


### PR DESCRIPTION
### Motivation
- SeedKeeper v2 treats `Masterseed` subtype `0x00` as raw hex payloads, so storing an xprv as a UTF-8 masterseed is ambiguous and can be misinterpreted; the change makes xprv storage explicit and robust. 
- Preserve backward compatibility by recognising legacy encodings while preferring a clear, text-based `Data` entry for newly saved xprvs. 

### Description
- Save xprv seeds on SeedKeeper v2 as `Data` records with a deterministic `XPRV:` label and a 2-byte big-endian length prefix for the stored UTF-8 xprv text. 
- Add `_decode_seedkeeper_text` to decode SeedKeeper payloads that may include 1- or 2-byte length prefixes or raw UTF-8. 
- Add `_extract_xprv_from_masterseed_secret` to robustly parse legacy `Masterseed` subtype `0x00` payloads and recover xprv/tprv text when present. 
- Update the SeedKeeper import workflow to recognise `Data` + `XPRV:` entries and to fallback to the legacy parsing logic for existing `Masterseed` subtype `0x00` entries. 
- Ensure header creation uses the appropriate `make_header` signature for `Data` vs `Masterseed` records. 
- Add focused unit tests for the new decoding and legacy extraction routines in `tests/test_seedkeeper_xprv_storage.py`. 

### Testing
- Ran `pytest -q tests/test_seedkeeper_xprv_storage.py` which passed (`2 passed`).
- Ran `pytest -q tests/test_flows_seed.py -k "scan_xprv_flow or xprv_view_seed_words_shows_human_message"` which passed (`2 passed, 30 deselected`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e361cfca48322a24a55cbf848b250)