### PR TITLE
Hide Password Generator from Create Seed menu flow

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -336,7 +336,7 @@ class LoadSeedView(View):
 
         elif button_data[selected_menu_num] == self.CREATE:
             from .tools_views import ToolsMenuView
-            return Destination(ToolsMenuView)
+            return Destination(ToolsMenuView, view_args={"include_password_generator": False})
     
 class SeedKeeperSelectView(View):
     def entropy_to_mnemonic(self, entropy_bytes, wordlist):

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -349,8 +349,15 @@ class ToolsMenuView(View):
     CLEAR_DESCRIPTOR = ButtonOption("Clear Multisig Descriptor")
     NETWORK_INFO = ButtonOption("Network Info")
 
+    def __init__(self, include_password_generator: bool = True):
+        super().__init__()
+        self.include_password_generator = include_password_generator
+
     def run(self):
-        button_data = [self.IMAGE, self.DICE, self.PASSWORD_GENERATOR]
+        button_data = [self.IMAGE, self.DICE]
+
+        if getattr(self, "include_password_generator", True):
+            button_data.append(self.PASSWORD_GENERATOR)
         
         if self.settings.get_value(SettingsConstants.SETTING__SLIP39_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.extend([self.SLIP39_IMAGE, self.SLIP39_DICE])
@@ -3707,7 +3714,7 @@ class ToolsSatochipImportSeedView(View):
         elif button_data[selected_menu_num] == self.TYPE_SLIP39:
             return Destination(SeedSlip39MnemonicStartView)
         elif button_data[selected_menu_num] == self.CREATE:
-            return Destination(ToolsMenuView)
+            return Destination(ToolsMenuView, view_args={"include_password_generator": False})
         elif button_data[selected_menu_num] == self.TYPE_ELECTRUM:
             return Destination(SeedElectrumMnemonicStartView)
         

--- a/tests/test_create_seed_menu.py
+++ b/tests/test_create_seed_menu.py
@@ -1,0 +1,46 @@
+from seedsigner.views import seed_views, tools_views
+
+
+class _Settings:
+    @staticmethod
+    def get_value(key):
+        if key == seed_views.SettingsConstants.SETTING__SEED_WORD_LENGTHS:
+            return [12]
+        return seed_views.SettingsConstants.OPTION__DISABLED
+
+
+def test_create_seed_entry_hides_password_generator(monkeypatch):
+    view = object.__new__(seed_views.LoadSeedView)
+    view.settings = _Settings()
+
+    captured = {}
+
+    def fake_run_screen(self, *_args, **kwargs):
+        button_data = kwargs["button_data"]
+        captured["button_data"] = button_data
+        return button_data.index(seed_views.LoadSeedView.CREATE)
+
+    monkeypatch.setattr(seed_views.LoadSeedView, "run_screen", fake_run_screen)
+
+    dest = seed_views.LoadSeedView.run(view)
+
+    assert dest.View_cls is tools_views.ToolsMenuView
+    assert dest.view_args == {"include_password_generator": False}
+
+
+def test_tools_menu_hides_password_generator_when_disabled(monkeypatch):
+    view = object.__new__(tools_views.ToolsMenuView)
+    view.settings = _Settings()
+    view.include_password_generator = False
+
+    captured = {}
+
+    def fake_run_screen(self, *_args, **kwargs):
+        captured["button_data"] = kwargs["button_data"]
+        return tools_views.RET_CODE__BACK_BUTTON
+
+    monkeypatch.setattr(tools_views.ToolsMenuView, "run_screen", fake_run_screen)
+
+    tools_views.ToolsMenuView.run(view)
+
+    assert tools_views.ToolsMenuView.PASSWORD_GENERATOR not in captured["button_data"]


### PR DESCRIPTION
### Motivation

- The Password Generator option was visible when entering the "Create a seed" flow, but it should only be available from the Tools entry point.

### Description

- Add an `include_password_generator` toggle to `ToolsMenuView` (default `True`) and only append the `PASSWORD_GENERATOR` button when the toggle is set.
- Preserve backward compatibility by using `getattr(self, "include_password_generator", True)` to handle older instantiations that don't pass the flag.
- Update create-seed entry points to open `ToolsMenuView` with `view_args={"include_password_generator": False}` from `LoadSeedView` and the Satochip import create flow so Password Generator is hidden in that context.
- Add tests (`tests/test_create_seed_menu.py`) validating the route/view_args and that the Password Generator button is omitted when disabled.

### Testing

- Ran `pytest -q tests/test_create_seed_menu.py tests/test_password_generator_views.py::test_tools_menu_back_returns_back_stack` and all tests passed.
- Test run result: `3 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699676277bb08322bc8dcbd9d211096c)