### PR TITLE
Align FOX_PI io_config with verified gpiochip mapping

### DIFF
--- a/docs/hardware_platform_support.md
+++ b/docs/hardware_platform_support.md
@@ -28,6 +28,7 @@ Current profiles in `io_config.json`:
 - `RPI_26` (legacy Raspberry Pi 26-pin variants)
 - `FOX_22` (Luckfox Pico 22-pin)
 - `FOX_40` (Luckfox Pico 40-pin)
+- `FOX_PI` (Luckfox Pico Pi)
 
 ## Button GPIO mapping format
 
@@ -141,3 +142,25 @@ This is a quick reference summary of the mappings currently defined in
   - Resolution: `800x600`
   - Pixel format: `NV12`
   - Framerate: `10`
+
+### `FOX_PI`
+
+- Display:
+  - `dc`: `["/dev/gpiochip1", 27]`
+  - `rst`: `["/dev/gpiochip1", 24]`
+  - `bl`: `["/dev/gpiochip2", 6]`
+  - SPI: `bus 0`, `device 0`
+- Buttons (all with `"pull_up"`):
+  - `KEY_UP`: `["/dev/gpiochip3", 26, "pull_up"]`
+  - `KEY_DOWN`: `["/dev/gpiochip1", 20, "pull_up"]`
+  - `KEY_LEFT`: `["/dev/gpiochip0", 1, "pull_up"]`
+  - `KEY_RIGHT`: `["/dev/gpiochip3", 25, "pull_up"]`
+  - `KEY_PRESS`: `["/dev/gpiochip0", 0, "pull_up"]`
+  - `KEY1`: `["/dev/gpiochip4", 17, "pull_up"]`
+  - `KEY2`: `["/dev/gpiochip3", 27, "pull_up"]`
+  - `KEY3`: `["/dev/gpiochip1", 23, "pull_up"]`
+- Camera:
+  - Device: `/dev/video12`
+  - Resolution: `800x600`
+  - Pixel format: `GREY`
+  - Framerate: `6`

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -34,6 +34,7 @@ def _get_system_type_and_variant(runtime_profile: str, hardware_profile: str | N
         "rpi_40": "Raspberry Pi",
         "luckfox_22": "Luckfox Pico",
         "luckfox_40": "Luckfox Pico",
+        "luckfox_pi": "Luckfox Pico",
     }
     system_type = system_type_map.get(runtime_profile, "Unknown")
 
@@ -432,7 +433,7 @@ class Controller(Singleton):
             
             # Skip the "remove SD card" tip on Luckfox, where removable media
             # handling and expected workflows differ from SeedSigner OS defaults.
-            if Settings.RUNTIME_PROFILE not in {"luckfox_22", "luckfox_40", "desktop"}:
+            if Settings.RUNTIME_PROFILE not in {"luckfox_22", "luckfox_40", "luckfox_pi", "desktop"}:
                 # Set up our one-time toast notification tip to remove the SD card
                 self.activate_toast(RemoveSDCardToastManagerThread())
 

--- a/src/seedsigner/hardware/camera.py
+++ b/src/seedsigner/hardware/camera.py
@@ -26,7 +26,7 @@ class Camera(Singleton):
 
     @staticmethod
     def _is_luckfox_profile(runtime_profile: str) -> bool:
-        return runtime_profile in {"luckfox_22", "luckfox_40"}
+        return runtime_profile in {"luckfox_22", "luckfox_40", "luckfox_pi"}
 
     @classmethod
     def _get_hardware_camera_config(cls):

--- a/src/seedsigner/hardware/io_config.json
+++ b/src/seedsigner/hardware/io_config.json
@@ -20,25 +20,69 @@
         "raspberry pi 400 rev 1\\.[0-9]+"
       ],
       "display": {
-        "dc": ["/dev/gpiochip0", 25],
-        "rst": ["/dev/gpiochip0", 27],
-        "bl": ["/dev/gpiochip0", 24],
+        "dc": [
+          "/dev/gpiochip0",
+          25
+        ],
+        "rst": [
+          "/dev/gpiochip0",
+          27
+        ],
+        "bl": [
+          "/dev/gpiochip0",
+          24
+        ],
         "spi_bus": 0,
         "spi_device": 0
       },
       "buttons": {
-        "KEY_UP": ["/dev/gpiochip0", 6, "pull_up"],
-        "KEY_DOWN": ["/dev/gpiochip0", 19, "pull_up"],
-        "KEY_LEFT": ["/dev/gpiochip0", 5, "pull_up"],
-        "KEY_RIGHT": ["/dev/gpiochip0", 26, "pull_up"],
-        "KEY_PRESS": ["/dev/gpiochip0", 13, "pull_up"],
-        "KEY1": ["/dev/gpiochip0", 21, "pull_up"],
-        "KEY2": ["/dev/gpiochip0", 20, "pull_up"],
-        "KEY3": ["/dev/gpiochip0", 16, "pull_up"]
+        "KEY_UP": [
+          "/dev/gpiochip0",
+          6,
+          "pull_up"
+        ],
+        "KEY_DOWN": [
+          "/dev/gpiochip0",
+          19,
+          "pull_up"
+        ],
+        "KEY_LEFT": [
+          "/dev/gpiochip0",
+          5,
+          "pull_up"
+        ],
+        "KEY_RIGHT": [
+          "/dev/gpiochip0",
+          26,
+          "pull_up"
+        ],
+        "KEY_PRESS": [
+          "/dev/gpiochip0",
+          13,
+          "pull_up"
+        ],
+        "KEY1": [
+          "/dev/gpiochip0",
+          21,
+          "pull_up"
+        ],
+        "KEY2": [
+          "/dev/gpiochip0",
+          20,
+          "pull_up"
+        ],
+        "KEY3": [
+          "/dev/gpiochip0",
+          16,
+          "pull_up"
+        ]
       },
       "camera": {
         "device": "/dev/video0",
-        "resolution": [1280, 720],
+        "resolution": [
+          1280,
+          720
+        ],
         "pixelformat": "YUYV",
         "framerate": 4
       }
@@ -53,25 +97,69 @@
         "raspberry pi model a rev 1\\.[0-9]+"
       ],
       "display": {
-        "dc": ["/dev/gpiochip0", 25],
-        "rst": ["/dev/gpiochip0", 27],
-        "bl": ["/dev/gpiochip0", 24],
+        "dc": [
+          "/dev/gpiochip0",
+          25
+        ],
+        "rst": [
+          "/dev/gpiochip0",
+          27
+        ],
+        "bl": [
+          "/dev/gpiochip0",
+          24
+        ],
         "spi_bus": 0,
         "spi_device": 0
       },
       "buttons": {
-        "KEY_UP": ["/dev/gpiochip0", 3, "pull_up"],
-        "KEY_DOWN": ["/dev/gpiochip0", 17, "pull_up"],
-        "KEY_LEFT": ["/dev/gpiochip0", 2, "pull_up"],
-        "KEY_RIGHT": ["/dev/gpiochip0", 22, "pull_up"],
-        "KEY_PRESS": ["/dev/gpiochip0", 4, "pull_up"],
-        "KEY1": ["/dev/gpiochip0", 23, "pull_up"],
-        "KEY2": ["/dev/gpiochip0", 18, "pull_up"],
-        "KEY3": ["/dev/gpiochip0", 14, "pull_up"]
+        "KEY_UP": [
+          "/dev/gpiochip0",
+          3,
+          "pull_up"
+        ],
+        "KEY_DOWN": [
+          "/dev/gpiochip0",
+          17,
+          "pull_up"
+        ],
+        "KEY_LEFT": [
+          "/dev/gpiochip0",
+          2,
+          "pull_up"
+        ],
+        "KEY_RIGHT": [
+          "/dev/gpiochip0",
+          22,
+          "pull_up"
+        ],
+        "KEY_PRESS": [
+          "/dev/gpiochip0",
+          4,
+          "pull_up"
+        ],
+        "KEY1": [
+          "/dev/gpiochip0",
+          23,
+          "pull_up"
+        ],
+        "KEY2": [
+          "/dev/gpiochip0",
+          18,
+          "pull_up"
+        ],
+        "KEY3": [
+          "/dev/gpiochip0",
+          14,
+          "pull_up"
+        ]
       },
       "camera": {
         "device": "/dev/video0",
-        "resolution": [1280, 720],
+        "resolution": [
+          1280,
+          720
+        ],
         "pixelformat": "YUYV",
         "framerate": 4
       }
@@ -85,25 +173,61 @@
         "luckfox pico mini"
       ],
       "display": {
-        "dc": ["/dev/gpiochip1", 20],
-        "rst": ["/dev/gpiochip1", 19],
-        "bl": ["/dev/gpiochip1", 11],
+        "dc": [
+          "/dev/gpiochip1",
+          20
+        ],
+        "rst": [
+          "/dev/gpiochip1",
+          19
+        ],
+        "bl": [
+          "/dev/gpiochip1",
+          11
+        ],
         "spi_bus": 0,
         "spi_device": 0
       },
       "buttons": {
-        "KEY_UP": ["/dev/gpiochip1", 25],
-        "KEY_DOWN": ["/dev/gpiochip1", 27],
-        "KEY_LEFT": ["/dev/gpiochip1", 24],
-        "KEY_RIGHT": ["/dev/gpiochip1", 22],
-        "KEY_PRESS": ["/dev/gpiochip1", 26],
-        "KEY1": ["/dev/gpiochip1", 23],
-        "KEY2": ["/dev/gpiochip0", 4],
-        "KEY3": ["/dev/gpiochip1", 21]
+        "KEY_UP": [
+          "/dev/gpiochip1",
+          25
+        ],
+        "KEY_DOWN": [
+          "/dev/gpiochip1",
+          27
+        ],
+        "KEY_LEFT": [
+          "/dev/gpiochip1",
+          24
+        ],
+        "KEY_RIGHT": [
+          "/dev/gpiochip1",
+          22
+        ],
+        "KEY_PRESS": [
+          "/dev/gpiochip1",
+          26
+        ],
+        "KEY1": [
+          "/dev/gpiochip1",
+          23
+        ],
+        "KEY2": [
+          "/dev/gpiochip0",
+          4
+        ],
+        "KEY3": [
+          "/dev/gpiochip1",
+          21
+        ]
       },
       "camera": {
         "device": "/dev/video12",
-        "resolution": [800, 600],
+        "resolution": [
+          800,
+          600
+        ],
         "pixelformat": "GREY",
         "framerate": 6
       }
@@ -117,25 +241,129 @@
         "luckfox pico pro max"
       ],
       "display": {
-        "dc": ["/dev/gpiochip1", 24],
-        "rst": ["/dev/gpiochip1", 25],
-        "bl": ["/dev/gpiochip2", 8],
+        "dc": [
+          "/dev/gpiochip1",
+          24
+        ],
+        "rst": [
+          "/dev/gpiochip1",
+          25
+        ],
+        "bl": [
+          "/dev/gpiochip2",
+          8
+        ],
         "spi_bus": 0,
         "spi_device": 0
       },
       "buttons": {
-        "KEY_UP": [58],
-        "KEY_DOWN": [53],
-        "KEY_LEFT": [59],
-        "KEY_RIGHT": [54],
-        "KEY_PRESS": [52],
-        "KEY1": [55],
-        "KEY2": [43],
-        "KEY3": [42]
+        "KEY_UP": [
+          58
+        ],
+        "KEY_DOWN": [
+          53
+        ],
+        "KEY_LEFT": [
+          59
+        ],
+        "KEY_RIGHT": [
+          54
+        ],
+        "KEY_PRESS": [
+          52
+        ],
+        "KEY1": [
+          55
+        ],
+        "KEY2": [
+          43
+        ],
+        "KEY3": [
+          42
+        ]
       },
       "camera": {
         "device": "/dev/video12",
-        "resolution": [800, 600],
+        "resolution": [
+          800,
+          600
+        ],
+        "pixelformat": "GREY",
+        "framerate": 6
+      }
+    },
+    {
+      "platform": "Luckfox Pico",
+      "variant": "Pi",
+      "shortname": "FOX_PI",
+      "runtime_profile": "luckfox_pi",
+      "regex": [
+        "luckfox pico pi"
+      ],
+      "display": {
+        "dc": [
+          "/dev/gpiochip1",
+          27
+        ],
+        "rst": [
+          "/dev/gpiochip1",
+          24
+        ],
+        "bl": [
+          "/dev/gpiochip2",
+          6
+        ],
+        "spi_bus": 0,
+        "spi_device": 0
+      },
+      "buttons": {
+        "KEY_UP": [
+          "/dev/gpiochip3",
+          26,
+          "pull_up"
+        ],
+        "KEY_DOWN": [
+          "/dev/gpiochip1",
+          20,
+          "pull_up"
+        ],
+        "KEY_LEFT": [
+          "/dev/gpiochip0",
+          1,
+          "pull_up"
+        ],
+        "KEY_RIGHT": [
+          "/dev/gpiochip3",
+          25,
+          "pull_up"
+        ],
+        "KEY_PRESS": [
+          "/dev/gpiochip0",
+          0,
+          "pull_up"
+        ],
+        "KEY1": [
+          "/dev/gpiochip4",
+          17,
+          "pull_up"
+        ],
+        "KEY2": [
+          "/dev/gpiochip3",
+          27,
+          "pull_up"
+        ],
+        "KEY3": [
+          "/dev/gpiochip1",
+          23,
+          "pull_up"
+        ]
+      },
+      "camera": {
+        "device": "/dev/video12",
+        "resolution": [
+          800,
+          600
+        ],
         "pixelformat": "GREY",
         "framerate": 6
       }

--- a/src/seedsigner/models/settings.py
+++ b/src/seedsigner/models/settings.py
@@ -59,6 +59,7 @@ def _get_system_type_and_variant(runtime_profile: str, hardware_config: str | No
         "rpi_40": "Raspberry Pi",
         "luckfox_22": "Luckfox Pico",
         "luckfox_40": "Luckfox Pico",
+        "luckfox_pi": "Luckfox Pico",
     }
     system_type = system_type_map.get(runtime_profile, "Unknown")
 
@@ -107,6 +108,7 @@ class Settings(Singleton):
             "rpi_40": SettingsConstants.DISPLAY_CONFIGURATION__ST7789__240x240,
             "luckfox_22": SettingsConstants.DISPLAY_CONFIGURATION__ST7789__240x240,
             "luckfox_40": SettingsConstants.DISPLAY_CONFIGURATION__ST7789__240x240,
+            "luckfox_pi": SettingsConstants.DISPLAY_CONFIGURATION__ST7789__240x240,
         }
         return profile_map.get(cls.RUNTIME_PROFILE, SettingsConstants.DISPLAY_CONFIGURATION__DESKTOP__240x240)
 
@@ -117,6 +119,7 @@ class Settings(Singleton):
             "rpi_40": 180,
             "luckfox_22": 270,
             "luckfox_40": 270,
+            "luckfox_pi": 270,
             "desktop": 180,
         }
         return profile_map.get(cls.RUNTIME_PROFILE, 180)

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -257,6 +257,7 @@ class SettingsConstants:
     HARDWARE__RPI_26 = "RPI_26"
     HARDWARE__LUCKFOX_22 = "FOX_22"
     HARDWARE__LUCKFOX_40 = "FOX_40"
+    HARDWARE__LUCKFOX_PI = "FOX_PI"
 
 
     # QR code constants

--- a/src/seedsigner/views/settings_views.py
+++ b/src/seedsigner/views/settings_views.py
@@ -821,6 +821,7 @@ class SystemInfoView(View):
             "rpi_40": "Raspberry Pi",
             "luckfox_22": "Luckfox Pico",
             "luckfox_40": "Luckfox Pico",
+            "luckfox_pi": "Luckfox Pico",
         }
         platform_name = platform_map.get(profile, "Unknown")
 

--- a/tests/test_io_config_profiles.py
+++ b/tests/test_io_config_profiles.py
@@ -1,0 +1,30 @@
+from seedsigner.hardware.io_config import detect_runtime_profile, get_hardware_pin_mapping, runtime_profile_to_hardware_profile
+
+
+def test_detect_runtime_profile_luckfox_pico_pi():
+    assert detect_runtime_profile("Luckfox Pico Pi") == "luckfox_pi"
+
+
+def test_runtime_profile_to_hardware_profile_luckfox_pico_pi():
+    assert runtime_profile_to_hardware_profile("luckfox_pi") == "FOX_PI"
+
+
+def test_fox_pi_display_control_lines_match_waveshare_hat_pins():
+    mapping = get_hardware_pin_mapping("FOX_PI")
+
+    assert mapping["display"]["dc"] == ["/dev/gpiochip1", 27]
+    assert mapping["display"]["rst"] == ["/dev/gpiochip1", 24]
+    assert mapping["display"]["bl"] == ["/dev/gpiochip2", 6]
+
+
+def test_fox_pi_buttons_use_periphery_pull_up_mapping():
+    mapping = get_hardware_pin_mapping("FOX_PI")
+
+    assert mapping["buttons"]["KEY_UP"] == ["/dev/gpiochip3", 26, "pull_up"]
+    assert mapping["buttons"]["KEY_DOWN"] == ["/dev/gpiochip1", 20, "pull_up"]
+    assert mapping["buttons"]["KEY_LEFT"] == ["/dev/gpiochip0", 1, "pull_up"]
+    assert mapping["buttons"]["KEY_RIGHT"] == ["/dev/gpiochip3", 25, "pull_up"]
+    assert mapping["buttons"]["KEY_PRESS"] == ["/dev/gpiochip0", 0, "pull_up"]
+    assert mapping["buttons"]["KEY1"] == ["/dev/gpiochip4", 17, "pull_up"]
+    assert mapping["buttons"]["KEY2"] == ["/dev/gpiochip3", 27, "pull_up"]
+    assert mapping["buttons"]["KEY3"] == ["/dev/gpiochip1", 23, "pull_up"]

--- a/tests/test_luckfox_camera_backend.py
+++ b/tests/test_luckfox_camera_backend.py
@@ -1,7 +1,17 @@
-from PIL import Image
+from importlib import import_module
+import sys
 
-from seedsigner.hardware.camera import Camera
+from PIL import Image
+from unittest.mock import MagicMock
+
 from seedsigner.hardware.pivideostream import VideoStream
+
+
+def _get_camera_class():
+    camera_module = sys.modules.get("seedsigner.hardware.camera")
+    if isinstance(camera_module, MagicMock):
+        del sys.modules["seedsigner.hardware.camera"]
+    return import_module("seedsigner.hardware.camera").Camera
 
 
 class DummyVideoStream:
@@ -13,7 +23,8 @@ class DummyVideoStream:
 
 
 def test_camera_read_video_stream_supports_pil_frames():
-    camera = Camera.__new__(Camera)
+    camera_class = _get_camera_class()
+    camera = camera_class.__new__(camera_class)
     camera._video_stream = DummyVideoStream(Image.new("RGB", (4, 4), color=(1, 2, 3)))
     camera._camera_rotation = 180
 
@@ -34,7 +45,8 @@ def test_camera_luckfox_stream_prefers_v4l2(monkeypatch):
 
     monkeypatch.setattr("seedsigner.hardware.pivideostream.VideoStream", FakeVideoStream)
 
-    camera = Camera.__new__(Camera)
+    camera_class = _get_camera_class()
+    camera = camera_class.__new__(camera_class)
     camera._video_stream = None
     camera._camera_index = 0
     camera._runtime_profile = "luckfox_22"
@@ -90,3 +102,8 @@ def test_configure_v4l2_capture_selects_supported_node(monkeypatch):
     assert stream._v4l2_pixelformat == "NV12"
     assert stream._v4l2_resolution == (800, 600)
     assert stream._v4l2_use_set_parm is True
+
+
+def test_camera_luckfox_profile_detection_includes_pico_pi():
+    camera_class = _get_camera_class()
+    assert camera_class._is_luckfox_profile("luckfox_pi") is True


### PR DESCRIPTION
### Motivation
- Ensure the Luckfox Pico Pi (FOX_PI) profile uses explicit periphery gpiochip selectors for display and buttons to match verified Waveshare wiring and to avoid ambiguous line-only mappings.
- Include the Pi variant in runtime/profile-aware code paths so camera, display, and settings defaults behave like other Luckfox profiles.

### Description
- Replaced the `FOX_PI` model entry in `src/seedsigner/hardware/io_config.json` with the requested periphery-formatted mapping, setting display pins to `dc: ["/dev/gpiochip1", 27]`, `rst: ["/dev/gpiochip1", 24]`, `bl: ["/dev/gpiochip2", 6]`, and SPI bus/device to `0,0`, and added full per-key button mappings including `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995be6331688322b7b2814a793676ba)