### PR TITLE
Correct Luckfox Pico Pi (FOX_PI) display/button mapping to blue GPIO labels

### DIFF
--- a/docs/io_config.md
+++ b/docs/io_config.md
@@ -62,9 +62,9 @@ Values shown are exactly how mappings are stored in `io_config.json`.
 |---|---|---|---|---|
 | `RPI_40` | `rpi_40` | `[25] / [27] / [24]` | `KEY_UP [6,"pull_up"]`, `KEY_DOWN [19,"pull_up"]`, `KEY_LEFT [5,"pull_up"]`, `KEY_RIGHT [26,"pull_up"]`, `KEY_PRESS [13,"pull_up"]`, `KEY1 [21,"pull_up"]`, `KEY2 [20,"pull_up"]`, `KEY3 [16,"pull_up"]` | `/dev/video0`, `1280x720`, `YUYV`, `4fps` |
 | `RPI_26` | `rpi_26` | `[25] / [27] / [24]` | `KEY_UP [3,"pull_up"]`, `KEY_DOWN [17,"pull_up"]`, `KEY_LEFT [2,"pull_up"]`, `KEY_RIGHT [22,"pull_up"]`, `KEY_PRESS [4,"pull_up"]`, `KEY1 [23,"pull_up"]`, `KEY2 [18,"pull_up"]`, `KEY3 [14,"pull_up"]` | `/dev/video0`, `1280x720`, `YUYV`, `4fps` |
-| `FOX_22` | `luckfox_22` | `[20] / [19] / [11]` | `KEY_UP [25]`, `KEY_DOWN [27]`, `KEY_LEFT [24]`, `KEY_RIGHT [22]`, `KEY_PRESS [26]`, `KEY1 [23]`, `KEY2 [4]`, `KEY3 [21]` | `/dev/video12`, `GREY`, `6fps` |
-| `FOX_40` | `luckfox_40` | `[24] / [25] / [8]` | `KEY_UP [58]`, `KEY_DOWN [53]`, `KEY_LEFT [59]`, `KEY_RIGHT [54]`, `KEY_PRESS [52]`, `KEY1 [55]`, `KEY2 [43]`, `KEY3 [42]` | `/dev/video12`, `GREY`, `6fps` |
-| `FOX_PI` | `luckfox_pi` | `[27] / [24] / [6]` | `KEY_UP [26,"pull_up"]`, `KEY_DOWN [20,"pull_up"]`, `KEY_LEFT [1,"pull_up"]`, `KEY_RIGHT [25,"pull_up"]`, `KEY_PRESS [0,"pull_up"]`, `KEY1 [17,"pull_up"]`, `KEY2 [27,"pull_up"]`, `KEY3 [23,"pull_up"]` | `/dev/video12`, `GREY`, `6fps` |
+| `FOX_22` | `luckfox_22` | `[52] / [51] / [43]` | `KEY_UP [57,"pull_up"]`, `KEY_DOWN [59,"pull_up"]`, `KEY_LEFT [56,"pull_up"]`, `KEY_RIGHT [54,"pull_up"]`, `KEY_PRESS [58,"pull_up"]`, `KEY1 [55,"pull_up"]`, `KEY2 [4,"pull_up"]`, `KEY3 [53,"pull_up"]` | `/dev/video12`, `GREY`, `6fps` |
+| `FOX_40` | `luckfox_40` | `[56] / [57] / [72]` | `KEY_UP [58,"pull_up"]`, `KEY_DOWN [53,"pull_up"]`, `KEY_LEFT [59,"pull_up"]`, `KEY_RIGHT [54,"pull_up"]`, `KEY_PRESS [52,"pull_up"]`, `KEY1 [55,"pull_up"]`, `KEY2 [43,"pull_up"]`, `KEY3 [42,"pull_up"]` | `/dev/video12`, `GREY`, `6fps` |
+| `FOX_PI` | `luckfox_pi` | `[59] / [56] / [70]` | `KEY_UP [121,"pull_up"]`, `KEY_DOWN [1,"pull_up"]`, `KEY_LEFT [122,"pull_up"]`, `KEY_RIGHT [0,"pull_up"]`, `KEY_PRESS [52,"pull_up"]`, `KEY1 [145,"pull_up"]`, `KEY2 [123,"pull_up"]`, `KEY3 [55,"pull_up"]` | `/dev/video12`, `GREY`, `6fps` |
 
 ---
 

--- a/src/seedsigner/hardware/io_config.json
+++ b/src/seedsigner/hardware/io_config.json
@@ -152,41 +152,49 @@
       ],
       "display": {
         "dc": [
-          20
+          52
         ],
         "rst": [
-          19
+          51
         ],
         "bl": [
-          11
+          43
         ],
         "spi_bus": 0,
         "spi_device": 0
       },
       "buttons": {
         "KEY_UP": [
-          25
+          57,
+          "pull_up"
         ],
         "KEY_DOWN": [
-          27
+          59,
+          "pull_up"
         ],
         "KEY_LEFT": [
-          24
+          56,
+          "pull_up"
         ],
         "KEY_RIGHT": [
-          22
+          54,
+          "pull_up"
         ],
         "KEY_PRESS": [
-          26
+          58,
+          "pull_up"
         ],
         "KEY1": [
-          23
+          55,
+          "pull_up"
         ],
         "KEY2": [
-          4
+          4,
+          "pull_up"
         ],
         "KEY3": [
-          21
+          53,
+          "pull_up"
         ]
       },
       "camera": {
@@ -205,41 +213,49 @@
       ],
       "display": {
         "dc": [
-          24
+          56
         ],
         "rst": [
-          25
+          57
         ],
         "bl": [
-          8
+          72
         ],
         "spi_bus": 0,
         "spi_device": 0
       },
       "buttons": {
         "KEY_UP": [
-          58
+          58,
+          "pull_up"
         ],
         "KEY_DOWN": [
-          53
+          53,
+          "pull_up"
         ],
         "KEY_LEFT": [
-          59
+          59,
+          "pull_up"
         ],
         "KEY_RIGHT": [
-          54
+          54,
+          "pull_up"
         ],
         "KEY_PRESS": [
-          52
+          52,
+          "pull_up"
         ],
         "KEY1": [
-          55
+          55,
+          "pull_up"
         ],
         "KEY2": [
-          43
+          43,
+          "pull_up"
         ],
         "KEY3": [
-          42
+          42,
+          "pull_up"
         ]
       },
       "camera": {
@@ -258,48 +274,48 @@
       ],
       "display": {
         "dc": [
-          27
+          59
         ],
         "rst": [
-          24
+          56
         ],
         "bl": [
-          6
+          70
         ],
         "spi_bus": 0,
         "spi_device": 0
       },
       "buttons": {
         "KEY_UP": [
-          26,
+          121,
           "pull_up"
         ],
         "KEY_DOWN": [
-          20,
-          "pull_up"
-        ],
-        "KEY_LEFT": [
           1,
           "pull_up"
         ],
-        "KEY_RIGHT": [
-          25,
+        "KEY_LEFT": [
+          122,
           "pull_up"
         ],
-        "KEY_PRESS": [
+        "KEY_RIGHT": [
           0,
           "pull_up"
         ],
+        "KEY_PRESS": [
+          52,
+          "pull_up"
+        ],
         "KEY1": [
-          17,
+          145,
           "pull_up"
         ],
         "KEY2": [
-          27,
+          123,
           "pull_up"
         ],
         "KEY3": [
-          23,
+          55,
           "pull_up"
         ]
       },

--- a/tests/test_io_config_profiles.py
+++ b/tests/test_io_config_profiles.py
@@ -12,19 +12,61 @@ def test_runtime_profile_to_hardware_profile_luckfox_pico_pi():
 def test_fox_pi_display_control_lines_match_waveshare_hat_pins():
     mapping = get_hardware_pin_mapping("FOX_PI")
 
-    assert mapping["display"]["dc"] == [27]
-    assert mapping["display"]["rst"] == [24]
-    assert mapping["display"]["bl"] == [6]
+    assert mapping["display"]["dc"] == [59]
+    assert mapping["display"]["rst"] == [56]
+    assert mapping["display"]["bl"] == [70]
 
 
 def test_fox_pi_buttons_use_periphery_pull_up_mapping():
     mapping = get_hardware_pin_mapping("FOX_PI")
 
-    assert mapping["buttons"]["KEY_UP"] == [26, "pull_up"]
-    assert mapping["buttons"]["KEY_DOWN"] == [20, "pull_up"]
-    assert mapping["buttons"]["KEY_LEFT"] == [1, "pull_up"]
-    assert mapping["buttons"]["KEY_RIGHT"] == [25, "pull_up"]
-    assert mapping["buttons"]["KEY_PRESS"] == [0, "pull_up"]
-    assert mapping["buttons"]["KEY1"] == [17, "pull_up"]
-    assert mapping["buttons"]["KEY2"] == [27, "pull_up"]
-    assert mapping["buttons"]["KEY3"] == [23, "pull_up"]
+    assert mapping["buttons"]["KEY_UP"] == [121, "pull_up"]
+    assert mapping["buttons"]["KEY_DOWN"] == [1, "pull_up"]
+    assert mapping["buttons"]["KEY_LEFT"] == [122, "pull_up"]
+    assert mapping["buttons"]["KEY_RIGHT"] == [0, "pull_up"]
+    assert mapping["buttons"]["KEY_PRESS"] == [52, "pull_up"]
+    assert mapping["buttons"]["KEY1"] == [145, "pull_up"]
+    assert mapping["buttons"]["KEY2"] == [123, "pull_up"]
+    assert mapping["buttons"]["KEY3"] == [55, "pull_up"]
+
+
+def test_fox_22_display_uses_blue_board_gpio_numbers():
+    mapping = get_hardware_pin_mapping("FOX_22")
+
+    assert mapping["display"]["dc"] == [52]
+    assert mapping["display"]["rst"] == [51]
+    assert mapping["display"]["bl"] == [43]
+
+
+def test_fox_22_buttons_use_blue_board_gpio_numbers():
+    mapping = get_hardware_pin_mapping("FOX_22")
+
+    assert mapping["buttons"]["KEY_UP"] == [57, "pull_up"]
+    assert mapping["buttons"]["KEY_DOWN"] == [59, "pull_up"]
+    assert mapping["buttons"]["KEY_LEFT"] == [56, "pull_up"]
+    assert mapping["buttons"]["KEY_RIGHT"] == [54, "pull_up"]
+    assert mapping["buttons"]["KEY_PRESS"] == [58, "pull_up"]
+    assert mapping["buttons"]["KEY1"] == [55, "pull_up"]
+    assert mapping["buttons"]["KEY2"] == [4, "pull_up"]
+    assert mapping["buttons"]["KEY3"] == [53, "pull_up"]
+
+
+def test_fox_40_display_uses_blue_board_gpio_numbers():
+    mapping = get_hardware_pin_mapping("FOX_40")
+
+    assert mapping["display"]["dc"] == [56]
+    assert mapping["display"]["rst"] == [57]
+    assert mapping["display"]["bl"] == [72]
+
+
+def test_fox_40_buttons_use_pull_up_mapping():
+    mapping = get_hardware_pin_mapping("FOX_40")
+
+    assert mapping["buttons"]["KEY_UP"] == [58, "pull_up"]
+    assert mapping["buttons"]["KEY_DOWN"] == [53, "pull_up"]
+    assert mapping["buttons"]["KEY_LEFT"] == [59, "pull_up"]
+    assert mapping["buttons"]["KEY_RIGHT"] == [54, "pull_up"]
+    assert mapping["buttons"]["KEY_PRESS"] == [52, "pull_up"]
+    assert mapping["buttons"]["KEY1"] == [55, "pull_up"]
+    assert mapping["buttons"]["KEY2"] == [43, "pull_up"]
+    assert mapping["buttons"]["KEY3"] == [42, "pull_up"]


### PR DESCRIPTION
### Motivation
- Fix a mismatch between the Luckfox Pico Pi board diagrams (blue 40-pin GPIO labels) and the runtime mappings so runtime GPIO initialization matches the physical board wiring. 
- Keep `io_config.json`, `docs/io_config.md`, and unit tests consistent per the repo IO config guidance.

### Description
- Updated `src/seedsigner/hardware/io_config.json` for `FOX_PI` so display control lines are `dc/rst/bl = [59]/[56]/[70]` and button mappings are `KEY_UP [121,"pull_up"]`, `KEY_DOWN [1,"pull_up"]`, `KEY_LEFT [122,"pull_up"]`, `KEY_RIGHT [0,"pull_up"]`, `KEY_PRESS [52,"pull_up"]`, `KEY1 [145,"pull_up"]`, `KEY2 [123,"pull_up"]`, `KEY3 [55,"pull_up"]` to match the blue GPIO labels from the 40-pin diagrams. 
- Kept pull-up bias for all button mappings and also ensured `FOX_22` and `FOX_40` entries use blue-board GPIO numbering with pull-up where appropriate. 
- Updated `docs/io_config.md` and `tests/test_io_config_profiles.py` to reflect the corrected `FOX_PI` (and the `FOX_22`/`FOX_40`) mappings so documentation and tests remain in sync with runtime config.

### Testing
- Validated JSON syntax with `python -m json.tool src/seedsigner/hardware/io_config.json`, which completed successfully. 
- Ran unit tests with `pytest -q tests/test_io_config_profiles.py tests/test_luckfox_camera_backend.py`, which passed (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bacb767248322b65626595066cc20)