### PR TITLE
Fix mnemonic wordlist mismatch across dice generation and manual seed entry

### DIFF
--- a/src/seedsigner/helpers/mnemonic_generation.py
+++ b/src/seedsigner/helpers/mnemonic_generation.py
@@ -83,7 +83,10 @@ def calculate_checksum(mnemonic: list | str, wordlist_language_code: str = Setti
     # calculate the proper checksum bits while doing so. For a 12-word seed it will just
     # overwrite the last 4 bits from the above result with the checksum; for a 24-word
     # seed it'll overwrite the last 8 bits.
-    return bip39.mnemonic_from_bytes(mnemonic_bytes).split()
+    return bip39.mnemonic_from_bytes(
+        mnemonic_bytes,
+        wordlist=Seed.get_wordlist(wordlist_language_code),
+    ).split()
 
 
 

--- a/src/seedsigner/models/seed_storage.py
+++ b/src/seedsigner/models/seed_storage.py
@@ -89,22 +89,29 @@ class SeedStorage:
         return None
     
 
-    def get_pending_mnemonic_fingerprint(self, network: str = SettingsConstants.MAINNET) -> str:
+    def get_pending_mnemonic_fingerprint(
+        self,
+        network: str = SettingsConstants.MAINNET,
+        wordlist_language_code: str = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH,
+    ) -> str:
         try:
             if self._pending_is_electrum:
                 seed = ElectrumSeed(self._pending_mnemonic)
             else:
-                seed = Seed(self._pending_mnemonic)
+                seed = Seed(self._pending_mnemonic, wordlist_language_code=wordlist_language_code)
             return seed.get_fingerprint(network)
         except InvalidSeedException:
             return None
 
 
-    def convert_pending_mnemonic_to_pending_seed(self):
+    def convert_pending_mnemonic_to_pending_seed(
+        self,
+        wordlist_language_code: str = SettingsConstants.WORDLIST_LANGUAGE__ENGLISH,
+    ):
         if self._pending_is_electrum:
             self.pending_seed = ElectrumSeed(self._pending_mnemonic)
         else:
-            self.pending_seed = Seed(self._pending_mnemonic)
+            self.pending_seed = Seed(self._pending_mnemonic, wordlist_language_code=wordlist_language_code)
         self.discard_pending_mnemonic()
     
 

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -526,7 +526,9 @@ class SeedKeeperSelectView(View):
 
         from seedsigner.models.seed import InvalidSeedException
         try:
-            self.controller.storage.convert_pending_mnemonic_to_pending_seed()
+            self.controller.storage.convert_pending_mnemonic_to_pending_seed(
+                wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE),
+            )
         except InvalidSeedException:
             return Destination(SeedMnemonicInvalidView)
 
@@ -1011,7 +1013,9 @@ class SeedMnemonicEntryView(View):
             # Attempt to finalize the mnemonic
             from seedsigner.models.seed import InvalidSeedException
             try:
-                self.controller.storage.convert_pending_mnemonic_to_pending_seed()
+                self.controller.storage.convert_pending_mnemonic_to_pending_seed(
+                    wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE),
+                )
             except InvalidSeedException:
                 return Destination(SeedMnemonicInvalidView)
 

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -813,7 +813,10 @@ class ToolsDiceEntropyEntryView(View):
             loading_screen.stop()
             return Destination(SeedSlip39CreateFromBytesView, view_args=dict(secret=entropy_bytes), clear_history=True)
         else:
-            dice_seed_phrase = mnemonic_generation.generate_mnemonic_from_dice(ret)
+            dice_seed_phrase = mnemonic_generation.generate_mnemonic_from_dice(
+                ret,
+                wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE),
+            )
             seed = Seed(dice_seed_phrase, wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE))
             self.controller.storage.set_pending_seed(seed)
             loading_screen.stop()
@@ -1019,14 +1022,19 @@ class ToolsCalcFinalWordDoneView(View):
         selected_menu_num = ToolsCalcFinalWordDoneScreen(
             final_word=final_word,
             mnemonic_word_length=mnemonic_word_length,
-            fingerprint=self.controller.storage.get_pending_mnemonic_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK)),
+            fingerprint=self.controller.storage.get_pending_mnemonic_fingerprint(
+                self.settings.get_value(SettingsConstants.SETTING__NETWORK),
+                wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE),
+            ),
             button_data=button_data,
         ).display()
 
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
         
-        self.controller.storage.convert_pending_mnemonic_to_pending_seed()
+        self.controller.storage.convert_pending_mnemonic_to_pending_seed(
+            wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE),
+        )
 
         if button_data[selected_menu_num] == self.LOAD:
             return Destination(SeedFinalizeView)

--- a/tests/test_mnemonic_generation.py
+++ b/tests/test_mnemonic_generation.py
@@ -6,7 +6,6 @@ from embit import bip39
 from seedsigner.helpers import mnemonic_generation
 
 
-
 def test_dice_rolls():
     """ Given random dice rolls, the resulting mnemonic should be valid. """
     for length, rolls in mnemonic_generation.DICE_ROLLS_REQUIRED.items():
@@ -14,7 +13,6 @@ def test_dice_rolls():
         mnemonic = mnemonic_generation.generate_mnemonic_from_dice(dice_rolls)
         assert len(mnemonic) == length
         assert bip39.mnemonic_is_valid(" ".join(mnemonic))
-
 
 
 def test_calculate_checksum_input_type():
@@ -54,8 +52,6 @@ def test_calculate_checksum_input_type():
         _try_all_input_formats(partial)
 
 
-
-
 def test_calculate_checksum_invalid_mnemonics():
     """
         Should raise an Exception on a mnemonic that is invalid due to length or using invalid words.
@@ -85,7 +81,6 @@ def test_calculate_checksum_invalid_mnemonics():
     assert "not in the dictionary" in str(e)
 
 
-
 def test_calculate_checksum_with_default_final_word():
     """ 11-word and 23-word mnemonics use word `0000` as a temp final word to complete
         the mnemonic.
@@ -104,6 +99,37 @@ def test_calculate_checksum_with_default_final_word():
     mnemonic2 = mnemonic_generation.calculate_checksum(partial_mnemonic)
     assert mnemonic1 == mnemonic2
 
+
+def test_calculate_checksum_uses_configured_wordlist(monkeypatch):
+    from seedsigner.models.settings_definition import SettingsConstants
+
+    called = {}
+
+    def fake_get_wordlist(code):
+        called.setdefault("get_wordlist", []).append(code)
+        return ["abandon"] * 2048
+
+    def fake_mnemonic_to_bytes(_mnemonic, ignore_checksum, wordlist):
+        assert ignore_checksum is True
+        called["to_bytes_wordlist"] = wordlist
+        return b"\x00" * 16
+
+    def fake_mnemonic_from_bytes(entropy, wordlist):
+        called["from_bytes_entropy_len"] = len(entropy)
+        called["from_bytes_wordlist"] = wordlist
+        return "abandon " * 11 + "about"
+
+    monkeypatch.setattr(mnemonic_generation.Seed, "get_wordlist", fake_get_wordlist)
+    monkeypatch.setattr(mnemonic_generation.bip39, "mnemonic_to_bytes", fake_mnemonic_to_bytes)
+    monkeypatch.setattr(mnemonic_generation.bip39, "mnemonic_from_bytes", fake_mnemonic_from_bytes)
+
+    mnemonic_generation.calculate_checksum(
+        "abandon " * 11 + "abandon",
+        wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH,
+    )
+
+    assert called["get_wordlist"] == [SettingsConstants.WORDLIST_LANGUAGE__ENGLISH, SettingsConstants.WORDLIST_LANGUAGE__ENGLISH]
+    assert called["from_bytes_entropy_len"] == 16
 
 def test_generate_mnemonic_from_bytes():
     """
@@ -137,7 +163,6 @@ def test_generate_mnemonic_from_bytes():
     assert bip39.mnemonic_is_valid(" ".join(mnemonic))
 
 
-
 def test_verify_against_coldcard_sample():
     """ https://coldcard.com/docs/verifying-dice-roll-math """
     dice_rolls = "123456"
@@ -155,7 +180,6 @@ def test_entropy_checks():
 
     assert mnemonic_generation.byte_entropy_is_sufficient(os.urandom(16))
     assert not mnemonic_generation.byte_entropy_is_sufficient(b"\x00" * 16)
-
 
 
 def test_known_dice_rolls():
@@ -183,7 +207,6 @@ def test_known_dice_rolls():
     actual = " ".join(mnemonic)
     assert bip39.mnemonic_is_valid(actual)
     assert actual == expected
-
 
 
 def test_50_dice_rolls():

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -11,7 +11,6 @@ from seedsigner.models.settings import SettingsConstants
 from seedsigner.views import seed_views
 
 
-
 def test_seed():
     seed = Seed(mnemonic="obscure bone gas open exotic abuse virus bunker shuffle nasty ship dash".split())
     
@@ -380,6 +379,63 @@ class TestSlip39ExtendableSetting(BaseTest):
         assert not seed.extendable
 
 
+def test_seed_storage_convert_pending_mnemonic_passes_wordlist_language(monkeypatch):
+    from seedsigner.models.seed_storage import SeedStorage
+    from seedsigner.models.settings_definition import SettingsConstants
+
+    captured = {}
+
+    class DummySeed:
+        def __init__(self, mnemonic, passphrase="", wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH):
+            captured["mnemonic"] = list(mnemonic)
+            captured["wordlist_language_code"] = wordlist_language_code
+
+    monkeypatch.setattr("seedsigner.models.seed_storage.Seed", DummySeed)
+    monkeypatch.setattr("seedsigner.models.seed_storage.wipe_list", lambda values: None)
+
+    storage = SeedStorage()
+    storage.init_pending_mnemonic(num_words=12)
+    for i in range(12):
+        storage.update_pending_mnemonic("abandon", i)
+
+    storage.convert_pending_mnemonic_to_pending_seed(wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH)
+
+    assert captured["mnemonic"] == ["abandon"] * 12
+    assert captured["wordlist_language_code"] == SettingsConstants.WORDLIST_LANGUAGE__ENGLISH
+
+
+def test_seed_storage_pending_mnemonic_fingerprint_passes_wordlist_language(monkeypatch):
+    from seedsigner.models.seed_storage import SeedStorage
+    from seedsigner.models.settings_definition import SettingsConstants
+
+    captured = {}
+
+    class DummySeed:
+        def __init__(self, mnemonic, passphrase="", wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH):
+            captured["mnemonic"] = list(mnemonic)
+            captured["wordlist_language_code"] = wordlist_language_code
+
+        def get_fingerprint(self, network):
+            captured["network"] = network
+            return "deadbeef"
+
+    monkeypatch.setattr("seedsigner.models.seed_storage.Seed", DummySeed)
+    monkeypatch.setattr("seedsigner.models.seed_storage.wipe_list", lambda values: None)
+
+    storage = SeedStorage()
+    storage.init_pending_mnemonic(num_words=12)
+    for i in range(12):
+        storage.update_pending_mnemonic("abandon", i)
+
+    fingerprint = storage.get_pending_mnemonic_fingerprint(
+        network=SettingsConstants.TESTNET,
+        wordlist_language_code=SettingsConstants.WORDLIST_LANGUAGE__ENGLISH,
+    )
+
+    assert fingerprint == "deadbeef"
+    assert captured["mnemonic"] == ["abandon"] * 12
+    assert captured["wordlist_language_code"] == SettingsConstants.WORDLIST_LANGUAGE__ENGLISH
+    assert captured["network"] == SettingsConstants.TESTNET
 
 def test_seed_storage_allows_multiple_xprvs():
     from seedsigner.models.seed_storage import SeedStorage


### PR DESCRIPTION
### Motivation
- A crash occurred when a 12-word mnemonic was generated from dice entropy and then re-entered manually because different code paths used different BIP-39 wordlists, causing words to be reported as "not in the dictionary".

### Description
- Ensure checksum recomputation in `calculate_checksum` explicitly passes the configured `wordlist_language_code` into `bip39.mnemonic_from_bytes` so the selected wordlist is used when rebuilding mnemonics.
- Propagate `wordlist_language_code` through `SeedStorage` by adding parameters to `get_pending_mnemonic_fingerprint` and `convert_pending_mnemonic_to_pending_seed` and use it when constructing `Seed` instances.
- Update view layers (`seed_views.py` and `tools_views.py`) to pass the active `SettingsConstants.SETTING__WORDLIST_LANGUAGE` when finalizing pending mnemonics and when generating dice-based mnemonics, so generation and parsing use the same wordlist.
- Add unit tests to verify `calculate_checksum` uses the configured wordlist and that `SeedStorage` forwards `wordlist_language_code` for conversion and fingerprinting.

### Testing
- Ran the targeted tests `pytest -q tests/test_mnemonic_generation.py::test_calculate_checksum_uses_configured_wordlist tests/test_seed.py::test_seed_storage_convert_pending_mnemonic_passes_wordlist_language tests/test_seed.py::test_seed_storage_pending_mnemonic_fingerprint_passes_wordlist_language` and they passed.
- Ran the full relevant test modules `pytest -q tests/test_mnemonic_generation.py tests/test_seed.py` and they passed (82 passed; test run produced unrelated thread warnings from the GUI test harness in this environment).
- Additional focused runs were executed during development to validate dice->mnemonic->manual-entry roundtrips and seed finalization behavior, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a05f617ab48322aea30acb6ac0dd55)