### PR TITLE
Keycard & Specter DIY Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Support and discussion relating to this fork can happen via this [Telegram Group
   - PSBT verification and transaction signing directly on-card
   - Message signing
   - Address explorer integration for Satochip cards
+  - Backend selection note: entering via the KeyCard menu now forces the keycard backend (no auto-detection in that flow). Auto fallback logic is only used in generic/satochip flows where backend is not explicitly set.
 * SLIP39 seed support
   - Create, import and extend SLIP39 seed shares (Can load from text, QR or Seedkeeper)
   - Save SLIP39 shares to Seedkeeper

--- a/docs/smartcard_support_installation.md
+++ b/docs/smartcard_support_installation.md
@@ -80,6 +80,38 @@ _Choose option 1 to install Rust_
     cd pysatochip
     python setup.py install
 
+### Optional: Keycard Backend (pysatochip compatibility layer)
+
+SeedSigner can now use the `keycard-cli` Python compatibility adapter for
+Satochip-style flows (xpub export and signing).
+
+1. Install the module:
+
+    cd ~/keycard-cli/python
+    pip3 install -e .
+
+2. Select backend behavior with environment variables:
+
+    export SEEDSIGNER_SMARTCARD_BACKEND=auto
+
+Available values:
+
+- `auto` (default): use pysatochip first, then fall back to keycard compat for `satochip` flows.
+- `pysatochip`: force legacy pysatochip backend.
+- `keycard`: force keycard compat backend for `satochip` flows.
+
+If `keycard_cli` is not installed in the active environment, you can also point
+SeedSigner to a checkout directly:
+
+    export SEEDSIGNER_KEYCARD_CLI_PATH=/home/pi/keycard-cli/python
+
+For cards configured with a custom Keycard pairing password, set:
+
+    export SEEDSIGNER_KEYCARD_PAIRING_PASSWORD='your-pairing-password'
+
+When using the keycard backend, uninitialised cards must be initialised with
+`keycard-cli` tooling first.
+
 ### LibNFC + IFDNFC (Optional: Needed for PN352 connected via GPIO Pins)
 
 **Install LibNFC**

--- a/docs/smartcard_support_installation.md
+++ b/docs/smartcard_support_installation.md
@@ -262,3 +262,14 @@ The key file can include either a single key or an ENC/MAC/DEK key set. When sav
 file is stored at the card root as `javacard-keys.txt`. You can also save/load the same plaintext
 format on a Seedkeeper card; the entries are labeled with the `jc_keys` prefix so the same parser
 can be used for both locations.
+
+### Javacard DIY BIP39 Mnemonics (Specter JavaCard)
+The same **Card Keys** menu now includes **Load Mnemonic** and **Save Mnemonic** options for
+Specter JavaCard `MemoryCard` applets. This uses the Specter Python module (`specter_card`) to
+open a secure channel and read/write mnemonic text.
+
+If the module is not installed globally, set:
+
+    export SEEDSIGNER_SPECTER_CARD_PY_PATH=/path/to/specter-javacard/py
+
+The loader expects a standard 12/15/18/21/24-word BIP39 mnemonic payload.

--- a/requirements-desktop.txt
+++ b/requirements-desktop.txt
@@ -1,5 +1,6 @@
 # Desktop simulation dependencies
 pyscard==2.3.1
+keycard
 pygame==2.5.2
 numpy==2.2.6
 opencv-python==4.12.0.88

--- a/requirements-raspi.txt
+++ b/requirements-raspi.txt
@@ -1,3 +1,4 @@
 spidev==3.5
 python-periphery==2.4.1
 pyscard==2.3.1
+keycard

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -200,6 +200,7 @@ class Controller(Singleton):
     FLOW__VERIFY_SINGLESIG_ADDR = "singlesig_addr"
     FLOW__ADDRESS_EXPLORER = "address_explorer"
     FLOW__SIGN_MESSAGE = "sign_message"
+    FLOW__SATOCHIP_IMPORT_SEED = "satochip_import_seed"
     FLOW__GPG_MESSAGE = "gpg_message"
     resume_main_flow: str = None
 

--- a/src/seedsigner/helpers/iso7816.py
+++ b/src/seedsigner/helpers/iso7816.py
@@ -46,6 +46,10 @@ def format_sw_error(sw1: int, sw2: int) -> str:
         unknown codes, a generic "unknown" message is returned.
     """
     status_word = (sw1 << 8) | sw2
+    if sw1 == 0x63 and (sw2 & 0xF0) == 0xC0:
+        tries_left = sw2 & 0x0F
+        attempt_word = "attempt" if tries_left == 1 else "attempts"
+        return f"PIN is incorrect: {tries_left} {attempt_word} remaining ({status_word:#06x})"
     description = ISO7816_STATUS_WORDS.get(status_word)
     if description:
         return f"{description} ({status_word:#06x})"

--- a/src/seedsigner/helpers/keycard_connector.py
+++ b/src/seedsigner/helpers/keycard_connector.py
@@ -206,6 +206,7 @@ class KeycardSatochipConnector:
         self._secure_open = False
         self._last_path = None
         self._label = None
+        self._last_select_has_key_uid = False
         self.pin = None
         self.parser = SimpleNamespace(authentikey=None)
         self.UID_SHA1 = _uid_sha1_from_instance_uid(None)
@@ -322,6 +323,14 @@ class KeycardSatochipConnector:
         if self.pin is None:
             raise ValueError("PIN has not been set")
 
+        # Keycard tracks a session-level verified PIN state; avoid sending a
+        # duplicate VERIFY PIN APDU if we already have a verified session.
+        try:
+            if bool(getattr(self._card, "is_pin_verified", False)):
+                return (0x90, 0x00)
+        except Exception:
+            pass
+
         pin_text = _pin_to_text(self.pin)
         try:
             ok = self._card.verify_pin(pin_text)
@@ -345,11 +354,26 @@ class KeycardSatochipConnector:
         try:
             info = self._card.select()
             instance_uid = getattr(info, "instance_uid", None)
+            self._last_select_has_key_uid = bool(getattr(info, "key_uid", None))
             if isinstance(instance_uid, bytes):
                 instance_uid = instance_uid.hex()
             self.UID_SHA1 = _uid_sha1_from_instance_uid(instance_uid)
         except Exception:
             pass
+
+    @staticmethod
+    def _sw_to_tuple(status_word: int) -> tuple[int, int]:
+        return ((status_word >> 8) & 0xFF, status_word & 0xFF)
+
+    def _load_key_with_sw(self, key_type, **kwargs) -> tuple[int, int]:
+        try:
+            self._card.load_key(key_type, **kwargs)
+            return (0x90, 0x00)
+        except Exception as exc:
+            status_word = self._extract_status_word(exc)
+            if status_word is not None:
+                return self._sw_to_tuple(status_word)
+            raise
 
     def card_get_label(self):
         return self._label or "Keycard"
@@ -420,8 +444,14 @@ class KeycardSatochipConnector:
         out["device_initialized"] = True
         if isinstance(path_indices, list):
             out["path"] = _path_from_indices(path_indices)
-        out["key_initialized"] = bool(out.get("initialized", out.get("key_initialized", False)))
-        out["is_seeded"] = bool(out.get("key_initialized", False))
+        key_initialized = bool(
+            out.get(
+                "key_initialized",
+                out.get("initialized", self._last_select_has_key_uid),
+            )
+        ) or bool(self._last_select_has_key_uid)
+        out["key_initialized"] = key_initialized
+        out["is_seeded"] = bool(out.get("is_seeded", key_initialized))
         out.setdefault("setup_done", True)
         pin_tries = self._pin_tries_from_status()
         if pin_tries is not None:
@@ -550,9 +580,52 @@ class KeycardSatochipConnector:
         sw1, sw2 = self._verify_pin_sw()
         if (sw1, sw2) != (0x90, 0x00):
             return ([], sw1, sw2)
+
         seed = bytes(seed_bytes)
-        self._card.load_key(self._constants.LoadKeyType.BIP39_SEED, bip39_seed=seed)
-        return ([], 0x90, 0x00)
+
+        sw1, sw2 = self._load_key_with_sw(
+            self._constants.LoadKeyType.BIP39_SEED,
+            bip39_seed=seed,
+        )
+        if (sw1, sw2) == (0x90, 0x00):
+            return ([], 0x90, 0x00)
+
+        if (sw1, sw2) != (0x69, 0x85):
+            return ([], sw1, sw2)
+
+        # Some firmware reports a stale key state and requires a clear before
+        # accepting a new import, even when status looks unseeded.
+        try:
+            self._card.remove_key()
+        except Exception as remove_exc:
+            remove_sw = self._extract_status_word(remove_exc)
+            # Ignore "conditions not satisfied" while clearing state;
+            # still attempt import fallbacks below.
+            if remove_sw not in (None, 0x6985):
+                sw1, sw2 = self._sw_to_tuple(remove_sw)
+                return ([], sw1, sw2)
+
+        sw1, sw2 = self._load_key_with_sw(
+            self._constants.LoadKeyType.BIP39_SEED,
+            bip39_seed=seed,
+        )
+        if (sw1, sw2) == (0x90, 0x00):
+            return ([], 0x90, 0x00)
+
+        if (sw1, sw2) != (0x69, 0x85):
+            return ([], sw1, sw2)
+
+        # Additional compatibility fallback: import root key material explicitly
+        # as EXTENDED_ECC at m.
+        root = bip32.HDKey.from_seed(seed)
+        uncompressed_pub = b"\x04" + root.key.get_public_key()._point
+        sw1, sw2 = self._load_key_with_sw(
+            self._constants.LoadKeyType.EXTENDED_ECC,
+            public_key=uncompressed_pub,
+            private_key=root.key.secret,
+            chain_code=root.chain_code,
+        )
+        return ([], sw1, sw2)
 
     def card_remove_key(self):
         self._ensure_secure_channel()

--- a/src/seedsigner/helpers/keycard_connector.py
+++ b/src/seedsigner/helpers/keycard_connector.py
@@ -97,6 +97,16 @@ def _value_to_text(value) -> str:
     raise ValueError("Unsupported value format")
 
 
+def _digits_from_bytes(data: bytes, length: int) -> str:
+    if length <= 0:
+        raise ValueError("length must be positive")
+    # Deterministically map arbitrary bytes to ASCII digits.
+    out = []
+    for i in range(length):
+        out.append(str(data[i % len(data)] % 10))
+    return "".join(out)
+
+
 def _uid_sha1_from_instance_uid(instance_uid_hex: str | None) -> str:
     if instance_uid_hex:
         try:
@@ -273,7 +283,10 @@ class KeycardSatochipConnector:
         return None
 
     def _pin_tries_from_status(self) -> int | None:
-        status = getattr(self._card, "status", None)
+        try:
+            status = getattr(self._card, "status", None)
+        except Exception:
+            return None
         if not isinstance(status, dict):
             return None
 
@@ -364,19 +377,117 @@ class KeycardSatochipConnector:
         return ([], sw1, sw2)
 
     def card_get_status(self):
+        self._refresh_uid()
+
+        # A factory-fresh Keycard is present, but it cannot be paired until
+        # device init (PIN/PUK/pairing secret) has completed.
+        try:
+            if bool(self._card.is_initialized) is False:
+                out = {
+                    "setup_done": False,
+                    "device_initialized": False,
+                    "key_initialized": False,
+                    "is_seeded": False,
+                }
+                return ([], 0x90, 0x00, out)
+        except Exception:
+            # If the backend cannot report init state yet, fall through to the
+            # regular secure-channel path below.
+            pass
+
         self._ensure_secure_channel()
-        status = self._card.status
-        path_indices = self._card.get_key_path
-        out = dict(status) if isinstance(status, dict) else {}
+        out = {}
+
+        # Some card states return SW=6985 for GET STATUS even though the card
+        # is present and initialized for further setup/import actions.
+        try:
+            status = self._card.status
+            if isinstance(status, dict):
+                out.update(status)
+        except Exception as exc:
+            sw = self._extract_status_word(exc)
+            if sw != 0x6985:
+                raise
+
+        try:
+            path_indices = self._card.get_key_path
+        except Exception as exc:
+            sw = self._extract_status_word(exc)
+            if sw != 0x6985:
+                raise
+            path_indices = None
+
+        out["device_initialized"] = True
         if isinstance(path_indices, list):
             out["path"] = _path_from_indices(path_indices)
-        out["key_initialized"] = bool(out.get("initialized", out.get("key_initialized", True)))
+        out["key_initialized"] = bool(out.get("initialized", out.get("key_initialized", False)))
         out["is_seeded"] = bool(out.get("key_initialized", False))
-        out.setdefault("setup_done", bool(out.get("key_initialized", True)))
+        out.setdefault("setup_done", True)
         pin_tries = self._pin_tries_from_status()
         if pin_tries is not None:
             out.setdefault("PIN0_remaining_tries", pin_tries)
         return ([], 0x90, 0x00, out)
+
+    def card_setup(
+        self,
+        pin_tries_0,
+        ublk_tries_0,
+        pin_0,
+        ublk_0,
+        pin_tries_1,
+        ublk_tries_1,
+        pin_1,
+        ublk_1,
+        secmemsize,
+        memsize,
+        create_object_ACL,
+        create_key_ACL,
+        create_pin_ACL,
+        option_flags=0,
+        hmacsha160_key=None,
+        amount_limit=0,
+    ):
+        _ = pin_tries_0
+        _ = ublk_tries_0
+        _ = pin_tries_1
+        _ = ublk_tries_1
+        _ = pin_1
+        _ = ublk_1
+        _ = secmemsize
+        _ = memsize
+        _ = create_object_ACL
+        _ = create_key_ACL
+        _ = create_pin_ACL
+        _ = option_flags
+        _ = hmacsha160_key
+        _ = amount_limit
+
+        pin_text = _value_to_text(pin_0)
+        if not (len(pin_text) == 6 and pin_text.isdigit()):
+            raise ValueError("Keycard PIN must be exactly 6 digits")
+
+        if isinstance(ublk_0, list):
+            source = bytes(ublk_0) or b"\x00"
+            puk_text = _digits_from_bytes(source, 12)
+        else:
+            puk_text = _value_to_text(ublk_0)
+            if not puk_text.isdigit():
+                source = puk_text.encode("utf-8") or b"\x00"
+                puk_text = _digits_from_bytes(source, 12)
+            elif len(puk_text) != 12:
+                source = puk_text.encode("utf-8")
+                puk_text = _digits_from_bytes(source, 12)
+
+        try:
+            self._card.init(pin_text, puk_text, self._pairing_password)
+            self.pin = list(pin_text.encode("utf-8"))
+            self._secure_open = False
+            return ([], 0x90, 0x00)
+        except Exception as exc:
+            status_word = self._extract_status_word(exc)
+            if status_word is not None:
+                return ([], (status_word >> 8) & 0xFF, status_word & 0xFF)
+            raise
 
     def card_change_PIN(self, pin_nbr, old_pin, new_pin):
         _ = pin_nbr

--- a/src/seedsigner/helpers/keycard_connector.py
+++ b/src/seedsigner/helpers/keycard_connector.py
@@ -5,6 +5,7 @@ import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+import re
 
 from embit import bip32, ec
 
@@ -184,7 +185,7 @@ class KeycardSatochipConnector:
     is_keycard_backend = True
     requires_message_digest = True
     needs_secure_channel = False
-    card_type = "Satochip"
+    card_type = "Keycard"
 
     def __init__(self, inner) -> None:
         self._card = inner["card"]
@@ -244,12 +245,88 @@ class KeycardSatochipConnector:
         self._secure_open = True
 
     def _ensure_pin_verified(self) -> None:
+        sw1, sw2 = self._verify_pin_sw()
+        if (sw1, sw2) != (0x90, 0x00):
+            raise ValueError(f"APDU failed with SW={sw1:02X}{sw2:02X}")
+
+    @staticmethod
+    def _extract_status_word(exc: Exception) -> int | None:
+        for attr in ("status_word", "sw"):
+            value = getattr(exc, attr, None)
+            if isinstance(value, int):
+                return value & 0xFFFF
+
+        sw1 = getattr(exc, "sw1", None)
+        sw2 = getattr(exc, "sw2", None)
+        if isinstance(sw1, int) and isinstance(sw2, int):
+            return ((sw1 & 0xFF) << 8) | (sw2 & 0xFF)
+
+        text = str(exc)
+        match = re.search(r"SW\s*=\s*([0-9A-Fa-f]{4})", text)
+        if match:
+            return int(match.group(1), 16)
+
+        match = re.search(r"0x([0-9A-Fa-f]{4})", text)
+        if match:
+            return int(match.group(1), 16)
+
+        return None
+
+    def _pin_tries_from_status(self) -> int | None:
+        status = getattr(self._card, "status", None)
+        if not isinstance(status, dict):
+            return None
+
+        direct_keys = (
+            "PIN0_remaining_tries",
+            "pin_remaining_tries",
+            "pin_retry_counter",
+            "pin_retry_count",
+            "pin_tries_left",
+            "pin_attempts_left",
+        )
+        for key in direct_keys:
+            value = status.get(key)
+            if isinstance(value, int):
+                return value
+
+        pin_status = status.get("pin")
+        if isinstance(pin_status, dict):
+            for key in ("remaining_tries", "tries_left", "attempts_left"):
+                value = pin_status.get(key)
+                if isinstance(value, int):
+                    return value
+
+        return None
+
+    def _pin_failure_sw(self, fallback_sw: tuple[int, int] = (0x63, 0xC0)) -> tuple[int, int]:
+        tries = self._pin_tries_from_status()
+        if isinstance(tries, int) and 0 <= tries <= 15:
+            return (0x63, 0xC0 | tries)
+        return fallback_sw
+
+    def _verify_pin_sw(self) -> tuple[int, int]:
         if self.pin is None:
             raise ValueError("PIN has not been set")
+
         pin_text = _pin_to_text(self.pin)
-        ok = self._card.verify_pin(pin_text)
-        if not ok:
-            raise ValueError("Invalid PIN")
+        try:
+            ok = self._card.verify_pin(pin_text)
+        except Exception as exc:
+            status_word = self._extract_status_word(exc)
+            if status_word is None:
+                raise
+            if 0x63C0 <= status_word <= 0x63CF:
+                return ((status_word >> 8) & 0xFF, status_word & 0xFF)
+            # Some firmware reports PIN failure as 6A80; translate it to 63Cx
+            # so UI can render a proper incorrect-PIN message.
+            if status_word == 0x6A80:
+                return self._pin_failure_sw()
+            return ((status_word >> 8) & 0xFF, status_word & 0xFF)
+
+        if ok:
+            return (0x90, 0x00)
+        return self._pin_failure_sw()
 
     def _refresh_uid(self) -> None:
         try:
@@ -282,14 +359,9 @@ class KeycardSatochipConnector:
         self.pin = pin
 
     def card_verify_PIN(self):
-        if self.pin is None:
-            raise ValueError("PIN has not been set")
         self._ensure_secure_channel()
-        pin_text = _pin_to_text(self.pin)
-        ok = self._card.verify_pin(pin_text)
-        if ok:
-            return ([], 0x90, 0x00)
-        return ([], 0x63, 0xC0)
+        sw1, sw2 = self._verify_pin_sw()
+        return ([], sw1, sw2)
 
     def card_get_status(self):
         self._ensure_secure_channel()
@@ -301,6 +373,9 @@ class KeycardSatochipConnector:
         out["key_initialized"] = bool(out.get("initialized", out.get("key_initialized", True)))
         out["is_seeded"] = bool(out.get("key_initialized", False))
         out.setdefault("setup_done", bool(out.get("key_initialized", True)))
+        pin_tries = self._pin_tries_from_status()
+        if pin_tries is not None:
+            out.setdefault("PIN0_remaining_tries", pin_tries)
         return ([], 0x90, 0x00, out)
 
     def card_change_PIN(self, pin_nbr, old_pin, new_pin):
@@ -308,9 +383,10 @@ class KeycardSatochipConnector:
         self._ensure_secure_channel()
         old_text = _value_to_text(old_pin)
         new_text = _value_to_text(new_pin)
-        ok = self._card.verify_pin(old_text)
-        if not ok:
-            return ([], 0x63, 0xC0)
+        self.pin = list(old_text.encode("utf-8"))
+        sw1, sw2 = self._verify_pin_sw()
+        if (sw1, sw2) != (0x90, 0x00):
+            return ([], sw1, sw2)
         self._card.change_pin(new_text)
         self.pin = list(new_text.encode("utf-8"))
         return ([], 0x90, 0x00)
@@ -340,7 +416,9 @@ class KeycardSatochipConnector:
 
     def card_set_label(self, label):
         self._ensure_secure_channel()
-        self._ensure_pin_verified()
+        sw1, sw2 = self._verify_pin_sw()
+        if (sw1, sw2) != (0x90, 0x00):
+            return ([], sw1, sw2)
         label_text = _value_to_text(label)
         self._card.store_data(label_text.encode("utf-8"), slot=self._constants.StorageSlot.PUBLIC)
         self._label = label_text
@@ -348,7 +426,9 @@ class KeycardSatochipConnector:
 
     def card_reset_factory(self):
         self._ensure_secure_channel()
-        self._ensure_pin_verified()
+        sw1, sw2 = self._verify_pin_sw()
+        if (sw1, sw2) != (0x90, 0x00):
+            return ([], sw1, sw2)
         self._card.factory_reset()
         self._secure_open = False
         self.pin = None
@@ -356,14 +436,18 @@ class KeycardSatochipConnector:
 
     def card_bip32_import_seed(self, seed_bytes):
         self._ensure_secure_channel()
-        self._ensure_pin_verified()
+        sw1, sw2 = self._verify_pin_sw()
+        if (sw1, sw2) != (0x90, 0x00):
+            return ([], sw1, sw2)
         seed = bytes(seed_bytes)
         self._card.load_key(self._constants.LoadKeyType.BIP39_SEED, bip39_seed=seed)
         return ([], 0x90, 0x00)
 
     def card_remove_key(self):
         self._ensure_secure_channel()
-        self._ensure_pin_verified()
+        sw1, sw2 = self._verify_pin_sw()
+        if (sw1, sw2) != (0x90, 0x00):
+            return ([], sw1, sw2)
         self._card.remove_key()
         return ([], 0x90, 0x00)
 
@@ -378,6 +462,9 @@ class KeycardSatochipConnector:
 
     def card_bip32_get_extendedkey(self, path):
         self._ensure_secure_channel()
+        sw1, sw2 = self._verify_pin_sw()
+        if (sw1, sw2) != (0x90, 0x00):
+            raise ValueError(f"APDU failed with SW={sw1:02X}{sw2:02X}")
         from keycard.parsing import tlv as kc_tlv
 
         path_str = path.decode("ascii") if isinstance(path, bytes) else str(path)

--- a/src/seedsigner/helpers/keycard_connector.py
+++ b/src/seedsigner/helpers/keycard_connector.py
@@ -1,0 +1,489 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from embit import bip32, ec
+
+
+_XPUB_HEADERS_MAINNET = {
+    "standard": 0x0488B21E,  # xpub
+    "p2wpkh-p2sh": 0x049D7CB2,  # ypub
+    "p2wsh-p2sh": 0x0295B43F,  # Ypub
+    "p2wpkh": 0x04B24746,  # zpub
+    "p2wsh": 0x02AA7ED3,  # Zpub
+}
+
+_XPUB_HEADERS_TESTNET = {
+    "standard": 0x043587CF,  # tpub
+    "p2wpkh-p2sh": 0x044A5262,  # upub
+    "p2wsh-p2sh": 0x024289EF,  # Upub
+    "p2wpkh": 0x045F1CF6,  # vpub
+    "p2wsh": 0x02575483,  # Vpub
+}
+
+
+def _candidate_keycard_paths() -> list[Path]:
+    candidates: list[Path] = []
+
+    env_path = os.environ.get("SEEDSIGNER_KEYCARD_PY_PATH") or os.environ.get("SEEDSIGNER_KEYCARD_CLI_PATH")
+    if env_path:
+        candidates.append(Path(env_path).expanduser())
+
+    # Default local-dev layout:
+    #   GitHub/
+    #     seedsigner/
+    #     keycard-py/
+    repo_root = Path(__file__).resolve().parents[3]
+    candidates.append(repo_root.parent / "keycard-py")
+
+    return candidates
+
+
+def get_keycard_class():
+    """Return (KeyCard, constants) from keycard-py if available, otherwise None.
+
+    The import is attempted directly first. If unavailable, we try common
+    local-development paths and an optional explicit environment variable.
+    """
+
+    try:
+        from keycard.keycard import KeyCard
+        from keycard import constants
+
+        return KeyCard, constants
+    except Exception:
+        pass
+
+    for candidate in _candidate_keycard_paths():
+        try:
+            if not candidate.exists() or not candidate.is_dir():
+                continue
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+
+            from keycard.keycard import KeyCard
+            from keycard import constants
+
+            return KeyCard, constants
+        except Exception:
+            continue
+
+    return None
+
+
+def _pin_to_text(pin) -> str:
+    if isinstance(pin, str):
+        return pin
+    if isinstance(pin, (bytes, bytearray)):
+        return bytes(pin).decode("utf-8")
+    if isinstance(pin, list):
+        return bytes(pin).decode("utf-8")
+    raise ValueError("Unsupported PIN format")
+
+
+def _value_to_text(value) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value).decode("utf-8")
+    if isinstance(value, list):
+        return bytes(value).decode("utf-8")
+    raise ValueError("Unsupported value format")
+
+
+def _uid_sha1_from_instance_uid(instance_uid_hex: str | None) -> str:
+    if instance_uid_hex:
+        try:
+            uid_bytes = bytes.fromhex(instance_uid_hex)
+            return hashlib.sha1(uid_bytes).hexdigest()
+        except Exception:
+            pass
+    return hashlib.sha1(b"keycard").hexdigest()
+
+
+def _normalize_uncompressed_pubkey(pubkey: bytes) -> bytes:
+    if len(pubkey) == 65 and pubkey[0] == 0x04:
+        return pubkey
+    if len(pubkey) == 64:
+        return b"\x04" + pubkey
+    raise ValueError("Expected uncompressed public key format")
+
+
+def _compress_pub(pubkey: bytes) -> bytes:
+    if len(pubkey) == 33:
+        return pubkey
+    if len(pubkey) == 65 and pubkey[0] == 0x04:
+        x = pubkey[1:33]
+        y_last = pubkey[64]
+        prefix = b"\x03" if (y_last & 1) else b"\x02"
+        return prefix + x
+    if len(pubkey) == 64:
+        x = pubkey[:32]
+        y_last = pubkey[63]
+        prefix = b"\x03" if (y_last & 1) else b"\x02"
+        return prefix + x
+    raise ValueError("Unexpected public key format")
+
+
+def _hash160(data: bytes) -> bytes:
+    sha = hashlib.sha256(data).digest()
+    return hashlib.new("ripemd160", sha).digest()
+
+
+def _parse_bip32_path(path: str) -> list[int]:
+    text = path.strip()
+    if text in ("", "m"):
+        return []
+    if not text.startswith("m/"):
+        raise ValueError(f"unsupported path format: {path}")
+    parts = text[2:].split("/")
+    result: list[int] = []
+    for p in parts:
+        hardened = p.endswith("'") or p.endswith("h") or p.endswith("H")
+        if hardened:
+            p = p[:-1]
+        idx = int(p)
+        if idx < 0 or idx >= 0x80000000:
+            raise ValueError(f"invalid path index: {idx}")
+        if hardened:
+            idx |= 0x80000000
+        result.append(idx)
+    return result
+
+
+def _path_from_indices(indices: list[int]) -> str:
+    if not indices:
+        return "m"
+    parts = []
+    for i in indices:
+        base = i & 0x7FFFFFFF
+        hardened = bool(i & 0x80000000)
+        parts.append(f"{base}{"'" if hardened else ""}")
+    return "m/" + "/".join(parts)
+
+
+class ECPubkeyCompat:
+    def __init__(self, raw_pub: bytes):
+        self._raw_pub = _normalize_uncompressed_pubkey(raw_pub)
+
+    def get_public_key_bytes(self, compressed: bool = True) -> bytes:
+        return _compress_pub(self._raw_pub) if compressed else self._raw_pub
+
+    def get_public_key_hex(self, compressed: bool = True) -> str:
+        return self.get_public_key_bytes(compressed=compressed).hex()
+
+
+class KeycardSatochipConnector:
+    """Thin adapter exposing the pysatochip-style calls used by SeedSigner."""
+
+    is_keycard_backend = True
+    requires_message_digest = True
+    needs_secure_channel = False
+    card_type = "Satochip"
+
+    def __init__(self, inner) -> None:
+        self._card = inner["card"]
+        self._constants = inner["constants"]
+        self._pairing_password = inner["pairing_password"]
+        self._pairing_index = None
+        self._pairing_key = None
+        self._secure_open = False
+        self._last_path = None
+        self._label = None
+        self.pin = None
+        self.parser = SimpleNamespace(authentikey=None)
+        self.UID_SHA1 = _uid_sha1_from_instance_uid(None)
+        self._refresh_uid()
+
+    # Well-known Status Keycard factory default pairing password.
+    # Any card that hasn't had its PSK changed will accept this.
+    DEFAULT_PAIRING_PASSWORD = "KeycardDefaultPairing"
+
+    @classmethod
+    def create(cls, card_filter=None):
+        if card_filter:
+            normalized = [str(v).lower() for v in (card_filter if isinstance(card_filter, (list, tuple)) else [card_filter])]
+            if not any(v == "satochip" for v in normalized):
+                raise ValueError("Keycard backend only supports Satochip-style flows")
+
+        keycard_api = get_keycard_class()
+        if keycard_api is None:
+            raise ImportError(
+                "Unable to load keycard backend. Install keycard-py or set SEEDSIGNER_KEYCARD_PY_PATH."
+            )
+        keycard_cls, constants = keycard_api
+
+        pairing_password = (
+            os.environ.get("SEEDSIGNER_KEYCARD_PAIRING_PASSWORD")
+            or cls.DEFAULT_PAIRING_PASSWORD
+        )
+        card = keycard_cls()
+        try:
+            card.transport.connect()
+        except Exception:
+            card.transport.disconnect()
+            card.transport.connect()
+        return cls({
+            "card": card,
+            "constants": constants,
+            "pairing_password": pairing_password,
+        })
+
+    def _ensure_secure_channel(self) -> None:
+        if self._secure_open:
+            return
+
+        self._card.select()
+        self._pairing_index, self._pairing_key = self._card.pair(self._pairing_password)
+        self._card.open_secure_channel(self._pairing_index, self._pairing_key)
+        self._secure_open = True
+
+    def _ensure_pin_verified(self) -> None:
+        if self.pin is None:
+            raise ValueError("PIN has not been set")
+        pin_text = _pin_to_text(self.pin)
+        ok = self._card.verify_pin(pin_text)
+        if not ok:
+            raise ValueError("Invalid PIN")
+
+    def _refresh_uid(self) -> None:
+        try:
+            info = self._card.select()
+            instance_uid = getattr(info, "instance_uid", None)
+            if isinstance(instance_uid, bytes):
+                instance_uid = instance_uid.hex()
+            self.UID_SHA1 = _uid_sha1_from_instance_uid(instance_uid)
+        except Exception:
+            pass
+
+    def card_get_label(self):
+        return self._label or "Keycard"
+
+    def card_disconnect(self):
+        try:
+            return self._card.transport.disconnect()
+        finally:
+            self._secure_open = False
+
+    def set_mode_factory_reset(self, enabled: bool):
+        _ = enabled
+        return None
+
+    def card_initiate_secure_channel(self):
+        return ([], 0x90, 0x00)
+
+    def set_pin(self, pin_nbr, pin):
+        _ = pin_nbr
+        self.pin = pin
+
+    def card_verify_PIN(self):
+        if self.pin is None:
+            raise ValueError("PIN has not been set")
+        self._ensure_secure_channel()
+        pin_text = _pin_to_text(self.pin)
+        ok = self._card.verify_pin(pin_text)
+        if ok:
+            return ([], 0x90, 0x00)
+        return ([], 0x63, 0xC0)
+
+    def card_get_status(self):
+        self._ensure_secure_channel()
+        status = self._card.status
+        path_indices = self._card.get_key_path
+        out = dict(status) if isinstance(status, dict) else {}
+        if isinstance(path_indices, list):
+            out["path"] = _path_from_indices(path_indices)
+        out["key_initialized"] = bool(out.get("initialized", out.get("key_initialized", True)))
+        out["is_seeded"] = bool(out.get("key_initialized", False))
+        out.setdefault("setup_done", bool(out.get("key_initialized", True)))
+        return ([], 0x90, 0x00, out)
+
+    def card_change_PIN(self, pin_nbr, old_pin, new_pin):
+        _ = pin_nbr
+        self._ensure_secure_channel()
+        old_text = _value_to_text(old_pin)
+        new_text = _value_to_text(new_pin)
+        ok = self._card.verify_pin(old_text)
+        if not ok:
+            return ([], 0x63, 0xC0)
+        self._card.change_pin(new_text)
+        self.pin = list(new_text.encode("utf-8"))
+        return ([], 0x90, 0x00)
+
+    def card_change_PUK(self, pin_nbr, old_puk, new_puk):
+        _ = pin_nbr
+        _ = old_puk
+        self._ensure_secure_channel()
+        self._ensure_pin_verified()
+        new_text = _value_to_text(new_puk)
+        self._card.change_puk(new_text)
+        return ([], 0x90, 0x00)
+
+    def card_unblock_PIN(self, pin_nbr, puk, new_pin=None):
+        _ = pin_nbr
+        self._ensure_secure_channel()
+        puk_text = _value_to_text(puk)
+        if new_pin is None:
+            if self.pin is None:
+                raise ValueError("New PIN is required")
+            new_pin_text = _pin_to_text(self.pin)
+        else:
+            new_pin_text = _value_to_text(new_pin)
+        self._card.unblock_pin(puk_text, new_pin_text)
+        self.pin = list(new_pin_text.encode("utf-8"))
+        return ([], 0x90, 0x00)
+
+    def card_set_label(self, label):
+        self._ensure_secure_channel()
+        self._ensure_pin_verified()
+        label_text = _value_to_text(label)
+        self._card.store_data(label_text.encode("utf-8"), slot=self._constants.StorageSlot.PUBLIC)
+        self._label = label_text
+        return ([], 0x90, 0x00)
+
+    def card_reset_factory(self):
+        self._ensure_secure_channel()
+        self._ensure_pin_verified()
+        self._card.factory_reset()
+        self._secure_open = False
+        self.pin = None
+        return ([], 0x90, 0x00)
+
+    def card_bip32_import_seed(self, seed_bytes):
+        self._ensure_secure_channel()
+        self._ensure_pin_verified()
+        seed = bytes(seed_bytes)
+        self._card.load_key(self._constants.LoadKeyType.BIP39_SEED, bip39_seed=seed)
+        return ([], 0x90, 0x00)
+
+    def card_remove_key(self):
+        self._ensure_secure_channel()
+        self._ensure_pin_verified()
+        self._card.remove_key()
+        return ([], 0x90, 0x00)
+
+    def card_bip32_get_authentikey(self):
+        key = self._card.ident()
+        wrapped = ECPubkeyCompat(key)
+        self.parser.authentikey = wrapped
+        return wrapped
+
+    def card_export_authentikey(self):
+        return self.card_bip32_get_authentikey()
+
+    def card_bip32_get_extendedkey(self, path):
+        self._ensure_secure_channel()
+        from keycard.parsing import tlv as kc_tlv
+
+        path_str = path.decode("ascii") if isinstance(path, bytes) else str(path)
+        if path_str in ("", "m"):
+            path_str = "m"
+
+        # Navigate the card to the requested derivation path, then export the
+        # current key with its chain code.  Using derive_key + CURRENT avoids
+        # SW=6A80 that is returned by some Status keycard firmware when
+        # DERIVE + EXTENDED_PUBLIC are combined in a single EXPORT KEY APDU.
+        self._card.derive_key(path_str)
+
+        response = self._card.send_secure_apdu(
+            ins=self._constants.INS_EXPORT_KEY,
+            p1=self._constants.DerivationOption.CURRENT,
+            p2=self._constants.KeyExportOption.EXTENDED_PUBLIC,
+            data=b"",
+        )
+        outer = kc_tlv.parse_tlv(response)
+        tpl = outer.get(0xA1)
+        if not tpl:
+            raise ValueError("Missing keypair template (tag 0xA1) in export response")
+        inner = kc_tlv.parse_tlv(tpl[0])
+        pubkey = inner.get(0x80, [None])[0]
+        chain_code = inner.get(0x82, [None])[0]
+
+        if not pubkey:
+            raise ValueError("Missing public key in export response")
+        if not chain_code:
+            raise ValueError("Missing chain code in export response")
+
+        self._last_path = path_str
+        return ECPubkeyCompat(pubkey), chain_code
+
+    def card_bip32_get_xpub(self, path, xtype, is_mainnet):
+        path_str = path.decode("ascii") if isinstance(path, bytes) else str(path)
+        indices = _parse_bip32_path(path_str)
+        depth = len(indices)
+        child_index = indices[-1] if indices else 0
+
+        # Compute parent fingerprint first so that _last_path ends up as the
+        # child path after both derive operations.
+        if depth == 0:
+            fingerprint = b"\x00\x00\x00\x00"
+        else:
+            parent_path = _path_from_indices(indices[:-1])
+            parent, _ = self.card_bip32_get_extendedkey(parent_path)
+            fingerprint = _hash160(parent.get_public_key_bytes(compressed=True))[:4]
+
+        child, child_chain = self.card_bip32_get_extendedkey(path_str)
+
+        header_map = _XPUB_HEADERS_MAINNET if is_mainnet else _XPUB_HEADERS_TESTNET
+        version = header_map.get(xtype)
+        if version is None:
+            raise ValueError(f"unsupported xtype: {xtype}")
+        version_bytes = int(version).to_bytes(4, "big")
+
+        hd = bip32.HDKey(
+            key=ec.PublicKey.parse(child.get_public_key_bytes(compressed=True)),
+            chain_code=child_chain,
+            version=version_bytes,
+            depth=depth,
+            fingerprint=fingerprint,
+            child_number=child_index,
+        )
+        return hd.to_base58()
+
+    @staticmethod
+    def _normalize_digest(data):
+        if isinstance(data, list):
+            digest = bytes(data)
+        elif isinstance(data, bytes):
+            digest = data
+        else:
+            digest = bytes.fromhex(str(data))
+        if len(digest) != 32:
+            raise ValueError("digest must be exactly 32 bytes")
+        return digest
+
+    def card_sign_transaction_hash(self, keynbr, txhash, chalresponse=None):
+        _ = chalresponse
+        self._ensure_secure_channel()
+        digest = self._normalize_digest(txhash)
+
+        if int(keynbr) == 0xFF and self._last_path:
+            sig = self._card.sign_with_path(digest, self._last_path)
+        else:
+            sig = self._card.sign(digest)
+
+        der = sig.signature_der
+        return (list(der), 0x90, 0x00)
+
+    def card_sign_message(self, keynbr, pubkey, message, hmac=b"", altcoin=None):
+        _ = pubkey
+        _ = hmac
+        _ = altcoin
+        self._ensure_secure_channel()
+        digest = self._normalize_digest(message)
+
+        if int(keynbr) == 0xFF and self._last_path:
+            sig = self._card.sign_with_path(digest, self._last_path)
+        else:
+            sig = self._card.sign(digest)
+
+        der = sig.signature_der
+        compact = getattr(sig, "signature", None)
+        if not compact or len(compact) != 65:
+            compact = b"\x1f" + b"\x00" * 64
+        return (list(der), 0x90, 0x00, compact)

--- a/src/seedsigner/helpers/keycard_signer.py
+++ b/src/seedsigner/helpers/keycard_signer.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import os
+import random
+from concurrent.futures import TimeoutError
+
+from embit.psbt import PSBT
+from embit.util import secp256k1
+
+from seedsigner.helpers.iso7816 import format_sw_error
+from seedsigner.helpers.satochip_signer import _call_with_timeout, _format_path
+from seedsigner.models.settings import Settings, SettingsConstants
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def sign_psbt_with_keycard(psbt: PSBT, connector) -> int:
+    """Sign PSBT inputs with a Keycard backend.
+
+    Keycard shells may reject pubkey export for arbitrary child paths with
+    SW=6982. For single-derivation inputs, this signer falls back to path-based
+    signing by setting the connector's current derivation path directly.
+    """
+
+    settings = Settings.get_instance()
+    timeout = settings.get_value(SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT)
+    pre_dummy_max = settings.get_value(SettingsConstants.SETTING__SATOCHIP_MAX_PRE_DUMMIES)
+    post_dummy_max = settings.get_value(SettingsConstants.SETTING__SATOCHIP_MAX_POST_DUMMIES)
+    in_tx_dummy_max = settings.get_value(SettingsConstants.SETTING__SATOCHIP_MAX_IN_TX_DUMMIES)
+    dummy_prob = settings.get_value(SettingsConstants.SETTING__SATOCHIP_DUMMY_PROBABILITY) / 100
+
+    signed = 0
+
+    pre_dummy_count = random.randint(0, pre_dummy_max)
+    logger.info("Pre-signing dummy signatures: %d", pre_dummy_count)
+    for _ in range(pre_dummy_count):
+        dummy_hash = os.urandom(32)
+        extra = random.randint(1, in_tx_dummy_max) if random.random() < dummy_prob else 0
+        for _ in range(1 + extra):
+            try:
+                _call_with_timeout(
+                    connector.card_sign_transaction_hash,
+                    timeout,
+                    0xFF,
+                    list(dummy_hash),
+                    None,
+                )
+            except Exception:
+                pass
+
+    indices = list(range(len(psbt.inputs)))
+    random.shuffle(indices)
+    for i in indices:
+        inp = psbt.inputs[i]
+        if len(inp.bip32_derivations) == 0:
+            logger.debug("Keycard signer input %d: skipped (no bip32 derivations)", i)
+            continue
+
+        matched_or_fallback = False
+        for pubkey, deriv in inp.bip32_derivations.items():
+            path = _format_path(deriv.derivation)
+            logger.info(
+                "Keycard signer input %d: attempting derive path=%s fp=%s",
+                i,
+                path,
+                getattr(deriv, "fingerprint", b"").hex() if getattr(deriv, "fingerprint", None) is not None else "unknown",
+            )
+
+            # Keycard backend: path-based fallback for single-derivation inputs.
+            if len(inp.bip32_derivations) == 1:
+                try:
+                    setattr(connector, "_last_path", path)
+                    matched_or_fallback = True
+                    logger.info(
+                        "Keycard signer input %d: using path-sign fallback path=%s",
+                        i,
+                        path,
+                    )
+                except Exception as e:
+                    logger.info(
+                        "Keycard signer input %d: path-sign fallback failed path=%s error=%s",
+                        i,
+                        path,
+                        e,
+                    )
+                    continue
+            else:
+                # For multi-derivation inputs we avoid guessing.
+                logger.info(
+                    "Keycard signer input %d: skipping non-single-derivation input",
+                    i,
+                )
+                continue
+
+            tx_hash = psbt.sighash(i)
+            extra_sigs = random.randint(1, in_tx_dummy_max) if random.random() < dummy_prob else 0
+            if extra_sigs:
+                logger.info(
+                    "Input %d selected for dummy signing: %d dummy signatures",
+                    i,
+                    extra_sigs,
+                )
+            else:
+                logger.info("Input %d not selected for dummy signing", i)
+
+            results: list[tuple | None] = []
+            for _ in range(1 + extra_sigs):
+                try:
+                    results.append(
+                        _call_with_timeout(
+                            connector.card_sign_transaction_hash,
+                            timeout,
+                            0xFF,
+                            list(tx_hash),
+                            None,
+                        )
+                    )
+                except TimeoutError:
+                    logger.warning("Keycard signing timed out")
+                    results.append(None)
+                except Exception:
+                    results.append(None)
+
+            chosen = random.choice(results) if results else None
+            if chosen is None:
+                for res in results:
+                    if res is not None:
+                        chosen = res
+                        break
+
+            sig, sw1, sw2 = chosen if chosen is not None else (None, None, None)
+            if sw1 != 0x90 or sw2 != 0x00:
+                if sw1 is None or sw2 is None:
+                    logger.warning("Keycard signing failed")
+                else:
+                    logger.warning("Keycard signing failed: %s", format_sw_error(sw1, sw2))
+                continue
+
+            sig_der = bytes(sig)
+            try:
+                sig_obj = secp256k1.ecdsa_signature_parse_der(sig_der)
+                sig_norm = secp256k1.ecdsa_signature_normalize(sig_obj)
+                sig_der = secp256k1.ecdsa_signature_serialize_der(sig_norm)
+            except Exception as e:
+                logger.warning("Failed to normalize Keycard signature: %s", e)
+
+            inp.partial_sigs[pubkey] = sig_der + b"\x01"
+            signed += 1
+            logger.info("Keycard signer input %d: signature appended (signed_count=%d)", i, signed)
+            break
+
+        if not matched_or_fallback:
+            logger.info("Keycard signer input %d: no signable path found", i)
+
+    post_dummy_count = random.randint(0, post_dummy_max)
+    logger.info("Post-signing dummy signatures: %d", post_dummy_count)
+    for _ in range(post_dummy_count):
+        dummy_hash = os.urandom(32)
+        extra = random.randint(1, in_tx_dummy_max) if random.random() < dummy_prob else 0
+        for _ in range(1 + extra):
+            try:
+                _call_with_timeout(
+                    connector.card_sign_transaction_hash,
+                    timeout,
+                    0xFF,
+                    list(dummy_hash),
+                    None,
+                )
+            except Exception:
+                pass
+
+    return signed

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -238,19 +238,53 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
     for i in indices:
         inp = psbt.inputs[i]
         if len(inp.bip32_derivations) == 0:
+            logger.debug("PSBT signer input %d: skipped (no bip32 derivations)", i)
             continue
+
+        matched_pubkey = False
         for pubkey, deriv in inp.bip32_derivations.items():
             path = _format_path(deriv.derivation)
+            logger.info(
+                "PSBT signer input %d: attempting derive path=%s fp=%s",
+                i,
+                path,
+                getattr(deriv, "fingerprint", b"").hex() if getattr(deriv, "fingerprint", None) is not None else "unknown",
+            )
             try:
                 key, _chaincode = _get_extended_key(connector, path)
                 card_pub = PublicKey.parse(
                     key.get_public_key_bytes(compressed=True)
                 )
-            except Exception:
-                continue
-            if card_pub != pubkey:
+            except Exception as e:
+                logger.info(
+                    "PSBT signer input %d: derive failed path=%s error=%s",
+                    i,
+                    path,
+                    e,
+                )
                 continue
 
+            if card_pub != pubkey:
+                try:
+                    expected_hex = pubkey.sec().hex()
+                except Exception:
+                    expected_hex = str(pubkey)
+                try:
+                    card_hex = card_pub.sec().hex()
+                except Exception:
+                    card_hex = str(card_pub)
+                logger.info(
+                    "PSBT signer input %d: pubkey mismatch path=%s fp=%s expected=%s card=%s",
+                    i,
+                    path,
+                    getattr(deriv, "fingerprint", b"").hex() if getattr(deriv, "fingerprint", None) is not None else "unknown",
+                    expected_hex,
+                    card_hex,
+                )
+                continue
+
+            matched_pubkey = True
+            logger.info("PSBT signer input %d: matched card pubkey path=%s", i, path)
             tx_hash = psbt.sighash(i)
 
             extra_sigs = (
@@ -264,6 +298,7 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
                 )
             else:
                 logger.info("Input %d not selected for dummy signing", i)
+
             results: list[tuple | None] = []
             for _ in range(1 + extra_sigs):
                 try:
@@ -281,12 +316,14 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
                     results.append(None)
                 except Exception:
                     results.append(None)
+
             chosen = random.choice(results) if results else None
             if chosen is None:
                 for res in results:
                     if res is not None:
                         chosen = res
                         break
+
             sig, sw1, sw2 = chosen if chosen is not None else (None, None, None)
             if sw1 != 0x90 or sw2 != 0x00:
                 if sw1 is None or sw2 is None:
@@ -296,17 +333,22 @@ def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
                         "Satochip signing failed: %s", format_sw_error(sw1, sw2)
                     )
                 continue
+
             sig_der = bytes(sig)
-            # ensure low-S signature; gracefully handle normalization errors
             try:
                 sig_obj = secp256k1.ecdsa_signature_parse_der(sig_der)
                 sig_norm = secp256k1.ecdsa_signature_normalize(sig_obj)
                 sig_der = secp256k1.ecdsa_signature_serialize_der(sig_norm)
             except Exception as e:
                 logger.warning("Failed to normalize Satochip signature: %s", e)
+
             inp.partial_sigs[pubkey] = sig_der + b"\x01"
             signed += 1
+            logger.info("PSBT signer input %d: signature appended (signed_count=%d)", i, signed)
             break
+
+        if not matched_pubkey:
+            logger.info("PSBT signer input %d: no matching card pubkey found", i)
 
     # Issue 0-N dummy signing requests after signing completes, again applying
     # the per-input dummy settings to potentially sign each dummy hash multiple

--- a/src/seedsigner/helpers/satochip_signer.py
+++ b/src/seedsigner/helpers/satochip_signer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from binascii import b2a_base64
+import hashlib
 import logging
 import os
 import random
@@ -155,6 +156,26 @@ def format_path_string(path: str) -> str:
     if path == "" or path == "m":
         return "m"
     return "m/" + path
+
+
+def _compact_size(value: int) -> bytes:
+    if value < 0xFD:
+        return bytes([value])
+    if value <= 0xFFFF:
+        return b"\xfd" + value.to_bytes(2, "little")
+    if value <= 0xFFFFFFFF:
+        return b"\xfe" + value.to_bytes(4, "little")
+    return b"\xff" + value.to_bytes(8, "little")
+
+
+def _bitcoin_message_digest(message: str) -> bytes:
+    payload = message.encode("utf-8")
+    serialized = (
+        b"\x18Bitcoin Signed Message:\n"
+        + _compact_size(len(payload))
+        + payload
+    )
+    return hashlib.sha256(hashlib.sha256(serialized).digest()).digest()
 
 
 def sign_psbt_with_satochip(psbt: PSBT, connector) -> int:
@@ -327,9 +348,14 @@ def sign_message_with_satochip(derivation_path: str, message: str, connector) ->
     timeout = settings.get_value(SettingsConstants.SETTING__SATOCHIP_MSG_SIGN_TIMEOUT)
     path = format_path_string(derivation_path)
     key, _chaincode = _get_extended_key(connector, path)
+
+    message_payload = message
+    if getattr(connector, "requires_message_digest", False):
+        message_payload = _bitcoin_message_digest(message)
+
     try:
         _resp, sw1, sw2, compsig = _call_with_timeout(
-            connector.card_sign_message, timeout, 0xFF, key, message
+            connector.card_sign_message, timeout, 0xFF, key, message_payload
         )
     except TimeoutError:
         raise Exception("Satochip signing timed out")

--- a/src/seedsigner/helpers/seedkeeper_utils.py
+++ b/src/seedsigner/helpers/seedkeeper_utils.py
@@ -83,7 +83,19 @@ def _requested_satochip_flow(init_card_filter) -> bool:
 def _init_legacy_connector(init_card_filter):
     from pysatochip.CardConnector import CardConnector
 
-    return CardConnector(card_filter=init_card_filter)
+    connector = CardConnector(card_filter=init_card_filter)
+    # The CardConnector uses a background thread to establish the card
+    # connection.  Without a delay the thread may not have run yet, so
+    # card_get_status() would return before actually trying to talk to the
+    # card and the probe below would not detect wrong-card-type errors.
+    # 0.6 s matches the 0.5 s sleep in the outer retry loop that the
+    # pysatochip authors themselves found necessary for reader initialisation.
+    time.sleep(0.6)
+    # Probe: throws (e.g. "Card Initialization must be satisfied") when the
+    # inserted card is not a Satochip.  The caller catches this and falls
+    # back to the keycard-compat backend.
+    connector.card_get_status()
+    return connector
 
 
 def _init_card_connector(init_card_filter, backend_preference: str | None = None):
@@ -265,7 +277,7 @@ def disconnect_smartcard_connections(controller):
         pass
 
 
-def init_satochip(parentObject, init_card_filter=None, require_pin=True, backend_preference: str | None = None):
+def init_satochip(parentObject, init_card_filter=None, require_pin=True, backend_preference: str | None = None, allow_unseeded: bool = False):
     from seedsigner.models.settings import (
         Settings,
         SettingsConstants,
@@ -307,9 +319,14 @@ def init_satochip(parentObject, init_card_filter=None, require_pin=True, backend
         if Satochip_Connector is None:
             print("No Working CardConnector, Connecting")
             print("Card Filter:", init_card_filter)
+            print("Backend Preference:", controller_backend_pref or "auto")
             Satochip_Connector = _init_card_connector(
                 init_card_filter,
                 backend_preference=controller_backend_pref,
+            )
+            print(
+                "Card Backend:",
+                "keycard" if getattr(Satochip_Connector, "is_keycard_backend", False) else "pysatochip",
             )
     except Exception as e:
         parentObject.run_screen(
@@ -482,14 +499,18 @@ def init_satochip(parentObject, init_card_filter=None, require_pin=True, backend
 
     else:
         if getattr(Satochip_Connector, "is_keycard_backend", False):
-            parentObject.run_screen(
-                WarningScreen,
-                title="Card Uninitialised",
-                status_headline=None,
-                text="Initialize Keycard first\nusing keycard-cli.",
-                show_back_button=True,
-            )
-            return None
+            # In keycard flows that allow unseeded cards (e.g. "Initialise with
+            # Seed"), continue into the generic setup path below so a factory-
+            # fresh card can be initialized in-app before importing a seed.
+            if not allow_unseeded:
+                parentObject.run_screen(
+                    WarningScreen,
+                    title="Card Uninitialised",
+                    status_headline=None,
+                    text="Initialize Keycard first\nusing keycard-cli.",
+                    show_back_button=True,
+                )
+                return None
 
         print("Card Needs Initial Setup")
         parentObject.run_screen(
@@ -500,7 +521,12 @@ def init_satochip(parentObject, init_card_filter=None, require_pin=True, backend
             show_back_button=True,
         )
 
-        pin_str = prompt_for_pin(parentObject, "New Card PIN")
+        pin_str = prompt_for_pin(
+            parentObject,
+            "New Card PIN",
+            numeric_only=is_keycard_backend,
+            exact_length=6 if is_keycard_backend else None,
+        )
 
         if pin_str is None:
             return None

--- a/src/seedsigner/helpers/seedkeeper_utils.py
+++ b/src/seedsigner/helpers/seedkeeper_utils.py
@@ -584,9 +584,9 @@ def init_satochip(parentObject, init_card_filter=None, require_pin=True, backend
             print("Setup Succeeded")
             parentObject.run_screen(
                 LargeIconStatusScreen,
-                title="Success",
+                title="Card Setup",
                 status_headline=None,
-                text=f"Card Setup Complete",
+                text="PIN set. Import seed next.",
                 show_back_button=False,
             )
             # Save the PIN for the newly set up card...

--- a/src/seedsigner/helpers/seedkeeper_utils.py
+++ b/src/seedsigner/helpers/seedkeeper_utils.py
@@ -1,4 +1,3 @@
-from pysatochip.CardConnector import CardConnector
 from pysatochip.JCconstants import (
     JCconstants,
     SEEDKEEPER_DIC_TYPE,
@@ -16,6 +15,7 @@ from seedsigner.gui.screens import (
 )
 from seedsigner.gui.screens.screen import LoadingScreenThread
 from seedsigner.helpers.iso7816 import format_sw_error
+from seedsigner.helpers.keycard_connector import KeycardSatochipConnector
 
 
 import os
@@ -25,6 +25,54 @@ import platform
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _requested_satochip_flow(init_card_filter) -> bool:
+    if init_card_filter is None:
+        return False
+    values = init_card_filter
+    if not isinstance(values, (list, tuple, set)):
+        values = [values]
+    return any(str(v).lower() == "satochip" for v in values)
+
+
+def _init_legacy_connector(init_card_filter):
+    from pysatochip.CardConnector import CardConnector
+
+    return CardConnector(card_filter=init_card_filter)
+
+
+def _init_card_connector(init_card_filter, backend_preference: str | None = None):
+    """Create the most appropriate connector for the requested card flow.
+
+    Selection is controlled by ``SEEDSIGNER_SMARTCARD_BACKEND``:
+    - ``auto`` (default): try pysatochip first, then keycard for satochip flows
+    - ``pysatochip``: force legacy backend
+    - ``keycard``: force keycard compat backend (satochip flow only)
+    """
+
+    backend_pref = (backend_preference or os.environ.get("SEEDSIGNER_SMARTCARD_BACKEND", "auto")).strip().lower()
+    keycard_allowed = _requested_satochip_flow(init_card_filter)
+
+    if backend_pref == "keycard":
+        if not keycard_allowed:
+            raise Exception("Keycard backend only supports satochip card flows")
+        return KeycardSatochipConnector.create(card_filter=init_card_filter)
+
+    if backend_pref == "pysatochip":
+        return _init_legacy_connector(init_card_filter)
+
+    # auto backend
+    try:
+        return _init_legacy_connector(init_card_filter)
+    except Exception as legacy_error:
+        if not keycard_allowed:
+            raise legacy_error
+        try:
+            logger.info("pysatochip init failed; trying keycard compat backend")
+            return KeycardSatochipConnector.create(card_filter=init_card_filter)
+        except Exception:
+            raise legacy_error
 
 
 def calculate_seedkeeper_secret_size(secret_dic: dict) -> int:
@@ -145,7 +193,7 @@ def disconnect_smartcard_connections(controller):
         pass
 
 
-def init_satochip(parentObject, init_card_filter=None, require_pin=True):
+def init_satochip(parentObject, init_card_filter=None, require_pin=True, backend_preference: str | None = None):
     from seedsigner.models.settings import (
         Settings,
         SettingsConstants,
@@ -155,6 +203,9 @@ def init_satochip(parentObject, init_card_filter=None, require_pin=True):
     # Check for existing card connector
     print("Checking existing card connector...")
     Satochip_Connector = getattr(parentObject.controller, "Satochip_Connector", None)
+    controller_backend_pref = backend_preference
+    if controller_backend_pref is None:
+        controller_backend_pref = getattr(parentObject.controller, "smartcard_backend_preference", None)
 
     # If a specific applet/card filter is requested, do not reuse an existing
     # connector that may still be attached to a previous flow/card type.
@@ -184,7 +235,10 @@ def init_satochip(parentObject, init_card_filter=None, require_pin=True):
         if Satochip_Connector is None:
             print("No Working CardConnector, Connecting")
             print("Card Filter:", init_card_filter)
-            Satochip_Connector = CardConnector(card_filter=init_card_filter)
+            Satochip_Connector = _init_card_connector(
+                init_card_filter,
+                backend_preference=controller_backend_pref,
+            )
     except Exception as e:
         parentObject.run_screen(
             WarningScreen,
@@ -340,6 +394,16 @@ def init_satochip(parentObject, init_card_filter=None, require_pin=True):
                 return None
 
     else:
+        if getattr(Satochip_Connector, "is_keycard_backend", False):
+            parentObject.run_screen(
+                WarningScreen,
+                title="Card Uninitialised",
+                status_headline=None,
+                text="Initialize Keycard first\nusing keycard-cli.",
+                show_back_button=True,
+            )
+            return None
+
         print("Card Needs Initial Setup")
         parentObject.run_screen(
             WarningScreen,

--- a/src/seedsigner/helpers/seedkeeper_utils.py
+++ b/src/seedsigner/helpers/seedkeeper_utils.py
@@ -27,6 +27,50 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _decode_attempts_from_sw(sw1: int, sw2: int) -> int | None:
+    if sw1 == 0x63 and (sw2 & 0xF0) == 0xC0:
+        return sw2 & 0x0F
+    return None
+
+
+def get_pin_attempts_left(connector=None, sw1: int | None = None, sw2: int | None = None) -> int | None:
+    attempts = None
+    if sw1 is not None and sw2 is not None:
+        attempts = _decode_attempts_from_sw(sw1, sw2)
+        if attempts is not None:
+            return attempts
+
+    if connector is None:
+        return None
+
+    try:
+        _r, _a, _b, status = connector.card_get_status()
+    except Exception:
+        return None
+
+    pin_tries = status.get("PIN0_remaining_tries")
+    if isinstance(pin_tries, int):
+        return pin_tries
+    return None
+
+
+def show_incorrect_pin_warning(parent_view, connector=None, sw1: int | None = None, sw2: int | None = None) -> None:
+    attempts_left = get_pin_attempts_left(connector=connector, sw1=sw1, sw2=sw2)
+    if attempts_left is not None:
+        attempt_word = "attempt" if attempts_left == 1 else "attempts"
+        text = f"PIN is incorrect.\n{attempts_left} {attempt_word} remaining."
+    else:
+        text = "PIN is incorrect."
+
+    parent_view.run_screen(
+        WarningScreen,
+        title="Incorrect PIN",
+        status_headline=None,
+        text=text,
+        show_back_button=True,
+    )
+
+
 def _requested_satochip_flow(init_card_filter) -> bool:
     if init_card_filter is None:
         return False
@@ -147,8 +191,14 @@ def format_seedkeeper_space_error(required_bytes: int, free_bytes: int) -> str:
     )
 
 
-def prompt_for_pin(parent_view, title: str):
-    """Prompt for a PIN and enforce length requirements."""
+def prompt_for_pin(
+    parent_view,
+    title: str,
+    *,
+    numeric_only: bool = False,
+    exact_length: int | None = None,
+):
+    """Prompt for a PIN and enforce configurable PIN requirements."""
 
     while True:
         ret = seed_screens.SeedAddPassphraseScreen(title=title).display()
@@ -156,6 +206,28 @@ def prompt_for_pin(parent_view, title: str):
             return None
 
         pin_str = ret.get("passphrase", "")
+        if numeric_only and not all(ch in "0123456789" for ch in pin_str):
+            parent_view.run_screen(
+                WarningScreen,
+                title="Invalid PIN",
+                status_headline=None,
+                text="PIN must contain digits only.",
+                show_back_button=True,
+            )
+            continue
+
+        if exact_length is not None:
+            if len(pin_str) == exact_length:
+                return pin_str
+            parent_view.run_screen(
+                WarningScreen,
+                title="Invalid PIN",
+                status_headline=None,
+                text=f"PIN must be exactly {exact_length} digits.",
+                show_back_button=True,
+            )
+            continue
+
         if JCconstants.PIN_MIN_SIZE <= len(pin_str) <= JCconstants.PIN_MAX_SIZE:
             return pin_str
 
@@ -249,11 +321,18 @@ def init_satochip(parentObject, init_card_filter=None, require_pin=True, backend
         )
         return None
 
+    is_keycard_backend = getattr(Satochip_Connector, "is_keycard_backend", False)
+
     if require_pin:
         # Prompt for pin if one hasn't been set, otherwise a cached pin will be used
         if parentObject.controller.Satochip_PIN is None:
             print("No Cached pin, prompting for pin")
-            pin_str = prompt_for_pin(parentObject, "Card PIN")
+            pin_str = prompt_for_pin(
+                parentObject,
+                "Card PIN",
+                numeric_only=is_keycard_backend,
+                exact_length=6 if is_keycard_backend else None,
+            )
             if pin_str is None:
                 return None
             card_pin = list(pin_str.encode("utf-8"))
@@ -361,6 +440,14 @@ def init_satochip(parentObject, init_card_filter=None, require_pin=True, backend
                 if sw1 == 0x90 and sw2 == 0x00:
                     print("Pin Correct")
                     pass  # Pin is correct
+                elif sw1 == 0x63 and (sw2 & 0xF0) == 0xC0:
+                    show_incorrect_pin_warning(
+                        parentObject,
+                        connector=Satochip_Connector,
+                        sw1=sw1,
+                        sw2=sw2,
+                    )
+                    return None
                 else:
                     parentObject.run_screen(
                         WarningScreen,

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -8,8 +8,24 @@ from datetime import datetime
 from binascii import a2b_base64, b2a_base64
 from enum import IntEnum
 from embit import psbt, bip39, ec, bip32
-from pyzbar import pyzbar
-from pyzbar.pyzbar import ZBarSymbol
+
+_ZBAR_IMPORT_ERROR = None
+try:
+    from pyzbar import pyzbar
+    from pyzbar.pyzbar import ZBarSymbol
+except Exception as exc:  # pragma: no cover - depends on host runtime libs
+    pyzbar = None
+    ZBarSymbol = None
+    _ZBAR_IMPORT_ERROR = exc
+
+_OPENCV_IMPORT_ERROR = None
+try:
+    import cv2
+    import numpy as np
+except Exception as exc:  # pragma: no cover - depends on host runtime libs
+    cv2 = None
+    np = None
+    _OPENCV_IMPORT_ERROR = exc
 from urtypes.crypto import PSBT as UR_PSBT
 from urtypes.crypto import Account, Output
 from urtypes.bytes import Bytes
@@ -60,6 +76,41 @@ class DecodeQR:
         self.is_encryptionkey = is_encryptionkey
         self.is_text = is_text
         self.is_nonUTF8 = False
+
+
+    @staticmethod
+    def is_qr_scanner_available() -> bool:
+        return (
+            (pyzbar is not None and ZBarSymbol is not None)
+            or DecodeQR._opencv_available_desktop()
+        )
+
+
+    @staticmethod
+    def _opencv_available_desktop() -> bool:
+        if cv2 is None or np is None:
+            return False
+
+        try:
+            from seedsigner.hardware.microsd import MicroSD
+
+            return MicroSD.is_desktop_mode()
+        except Exception:
+            return False
+
+
+    @staticmethod
+    def get_qr_scanner_error() -> str:
+        if DecodeQR.is_qr_scanner_available():
+            return ""
+        errors = []
+        if _ZBAR_IMPORT_ERROR is not None:
+            errors.append(f"zbar backend unavailable: {_ZBAR_IMPORT_ERROR}")
+        if _OPENCV_IMPORT_ERROR is not None:
+            errors.append(f"opencv backend unavailable: {_OPENCV_IMPORT_ERROR}")
+        if errors:
+            return " | ".join(errors)
+        return "QR scanning backend unavailable"
 
 
     def add_image(self, image):
@@ -458,15 +509,61 @@ class DecodeQR:
         if image is None:
             return None
 
-        barcodes = pyzbar.decode(image, symbols=[ZBarSymbol.QRCODE], binary=is_binary)
+        if pyzbar is not None and ZBarSymbol is not None:
+            barcodes = pyzbar.decode(image, symbols=[ZBarSymbol.QRCODE], binary=is_binary)
 
-        # if barcodes:
-            # print("--------------- extract_qr_data ---------------")
-            # print(barcodes)
+            # if barcodes:
+                # print("--------------- extract_qr_data ---------------")
+                # print(barcodes)
 
-        for barcode in barcodes:
-            # Only pull and return the first barcode
-            return barcode.data
+            for barcode in barcodes:
+                # Only pull and return the first barcode
+                return barcode.data
+
+        if DecodeQR._opencv_available_desktop():
+            return DecodeQR._extract_qr_data_opencv(image, is_binary=is_binary)
+
+        if not DecodeQR.is_qr_scanner_available():
+            # Keep non-camera flows operational when zbar shared libraries are missing.
+            logger.warning("QR scanning unavailable: %s", DecodeQR.get_qr_scanner_error())
+            return None
+
+        return None
+
+
+    @staticmethod
+    def _extract_qr_data_opencv(image, is_binary: bool = False) -> bytes | None:
+        try:
+            if isinstance(image, np.ndarray):
+                frame = image
+            else:
+                frame = np.array(image.convert("RGB"))
+
+            if frame.ndim == 3:
+                gray = cv2.cvtColor(frame, cv2.COLOR_RGB2GRAY)
+            else:
+                gray = frame
+
+            detector = cv2.QRCodeDetector()
+            data, _points, _straight_qrcode = detector.detectAndDecode(gray)
+
+            if not data:
+                ok, decoded_infos, _points_multi, _straight_multi = detector.detectAndDecodeMulti(gray)
+                if ok and decoded_infos:
+                    for candidate in decoded_infos:
+                        if candidate:
+                            data = candidate
+                            break
+
+            if not data:
+                return None
+
+            if is_binary:
+                return data.encode("utf-8")
+            return data.encode("utf-8")
+        except Exception as exc:
+            logger.debug("OpenCV QR decode failed: %s", exc)
+            return None
 
 
     @staticmethod

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -433,6 +433,8 @@ class SettingsConstants:
     SETTING__CACHE_SCARD_PIN = "cache_scard_pin"
     SETTING__SCARD_PIN_ATTEMPTS = "scard_pin_attempts"
     SETTING__SMARTCARD_SUPPORT = "smartcard_support"
+    SETTING__SATOCHIP_SUPPORT = "satochip_support"
+    SETTING__KEYCARD_SUPPORT = "keycard_support"
     SETTING__WIPE_TIMER = "wipe_timer"
 
     SETTING__DISPLAY_CONFIGURATION = "display_config"
@@ -1054,6 +1056,20 @@ class SettingsDefinition:
                       display_name=_mft("Smartcard support"),
                       visibility=SettingsConstants.VISIBILITY__ADVANCED,
                       default_value=SettingsConstants.OPTION__ENABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                  attr_name=SettingsConstants.SETTING__SATOCHIP_SUPPORT,
+                  abbreviated_name="satochip",
+                  display_name=_mft("Satochip support"),
+                  visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                  default_value=SettingsConstants.OPTION__ENABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                  attr_name=SettingsConstants.SETTING__KEYCARD_SUPPORT,
+                  abbreviated_name="keycard",
+                  display_name=_mft("KeyCard support"),
+                  visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                  default_value=SettingsConstants.OPTION__ENABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__PRIVACY_WARNINGS,

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -1070,7 +1070,7 @@ class SettingsDefinition:
                   abbreviated_name="keycard",
                   display_name=_mft("KeyCard support"),
                   visibility=SettingsConstants.VISIBILITY__ADVANCED,
-                  default_value=SettingsConstants.OPTION__ENABLED),
+                  default_value=SettingsConstants.OPTION__DISABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                   attr_name=SettingsConstants.SETTING__SPECTER_DIY_SUPPORT,

--- a/src/seedsigner/models/settings_definition.py
+++ b/src/seedsigner/models/settings_definition.py
@@ -435,6 +435,7 @@ class SettingsConstants:
     SETTING__SMARTCARD_SUPPORT = "smartcard_support"
     SETTING__SATOCHIP_SUPPORT = "satochip_support"
     SETTING__KEYCARD_SUPPORT = "keycard_support"
+    SETTING__SPECTER_DIY_SUPPORT = "specter_diy_support"
     SETTING__WIPE_TIMER = "wipe_timer"
 
     SETTING__DISPLAY_CONFIGURATION = "display_config"
@@ -1070,6 +1071,13 @@ class SettingsDefinition:
                   display_name=_mft("KeyCard support"),
                   visibility=SettingsConstants.VISIBILITY__ADVANCED,
                   default_value=SettingsConstants.OPTION__ENABLED),
+
+        SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
+                  attr_name=SettingsConstants.SETTING__SPECTER_DIY_SUPPORT,
+                  abbreviated_name="specter_diy",
+                  display_name=_mft("Specter-DIY support"),
+                  visibility=SettingsConstants.VISIBILITY__ADVANCED,
+                  default_value=SettingsConstants.OPTION__DISABLED),
 
         SettingsEntry(category=SettingsConstants.CATEGORY__FEATURES,
                       attr_name=SettingsConstants.SETTING__PRIVACY_WARNINGS,

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -83,7 +83,11 @@ class PSBTSelectSeedView(View):
 
             button_data.append(ButtonOption(button_str, SeedSignerIconConstants.FINGERPRINT))
 
-        button_data.append(self.SATOCHIP)
+        if (
+            self.settings.get_value(SettingsConstants.SETTING__SATOCHIP_SUPPORT)
+            == SettingsConstants.OPTION__ENABLED
+        ):
+            button_data.append(self.SATOCHIP)
         button_data.append(self.SCAN_SEED)
         if self.settings.get_value(SettingsConstants.SETTING__WIF_KEYS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.SCAN_WIF)

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 class PSBTSelectSeedView(View):
     SCAN_SEED = ButtonOption("Scan a seed", SeedSignerIconConstants.QRCODE)
     SATOCHIP = ButtonOption("Use Satochip card", SeedSignerIconConstants.FINGERPRINT)
+    KEYCARD = ButtonOption("Use Keycard", SeedSignerIconConstants.FINGERPRINT)
     TYPE_12WORD = ButtonOption("Enter 12-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=12)
     TYPE_15WORD = ButtonOption("Enter 15-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=15)
     TYPE_18WORD = ButtonOption("Enter 18-word seed", FontAwesomeIconConstants.KEYBOARD, return_data=18)
@@ -88,6 +89,11 @@ class PSBTSelectSeedView(View):
             == SettingsConstants.OPTION__ENABLED
         ):
             button_data.append(self.SATOCHIP)
+        if (
+            self.settings.get_value(SettingsConstants.SETTING__KEYCARD_SUPPORT)
+            == SettingsConstants.OPTION__ENABLED
+        ):
+            button_data.append(self.KEYCARD)
         button_data.append(self.SCAN_SEED)
         if self.settings.get_value(SettingsConstants.SETTING__WIF_KEYS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.SCAN_WIF)
@@ -152,11 +158,24 @@ class PSBTSelectSeedView(View):
             from seedsigner.views.scan_views import ScanBIP38QRView
             return Destination(ScanBIP38QRView)
 
-        elif button_data[selected_menu_num] == self.SATOCHIP:
+        elif button_data[selected_menu_num] in [self.SATOCHIP, self.KEYCARD]:
             from seedsigner.helpers import seedkeeper_utils
             from embit.bip32 import HDKey
 
-            connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
+            card_choice = button_data[selected_menu_num]
+            if card_choice == self.KEYCARD:
+                backend_preference = "keycard"
+                card_label = "Keycard"
+                self.controller.smartcard_backend_preference = "keycard"
+            else:
+                backend_preference = None
+                card_label = "Satochip"
+                self.controller.smartcard_backend_preference = None
+
+            init_kwargs = {"init_card_filter": ["satochip"]}
+            if backend_preference is not None:
+                init_kwargs["backend_preference"] = backend_preference
+            connector = seedkeeper_utils.init_satochip(self, **init_kwargs)
             if not connector:
                 return Destination(PSBTSelectSeedView, clear_history=True)
 
@@ -183,7 +202,7 @@ class PSBTSelectSeedView(View):
                     parser = PSBTParser(psbt)
                     parser.parse()
                 except Exception as e:
-                    logger.exception("Failed to parse PSBT with Satochip data")
+                    logger.exception("Failed to parse PSBT with %s data", card_label)
                     self.run_screen(
                         WarningScreen,
                         title="Failed",
@@ -232,7 +251,7 @@ class PSBTSelectSeedView(View):
                     account_xpub = connector.card_bip32_get_xpub(account_path_str, xtype, is_mainnet)
                     master_xpub = connector.card_bip32_get_xpub("", xtype, is_mainnet)
                 except Exception as e:
-                    logger.exception("Failed to export xpub from Satochip card")
+                    logger.exception("Failed to export xpub from %s card", card_label)
                     loading.stop()
                     loading_stopped = True
                     self.run_screen(
@@ -256,7 +275,7 @@ class PSBTSelectSeedView(View):
                         network=network,
                     )
                 except Exception as e:
-                    logger.exception("Failed to parse PSBT with Satochip data")
+                    logger.exception("Failed to parse PSBT with %s data", card_label)
                     loading.stop()
                     loading_stopped = True
                     self.run_screen(
@@ -276,7 +295,8 @@ class PSBTSelectSeedView(View):
                 psbt_fingerprints = set(PSBTParser.get_input_fingerprints(self.controller.psbt))
                 if not card_fingerprints.intersection(psbt_fingerprints):
                     logger.warning(
-                        "Satochip fingerprint mismatch: card %s vs psbt %s",
+                        "%s fingerprint mismatch: card %s vs psbt %s",
+                        card_label,
                         sorted(card_fingerprints),
                         sorted(psbt_fingerprints),
                     )
@@ -929,30 +949,68 @@ class PSBTFinalizeView(View):
             return Destination(BackStackView)
 
         sig_cnt = PSBTParser.sig_count(psbt)
+        logger.info(
+            "PSBTFinalize: approve selected; signer_mode=%s initial_sig_count=%d inputs=%d",
+            "card" if self.controller.psbt_sign_with_satochip else "seed",
+            sig_cnt,
+            len(getattr(psbt, "inputs", []) or []),
+        )
 
         connector = None
         if self.controller.psbt_sign_with_satochip:
             from seedsigner.helpers import seedkeeper_utils
             connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
             if not connector:
+                logger.info("PSBTFinalize: card connector init failed; returning to finalize screen")
                 return Destination(PSBTFinalizeView)
+            logger.info(
+                "PSBTFinalize: card connector ready backend=%s card_type=%s uid=%s",
+                "keycard" if getattr(connector, "is_keycard_backend", False) else "pysatochip",
+                getattr(connector, "card_type", "unknown"),
+                getattr(connector, "UID_SHA1", "unknown"),
+            )
 
         from seedsigner.gui.screens.screen import LoadingScreenThread
         loading = LoadingScreenThread(text=_("Signing PSBT..."))
         loading.start()
         try:
             if self.controller.psbt_sign_with_satochip:
-                from seedsigner.helpers.satochip_signer import sign_psbt_with_satochip
-                sign_psbt_with_satochip(psbt, connector)
+                if getattr(connector, "is_keycard_backend", False):
+                    from seedsigner.helpers.keycard_signer import sign_psbt_with_keycard
+                    added = sign_psbt_with_keycard(psbt, connector)
+                else:
+                    from seedsigner.helpers.satochip_signer import sign_psbt_with_satochip
+                    added = sign_psbt_with_satochip(psbt, connector)
+                logger.info("PSBTFinalize: card signer reported added_signatures=%d", added)
             else:
                 psbt.sign_with(psbt_parser.root)
             if isinstance(self.controller.psbt_seed, WIFKey):
                 tx = finalize_psbt(psbt)
                 self.controller.signed_tx_hex = tx.serialize().hex() if tx else None
+                logger.info(
+                    "PSBTFinalize: WIF finalize result tx_present=%s hex_len=%s",
+                    tx is not None,
+                    len(self.controller.signed_tx_hex) if self.controller.signed_tx_hex else 0,
+                )
             else:
                 self.controller.signed_tx_hex = None
 
             trimmed_psbt = PSBTParser.trim(psbt)
+            trimmed_sig_cnt = PSBTParser.sig_count(trimmed_psbt)
+            logger.info(
+                "PSBTFinalize: post-sign trimmed_sig_count=%d delta=%d",
+                trimmed_sig_cnt,
+                trimmed_sig_cnt - sig_cnt,
+            )
+
+            try:
+                tx_preview = finalize_psbt(trimmed_psbt)
+                logger.info(
+                    "PSBTFinalize: finalize_psbt(trimmed) tx_present=%s",
+                    tx_preview is not None,
+                )
+            except Exception as e:
+                logger.info("PSBTFinalize: finalize_psbt(trimmed) raised=%s", e)
         except Exception:
             if self.controller.psbt_sign_with_satochip:
                 logger.exception("Failed to sign PSBT with Satochip")
@@ -962,10 +1020,15 @@ class PSBTFinalizeView(View):
             loading.stop()
 
         if sig_cnt == PSBTParser.sig_count(trimmed_psbt):
+            logger.info(
+                "PSBTFinalize: no new signatures detected; routing=%s",
+                "PSBTFinalizeView" if self.controller.psbt_sign_with_satochip else "PSBTSigningErrorView",
+            )
             if self.controller.psbt_sign_with_satochip:
                 return Destination(PSBTFinalizeView)
             return Destination(PSBTSigningErrorView)
 
+        logger.info("PSBTFinalize: signatures added; routing=PSBTSignedQRDisplayView")
         self.controller.psbt = trimmed_psbt
         self.controller.psbt_sign_with_satochip = False
         return Destination(PSBTSignedQRDisplayView)

--- a/src/seedsigner/views/scan_views.py
+++ b/src/seedsigner/views/scan_views.py
@@ -118,8 +118,29 @@ class ScanView(View):
         return finalize_xprv_seed(controller=self.controller, candidate=xprv)
 
 
+    def _scanner_unavailable_destination(self) -> Destination:
+        if DecodeQR.is_qr_scanner_available():
+            return None
+
+        return Destination(
+            ErrorView,
+            view_args=dict(
+                title="Error",
+                status_headline=_("QR Scanner Unavailable"),
+                text=_("QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."),
+                button_text=_("Back"),
+                next_destination=Destination(BackStackView, skip_current_view=True),
+            ),
+            skip_current_view=True,
+        )
+
+
     def run(self):
         from seedsigner.gui.screens.scan_screens import ScanScreen
+
+        unavailable = self._scanner_unavailable_destination()
+        if unavailable is not None:
+            return unavailable
 
         # Start the live preview and background QR reading
         self.run_screen(
@@ -395,6 +416,10 @@ class ScanSlip39ShareQRView(ScanView):
     def run(self):
         from seedsigner.gui.screens.scan_screens import ScanScreen
         from seedsigner.models.qr_type import QRType
+
+        unavailable = self._scanner_unavailable_destination()
+        if unavailable is not None:
+            return unavailable
 
         self.run_screen(
             ScanScreen,

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -271,6 +271,7 @@ class LoadSeedView(View):
     TYPE_AEZEED = ButtonOption("Enter Aezeed seed", FontAwesomeIconConstants.KEYBOARD)
     TYPE_SLIP39 = ButtonOption("SLIP-39 Shares", FontAwesomeIconConstants.KEYBOARD)
     IMPORT_SEEDKEEPER = ButtonOption("From SeedKeeper", FontAwesomeIconConstants.LOCK)
+    IMPORT_SPECTER_DIY = ButtonOption("From Specter-DIY", FontAwesomeIconConstants.LOCK)
     BITBOX_BACKUP = ButtonOption("BitBox02 backup", SeedSignerIconConstants.MICROSD)
     PASSPORT_BACKUP = ButtonOption("Passport backup", SeedSignerIconConstants.MICROSD)
     TAPSIGNER_BACKUP = ButtonOption("TAPSIGNER backup", SeedSignerIconConstants.MICROSD)
@@ -292,6 +293,9 @@ class LoadSeedView(View):
 
         if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.IMPORT_SEEDKEEPER)
+
+        if self.settings.get_value(SettingsConstants.SETTING__SPECTER_DIY_SUPPORT) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.IMPORT_SPECTER_DIY)
 
         if self.settings.get_value(SettingsConstants.SETTING__SLIP39_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_SLIP39)
@@ -333,6 +337,10 @@ class LoadSeedView(View):
 
         elif button_data[selected_menu_num] == self.IMPORT_SEEDKEEPER:
             return Destination(SeedKeeperSelectView)
+
+        elif button_data[selected_menu_num] == self.IMPORT_SPECTER_DIY:
+            from .tools_views import ToolsJavacardLoadMnemonicView
+            return Destination(ToolsJavacardLoadMnemonicView)
 
         elif button_data[selected_menu_num] == self.TYPE_ELECTRUM:
             return Destination(SeedElectrumMnemonicStartView)
@@ -2124,6 +2132,7 @@ class SeedBackupView(View):
     EXPORT_SEEDQR = ButtonOption("Export as SeedQR")
     EXPORT_PLAINTEXTQR = ButtonOption("Export as Plaintext QR")
     TO_SEEDKEEPER = ButtonOption("To SeedKeeper")
+    TO_SPECTER_DIY = ButtonOption("To Specter-DIY")
     REGENERATE_SHARES = ButtonOption("Regenerate Shares")
 
     def __init__(self, seed_num):
@@ -2137,6 +2146,8 @@ class SeedBackupView(View):
         button_data = [self.VIEW_WORDS]
         if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TO_SEEDKEEPER)
+        if self.settings.get_value(SettingsConstants.SETTING__SPECTER_DIY_SUPPORT) == SettingsConstants.OPTION__ENABLED:
+            button_data.append(self.TO_SPECTER_DIY)
         if isinstance(self.seed, Slip39Seed):
             button_data.append(self.REGENERATE_SHARES)
 
@@ -2174,6 +2185,10 @@ class SeedBackupView(View):
             if isinstance(self.seed, Slip39Seed):
                 return Destination(SeedSlip39SelectShareView, view_args={"seed_num": self.seed_num, "next_view": SaveToSeedkeeperView})
             return Destination(SaveToSeedkeeperView, view_args={"seed_num": self.seed_num})
+
+        elif button_data[selected_menu_num] == self.TO_SPECTER_DIY:
+            from .tools_views import ToolsJavacardSaveMnemonicView
+            return Destination(ToolsJavacardSaveMnemonicView)
 
         elif button_data[selected_menu_num] == self.REGENERATE_SHARES:
             return Destination(SeedSlip39RegenerateSharesView, view_args={"seed_num": self.seed_num})

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -161,7 +161,10 @@ class SeedSelectSeedView(View):
         for seed in seeds:
             button_str = seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
             button_data.append(ButtonOption(button_str, SeedSignerIconConstants.FINGERPRINT, icon_color="blue"))
-        if self.flow in [Controller.FLOW__SIGN_MESSAGE, Controller.FLOW__VERIFY_SINGLESIG_ADDR]:
+        if (
+            self.flow in [Controller.FLOW__SIGN_MESSAGE, Controller.FLOW__VERIFY_SINGLESIG_ADDR]
+            and self.settings.get_value(SettingsConstants.SETTING__SATOCHIP_SUPPORT) == SettingsConstants.OPTION__ENABLED
+        ):
             button_data.append(self.SATOCHIP)
 
         button_data.append(self.SCAN_SEED)

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1187,7 +1187,13 @@ class SeedFinalizeView(View):
         )
 
         if button_data[selected_menu_num] == self.FINALIZE:
+            from seedsigner.controller import Controller
             seed_num = self.controller.storage.finalize_pending_seed()
+            if self.controller.resume_main_flow == Controller.FLOW__SATOCHIP_IMPORT_SEED:
+                from seedsigner.views.tools_views import ToolsSatochipImportSeedView
+
+                self.controller.resume_main_flow = None
+                return Destination(ToolsSatochipImportSeedView, clear_history=True)
             return Destination(SeedOptionsView, view_args={"seed_num": seed_num}, clear_history=True)
 
         elif button_data[selected_menu_num] == self.TYPE_PASSPHRASE:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -3464,7 +3464,7 @@ class ToolsKeycardChangePinView(View):
         if not connector:
             return Destination(BackStackView)
 
-        new_pin_str = seedkeeper_utils.prompt_for_pin(self, "New PIN")
+        new_pin_str = _prompt_keycard_new_pin(self, "New PIN")
         if new_pin_str is None:
             return Destination(BackStackView)
 
@@ -3480,13 +3480,21 @@ class ToolsKeycardChangePinView(View):
                 show_back_button=False,
             )
         else:
-            self.run_screen(
-                WarningScreen,
-                title="Failed",
-                status_headline=None,
-                text="PIN update failed",
-                show_back_button=True,
-            )
+            if sw1 == 0x63 and (sw2 & 0xF0) == 0xC0:
+                seedkeeper_utils.show_incorrect_pin_warning(
+                    self,
+                    connector=connector,
+                    sw1=sw1,
+                    sw2=sw2,
+                )
+            else:
+                self.run_screen(
+                    WarningScreen,
+                    title="Failed",
+                    status_headline=None,
+                    text="PIN update failed",
+                    show_back_button=True,
+                )
         return Destination(MainMenuView)
 
 
@@ -3560,7 +3568,7 @@ class ToolsKeycardUnblockPinView(View):
             )
             return Destination(BackStackView)
 
-        new_pin_str = seedkeeper_utils.prompt_for_pin(self, "New PIN")
+        new_pin_str = _prompt_keycard_new_pin(self, "New PIN")
         if new_pin_str is None:
             return Destination(BackStackView)
 
@@ -3579,13 +3587,21 @@ class ToolsKeycardUnblockPinView(View):
                 show_back_button=False,
             )
         else:
-            self.run_screen(
-                WarningScreen,
-                title="Failed",
-                status_headline=None,
-                text="PIN unblock failed",
-                show_back_button=True,
-            )
+            if sw1 == 0x63 and (sw2 & 0xF0) == 0xC0:
+                seedkeeper_utils.show_incorrect_pin_warning(
+                    self,
+                    connector=connector,
+                    sw1=sw1,
+                    sw2=sw2,
+                )
+            else:
+                self.run_screen(
+                    WarningScreen,
+                    title="Failed",
+                    status_headline=None,
+                    text="PIN unblock failed",
+                    show_back_button=True,
+                )
         return Destination(MainMenuView)
 
 
@@ -3614,13 +3630,21 @@ class ToolsKeycardSetNameView(View):
                 show_back_button=False,
             )
         else:
-            self.run_screen(
-                WarningScreen,
-                title="Failed",
-                status_headline=None,
-                text="Name update failed",
-                show_back_button=True,
-            )
+            if sw1 == 0x63 and (sw2 & 0xF0) == 0xC0:
+                seedkeeper_utils.show_incorrect_pin_warning(
+                    self,
+                    connector=connector,
+                    sw1=sw1,
+                    sw2=sw2,
+                )
+            else:
+                self.run_screen(
+                    WarningScreen,
+                    title="Failed",
+                    status_headline=None,
+                    text="Name update failed",
+                    show_back_button=True,
+                )
         return Destination(MainMenuView)
 
 
@@ -3991,11 +4015,12 @@ class ToolsSatochipImportSeedView(View):
         # appropriate action (like resetting the card) before proceeding.
         _resp, _sw1, _sw2, status = Satochip_Connector.card_get_status()
         if status.get("is_seeded"):
+            card_name = "Keycard" if getattr(Satochip_Connector, "is_keycard_backend", False) else "Satochip"
             self.run_screen(
                 WarningScreen,
                 title=_("Already Seeded"),
                 status_headline=None,
-                text=_("Satochip card already contains a seed."),
+                text=_(f"{card_name} card already contains a seed."),
                 show_back_button=False,
             )
             return Destination(MainMenuView)
@@ -5173,6 +5198,37 @@ def _prompt_specter_new_pin(parent_view, title: str) -> str | None:
         )
         if selected == 0:
             return pin
+
+
+def _prompt_keycard_new_pin(parent_view, title: str) -> str | None:
+    while True:
+        ret = seed_screens.SeedAddPassphraseScreen(title=title).display()
+        if isinstance(ret, dict) and "is_back_button" in ret:
+            return None
+
+        pin = ret.get("passphrase", "")
+        if all(ch in "0123456789" for ch in pin):
+            if len(pin) == 6:
+                return pin
+
+            parent_view.run_screen(
+                WarningScreen,
+                title="Invalid PIN Length",
+                status_headline=None,
+                text="Keycard PIN must be exactly 6 digits.",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            continue
+
+        parent_view.run_screen(
+            WarningScreen,
+            title="Non-Numeric PIN",
+            status_headline=None,
+            text="Keycard PIN must contain digits 0-9 only.",
+            show_back_button=False,
+            button_data=[ButtonOption("I Understand")],
+        )
 
 
 def _unlock_specter_card_if_needed(parent_view, secure_applet, secure_channel) -> bool:

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -1117,7 +1117,7 @@ class ToolsAddressExplorerSelectSourceView(View):
         # Most of the options require us to go through a side flow(s) before we can
         # continue to the address explorer. Set the Controller-level flow so that it
         # knows to re-route us once the side flow is complete.        
-        self.controller.resume_main_flow = Controller.FLOW__ADDRESS_EXPLORER
+        self.controller.resume_main_flow = self.controller.FLOW__ADDRESS_EXPLORER
 
         if len(seeds) > 0 and selected_menu_num < len(seeds):
             # User selected one of the n seeds
@@ -4068,7 +4068,7 @@ class ToolsSatochipImportSeedView(View):
         # Most of the options require us to go through a side flow(s) before we can
         # continue to the address explorer. Set the Controller-level flow so that it
         # knows to re-route us once the side flow is complete.        
-        self.controller.resume_main_flow = Controller.FLOW__SATOCHIP_IMPORT_SEED
+        self.controller.resume_main_flow = self.controller.FLOW__SATOCHIP_IMPORT_SEED
 
         if len(seeds) > 0 and selected_menu_num < len(seeds):
             # User selected one of the n seeds
@@ -4086,7 +4086,24 @@ class ToolsSatochipImportSeedView(View):
                 self.loading_screen = LoadingScreenThread(text="Importing Secret\n\n\n\n\n\n")
                 self.loading_screen.start()
 
-                Satochip_Connector.card_bip32_import_seed(seeds[selected_menu_num].seed_bytes)
+                _resp, sw1, sw2 = Satochip_Connector.card_bip32_import_seed(seeds[selected_menu_num].seed_bytes)
+                if (sw1, sw2) != (0x90, 0x00):
+                    if (
+                        getattr(Satochip_Connector, "is_keycard_backend", False)
+                        and (sw1, sw2) == (0x69, 0x85)
+                    ):
+                        raise ValueError(
+                            "Keycard blocked seed import (SW=6985).\n"
+                            "Try Factory Reset Card, then retry import."
+                        )
+                    raise ValueError(f"Import failed with SW={sw1:02X}{sw2:02X}")
+
+                _status_resp, status_sw1, status_sw2, post_status = Satochip_Connector.card_get_status()
+                if (status_sw1, status_sw2) != (0x90, 0x00):
+                    raise ValueError(f"Status check failed with SW={status_sw1:02X}{status_sw2:02X}")
+
+                if not (post_status.get("is_seeded") or post_status.get("key_initialized")):
+                    raise ValueError("Card did not report a seeded key after import")
 
                 self.loading_screen.stop()
 
@@ -4101,11 +4118,14 @@ class ToolsSatochipImportSeedView(View):
             except Exception as e:
                 self.loading_screen.stop()
                 logger.exception("Satochip Import Failed: %s", e)
+                error_text = str(e) or "Seed Import Failed"
+                if len(error_text) > 120:
+                    error_text = error_text[:120]
                 self.run_screen(
                     WarningScreen,
                     title="Failed",
                     status_headline=None,
-                    text=f"Seed Import Failed",
+                    text=error_text,
                     show_back_button=False,
                 )
 
@@ -4729,11 +4749,10 @@ class SatochipLoadDescriptorDetailsView(View):
             return Destination(BackStackView)
 
         self.controller.multisig_wallet_descriptor = descriptor
-        from seedsigner.controller import Controller
-        if self.controller.resume_main_flow == Controller.FLOW__ADDRESS_EXPLORER:
+        if self.controller.resume_main_flow == self.controller.FLOW__ADDRESS_EXPLORER:
             from seedsigner.views.seed_views import MultisigWalletDescriptorView
             return Destination(MultisigWalletDescriptorView, skip_current_view=True)
-        elif self.controller.resume_main_flow == Controller.FLOW__VERIFY_SINGLESIG_ADDR:
+        elif self.controller.resume_main_flow == self.controller.FLOW__VERIFY_SINGLESIG_ADDR:
             from seedsigner.views.seed_views import SeedAddressVerificationView
             self.controller.resume_main_flow = None
             return Destination(SeedAddressVerificationView, skip_current_view=True)
@@ -7023,7 +7042,7 @@ class ToolsGPGMenuView(View):
             )
             return Destination(BackStackView)
 
-        if self.controller.resume_main_flow == Controller.FLOW__GPG_MESSAGE:
+        if self.controller.resume_main_flow == self.controller.FLOW__GPG_MESSAGE:
             self.controller.resume_main_flow = None
             return Destination(ToolsGPGDecryptMessageView, skip_current_view=True)
 
@@ -10023,9 +10042,8 @@ class ToolsGPGDecryptMessageView(View):
                     button_data=[load, cont],
                 )
                 if selected == 0:
-                    from seedsigner.controller import Controller
                     self.controller.gpg_pending_message = ciphertext
-                    self.controller.resume_main_flow = Controller.FLOW__GPG_MESSAGE
+                    self.controller.resume_main_flow = self.controller.FLOW__GPG_MESSAGE
                     return Destination(ToolsGPGImportPrivkeyMenuView)
                 return Destination(BackStackView)
 
@@ -10055,9 +10073,8 @@ class ToolsGPGDecryptMessageView(View):
                     button_data=[load, cont],
                 )
                 if selected == 0:
-                    from seedsigner.controller import Controller
                     self.controller.gpg_pending_message = ciphertext
-                    self.controller.resume_main_flow = Controller.FLOW__GPG_MESSAGE
+                    self.controller.resume_main_flow = self.controller.FLOW__GPG_MESSAGE
                     return Destination(ToolsGPGImportPubkeyMenuView)
             if verified:
                 self.run_screen(

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -1091,11 +1091,13 @@ class ToolsAddressExplorerSelectSourceView(View):
             21: self.TYPE_21WORD,
             24: self.TYPE_24WORD,
         }
-        button_data = (
-            button_data
-            + [self.SCAN_SEED, self.SCAN_DESCRIPTOR, self.SATOCHIP]
-            + [options[l] for l in seed_lengths]
-        )
+        button_data = button_data + [self.SCAN_SEED, self.SCAN_DESCRIPTOR]
+        if (
+            self.settings.get_value(SettingsConstants.SETTING__SATOCHIP_SUPPORT)
+            == SettingsConstants.OPTION__ENABLED
+        ):
+            button_data.append(self.SATOCHIP)
+        button_data += [options[l] for l in seed_lengths]
         if self.settings.get_value(SettingsConstants.SETTING__ELECTRUM_SEEDS) == SettingsConstants.OPTION__ENABLED:
             button_data.append(self.TYPE_ELECTRUM)
 
@@ -1392,11 +1394,25 @@ class ToolsTextQRView(View):
 class ToolsSmartcardMenuView(View):
     COMMON = ButtonOption("Common Functions")
     SATOCHIP = ButtonOption("Satochip Functions")
+    KEYCARD = ButtonOption("KeyCard Functions")
     SEEDKEEPER = ButtonOption("SeedKeeper Functions")
     Satochip_DIY = ButtonOption("DIY Tools")
 
     def run(self):
-        button_data = [self.COMMON, self.SEEDKEEPER, self.SATOCHIP, self.Satochip_DIY]
+        button_data = [self.COMMON, self.SEEDKEEPER]
+        satochip_enabled = (
+            self.settings.get_value(SettingsConstants.SETTING__SATOCHIP_SUPPORT)
+            == SettingsConstants.OPTION__ENABLED
+        )
+        keycard_enabled = (
+            self.settings.get_value(SettingsConstants.SETTING__KEYCARD_SUPPORT)
+            == SettingsConstants.OPTION__ENABLED
+        )
+        if satochip_enabled:
+            button_data.append(self.SATOCHIP)
+        if keycard_enabled:
+            button_data.append(self.KEYCARD)
+        button_data.append(self.Satochip_DIY)
 
         selected_menu_num = self.run_screen(
             ButtonListScreen,
@@ -1409,15 +1425,23 @@ class ToolsSmartcardMenuView(View):
             return Destination(BackStackView)
 
         elif button_data[selected_menu_num] == self.COMMON:
+            self.controller.smartcard_backend_preference = None
             return Destination(ToolsCommonView)
         
         elif button_data[selected_menu_num] == self.SATOCHIP:
+            self.controller.smartcard_backend_preference = None
             return Destination(ToolsSatochipView)
+
+        elif button_data[selected_menu_num] == self.KEYCARD:
+            self.controller.smartcard_backend_preference = "keycard"
+            return Destination(ToolsKeycardView)
         
         elif button_data[selected_menu_num] == self.SEEDKEEPER:
+            self.controller.smartcard_backend_preference = None
             return Destination(ToolsSeedkeeperView)
 
         elif button_data[selected_menu_num] == self.Satochip_DIY:
+            self.controller.smartcard_backend_preference = None
             return Destination(ToolsSatochipDIYView)
 
 class ToolsCommonView(View):
@@ -3349,6 +3373,327 @@ class ToolsSatochipView(View):
             return Destination(ToolsSatochipLoadPsbtView)
         elif button_data[selected_menu_num] == self.ADVANCED:
             return Destination(ToolsSatochipAdvancedView)
+
+
+class ToolsKeycardView(View):
+    IMPORT_SEED = ButtonOption("Initialise with Seed")
+    EXPORT_XPUB = ButtonOption("Export Xpub")
+    LOAD_DESCRIPTOR = ButtonOption("Load as Descriptor")
+    LOAD_PSBT = ButtonOption("Load PSBT")
+    CHANGE_PIN = ButtonOption("Change PIN")
+    CHANGE_PUK = ButtonOption("Set PUK")
+    UNBLOCK_PIN = ButtonOption("Unblock PIN with PUK")
+    SET_NAME = ButtonOption("Set Name")
+    REMOVE_SEED = ButtonOption("Remove Seed")
+    FACTORY_RESET = ButtonOption("Factory Reset Card")
+
+    def run(self):
+        self.controller.smartcard_backend_preference = "keycard"
+        button_data = [
+            self.IMPORT_SEED,
+            self.EXPORT_XPUB,
+            self.LOAD_DESCRIPTOR,
+            self.LOAD_PSBT,
+            self.CHANGE_PIN,
+            self.CHANGE_PUK,
+            self.UNBLOCK_PIN,
+            self.SET_NAME,
+            self.REMOVE_SEED,
+            self.FACTORY_RESET,
+        ]
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title="KeyCard",
+            is_button_text_centered=False,
+            button_data=button_data,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        elif button_data[selected_menu_num] == self.IMPORT_SEED:
+            return Destination(ToolsSatochipImportSeedView)
+
+        elif button_data[selected_menu_num] == self.EXPORT_XPUB:
+            return Destination(SatochipExportXpubSigTypeView)
+
+        elif button_data[selected_menu_num] == self.LOAD_DESCRIPTOR:
+            return Destination(SatochipLoadDescriptorScriptTypeView)
+
+        elif button_data[selected_menu_num] == self.LOAD_PSBT:
+            return Destination(ToolsSatochipLoadPsbtView)
+
+        elif button_data[selected_menu_num] == self.CHANGE_PIN:
+            return Destination(ToolsKeycardChangePinView)
+
+        elif button_data[selected_menu_num] == self.CHANGE_PUK:
+            return Destination(ToolsKeycardChangePukView)
+
+        elif button_data[selected_menu_num] == self.UNBLOCK_PIN:
+            return Destination(ToolsKeycardUnblockPinView)
+
+        elif button_data[selected_menu_num] == self.SET_NAME:
+            return Destination(ToolsKeycardSetNameView)
+
+        elif button_data[selected_menu_num] == self.REMOVE_SEED:
+            return Destination(ToolsKeycardRemoveSeedView)
+
+        elif button_data[selected_menu_num] == self.FACTORY_RESET:
+            return Destination(ToolsKeycardFactoryResetView)
+
+
+class ToolsKeycardChangePinView(View):
+    def run(self):
+        connector = seedkeeper_utils.init_satochip(
+            self,
+            init_card_filter=["satochip"],
+            backend_preference="keycard",
+        )
+        if not connector:
+            return Destination(BackStackView)
+
+        new_pin_str = seedkeeper_utils.prompt_for_pin(self, "New PIN")
+        if new_pin_str is None:
+            return Destination(BackStackView)
+
+        new_pin = list(new_pin_str.encode("utf-8"))
+        _response, sw1, sw2 = connector.card_change_PIN(0, connector.pin, new_pin)
+        if sw1 == 0x90 and sw2 == 0x00:
+            self.controller.Satochip_PIN = new_pin
+            self.run_screen(
+                LargeIconStatusScreen,
+                title="Success",
+                status_headline=None,
+                text="PIN Updated",
+                show_back_button=False,
+            )
+        else:
+            self.run_screen(
+                WarningScreen,
+                title="Failed",
+                status_headline=None,
+                text="PIN update failed",
+                show_back_button=True,
+            )
+        return Destination(MainMenuView)
+
+
+class ToolsKeycardChangePukView(View):
+    def run(self):
+        connector = seedkeeper_utils.init_satochip(
+            self,
+            init_card_filter=["satochip"],
+            backend_preference="keycard",
+        )
+        if not connector:
+            return Destination(BackStackView)
+
+        ret = seed_screens.SeedAddPassphraseScreen(title="New PUK").display()
+        if "is_back_button" in ret:
+            return Destination(BackStackView)
+
+        new_puk_str = ret.get("passphrase", "")
+        if len(new_puk_str) < 4:
+            self.run_screen(
+                WarningScreen,
+                title="Invalid PUK",
+                status_headline=None,
+                text="PUK must be at least 4 chars",
+                show_back_button=True,
+            )
+            return Destination(BackStackView)
+
+        _response, sw1, sw2 = connector.card_change_PUK(0, [], list(new_puk_str.encode("utf-8")))
+        if sw1 == 0x90 and sw2 == 0x00:
+            self.run_screen(
+                LargeIconStatusScreen,
+                title="Success",
+                status_headline=None,
+                text="PUK Updated",
+                show_back_button=False,
+            )
+        else:
+            self.run_screen(
+                WarningScreen,
+                title="Failed",
+                status_headline=None,
+                text="PUK update failed",
+                show_back_button=True,
+            )
+        return Destination(MainMenuView)
+
+
+class ToolsKeycardUnblockPinView(View):
+    def run(self):
+        connector = seedkeeper_utils.init_satochip(
+            self,
+            init_card_filter=["satochip"],
+            require_pin=False,
+            backend_preference="keycard",
+        )
+        if not connector:
+            return Destination(BackStackView)
+
+        puk_ret = seed_screens.SeedAddPassphraseScreen(title="PUK").display()
+        if "is_back_button" in puk_ret:
+            return Destination(BackStackView)
+        puk_str = puk_ret.get("passphrase", "")
+        if len(puk_str) < 4:
+            self.run_screen(
+                WarningScreen,
+                title="Invalid PUK",
+                status_headline=None,
+                text="PUK must be at least 4 chars",
+                show_back_button=True,
+            )
+            return Destination(BackStackView)
+
+        new_pin_str = seedkeeper_utils.prompt_for_pin(self, "New PIN")
+        if new_pin_str is None:
+            return Destination(BackStackView)
+
+        _response, sw1, sw2 = connector.card_unblock_PIN(
+            0,
+            list(puk_str.encode("utf-8")),
+            list(new_pin_str.encode("utf-8")),
+        )
+        if sw1 == 0x90 and sw2 == 0x00:
+            self.controller.Satochip_PIN = list(new_pin_str.encode("utf-8"))
+            self.run_screen(
+                LargeIconStatusScreen,
+                title="Success",
+                status_headline=None,
+                text="PIN Unblocked",
+                show_back_button=False,
+            )
+        else:
+            self.run_screen(
+                WarningScreen,
+                title="Failed",
+                status_headline=None,
+                text="PIN unblock failed",
+                show_back_button=True,
+            )
+        return Destination(MainMenuView)
+
+
+class ToolsKeycardSetNameView(View):
+    def run(self):
+        connector = seedkeeper_utils.init_satochip(
+            self,
+            init_card_filter=["satochip"],
+            backend_preference="keycard",
+        )
+        if not connector:
+            return Destination(BackStackView)
+
+        ret = seed_screens.SeedAddPassphraseScreen(title="New Name").display()
+        if "is_back_button" in ret:
+            return Destination(BackStackView)
+        label = ret.get("passphrase", "")
+
+        _response, sw1, sw2 = connector.card_set_label(label)
+        if sw1 == 0x90 and sw2 == 0x00:
+            self.run_screen(
+                LargeIconStatusScreen,
+                title="Success",
+                status_headline=None,
+                text="Name Updated",
+                show_back_button=False,
+            )
+        else:
+            self.run_screen(
+                WarningScreen,
+                title="Failed",
+                status_headline=None,
+                text="Name update failed",
+                show_back_button=True,
+            )
+        return Destination(MainMenuView)
+
+
+class ToolsKeycardRemoveSeedView(View):
+    def run(self):
+        connector = seedkeeper_utils.init_satochip(
+            self,
+            init_card_filter=["satochip"],
+            backend_preference="keycard",
+        )
+        if not connector:
+            return Destination(BackStackView)
+
+        ret = self.run_screen(
+            DireWarningScreen,
+            title="Warning",
+            status_headline=None,
+            text="Remove key from card?",
+            show_back_button=True,
+            button_data=[ButtonOption("Remove")],
+        )
+        if ret == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        _response, sw1, sw2 = connector.card_remove_key()
+        if sw1 == 0x90 and sw2 == 0x00:
+            self.run_screen(
+                LargeIconStatusScreen,
+                title="Success",
+                status_headline=None,
+                text="Seed Removed",
+                show_back_button=False,
+            )
+        else:
+            self.run_screen(
+                WarningScreen,
+                title="Failed",
+                status_headline=None,
+                text="Remove seed failed",
+                show_back_button=True,
+            )
+        return Destination(MainMenuView)
+
+
+class ToolsKeycardFactoryResetView(View):
+    def run(self):
+        connector = seedkeeper_utils.init_satochip(
+            self,
+            init_card_filter=["satochip"],
+            backend_preference="keycard",
+        )
+        if not connector:
+            return Destination(BackStackView)
+
+        ret = self.run_screen(
+            DireWarningScreen,
+            title="Warning",
+            status_headline=None,
+            text="Factory reset without backup loses funds.",
+            show_back_button=True,
+            button_data=[ButtonOption("Reset")],
+        )
+        if ret == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        _response, sw1, sw2 = connector.card_reset_factory()
+        if sw1 == 0x90 and sw2 == 0x00:
+            self.controller.Satochip_PIN = None
+            self.controller.Satochip_Connector = None
+            self.run_screen(
+                LargeIconStatusScreen,
+                title="Success",
+                status_headline=None,
+                text="Card Factory Reset",
+                show_back_button=False,
+            )
+        else:
+            self.run_screen(
+                WarningScreen,
+                title="Failed",
+                status_headline=None,
+                text="Factory reset failed",
+                show_back_button=True,
+            )
+        return Destination(MainMenuView)
 
 
 class ToolsSatochipLoadPsbtView(View):

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -1,8 +1,10 @@
 import base64
 import hashlib
+import hmac
 import json
 import logging
 import os
+import sys
 import time
 import platform
 import binascii
@@ -42,7 +44,7 @@ from seedsigner.helpers.iso7816 import format_sw_error
 from seedsigner.models.decode_qr import DecodeQR
 from seedsigner.models.encode_qr import GenericStaticQrEncoder
 from seedsigner.gui.screens.screen import ButtonOption
-from seedsigner.models.seed import Seed
+from seedsigner.models.seed import Seed, InvalidSeedException
 from seedsigner.models.seed import XprvSeed
 from seedsigner.models.settings_definition import SettingsConstants
 from seedsigner.views.seed_views import (
@@ -1396,6 +1398,7 @@ class ToolsSmartcardMenuView(View):
     SATOCHIP = ButtonOption("Satochip Functions")
     KEYCARD = ButtonOption("KeyCard Functions")
     SEEDKEEPER = ButtonOption("SeedKeeper Functions")
+    SPECTER_DIY = ButtonOption("Specter-DIY Functions")
     Satochip_DIY = ButtonOption("DIY Tools")
 
     def run(self):
@@ -1408,10 +1411,16 @@ class ToolsSmartcardMenuView(View):
             self.settings.get_value(SettingsConstants.SETTING__KEYCARD_SUPPORT)
             == SettingsConstants.OPTION__ENABLED
         )
+        specter_diy_enabled = (
+            self.settings.get_value(SettingsConstants.SETTING__SPECTER_DIY_SUPPORT)
+            == SettingsConstants.OPTION__ENABLED
+        )
         if satochip_enabled:
             button_data.append(self.SATOCHIP)
         if keycard_enabled:
             button_data.append(self.KEYCARD)
+        if specter_diy_enabled:
+            button_data.append(self.SPECTER_DIY)
         button_data.append(self.Satochip_DIY)
 
         selected_menu_num = self.run_screen(
@@ -1439,6 +1448,9 @@ class ToolsSmartcardMenuView(View):
         elif button_data[selected_menu_num] == self.SEEDKEEPER:
             self.controller.smartcard_backend_preference = None
             return Destination(ToolsSeedkeeperView)
+
+        elif button_data[selected_menu_num] == self.SPECTER_DIY:
+            return Destination(ToolsSpecterDIYView)
 
         elif button_data[selected_menu_num] == self.Satochip_DIY:
             self.controller.smartcard_backend_preference = None
@@ -4705,6 +4717,222 @@ class SatochipLoadDescriptorDetailsView(View):
 
         return Destination(MainMenuView)
 
+
+class ToolsSpecterDIYView(View):
+    CHANGE_PIN = ButtonOption("Change Card PIN")
+    LOAD_MNEMONIC = ButtonOption("Load Mnemonic")
+    SAVE_MNEMONIC = ButtonOption("Save Mnemonic")
+    WIPE_MNEMONIC = ButtonOption("Wipe Seed")
+
+    def run(self):
+        button_data = [self.CHANGE_PIN, self.LOAD_MNEMONIC, self.SAVE_MNEMONIC, self.WIPE_MNEMONIC]
+
+        selected_menu_num = self.run_screen(
+            ButtonListScreen,
+            title="Specter-DIY",
+            is_button_text_centered=False,
+            button_data=button_data,
+        )
+
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        choice = button_data[selected_menu_num]
+        if choice == self.CHANGE_PIN:
+            return Destination(ToolsSpecterDIYChangePinView)
+        if choice == self.LOAD_MNEMONIC:
+            return Destination(ToolsJavacardLoadMnemonicView)
+        if choice == self.SAVE_MNEMONIC:
+            return Destination(ToolsJavacardSaveMnemonicView)
+        return Destination(ToolsJavacardWipeMnemonicView)
+
+
+class ToolsJavacardWipeMnemonicView(View):
+    def run(self):
+        from seedsigner.gui.screens.screen import LoadingScreenThread
+
+        conn = None
+        secure_channel = None
+        try:
+            Card, MemoryCardApplet, SecureApplet = _get_specter_card_api()
+            conn = Card(SPECTER_JAVACARD_DEFAULT_AID)
+            conn.connect()
+            secure_applet = SecureApplet(conn)
+            memory_applet = MemoryCardApplet(conn)
+            secure_channel = _open_specter_secure_channel(secure_applet)
+            if not _unlock_specter_card_if_needed(self, secure_applet, secure_channel):
+                return Destination(BackStackView)
+
+            existing_data = memory_applet.get_data(secure_channel)
+            if not existing_data:
+                self.run_screen(
+                    WarningScreen,
+                    title="No Seed Found",
+                    status_headline=None,
+                    text="No seed data found on Specter Javacard.",
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
+
+            confirm = self.run_screen(
+                WarningScreen,
+                title="Wipe Seed?",
+                status_headline=None,
+                text="Delete stored seed data from card?",
+                show_back_button=False,
+                button_data=[ButtonOption("Wipe Seed"), ButtonOption("Cancel")],
+            )
+            if confirm != 0:
+                return Destination(BackStackView)
+
+            loading = LoadingScreenThread(text="Wiping Seed\n\n\n\n\n\n")
+            loading.start()
+            memory_applet.store_data(secure_channel, b"")
+            loading.stop()
+
+            self.run_screen(
+                LargeIconStatusScreen,
+                title="Seed Wiped",
+                status_headline=None,
+                text="Seed data deleted from Specter Javacard",
+                show_back_button=False,
+            )
+            return Destination(BackStackView)
+        except Exception as exc:
+            self.run_screen(
+                WarningScreen,
+                title="Wipe Failed",
+                status_headline=None,
+                text=str(exc),
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+        finally:
+            if secure_channel is not None:
+                try:
+                    secure_channel.close()
+                except Exception:
+                    pass
+            if conn is not None:
+                try:
+                    conn.disconnect()
+                except Exception:
+                    pass
+
+
+class ToolsSpecterDIYChangePinView(View):
+    def run(self):
+        conn = None
+        secure_channel = None
+        try:
+            Card, MemoryCardApplet, SecureApplet = _get_specter_card_api()
+            conn = Card(SPECTER_JAVACARD_DEFAULT_AID)
+            conn.connect()
+            secure_applet = SecureApplet(conn)
+            secure_channel = _open_specter_secure_channel(secure_applet)
+
+            status = secure_applet.pin_status(secure_channel)
+            pin_status = status.get("status")
+
+            if pin_status == "bricked":
+                _show_specter_card_bricked_warning(self)
+                return Destination(BackStackView)
+
+            if pin_status in ("disabled", "no_pin"):
+                # PIN is not set; prompt user to set a new PIN
+                new_pin = _prompt_specter_new_pin(self, "Set New PIN")
+                if new_pin is None:
+                    return Destination(BackStackView)
+                if not new_pin:
+                    self.run_screen(
+                        WarningScreen,
+                        title="Invalid PIN",
+                        status_headline=None,
+                        text="PIN cannot be empty.",
+                        show_back_button=False,
+                        button_data=[ButtonOption("I Understand")],
+                    )
+                    return Destination(BackStackView)
+                secure_applet.set_pin(secure_channel, new_pin.encode("utf-8"))
+                self.run_screen(
+                    LargeIconStatusScreen,
+                    title="PIN Set",
+                    status_headline=None,
+                    text="Card PIN has been set.",
+                    show_back_button=False,
+                )
+                return Destination(BackStackView)
+
+            # PIN is set; prompt for the current PIN once, then the new PIN.
+            ret = seed_screens.SeedAddPassphraseScreen(title="Current PIN").display()
+            if isinstance(ret, dict) and "is_back_button" in ret:
+                return Destination(BackStackView)
+            old_pin = ret.get("passphrase", "")
+            if not old_pin:
+                self.run_screen(
+                    WarningScreen,
+                    title="Invalid PIN",
+                    status_headline=None,
+                    text="PIN cannot be empty.",
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
+
+            new_pin = _prompt_specter_new_pin(self, "New PIN")
+            if new_pin is None:
+                return Destination(BackStackView)
+            if not new_pin:
+                self.run_screen(
+                    WarningScreen,
+                    title="Invalid PIN",
+                    status_headline=None,
+                    text="PIN cannot be empty.",
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
+
+            try:
+                secure_applet.change_pin(secure_channel, old_pin.encode("utf-8"), new_pin.encode("utf-8"))
+            except Exception as exc:
+                if _is_specter_pin_error(exc):
+                    _show_specter_incorrect_pin_warning(self, secure_applet, secure_channel)
+                    return Destination(BackStackView)
+                raise
+            self.run_screen(
+                LargeIconStatusScreen,
+                title="PIN Changed",
+                status_headline=None,
+                text="Card PIN has been changed.",
+                show_back_button=False,
+            )
+            return Destination(BackStackView)
+        except Exception as exc:
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text=str(exc),
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+        finally:
+            if secure_channel is not None:
+                try:
+                    secure_channel.close()
+                except Exception:
+                    pass
+            if conn is not None:
+                try:
+                    conn.disconnect()
+                except Exception:
+                    pass
+
+
 class ToolsSatochipDIYView(View):
     MANAGE_KEYS = ButtonOption("Card Keys")
     BUILD_APPLETS = ButtonOption("Build Applets")
@@ -4766,6 +4994,219 @@ class ToolsSatochipDIYView(View):
 
 JAVACARD_KEYS_MICROSD_FILENAME = "javacard-keys.txt"
 JAVACARD_KEYS_SEEDKEEPER_PREFIX = "jc_keys_"
+SPECTER_JAVACARD_DEFAULT_AID = "B00B5111CB01"
+
+
+def _candidate_specter_card_paths() -> list[Path]:
+    candidates: list[Path] = []
+    env_path = (
+        os.environ.get("SEEDSIGNER_SPECTER_CARD_PY_PATH")
+        or os.environ.get("SEEDSIGNER_SPECTER_JAVACARD_PATH")
+    )
+    if env_path:
+        candidates.append(Path(env_path).expanduser())
+
+    repo_root = Path(__file__).resolve().parents[3]
+    candidates.append(repo_root.parent / "specter-javacard" / "py")
+    candidates.append(repo_root / "specter-javacard" / "py")
+    return candidates
+
+
+def _get_specter_card_api():
+    try:
+        from specter_card import Card, MemoryCardApplet, SecureApplet
+        return Card, MemoryCardApplet, SecureApplet
+    except Exception:
+        pass
+
+    for candidate in _candidate_specter_card_paths():
+        try:
+            if not candidate.exists() or not candidate.is_dir():
+                continue
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            from specter_card import Card, MemoryCardApplet, SecureApplet
+            return Card, MemoryCardApplet, SecureApplet
+        except Exception:
+            continue
+
+    raise ImportError(
+        "Unable to load specter_card module. Install specter-javacard py module or set SEEDSIGNER_SPECTER_CARD_PY_PATH."
+    )
+
+
+def _normalize_bip39_mnemonic_text(text: str) -> str:
+    mnemonic = " ".join((text or "").strip().lower().split())
+    if not mnemonic:
+        raise ValueError("No mnemonic data found on card")
+    words = mnemonic.split(" ")
+    if len(words) not in (12, 15, 18, 21, 24):
+        raise ValueError("Stored data is not a 12/15/18/21/24-word mnemonic")
+    return mnemonic
+
+
+def _show_specter_card_bricked_warning(parent_view) -> None:
+    parent_view.run_screen(
+        WarningScreen,
+        title="Card Locked",
+        status_headline=None,
+        text=(
+            "PIN attempts exhausted. Reinstall Specter-DIY applet.\n"
+            "No factory reset available."
+        ),
+        show_back_button=False,
+        button_data=[ButtonOption("I Understand")],
+    )
+
+
+def _open_specter_secure_channel(secure_applet):
+    last_error = None
+    for mode in ("ee", "es", "ss"):
+        try:
+            return secure_applet.open_secure_channel(mode=mode)
+        except TypeError:
+            return secure_applet.open_secure_channel()
+        except Exception as exc:
+            last_error = exc
+    if last_error is not None:
+        raise last_error
+    return secure_applet.open_secure_channel()
+
+
+def _specter_compact_size(value: int) -> bytes:
+    if value < 0xFD:
+        return bytes([value])
+    if value <= 0xFFFF:
+        return b"\xfd" + value.to_bytes(2, "little")
+    if value <= 0xFFFFFFFF:
+        return b"\xfe" + value.to_bytes(4, "little")
+    return b"\xff" + value.to_bytes(8, "little")
+
+
+def _specter_tagged_hash(tag: str, data: bytes) -> bytes:
+    hashtag = hashlib.sha256(tag.encode("utf-8")).digest()
+    return hashlib.sha256(hashtag + hashtag + data).digest()
+
+
+def _specter_aead_encrypt(key: bytes, adata: bytes, plaintext: bytes) -> bytes:
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+    aes_key = _specter_tagged_hash("aes", key)
+    hmac_key = _specter_tagged_hash("hmac", key)
+
+    body = _specter_compact_size(len(adata)) + adata
+    if plaintext:
+        iv = os.urandom(16)
+        padded = plaintext + b"\x80"
+        if len(padded) % 16 != 0:
+            padded += b"\x00" * (16 - (len(padded) % 16))
+        enc = Cipher(algorithms.AES(aes_key), modes.CBC(iv)).encryptor()
+        body += iv + enc.update(padded) + enc.finalize()
+
+    mac = hmac.new(hmac_key, body, digestmod="sha256").digest()
+    return body + mac
+
+
+def _serialize_specter_plaintext_blob(entropy: bytes) -> bytes:
+    if len(entropy) not in (16, 20, 24, 28, 32):
+        raise ValueError("Invalid BIP39 entropy length")
+
+    adata = b"sdiy\x00" + (b"\x00" * 4)
+    key = b"\xcc" * 32
+    tlv = b"\x02" + bytes([len(entropy)]) + entropy
+    return _specter_aead_encrypt(key=key, adata=adata, plaintext=tlv)
+
+
+def _is_specter_pin_error(exc: Exception) -> bool:
+    err = str(exc).lower()
+    return "0502" in err or "0503" in err
+
+
+def _show_specter_incorrect_pin_warning(parent_view, secure_applet, secure_channel) -> None:
+    attempts_left = None
+    try:
+        status = secure_applet.pin_status(secure_channel)
+        if status.get("status") == "bricked":
+            _show_specter_card_bricked_warning(parent_view)
+            return
+        attempts_left = status.get("attempts_left")
+    except Exception:
+        pass
+
+    if isinstance(attempts_left, int):
+        attempt_word = "attempt" if attempts_left == 1 else "attempts"
+        text = f"PIN is incorrect.\n{attempts_left} {attempt_word} remaining."
+    else:
+        text = "PIN is incorrect."
+
+    parent_view.run_screen(
+        WarningScreen,
+        title="Incorrect PIN",
+        status_headline=None,
+        text=text,
+        show_back_button=False,
+        button_data=[ButtonOption("I Understand")],
+    )
+
+
+def _prompt_specter_new_pin(parent_view, title: str) -> str | None:
+    while True:
+        ret = seed_screens.SeedAddPassphraseScreen(title=title).display()
+        if isinstance(ret, dict) and "is_back_button" in ret:
+            return None
+
+        pin = ret.get("passphrase", "")
+        if all(ch in "0123456789" for ch in pin):
+            return pin
+
+        selected = parent_view.run_screen(
+            WarningScreen,
+            title="Non-Numeric PIN",
+            status_headline=None,
+            text=(
+                "Specter-DIY hardware supports PIN digits 0-9.\n"
+                "Use this PIN anyway?"
+            ),
+            show_back_button=False,
+            button_data=[ButtonOption("Continue"), ButtonOption("Enter Different PIN")],
+        )
+        if selected == 0:
+            return pin
+
+
+def _unlock_specter_card_if_needed(parent_view, secure_applet, secure_channel) -> bool:
+    status = secure_applet.pin_status(secure_channel)
+    if status.get("status") == "bricked":
+        _show_specter_card_bricked_warning(parent_view)
+        return False
+    if status.get("status") in ("disabled", "unlocked", "no_pin"):
+        return True
+    if status.get("status") != "locked":
+        return True
+
+    ret = seed_screens.SeedAddPassphraseScreen(title="Card PIN").display()
+    if isinstance(ret, dict) and "is_back_button" in ret:
+        return False
+    pin = ret.get("passphrase", "")
+    if not pin:
+        parent_view.run_screen(
+            WarningScreen,
+            title="Invalid PIN",
+            status_headline=None,
+            text="PIN cannot be empty.",
+            show_back_button=False,
+            button_data=[ButtonOption("I Understand")],
+        )
+        return False
+    try:
+        secure_applet.unlock(secure_channel, pin.encode("utf-8"))
+        return True
+    except Exception as exc:
+        if _is_specter_pin_error(exc):
+            _show_specter_incorrect_pin_warning(parent_view, secure_applet, secure_channel)
+            return False
+        raise
 
 
 def _normalize_javacard_key(value: str) -> str:
@@ -4876,6 +5317,8 @@ def _decode_seedkeeper_text(secret_dict: dict) -> str:
 class ToolsJavacardKeysView(View):
     LOAD_KEYS = ButtonOption("Load Keys")
     SAVE_KEYS = ButtonOption("Save Keys")
+    LOAD_MNEMONIC = ButtonOption("Load Mnemonic")
+    SAVE_MNEMONIC = ButtonOption("Save Mnemonic")
     UNLOCK_CARD = ButtonOption("Unlock Card")
     LOCK_CARD = ButtonOption("Lock Card")
     CLEAR_KEYS = ButtonOption("Clear Loaded Keys")
@@ -4884,6 +5327,8 @@ class ToolsJavacardKeysView(View):
         button_data = [
             self.LOAD_KEYS,
             self.SAVE_KEYS,
+            self.LOAD_MNEMONIC,
+            self.SAVE_MNEMONIC,
             self.UNLOCK_CARD,
             self.LOCK_CARD,
             self.CLEAR_KEYS,
@@ -4903,11 +5348,220 @@ class ToolsJavacardKeysView(View):
             return Destination(ToolsJavacardLoadKeysView)
         if choice == self.SAVE_KEYS:
             return Destination(ToolsJavacardSaveKeysView)
+        if choice == self.LOAD_MNEMONIC:
+            return Destination(ToolsJavacardLoadMnemonicView)
+        if choice == self.SAVE_MNEMONIC:
+            return Destination(ToolsJavacardSaveMnemonicView)
         if choice == self.UNLOCK_CARD:
             return Destination(ToolsJavacardUnlockCardView)
         if choice == self.LOCK_CARD:
             return Destination(ToolsJavacardLockCardView)
         return Destination(ToolsJavacardClearKeysView)
+
+
+class ToolsJavacardLoadMnemonicView(View):
+    def run(self):
+        from seedsigner.gui.screens.screen import LoadingScreenThread
+
+        conn = None
+        secure_channel = None
+        try:
+            Card, MemoryCardApplet, SecureApplet = _get_specter_card_api()
+            conn = Card(SPECTER_JAVACARD_DEFAULT_AID)
+            conn.connect()
+            secure_applet = SecureApplet(conn)
+            memory_applet = MemoryCardApplet(conn)
+            secure_channel = _open_specter_secure_channel(secure_applet)
+            if not _unlock_specter_card_if_needed(self, secure_applet, secure_channel):
+                return Destination(BackStackView)
+
+            loading = LoadingScreenThread(text="Loading Mnemonic\n\n\n\n\n\n")
+            loading.start()
+            raw = memory_applet.get_data(secure_channel)
+            loading.stop()
+            if not raw:
+                self.run_screen(
+                    WarningScreen,
+                    title="No Mnemonic Found",
+                    status_headline=None,
+                    text="No data found on Specter Javacard.",
+                    show_back_button=False,
+                    button_data=[ButtonOption("I Understand")],
+                )
+                return Destination(BackStackView)
+
+            decoded = memory_applet.decode_diy_data(secure_channel)
+            mnemonic_text = decoded.get("mnemonic")
+            if not mnemonic_text:
+                entropy = decoded.get("entropy")
+                if entropy:
+                    from embit import bip39
+                    mnemonic_text = bip39.mnemonic_from_bytes(entropy)
+            if not mnemonic_text:
+                raise ValueError("Stored data could not be decoded as Specter-DIY mnemonic")
+
+            mnemonic_text = _normalize_bip39_mnemonic_text(mnemonic_text)
+            mnemonic_words = mnemonic_text.split(" ")
+            self.controller.storage.init_pending_mnemonic(num_words=len(mnemonic_words))
+            for i, word in enumerate(mnemonic_words):
+                self.controller.storage.update_pending_mnemonic(word, i)
+            self.controller.storage.convert_pending_mnemonic_to_pending_seed(
+                wordlist_language_code=self.settings.get_value(SettingsConstants.SETTING__WORDLIST_LANGUAGE),
+            )
+            return Destination(SeedFinalizeView)
+        except InvalidSeedException:
+            self.run_screen(
+                WarningScreen,
+                title="Invalid Mnemonic",
+                status_headline=None,
+                text="Stored data is not a valid BIP39 mnemonic.",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+        except Exception as exc:
+            self.run_screen(
+                WarningScreen,
+                title="Load Failed",
+                status_headline=None,
+                text=str(exc),
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+        finally:
+            if secure_channel is not None:
+                try:
+                    secure_channel.close()
+                except Exception:
+                    pass
+            if conn is not None:
+                try:
+                    conn.disconnect()
+                except Exception:
+                    pass
+
+
+class ToolsJavacardSaveMnemonicView(View):
+    def run(self):
+        from seedsigner.gui.screens.screen import LoadingScreenThread
+
+        bip39_seeds: list[tuple[int, Seed]] = []
+        for i, seed in enumerate(self.controller.storage.seeds):
+            if type(seed) is Seed:
+                bip39_seeds.append((i, seed))
+
+        if not bip39_seeds:
+            self.run_screen(
+                WarningScreen,
+                title="No BIP39 Seed",
+                status_headline=None,
+                text="Load a BIP39 seed before saving.",
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+
+        selected_seed = bip39_seeds[0][1]
+        if len(bip39_seeds) > 1:
+            options = []
+            for _, seed in bip39_seeds:
+                fingerprint = seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
+                options.append(ButtonOption(fingerprint, SeedSignerIconConstants.FINGERPRINT))
+            selected = self.run_screen(
+                ButtonListScreen,
+                title="Select Seed",
+                is_button_text_centered=False,
+                button_data=options,
+                show_back_button=True,
+            )
+            if selected == RET_CODE__BACK_BUTTON:
+                return Destination(BackStackView)
+            selected_seed = bip39_seeds[selected][1]
+
+        mnemonic_text = " ".join(selected_seed.mnemonic_list).strip()
+        conn = None
+        secure_channel = None
+        try:
+            from embit import bip39
+
+            Card, MemoryCardApplet, SecureApplet = _get_specter_card_api()
+            conn = Card(SPECTER_JAVACARD_DEFAULT_AID)
+            conn.connect()
+            secure_applet = SecureApplet(conn)
+            memory_applet = MemoryCardApplet(conn)
+            secure_channel = _open_specter_secure_channel(secure_applet)
+            if not _unlock_specter_card_if_needed(self, secure_applet, secure_channel):
+                return Destination(BackStackView)
+
+            status = secure_applet.pin_status(secure_channel)
+            existing_data = memory_applet.get_data(secure_channel)
+
+            if status.get("status") in ("disabled", "no_pin") and not existing_data:
+                new_pin = _prompt_specter_new_pin(self, "Create PIN")
+                if new_pin is None:
+                    return Destination(BackStackView)
+                if not new_pin:
+                    self.run_screen(
+                        WarningScreen,
+                        title="Invalid PIN",
+                        status_headline=None,
+                        text="PIN cannot be empty.",
+                        show_back_button=False,
+                        button_data=[ButtonOption("I Understand")],
+                    )
+                    return Destination(BackStackView)
+                secure_applet.set_pin(secure_channel, new_pin.encode("utf-8"))
+
+            if existing_data:
+                overwrite = self.run_screen(
+                    WarningScreen,
+                    title="Overwrite Data?",
+                    status_headline=None,
+                    text="Card already has data. Overwrite it?",
+                    show_back_button=False,
+                    button_data=[ButtonOption("Overwrite"), ButtonOption("Abort Save")],
+                )
+                if overwrite != 0:
+                    return Destination(BackStackView)
+
+            entropy = bip39.mnemonic_to_bytes(mnemonic_text)
+            payload = _serialize_specter_plaintext_blob(entropy)
+
+            loading = LoadingScreenThread(text="Saving Mnemonic\n\n\n\n\n\n")
+            loading.start()
+            memory_applet.store_data(secure_channel, payload)
+            loading.stop()
+
+            self.run_screen(
+                LargeIconStatusScreen,
+                title="Saved",
+                status_headline=None,
+                text="Mnemonic saved to Specter Javacard",
+                show_back_button=False,
+            )
+            return Destination(BackStackView)
+        except Exception as exc:
+            self.run_screen(
+                WarningScreen,
+                title="Save Failed",
+                status_headline=None,
+                text=str(exc),
+                show_back_button=False,
+                button_data=[ButtonOption("I Understand")],
+            )
+            return Destination(BackStackView)
+        finally:
+            if secure_channel is not None:
+                try:
+                    secure_channel.close()
+                except Exception:
+                    pass
+            if conn is not None:
+                try:
+                    conn.disconnect()
+                except Exception:
+                    pass
 
 
 class ToolsJavacardLoadKeysView(View):

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -4004,7 +4004,13 @@ class ToolsSatochipImportSeedView(View):
 
     def run(self):
         from seedsigner.gui.screens.screen import LoadingScreenThread
-        Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
+        backend_preference = getattr(self.controller, "smartcard_backend_preference", None)
+        Satochip_Connector = seedkeeper_utils.init_satochip(
+            self,
+            init_card_filter=["satochip"],
+            allow_unseeded=True,
+            backend_preference=backend_preference,
+        )
 
         if not Satochip_Connector:
             return Destination(BackStackView)
@@ -4062,7 +4068,7 @@ class ToolsSatochipImportSeedView(View):
         # Most of the options require us to go through a side flow(s) before we can
         # continue to the address explorer. Set the Controller-level flow so that it
         # knows to re-route us once the side flow is complete.        
-        # self.controller.resume_main_flow = Controller.FLOW__SATOCHIP_IMPORT_SEED
+        self.controller.resume_main_flow = Controller.FLOW__SATOCHIP_IMPORT_SEED
 
         if len(seeds) > 0 and selected_menu_num < len(seeds):
             # User selected one of the n seeds

--- a/tests/test_decode_qr_zbar_optional.py
+++ b/tests/test_decode_qr_zbar_optional.py
@@ -1,0 +1,48 @@
+import importlib
+import sys
+from unittest.mock import MagicMock
+
+
+MODULE = "seedsigner.models.decode_qr"
+
+
+def test_decode_qr_import_survives_missing_pyzbar(monkeypatch):
+    sys.modules.pop(MODULE, None)
+    monkeypatch.setitem(sys.modules, "pyzbar", None)
+    sys.modules.pop("pyzbar.pyzbar", None)
+
+    decode_qr = importlib.import_module(MODULE)
+    monkeypatch.setattr(decode_qr.DecodeQR, "_opencv_available_desktop", lambda: False)
+
+    assert decode_qr.DecodeQR.is_qr_scanner_available() is False
+    assert decode_qr.DecodeQR.extract_qr_data(image=object()) is None
+
+
+def test_decode_qr_scanner_available_with_mocked_pyzbar(monkeypatch):
+    sys.modules.pop(MODULE, None)
+
+    pyzbar_pkg = MagicMock()
+    pyzbar_submodule = MagicMock()
+    pyzbar_submodule.ZBarSymbol = MagicMock()
+    pyzbar_submodule.ZBarSymbol.QRCODE = 0
+    pyzbar_submodule.decode.return_value = []
+
+    monkeypatch.setitem(sys.modules, "pyzbar", pyzbar_pkg)
+    monkeypatch.setitem(sys.modules, "pyzbar.pyzbar", pyzbar_submodule)
+
+    decode_qr = importlib.import_module(MODULE)
+
+    assert decode_qr.DecodeQR.is_qr_scanner_available() is True
+
+
+def test_decode_qr_uses_opencv_fallback_on_desktop(monkeypatch):
+    sys.modules.pop(MODULE, None)
+    monkeypatch.setitem(sys.modules, "pyzbar", None)
+    sys.modules.pop("pyzbar.pyzbar", None)
+
+    decode_qr = importlib.import_module(MODULE)
+    monkeypatch.setattr(decode_qr.DecodeQR, "_opencv_available_desktop", lambda: True)
+    monkeypatch.setattr(decode_qr.DecodeQR, "_extract_qr_data_opencv", lambda image, is_binary=False: b"fallback")
+
+    assert decode_qr.DecodeQR.is_qr_scanner_available() is True
+    assert decode_qr.DecodeQR.extract_qr_data(image=object(), is_binary=True) == b"fallback"

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -1224,3 +1224,86 @@ class TestSatochipImportSeedView(BaseTest):
         assert "xprv" in warning_text
         assert "slip39" in warning_text
         assert destination.View_cls == tools_views.BackStackView
+
+    def test_import_seed_non_9000_shows_failed_warning(self, monkeypatch):
+        from seedsigner.views import tools_views
+        from seedsigner.helpers import seedkeeper_utils
+
+        class MockSeed:
+            seed_bytes = b"\x01" * 64
+
+            def get_fingerprint(self, _network):
+                return "deadbeef"
+
+        class MockConnector:
+            def card_get_status(self):
+                return (None, 0x90, 0x00, {"is_seeded": False})
+
+            def card_bip32_import_seed(self, _seed_bytes):
+                return (None, 0x6A, 0x80)
+
+        monkeypatch.setattr(
+            seedkeeper_utils, "init_satochip", lambda *a, **k: MockConnector()
+        )
+
+        self.controller.storage.seeds = [MockSeed()]
+
+        view = tools_views.ToolsSatochipImportSeedView()
+        responses = iter([0, 0])
+        captured = {}
+
+        def fake_run_screen(screen_cls, **kwargs):
+            if screen_cls is tools_views.WarningScreen:
+                captured["warning_text"] = kwargs.get("text")
+            return next(responses)
+
+        monkeypatch.setattr(view, "run_screen", fake_run_screen)
+        destination = view.run()
+
+        warning_text = captured["warning_text"].lower()
+        assert "import failed with sw=6a80" in warning_text
+        assert destination.View_cls == tools_views.MainMenuView
+
+    def test_import_seed_unseeded_post_status_shows_failed_warning(self, monkeypatch):
+        from seedsigner.views import tools_views
+        from seedsigner.helpers import seedkeeper_utils
+
+        class MockSeed:
+            seed_bytes = b"\x01" * 64
+
+            def get_fingerprint(self, _network):
+                return "deadbeef"
+
+        class MockConnector:
+            def __init__(self):
+                self.status_calls = 0
+
+            def card_get_status(self):
+                self.status_calls += 1
+                # Pre-check and post-check both report unseeded.
+                return (None, 0x90, 0x00, {"is_seeded": False, "key_initialized": False})
+
+            def card_bip32_import_seed(self, _seed_bytes):
+                return (None, 0x90, 0x00)
+
+        monkeypatch.setattr(
+            seedkeeper_utils, "init_satochip", lambda *a, **k: MockConnector()
+        )
+
+        self.controller.storage.seeds = [MockSeed()]
+
+        view = tools_views.ToolsSatochipImportSeedView()
+        responses = iter([0, 0])
+        captured = {}
+
+        def fake_run_screen(screen_cls, **kwargs):
+            if screen_cls is tools_views.WarningScreen:
+                captured["warning_text"] = kwargs.get("text")
+            return next(responses)
+
+        monkeypatch.setattr(view, "run_screen", fake_run_screen)
+        destination = view.run()
+
+        warning_text = captured["warning_text"].lower()
+        assert "seeded key" in warning_text
+        assert destination.View_cls == tools_views.MainMenuView

--- a/tests/test_javacard_mnemonic_tools.py
+++ b/tests/test_javacard_mnemonic_tools.py
@@ -1,0 +1,774 @@
+import pytest
+
+from seedsigner.views import tools_views
+
+
+def test_normalize_bip39_mnemonic_text_normalizes_whitespace():
+    text = (
+        " Abandon   abandon abandon abandon abandon abandon abandon abandon "
+        "abandon abandon abandon abandon abandon abandon abandon abandon "
+        "abandon abandon abandon abandon abandon abandon abandon ART "
+    )
+    normalized = tools_views._normalize_bip39_mnemonic_text(text)
+    assert normalized.startswith("abandon abandon")
+    assert normalized.endswith("art")
+    assert len(normalized.split(" ")) == 24
+
+
+def test_normalize_bip39_mnemonic_text_rejects_invalid_word_count():
+    with pytest.raises(ValueError):
+        tools_views._normalize_bip39_mnemonic_text("abandon " * 11)
+
+
+def test_javacard_keys_menu_routes_to_load_mnemonic():
+    view = object.__new__(tools_views.ToolsJavacardKeysView)
+
+    def fake_run_screen(*args, **kwargs):
+        for i, option in enumerate(kwargs["button_data"]):
+            if option.button_label == "Load Mnemonic":
+                return i
+        return 0
+
+    view.run_screen = fake_run_screen
+    destination = view.run()
+
+    assert destination.View_cls == tools_views.ToolsJavacardLoadMnemonicView
+
+
+def test_javacard_keys_menu_routes_to_save_mnemonic():
+    view = object.__new__(tools_views.ToolsJavacardKeysView)
+
+    def fake_run_screen(*args, **kwargs):
+        for i, option in enumerate(kwargs["button_data"]):
+            if option.button_label == "Save Mnemonic":
+                return i
+        return 0
+
+    view.run_screen = fake_run_screen
+    destination = view.run()
+
+    assert destination.View_cls == tools_views.ToolsJavacardSaveMnemonicView
+
+
+def test_specter_menu_routes_to_wipe_seed():
+    view = object.__new__(tools_views.ToolsSpecterDIYView)
+
+    def fake_run_screen(*args, **kwargs):
+        for i, option in enumerate(kwargs["button_data"]):
+            if option.button_label == "Wipe Seed":
+                return i
+        return 0
+
+    view.run_screen = fake_run_screen
+    destination = view.run()
+
+    assert destination.View_cls == tools_views.ToolsJavacardWipeMnemonicView
+
+
+def test_javacard_load_mnemonic_decodes_sdiy_blob(monkeypatch):
+    class FakeLoadingScreenThread:
+        def __init__(self, text):
+            self.text = text
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    class FakeStorage:
+        def __init__(self):
+            self.words = []
+            self.word_count = None
+
+        def init_pending_mnemonic(self, num_words):
+            self.word_count = num_words
+
+        def update_pending_mnemonic(self, word, index):
+            self.words.append((index, word))
+
+        def convert_pending_mnemonic_to_pending_seed(self, wordlist_language_code):
+            self.wordlist_language_code = wordlist_language_code
+
+    class FakeController:
+        def __init__(self):
+            self.storage = FakeStorage()
+
+    class FakeSettings:
+        def get_value(self, _key):
+            return "en"
+
+    class FakeSecureChannel:
+        def close(self):
+            pass
+
+    class FakeCard:
+        def __init__(self, _aid):
+            pass
+
+        def connect(self):
+            pass
+
+        def disconnect(self):
+            pass
+
+    class FakeSecureApplet:
+        def __init__(self, _conn):
+            pass
+
+        def open_secure_channel(self):
+            return FakeSecureChannel()
+
+    class FakeMemoryCardApplet:
+        def __init__(self, _conn):
+            pass
+
+        def get_data(self, _secure_channel):
+            return bytes.fromhex("097364697900000000009b")
+
+        def decode_diy_data(self, _secure_channel):
+            return {
+                "encrypted": False,
+                "mnemonic": (
+                    "stock million price success you push rifle embrace "
+                    "tone limb december isolate"
+                ),
+            }
+
+    import seedsigner.gui.screens.screen as screen_module
+
+    monkeypatch.setattr(screen_module, "LoadingScreenThread", FakeLoadingScreenThread)
+    monkeypatch.setattr(
+        tools_views,
+        "_get_specter_card_api",
+        lambda: (FakeCard, FakeMemoryCardApplet, FakeSecureApplet),
+    )
+    monkeypatch.setattr(tools_views, "_unlock_specter_card_if_needed", lambda *a, **k: True)
+
+    view = object.__new__(tools_views.ToolsJavacardLoadMnemonicView)
+    view.controller = FakeController()
+    view.settings = FakeSettings()
+    view.run_screen = lambda *args, **kwargs: None
+
+    destination = view.run()
+
+    assert destination.View_cls == tools_views.SeedFinalizeView
+    assert view.controller.storage.word_count == 12
+    assert [word for _, word in sorted(view.controller.storage.words)] == [
+        "stock",
+        "million",
+        "price",
+        "success",
+        "you",
+        "push",
+        "rifle",
+        "embrace",
+        "tone",
+        "limb",
+        "december",
+        "isolate",
+    ]
+
+
+def test_specter_change_pin_prompts_current_then_new_only(monkeypatch):
+    prompts = []
+    changed = {}
+
+    class FakePrompt:
+        def __init__(self, title):
+            self.title = title
+
+        def display(self):
+            prompts.append(self.title)
+            if self.title == "Current PIN":
+                return {"passphrase": "1234"}
+            if self.title == "New PIN":
+                return {"passphrase": "9999"}
+            return {"passphrase": ""}
+
+    class FakeSecureChannel:
+        def close(self):
+            pass
+
+    class FakeCard:
+        def __init__(self, _aid):
+            pass
+
+        def connect(self):
+            pass
+
+        def disconnect(self):
+            pass
+
+    class FakeSecureApplet:
+        def __init__(self, _conn):
+            pass
+
+        def open_secure_channel(self):
+            return FakeSecureChannel()
+
+        def pin_status(self, _secure_channel):
+            return {"status": "locked"}
+
+        def change_pin(self, _secure_channel, old_pin, new_pin):
+            changed["old"] = old_pin
+            changed["new"] = new_pin
+
+    class FakeMemoryCardApplet:
+        def __init__(self, _conn):
+            pass
+
+    monkeypatch.setattr(
+        tools_views,
+        "_get_specter_card_api",
+        lambda: (FakeCard, FakeMemoryCardApplet, FakeSecureApplet),
+    )
+    monkeypatch.setattr(tools_views.seed_screens, "SeedAddPassphraseScreen", FakePrompt)
+
+    view = object.__new__(tools_views.ToolsSpecterDIYChangePinView)
+    view.run_screen = lambda *args, **kwargs: 0
+
+    destination = view.run()
+
+    assert destination.View_cls == tools_views.BackStackView
+    assert prompts == ["Current PIN", "New PIN"]
+    assert changed == {"old": b"1234", "new": b"9999"}
+
+
+def test_unlock_specter_card_shows_bricked_reinstall_warning():
+    class FakeParentView:
+        def __init__(self):
+            self.calls = []
+
+        def run_screen(self, _screen, **kwargs):
+            self.calls.append(kwargs)
+            return 0
+
+    class FakeSecureApplet:
+        def pin_status(self, _secure_channel):
+            return {"status": "bricked"}
+
+    parent = FakeParentView()
+    unlocked = tools_views._unlock_specter_card_if_needed(
+        parent,
+        FakeSecureApplet(),
+        secure_channel=object(),
+    )
+
+    assert unlocked is False
+    assert len(parent.calls) == 1
+    assert parent.calls[0]["title"] == "Card Locked"
+    assert "Reinstall Specter-DIY applet" in parent.calls[0]["text"]
+    assert "No factory reset available" in parent.calls[0]["text"]
+
+
+def test_prompt_specter_new_pin_warns_and_can_continue(monkeypatch):
+    prompts = iter([
+        {"passphrase": "12ab"},
+    ])
+
+    class FakePrompt:
+        def __init__(self, title):
+            self.title = title
+
+        def display(self):
+            return next(prompts)
+
+    class FakeParentView:
+        def __init__(self):
+            self.calls = []
+
+        def run_screen(self, _screen, **kwargs):
+            self.calls.append(kwargs)
+            return 0
+
+    monkeypatch.setattr(tools_views.seed_screens, "SeedAddPassphraseScreen", FakePrompt)
+    parent = FakeParentView()
+
+    pin = tools_views._prompt_specter_new_pin(parent, "New PIN")
+
+    assert pin == "12ab"
+    assert len(parent.calls) == 1
+    assert parent.calls[0]["title"] == "Non-Numeric PIN"
+    assert "digits 0-9" in parent.calls[0]["text"]
+
+
+def test_prompt_specter_new_pin_warns_and_can_reenter(monkeypatch):
+    prompts = iter([
+        {"passphrase": "12ab"},
+        {"passphrase": "1234"},
+    ])
+
+    class FakePrompt:
+        def __init__(self, title):
+            self.title = title
+
+        def display(self):
+            return next(prompts)
+
+    class FakeParentView:
+        def __init__(self):
+            self.calls = []
+
+        def run_screen(self, _screen, **kwargs):
+            self.calls.append(kwargs)
+            return 1
+
+    monkeypatch.setattr(tools_views.seed_screens, "SeedAddPassphraseScreen", FakePrompt)
+    parent = FakeParentView()
+
+    pin = tools_views._prompt_specter_new_pin(parent, "New PIN")
+
+    assert pin == "1234"
+    assert len(parent.calls) == 1
+    assert parent.calls[0]["title"] == "Non-Numeric PIN"
+
+
+def test_unlock_specter_card_wrong_pin_shows_attempts_remaining():
+    class FakeParentView:
+        def __init__(self):
+            self.calls = []
+
+        def run_screen(self, _screen, **kwargs):
+            self.calls.append(kwargs)
+            return 0
+
+    class FakeSecureApplet:
+        def __init__(self):
+            self._status_calls = 0
+
+        def pin_status(self, _secure_channel):
+            self._status_calls += 1
+            if self._status_calls == 1:
+                return {"status": "locked", "attempts_left": 5}
+            return {"status": "locked", "attempts_left": 4}
+
+        def unlock(self, _secure_channel, _pin):
+            raise Exception("Secure channel error: 0502")
+
+    class FakePrompt:
+        def __init__(self, title):
+            self.title = title
+
+        def display(self):
+            return {"passphrase": "0000"}
+
+    parent = FakeParentView()
+    secure_applet = FakeSecureApplet()
+
+    original = tools_views.seed_screens.SeedAddPassphraseScreen
+    tools_views.seed_screens.SeedAddPassphraseScreen = FakePrompt
+    try:
+        unlocked = tools_views._unlock_specter_card_if_needed(
+            parent,
+            secure_applet,
+            secure_channel=object(),
+        )
+    finally:
+        tools_views.seed_screens.SeedAddPassphraseScreen = original
+
+    assert unlocked is False
+    assert len(parent.calls) == 1
+    assert parent.calls[0]["title"] == "Incorrect PIN"
+    assert "4 attempts remaining" in parent.calls[0]["text"]
+
+
+def test_javacard_save_mnemonic_prompts_before_overwrite_and_can_abort(monkeypatch):
+    class FakeLoadingScreenThread:
+        def __init__(self, text):
+            self.text = text
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    class FakeSeed:
+        mnemonic_list = [
+            "stock", "million", "price", "success", "you", "push",
+            "rifle", "embrace", "tone", "limb", "december", "isolate",
+        ]
+
+        def get_fingerprint(self, _network):
+            return "f00dbabe"
+
+    class FakeStorage:
+        def __init__(self):
+            self.seeds = [FakeSeed()]
+
+    class FakeController:
+        def __init__(self):
+            self.storage = FakeStorage()
+
+    class FakeSettings:
+        def get_value(self, _key):
+            return "main"
+
+    class FakeSecureChannel:
+        def close(self):
+            pass
+
+    class FakeCard:
+        def __init__(self, _aid):
+            pass
+
+        def connect(self):
+            pass
+
+        def disconnect(self):
+            pass
+
+    class FakeSecureApplet:
+        def __init__(self, _conn):
+            pass
+
+        def open_secure_channel(self, mode=None):
+            _ = mode
+            return FakeSecureChannel()
+
+        def pin_status(self, _secure_channel):
+            return {"status": "locked"}
+
+    stored = {"called": False}
+
+    class FakeMemoryCardApplet:
+        def __init__(self, _conn):
+            pass
+
+        def get_data(self, _secure_channel):
+            return b"already-there"
+
+        def store_data(self, _secure_channel, _payload):
+            stored["called"] = True
+
+    import seedsigner.gui.screens.screen as screen_module
+
+    monkeypatch.setattr(screen_module, "LoadingScreenThread", FakeLoadingScreenThread)
+    monkeypatch.setattr(tools_views, "Seed", FakeSeed)
+    monkeypatch.setattr(
+        tools_views,
+        "_get_specter_card_api",
+        lambda: (FakeCard, FakeMemoryCardApplet, FakeSecureApplet),
+    )
+    monkeypatch.setattr(tools_views, "_unlock_specter_card_if_needed", lambda *a, **k: True)
+
+    prompts = []
+
+    def fake_run_screen(*args, **kwargs):
+        prompts.append(kwargs.get("title"))
+        if kwargs.get("title") == "Overwrite Data?":
+            return 1
+        return 0
+
+    view = object.__new__(tools_views.ToolsJavacardSaveMnemonicView)
+    view.controller = FakeController()
+    view.settings = FakeSettings()
+    view.run_screen = fake_run_screen
+
+    destination = view.run()
+
+    assert destination.View_cls == tools_views.BackStackView
+    assert "Overwrite Data?" in prompts
+    assert stored["called"] is False
+
+
+def test_javacard_save_mnemonic_overwrite_can_continue(monkeypatch):
+    class FakeLoadingScreenThread:
+        def __init__(self, text):
+            self.text = text
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    class FakeSeed:
+        mnemonic_list = [
+            "stock", "million", "price", "success", "you", "push",
+            "rifle", "embrace", "tone", "limb", "december", "isolate",
+        ]
+
+        def get_fingerprint(self, _network):
+            return "f00dbabe"
+
+    class FakeStorage:
+        def __init__(self):
+            self.seeds = [FakeSeed()]
+
+    class FakeController:
+        def __init__(self):
+            self.storage = FakeStorage()
+
+    class FakeSettings:
+        def get_value(self, _key):
+            return "main"
+
+    class FakeSecureChannel:
+        def close(self):
+            pass
+
+    class FakeCard:
+        def __init__(self, _aid):
+            pass
+
+        def connect(self):
+            pass
+
+        def disconnect(self):
+            pass
+
+    class FakeSecureApplet:
+        def __init__(self, _conn):
+            pass
+
+        def open_secure_channel(self, mode=None):
+            _ = mode
+            return FakeSecureChannel()
+
+        def pin_status(self, _secure_channel):
+            return {"status": "locked"}
+
+    stored = {"called": False, "payload": None}
+
+    class FakeMemoryCardApplet:
+        def __init__(self, _conn):
+            pass
+
+        def get_data(self, _secure_channel):
+            return b"already-there"
+
+        def store_data(self, _secure_channel, payload):
+            stored["called"] = True
+            stored["payload"] = payload
+
+    import seedsigner.gui.screens.screen as screen_module
+
+    monkeypatch.setattr(screen_module, "LoadingScreenThread", FakeLoadingScreenThread)
+    monkeypatch.setattr(tools_views, "Seed", FakeSeed)
+    monkeypatch.setattr(
+        tools_views,
+        "_get_specter_card_api",
+        lambda: (FakeCard, FakeMemoryCardApplet, FakeSecureApplet),
+    )
+    monkeypatch.setattr(tools_views, "_unlock_specter_card_if_needed", lambda *a, **k: True)
+
+    def fake_run_screen(*args, **kwargs):
+        if kwargs.get("title") == "Overwrite Data?":
+            return 0
+        return 0
+
+    view = object.__new__(tools_views.ToolsJavacardSaveMnemonicView)
+    view.controller = FakeController()
+    view.settings = FakeSettings()
+    view.run_screen = fake_run_screen
+
+    destination = view.run()
+
+    assert destination.View_cls == tools_views.BackStackView
+    assert stored["called"] is True
+    assert isinstance(stored["payload"], bytes)
+
+
+def test_javacard_save_mnemonic_empty_card_prompts_create_pin(monkeypatch):
+    class FakeLoadingScreenThread:
+        def __init__(self, text):
+            self.text = text
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    class FakeSeed:
+        mnemonic_list = [
+            "stock", "million", "price", "success", "you", "push",
+            "rifle", "embrace", "tone", "limb", "december", "isolate",
+        ]
+
+        def get_fingerprint(self, _network):
+            return "f00dbabe"
+
+    class FakeStorage:
+        def __init__(self):
+            self.seeds = [FakeSeed()]
+
+    class FakeController:
+        def __init__(self):
+            self.storage = FakeStorage()
+
+    class FakeSettings:
+        def get_value(self, _key):
+            return "main"
+
+    class FakeSecureChannel:
+        def close(self):
+            pass
+
+    class FakeCard:
+        def __init__(self, _aid):
+            pass
+
+        def connect(self):
+            pass
+
+        def disconnect(self):
+            pass
+
+    class FakeSecureApplet:
+        def __init__(self, _conn):
+            self.set_pin_calls = []
+
+        def open_secure_channel(self, mode=None):
+            _ = mode
+            return FakeSecureChannel()
+
+        def pin_status(self, _secure_channel):
+            return {"status": "no_pin"}
+
+        def set_pin(self, _secure_channel, pin):
+            self.set_pin_calls.append(pin)
+
+    secure_applet_ref = {"instance": None}
+
+    class FakeMemoryCardApplet:
+        def __init__(self, _conn):
+            pass
+
+        def get_data(self, _secure_channel):
+            return b""
+
+        def store_data(self, _secure_channel, _payload):
+            pass
+
+    def fake_get_api():
+        class _FakeSecureAppletFactory(FakeSecureApplet):
+            def __init__(self, _conn):
+                super().__init__(_conn)
+                secure_applet_ref["instance"] = self
+
+        return (FakeCard, FakeMemoryCardApplet, _FakeSecureAppletFactory)
+
+    import seedsigner.gui.screens.screen as screen_module
+
+    monkeypatch.setattr(screen_module, "LoadingScreenThread", FakeLoadingScreenThread)
+    monkeypatch.setattr(tools_views, "Seed", FakeSeed)
+    monkeypatch.setattr(tools_views, "_get_specter_card_api", fake_get_api)
+    monkeypatch.setattr(tools_views, "_unlock_specter_card_if_needed", lambda *a, **k: True)
+
+    prompt_titles = []
+
+    def fake_prompt(parent, title):
+        _ = parent
+        prompt_titles.append(title)
+        return "1234"
+
+    monkeypatch.setattr(tools_views, "_prompt_specter_new_pin", fake_prompt)
+
+    view = object.__new__(tools_views.ToolsJavacardSaveMnemonicView)
+    view.controller = FakeController()
+    view.settings = FakeSettings()
+    view.run_screen = lambda *args, **kwargs: 0
+
+    destination = view.run()
+
+    assert destination.View_cls == tools_views.BackStackView
+    assert prompt_titles == ["Create PIN"]
+    assert secure_applet_ref["instance"].set_pin_calls == [b"1234"]
+
+
+def test_javacard_save_mnemonic_empty_card_create_pin_cancel_aborts(monkeypatch):
+    class FakeLoadingScreenThread:
+        def __init__(self, text):
+            self.text = text
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    class FakeSeed:
+        mnemonic_list = [
+            "stock", "million", "price", "success", "you", "push",
+            "rifle", "embrace", "tone", "limb", "december", "isolate",
+        ]
+
+        def get_fingerprint(self, _network):
+            return "f00dbabe"
+
+    class FakeStorage:
+        def __init__(self):
+            self.seeds = [FakeSeed()]
+
+    class FakeController:
+        def __init__(self):
+            self.storage = FakeStorage()
+
+    class FakeSettings:
+        def get_value(self, _key):
+            return "main"
+
+    class FakeSecureChannel:
+        def close(self):
+            pass
+
+    class FakeCard:
+        def __init__(self, _aid):
+            pass
+
+        def connect(self):
+            pass
+
+        def disconnect(self):
+            pass
+
+    class FakeSecureApplet:
+        def __init__(self, _conn):
+            self.set_pin_calls = []
+
+        def open_secure_channel(self, mode=None):
+            _ = mode
+            return FakeSecureChannel()
+
+        def pin_status(self, _secure_channel):
+            return {"status": "no_pin"}
+
+        def set_pin(self, _secure_channel, pin):
+            self.set_pin_calls.append(pin)
+
+    store_called = {"value": False}
+
+    class FakeMemoryCardApplet:
+        def __init__(self, _conn):
+            pass
+
+        def get_data(self, _secure_channel):
+            return b""
+
+        def store_data(self, _secure_channel, _payload):
+            store_called["value"] = True
+
+    monkeypatch.setattr(
+        tools_views,
+        "_get_specter_card_api",
+        lambda: (FakeCard, FakeMemoryCardApplet, FakeSecureApplet),
+    )
+    monkeypatch.setattr(tools_views, "Seed", FakeSeed)
+    monkeypatch.setattr(tools_views, "_unlock_specter_card_if_needed", lambda *a, **k: True)
+    monkeypatch.setattr(tools_views, "_prompt_specter_new_pin", lambda *a, **k: None)
+
+    import seedsigner.gui.screens.screen as screen_module
+    monkeypatch.setattr(screen_module, "LoadingScreenThread", FakeLoadingScreenThread)
+
+    view = object.__new__(tools_views.ToolsJavacardSaveMnemonicView)
+    view.controller = FakeController()
+    view.settings = FakeSettings()
+    view.run_screen = lambda *args, **kwargs: 0
+
+    destination = view.run()
+
+    assert destination.View_cls == tools_views.BackStackView
+    assert store_called["value"] is False

--- a/tests/test_javacard_mnemonic_tools.py
+++ b/tests/test_javacard_mnemonic_tools.py
@@ -772,3 +772,39 @@ def test_javacard_save_mnemonic_empty_card_create_pin_cancel_aborts(monkeypatch)
 
     assert destination.View_cls == tools_views.BackStackView
     assert store_called["value"] is False
+
+
+def test_prompt_keycard_new_pin_requires_numeric_and_6_digits():
+    class FakeParentView:
+        def __init__(self):
+            self.calls = []
+
+        def run_screen(self, _screen, **kwargs):
+            self.calls.append(kwargs)
+            return 0
+
+    responses = iter([
+        {"passphrase": "12ab56"},
+        {"passphrase": "12345"},
+        {"passphrase": "123456"},
+    ])
+
+    class FakePrompt:
+        def __init__(self, title):
+            self.title = title
+
+        def display(self):
+            return next(responses)
+
+    parent = FakeParentView()
+    original = tools_views.seed_screens.SeedAddPassphraseScreen
+    tools_views.seed_screens.SeedAddPassphraseScreen = FakePrompt
+    try:
+        pin = tools_views._prompt_keycard_new_pin(parent, "New PIN")
+    finally:
+        tools_views.seed_screens.SeedAddPassphraseScreen = original
+
+    assert pin == "123456"
+    assert len(parent.calls) == 2
+    assert parent.calls[0]["title"] == "Non-Numeric PIN"
+    assert parent.calls[1]["title"] == "Invalid PIN Length"

--- a/tests/test_keycard_sign_psbt.py
+++ b/tests/test_keycard_sign_psbt.py
@@ -1,0 +1,57 @@
+import random
+import types
+
+from embit.ec import PrivateKey
+from embit.psbt import DerivationPath, InputScope, PSBT
+
+from seedsigner.helpers.keycard_signer import sign_psbt_with_keycard
+from seedsigner.models.settings import Settings
+from seedsigner.models.settings_definition import SettingsConstants
+
+
+class DummySettings:
+    def get_value(self, setting):
+        if setting == SettingsConstants.SETTING__SATOCHIP_SIGN_TIMEOUT:
+            return 1
+        return 0
+
+
+class DummyKeycardConnector:
+    is_keycard_backend = True
+
+    def __init__(self):
+        self.sign_order = []
+
+    def card_sign_transaction_hash(self, keynbr, h, none):
+        _ = keynbr
+        _ = none
+        idx = h[0]
+        self.sign_order.append(idx)
+        return (bytes([idx]) * 70, 0x90, 0x00)
+
+
+def test_sign_psbt_with_keycard_path_fallback_single_derivation(monkeypatch):
+    psbt = PSBT()
+    psbt.inputs = [InputScope()]
+
+    priv = PrivateKey(bytes([7]) * 32)
+    pub = priv.get_public_key()
+    psbt.inputs[0].bip32_derivations[pub] = DerivationPath(
+        b"\x00" * 4,
+        [0x80000054, 0x80000000, 0x80000000, 0, 0],
+    )
+
+    psbt.sighash = types.MethodType(
+        lambda self, idx, sighash=None: bytes([idx]) * 32,
+        psbt,
+    )
+
+    connector = DummyKeycardConnector()
+    monkeypatch.setattr(Settings, "get_instance", classmethod(lambda cls: DummySettings()))
+    random.seed(0)
+
+    signed = sign_psbt_with_keycard(psbt, connector)
+
+    assert signed == 1
+    assert getattr(connector, "_last_path", None) == "m/84'/0'/0'/0/0"
+    assert psbt.inputs[0].partial_sigs[pub].endswith(b"\x01")

--- a/tests/test_psbt_select_signers_keycard.py
+++ b/tests/test_psbt_select_signers_keycard.py
@@ -1,0 +1,65 @@
+from base import BaseTest
+
+from embit.psbt import PSBT
+
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
+from seedsigner.models.settings_definition import SettingsConstants
+from seedsigner.views import psbt_views
+
+
+class TestPSBTSelectSignerKeycard(BaseTest):
+    def test_psbt_select_signer_shows_keycard_when_enabled(self):
+        self.settings.set_value(
+            SettingsConstants.SETTING__KEYCARD_SUPPORT,
+            SettingsConstants.OPTION__ENABLED,
+        )
+
+        self.controller.psbt = PSBT()
+        self.controller.psbt_seed = None
+        self.controller.storage.seeds = []
+
+        view = psbt_views.PSBTSelectSeedView()
+        captured = {}
+
+        def fake_run_screen(screen_cls, **kwargs):
+            captured["button_data"] = kwargs["button_data"]
+            return RET_CODE__BACK_BUTTON
+
+        view.run_screen = fake_run_screen
+        view.run()
+
+        assert psbt_views.PSBTSelectSeedView.KEYCARD in captured["button_data"]
+
+    def test_psbt_keycard_selection_forces_keycard_backend(self, monkeypatch):
+        self.settings.set_value(
+            SettingsConstants.SETTING__KEYCARD_SUPPORT,
+            SettingsConstants.OPTION__ENABLED,
+        )
+
+        self.controller.psbt = PSBT()
+        self.controller.psbt_seed = None
+        self.controller.storage.seeds = []
+
+        called = {}
+
+        def fake_init_satochip(parent, init_card_filter=None, require_pin=True, backend_preference=None):
+            _ = parent
+            _ = require_pin
+            called["init_card_filter"] = init_card_filter
+            called["backend_preference"] = backend_preference
+            return None
+
+        from seedsigner.helpers import seedkeeper_utils
+        monkeypatch.setattr(seedkeeper_utils, "init_satochip", fake_init_satochip)
+
+        view = psbt_views.PSBTSelectSeedView()
+
+        def fake_run_screen(screen_cls, **kwargs):
+            return kwargs["button_data"].index(psbt_views.PSBTSelectSeedView.KEYCARD)
+
+        view.run_screen = fake_run_screen
+        destination = view.run()
+
+        assert called["init_card_filter"] == ["satochip"]
+        assert called["backend_preference"] == "keycard"
+        assert destination.View_cls == psbt_views.PSBTSelectSeedView

--- a/tests/test_satochip_sign_message.py
+++ b/tests/test_satochip_sign_message.py
@@ -43,6 +43,16 @@ class DummyConnector:
         return None, 0x90, 0x00, compsig
 
 
+class DummyDigestConnector(DummyConnector):
+    requires_message_digest = True
+
+    def card_sign_message(self, keynbr, pubkey, message, hmac=None):
+        assert isinstance(message, bytes)
+        assert len(message) == 32
+        compsig = b"\x02" * 65
+        return None, 0x90, 0x00, compsig
+
+
 def test_sign_message_with_satochip_returns_base64_signature():
     connector = DummyConnector()
     sig = sign_message_with_satochip("m/84'/0'/0'/0/0", "hello", connector)
@@ -53,6 +63,12 @@ def test_sign_message_with_satochip_accepts_hardened_notation_without_m_prefix()
     connector = DummyConnector()
     sig = sign_message_with_satochip("84h/0h/0h/0/0", "hello", connector)
     assert sig == b2a_base64(b"\x01" * 65).strip().decode()
+
+
+def test_sign_message_with_digest_backend_hashes_message_first():
+    connector = DummyDigestConnector()
+    sig = sign_message_with_satochip("m/84'/0'/0'/0/0", "hello", connector)
+    assert sig == b2a_base64(b"\x02" * 65).strip().decode()
 
 
 def test_sign_message_with_satochip_raises_when_authentikey_missing():

--- a/tests/test_satochip_sign_psbt.py
+++ b/tests/test_satochip_sign_psbt.py
@@ -42,6 +42,7 @@ class DummyConnector:
         return (bytes([idx]) * 70, 0x90, 0x00)
 
 
+
 def test_sign_psbt_processes_inputs_in_random_order(monkeypatch):
     psbt = PSBT()
     psbt.inputs = [InputScope(), InputScope(), InputScope()]
@@ -68,3 +69,7 @@ def test_sign_psbt_processes_inputs_in_random_order(monkeypatch):
     for i, inp in enumerate(psbt.inputs):
         pub = next(iter(inp.bip32_derivations.keys()))
         assert inp.partial_sigs[pub] == bytes([i]) * 70 + b"\x01"
+
+
+
+

--- a/tests/test_seedkeeper_utils_keycard_backend.py
+++ b/tests/test_seedkeeper_utils_keycard_backend.py
@@ -227,3 +227,378 @@ def test_get_pin_attempts_left_reads_connector_status_when_sw_missing():
 
     attempts = seedkeeper_utils.get_pin_attempts_left(connector=FakeConnector())
     assert attempts == 2
+
+
+def test_keycard_status_prefers_key_initialized_over_initialized(monkeypatch):
+    from seedsigner.helpers.keycard_connector import KeycardSatochipConnector
+
+    class MockTransport:
+        def connect(self):
+            return None
+
+        def disconnect(self):
+            return None
+
+    class MockInner:
+        is_initialized = True
+
+        def __init__(self):
+            self.transport = MockTransport()
+            self.status = {
+                "initialized": False,
+                "key_initialized": True,
+            }
+            self.get_key_path = []
+
+        def select(self):
+            return type("Info", (), {"instance_uid": b""})
+
+        def pair(self, _pairing_password):
+            return (0, b"k" * 32)
+
+        def open_secure_channel(self, _pairing_index, _pairing_key):
+            return None
+
+    class MockConstants:
+        class PairingMode:
+            EPHEMERAL = 1
+
+    monkeypatch.setattr(
+        "seedsigner.helpers.keycard_connector.get_keycard_class",
+        lambda: (MockInner, MockConstants),
+    )
+
+    connector = KeycardSatochipConnector.create(card_filter=["satochip"])
+    _resp, sw1, sw2, status = connector.card_get_status()
+
+    assert (sw1, sw2) == (0x90, 0x00)
+    assert status["key_initialized"] is True
+    assert status["is_seeded"] is True
+
+
+def test_keycard_status_uses_select_key_uid_as_seeded_signal(monkeypatch):
+    from seedsigner.helpers.keycard_connector import KeycardSatochipConnector
+
+    class MockTransport:
+        def connect(self):
+            return None
+
+        def disconnect(self):
+            return None
+
+    class MockInner:
+        is_initialized = True
+
+        def __init__(self):
+            self.transport = MockTransport()
+            self.status = {
+                "initialized": False,
+                "key_initialized": False,
+            }
+            self.get_key_path = []
+
+        def select(self):
+            return type(
+                "Info",
+                (),
+                {
+                    "instance_uid": b"",
+                    "key_uid": b"\x01" * 32,
+                },
+            )
+
+        def pair(self, _pairing_password):
+            return (0, b"k" * 32)
+
+        def open_secure_channel(self, _pairing_index, _pairing_key):
+            return None
+
+    class MockConstants:
+        class PairingMode:
+            EPHEMERAL = 1
+
+    monkeypatch.setattr(
+        "seedsigner.helpers.keycard_connector.get_keycard_class",
+        lambda: (MockInner, MockConstants),
+    )
+
+    connector = KeycardSatochipConnector.create(card_filter=["satochip"])
+    _resp, sw1, sw2, status = connector.card_get_status()
+
+    assert (sw1, sw2) == (0x90, 0x00)
+    assert status["key_initialized"] is True
+    assert status["is_seeded"] is True
+
+
+def test_keycard_import_seed_falls_back_to_extended_ecc_on_6985(monkeypatch):
+    from seedsigner.helpers.keycard_connector import KeycardSatochipConnector
+
+    class MockTransport:
+        def connect(self):
+            return None
+
+        def disconnect(self):
+            return None
+
+    class MockInner:
+        is_initialized = True
+
+        def __init__(self):
+            self.transport = MockTransport()
+            self.status = {"PIN0_remaining_tries": 3}
+            self.get_key_path = []
+            self.load_calls = []
+
+        def select(self):
+            return type("Info", (), {"instance_uid": b""})
+
+        def pair(self, _pairing_password):
+            return (0, b"k" * 32)
+
+        def open_secure_channel(self, _pairing_index, _pairing_key):
+            return None
+
+        def verify_pin(self, _pin_text):
+            return True
+
+        def remove_key(self):
+            return None
+
+        def load_key(self, key_type, **kwargs):
+            self.load_calls.append((key_type, kwargs))
+
+            class SwError(Exception):
+                def __init__(self, sw):
+                    super().__init__(f"SW={sw:04X}")
+                    self.sw = sw
+
+            # Simulate firmware rejecting BIP39 seed import but accepting
+            # EXTENDED_ECC import of root key + chain code.
+            if key_type == MockConstants.LoadKeyType.BIP39_SEED:
+                raise SwError(0x6985)
+            return b""
+
+    class MockConstants:
+        class PairingMode:
+            EPHEMERAL = 1
+
+        class LoadKeyType:
+            BIP39_SEED = 3
+            EXTENDED_ECC = 2
+
+    monkeypatch.setattr(
+        "seedsigner.helpers.keycard_connector.get_keycard_class",
+        lambda: (MockInner, MockConstants),
+    )
+
+    connector = KeycardSatochipConnector.create(card_filter=["satochip"])
+    connector.pin = list(b"123456")
+    _resp, sw1, sw2 = connector.card_bip32_import_seed(b"\x01" * 64)
+
+    assert (sw1, sw2) == (0x90, 0x00)
+    assert connector._card.load_calls[0][0] == MockConstants.LoadKeyType.BIP39_SEED
+    assert connector._card.load_calls[1][0] == MockConstants.LoadKeyType.BIP39_SEED
+    assert connector._card.load_calls[2][0] == MockConstants.LoadKeyType.EXTENDED_ECC
+    assert len(connector._card.load_calls[2][1]["public_key"]) == 65
+    assert len(connector._card.load_calls[2][1]["private_key"]) == 32
+    assert len(connector._card.load_calls[2][1]["chain_code"]) == 32
+
+
+def test_keycard_import_seed_remove_key_then_bip39_retry_succeeds(monkeypatch):
+    from seedsigner.helpers.keycard_connector import KeycardSatochipConnector
+
+    class MockTransport:
+        def connect(self):
+            return None
+
+        def disconnect(self):
+            return None
+
+    class MockInner:
+        is_initialized = True
+
+        def __init__(self):
+            self.transport = MockTransport()
+            self.status = {"PIN0_remaining_tries": 3}
+            self.get_key_path = []
+            self.load_calls = []
+            self.bip39_attempts = 0
+            self.remove_calls = 0
+
+        def select(self):
+            return type("Info", (), {"instance_uid": b""})
+
+        def pair(self, _pairing_password):
+            return (0, b"k" * 32)
+
+        def open_secure_channel(self, _pairing_index, _pairing_key):
+            return None
+
+        def verify_pin(self, _pin_text):
+            return True
+
+        def remove_key(self):
+            self.remove_calls += 1
+            return None
+
+        def load_key(self, key_type, **kwargs):
+            self.load_calls.append((key_type, kwargs))
+
+            class SwError(Exception):
+                def __init__(self, sw):
+                    super().__init__(f"SW={sw:04X}")
+                    self.sw = sw
+
+            if key_type == MockConstants.LoadKeyType.BIP39_SEED:
+                self.bip39_attempts += 1
+                if self.bip39_attempts == 1:
+                    raise SwError(0x6985)
+            return b""
+
+    class MockConstants:
+        class PairingMode:
+            EPHEMERAL = 1
+
+        class LoadKeyType:
+            BIP39_SEED = 3
+            EXTENDED_ECC = 2
+
+    monkeypatch.setattr(
+        "seedsigner.helpers.keycard_connector.get_keycard_class",
+        lambda: (MockInner, MockConstants),
+    )
+
+    connector = KeycardSatochipConnector.create(card_filter=["satochip"])
+    connector.pin = list(b"123456")
+    _resp, sw1, sw2 = connector.card_bip32_import_seed(b"\x01" * 64)
+
+    assert (sw1, sw2) == (0x90, 0x00)
+    assert connector._card.remove_calls == 1
+    assert connector._card.bip39_attempts == 2
+
+
+def test_keycard_import_seed_does_not_reverify_pin_when_already_verified(monkeypatch):
+    from seedsigner.helpers.keycard_connector import KeycardSatochipConnector
+
+    class MockTransport:
+        def connect(self):
+            return None
+
+        def disconnect(self):
+            return None
+
+    class MockInner:
+        is_initialized = True
+
+        def __init__(self):
+            self.transport = MockTransport()
+            self.status = {"PIN0_remaining_tries": 3}
+            self.get_key_path = []
+            self.is_pin_verified = False
+            self.verify_calls = 0
+
+        def select(self):
+            return type("Info", (), {"instance_uid": b""})
+
+        def pair(self, _pairing_password):
+            return (0, b"k" * 32)
+
+        def open_secure_channel(self, _pairing_index, _pairing_key):
+            return None
+
+        def verify_pin(self, _pin_text):
+            self.verify_calls += 1
+            self.is_pin_verified = True
+            return True
+
+        def load_key(self, _key_type, **_kwargs):
+            return b""
+
+    class MockConstants:
+        class PairingMode:
+            EPHEMERAL = 1
+
+        class LoadKeyType:
+            BIP39_SEED = 3
+            EXTENDED_ECC = 2
+
+    monkeypatch.setattr(
+        "seedsigner.helpers.keycard_connector.get_keycard_class",
+        lambda: (MockInner, MockConstants),
+    )
+
+    connector = KeycardSatochipConnector.create(card_filter=["satochip"])
+    connector.pin = list(b"123456")
+
+    # First verify during connection/login flow.
+    _resp, sw1, sw2 = connector.card_verify_PIN()
+    assert (sw1, sw2) == (0x90, 0x00)
+
+    # Import should not send a second VERIFY PIN APDU when session is already verified.
+    _resp, sw1, sw2 = connector.card_bip32_import_seed(b"\x02" * 64)
+    assert (sw1, sw2) == (0x90, 0x00)
+    assert connector._card.verify_calls == 1
+
+
+def test_keycard_import_seed_returns_sw_when_extended_fallback_fails(monkeypatch):
+    from seedsigner.helpers.keycard_connector import KeycardSatochipConnector
+
+    class MockTransport:
+        def connect(self):
+            return None
+
+        def disconnect(self):
+            return None
+
+    class MockInner:
+        is_initialized = True
+
+        def __init__(self):
+            self.transport = MockTransport()
+            self.status = {"PIN0_remaining_tries": 3}
+            self.get_key_path = []
+
+        def select(self):
+            return type("Info", (), {"instance_uid": b""})
+
+        def pair(self, _pairing_password):
+            return (0, b"k" * 32)
+
+        def open_secure_channel(self, _pairing_index, _pairing_key):
+            return None
+
+        def verify_pin(self, _pin_text):
+            return True
+
+        def remove_key(self):
+            return None
+
+        def load_key(self, key_type, **_kwargs):
+            class SwError(Exception):
+                def __init__(self, sw):
+                    super().__init__(f"SW={sw:04X}")
+                    self.sw = sw
+
+            # Force both BIP39 attempts and EXTENDED_ECC fallback to fail.
+            if key_type == MockConstants.LoadKeyType.BIP39_SEED:
+                raise SwError(0x6985)
+            raise SwError(0x6985)
+
+    class MockConstants:
+        class PairingMode:
+            EPHEMERAL = 1
+
+        class LoadKeyType:
+            BIP39_SEED = 3
+            EXTENDED_ECC = 2
+
+    monkeypatch.setattr(
+        "seedsigner.helpers.keycard_connector.get_keycard_class",
+        lambda: (MockInner, MockConstants),
+    )
+
+    connector = KeycardSatochipConnector.create(card_filter=["satochip"])
+    connector.pin = list(b"123456")
+    _resp, sw1, sw2 = connector.card_bip32_import_seed(b"\x01" * 64)
+
+    assert (sw1, sw2) == (0x69, 0x85)

--- a/tests/test_seedkeeper_utils_keycard_backend.py
+++ b/tests/test_seedkeeper_utils_keycard_backend.py
@@ -146,6 +146,62 @@ def test_keycard_connector_env_var_overrides_default_pairing_password(monkeypatc
     assert created["pairing_password"] == "custom-secret"
 
 
+def test_keycard_card_setup_normalizes_puk_for_init(monkeypatch):
+    from seedsigner.helpers.keycard_connector import KeycardSatochipConnector
+
+    captured = {}
+
+    class MockTransport:
+        def connect(self):
+            return None
+
+        def disconnect(self):
+            return None
+
+    class MockInner:
+        def __init__(self):
+            self.transport = MockTransport()
+
+        def select(self):
+            return type("Info", (), {"instance_uid": b""})
+
+        def init(self, pin, puk, pairing_secret):
+            captured["pin"] = pin
+            captured["puk"] = puk
+            captured["pairing_secret"] = pairing_secret
+
+    class MockConstants:
+        class PairingMode:
+            EPHEMERAL = 1
+
+    monkeypatch.setattr(
+        "seedsigner.helpers.keycard_connector.get_keycard_class",
+        lambda: (MockInner, MockConstants),
+    )
+
+    connector = KeycardSatochipConnector.create(card_filter=["satochip"])
+    response, sw1, sw2 = connector.card_setup(
+        5,
+        1,
+        list(b"123456"),
+        list(range(16)),
+        1,
+        1,
+        list(range(16)),
+        list(range(16)),
+        32,
+        0,
+        1,
+        1,
+        1,
+    )
+
+    assert (response, sw1, sw2) == ([], 0x90, 0x00)
+    assert captured["pin"] == "123456"
+    assert len(captured["puk"]) == 12
+    assert captured["puk"].isdigit()
+
+
 def test_show_incorrect_pin_warning_uses_attempts_from_status_word():
     class FakeParent:
         def __init__(self):

--- a/tests/test_seedkeeper_utils_keycard_backend.py
+++ b/tests/test_seedkeeper_utils_keycard_backend.py
@@ -1,0 +1,146 @@
+import pytest
+
+from seedsigner.helpers import seedkeeper_utils
+
+
+class DummyConnector:
+    pass
+
+
+def test_init_card_connector_prefers_keycard_when_forced(monkeypatch):
+    monkeypatch.setenv("SEEDSIGNER_SMARTCARD_BACKEND", "keycard")
+
+    called = {}
+
+    def mock_create(card_filter=None):
+        called["filter"] = card_filter
+        return DummyConnector()
+
+    monkeypatch.setattr(seedkeeper_utils.KeycardSatochipConnector, "create", mock_create)
+
+    connector = seedkeeper_utils._init_card_connector(["satochip"])
+
+    assert isinstance(connector, DummyConnector)
+    assert called["filter"] == ["satochip"]
+
+
+def test_init_card_connector_auto_falls_back_to_keycard(monkeypatch):
+    monkeypatch.setenv("SEEDSIGNER_SMARTCARD_BACKEND", "auto")
+    monkeypatch.setattr(
+        seedkeeper_utils,
+        "_init_legacy_connector",
+        lambda init_card_filter: (_ for _ in ()).throw(RuntimeError("legacy failed")),
+    )
+    monkeypatch.setattr(
+        seedkeeper_utils.KeycardSatochipConnector,
+        "create",
+        lambda card_filter=None: DummyConnector(),
+    )
+
+    connector = seedkeeper_utils._init_card_connector(["satochip"])
+    assert isinstance(connector, DummyConnector)
+
+
+def test_init_card_connector_auto_keeps_legacy_error_for_non_satochip(monkeypatch):
+    monkeypatch.setenv("SEEDSIGNER_SMARTCARD_BACKEND", "auto")
+    monkeypatch.setattr(
+        seedkeeper_utils,
+        "_init_legacy_connector",
+        lambda init_card_filter: (_ for _ in ()).throw(RuntimeError("legacy failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="legacy failed"):
+        seedkeeper_utils._init_card_connector(["seedkeeper"])
+
+
+def test_init_card_connector_respects_explicit_backend_preference(monkeypatch):
+    monkeypatch.setenv("SEEDSIGNER_SMARTCARD_BACKEND", "auto")
+
+    called = {}
+
+    def mock_create(card_filter=None):
+        called["filter"] = card_filter
+        return DummyConnector()
+
+    monkeypatch.setattr(seedkeeper_utils.KeycardSatochipConnector, "create", mock_create)
+
+    connector = seedkeeper_utils._init_card_connector(
+        ["satochip"],
+        backend_preference="keycard",
+    )
+
+    assert isinstance(connector, DummyConnector)
+    assert called["filter"] == ["satochip"]
+
+
+def test_keycard_connector_uses_default_pairing_password(monkeypatch):
+    from seedsigner.helpers.keycard_connector import KeycardSatochipConnector
+
+    monkeypatch.delenv("SEEDSIGNER_KEYCARD_PAIRING_PASSWORD", raising=False)
+
+    created = {}
+
+    class MockTransport:
+        def connect(self):
+            return None
+
+        def disconnect(self):
+            return None
+
+    class MockInner:
+        def __init__(self):
+            self.transport = MockTransport()
+
+        def select(self):
+            return type("Info", (), {"instance_uid": b""})
+
+    class MockConstants:
+        class PairingMode:
+            EPHEMERAL = 1
+
+    MockConnectorCls = (MockInner, MockConstants)
+    monkeypatch.setattr(
+        "seedsigner.helpers.keycard_connector.get_keycard_class",
+        lambda: MockConnectorCls,
+    )
+
+    connector = KeycardSatochipConnector.create(card_filter=["satochip"])
+    created["pairing_password"] = connector._pairing_password
+
+    assert created["pairing_password"] == KeycardSatochipConnector.DEFAULT_PAIRING_PASSWORD
+
+
+def test_keycard_connector_env_var_overrides_default_pairing_password(monkeypatch):
+    from seedsigner.helpers.keycard_connector import KeycardSatochipConnector
+
+    monkeypatch.setenv("SEEDSIGNER_KEYCARD_PAIRING_PASSWORD", "custom-secret")
+
+    created = {}
+
+    class MockTransport:
+        def connect(self):
+            return None
+
+        def disconnect(self):
+            return None
+
+    class MockInner:
+        def __init__(self):
+            self.transport = MockTransport()
+
+        def select(self):
+            return type("Info", (), {"instance_uid": b""})
+
+    class MockConstants:
+        class PairingMode:
+            EPHEMERAL = 1
+
+    monkeypatch.setattr(
+        "seedsigner.helpers.keycard_connector.get_keycard_class",
+        lambda: (MockInner, MockConstants),
+    )
+
+    connector = KeycardSatochipConnector.create(card_filter=["satochip"])
+    created["pairing_password"] = connector._pairing_password
+
+    assert created["pairing_password"] == "custom-secret"

--- a/tests/test_seedkeeper_utils_keycard_backend.py
+++ b/tests/test_seedkeeper_utils_keycard_backend.py
@@ -144,3 +144,30 @@ def test_keycard_connector_env_var_overrides_default_pairing_password(monkeypatc
     created["pairing_password"] = connector._pairing_password
 
     assert created["pairing_password"] == "custom-secret"
+
+
+def test_show_incorrect_pin_warning_uses_attempts_from_status_word():
+    class FakeParent:
+        def __init__(self):
+            self.calls = []
+
+        def run_screen(self, _screen, **kwargs):
+            self.calls.append(kwargs)
+            return 0
+
+    parent = FakeParent()
+
+    seedkeeper_utils.show_incorrect_pin_warning(parent, sw1=0x63, sw2=0xC3)
+
+    assert len(parent.calls) == 1
+    assert parent.calls[0]["title"] == "Incorrect PIN"
+    assert "3 attempts remaining" in parent.calls[0]["text"]
+
+
+def test_get_pin_attempts_left_reads_connector_status_when_sw_missing():
+    class FakeConnector:
+        def card_get_status(self):
+            return ([], 0x90, 0x00, {"PIN0_remaining_tries": 2})
+
+    attempts = seedkeeper_utils.get_pin_attempts_left(connector=FakeConnector())
+    assert attempts == 2

--- a/tests/test_tools_smartcard_keycard_menu.py
+++ b/tests/test_tools_smartcard_keycard_menu.py
@@ -1,0 +1,32 @@
+from base import BaseTest
+
+from seedsigner.views import tools_views
+from seedsigner.views.view import Destination
+
+
+class TestToolsSmartcardKeycardMenu(BaseTest):
+    def test_smartcard_menu_includes_keycard_entry(self):
+        view = tools_views.ToolsSmartcardMenuView()
+
+        captured = {}
+
+        def fake_run_screen(screen_cls, **kwargs):
+            captured["button_data"] = kwargs["button_data"]
+            return 0
+
+        view.run_screen = fake_run_screen
+        destination = view.run()
+
+        assert destination.View_cls == tools_views.ToolsCommonView
+        assert tools_views.ToolsSmartcardMenuView.KEYCARD in captured["button_data"]
+
+    def test_selecting_keycard_routes_to_keycard_view(self):
+        view = tools_views.ToolsSmartcardMenuView()
+
+        def fake_run_screen(screen_cls, **kwargs):
+            return kwargs["button_data"].index(tools_views.ToolsSmartcardMenuView.KEYCARD)
+
+        view.run_screen = fake_run_screen
+        destination: Destination = view.run()
+
+        assert destination.View_cls == tools_views.ToolsKeycardView

--- a/tests/test_tools_smartcard_keycard_menu.py
+++ b/tests/test_tools_smartcard_keycard_menu.py
@@ -1,11 +1,16 @@
 from base import BaseTest
 
+from seedsigner.models.settings_definition import SettingsConstants
 from seedsigner.views import tools_views
 from seedsigner.views.view import Destination
 
 
 class TestToolsSmartcardKeycardMenu(BaseTest):
     def test_smartcard_menu_includes_keycard_entry(self):
+        self.settings.set_value(
+            SettingsConstants.SETTING__KEYCARD_SUPPORT,
+            SettingsConstants.OPTION__ENABLED,
+        )
         view = tools_views.ToolsSmartcardMenuView()
 
         captured = {}
@@ -21,6 +26,10 @@ class TestToolsSmartcardKeycardMenu(BaseTest):
         assert tools_views.ToolsSmartcardMenuView.KEYCARD in captured["button_data"]
 
     def test_selecting_keycard_routes_to_keycard_view(self):
+        self.settings.set_value(
+            SettingsConstants.SETTING__KEYCARD_SUPPORT,
+            SettingsConstants.OPTION__ENABLED,
+        )
         view = tools_views.ToolsSmartcardMenuView()
 
         def fake_run_screen(screen_cls, **kwargs):

--- a/tests/test_tools_smartcard_support_toggles.py
+++ b/tests/test_tools_smartcard_support_toggles.py
@@ -1,0 +1,40 @@
+from base import BaseTest
+
+from seedsigner.models.settings_definition import SettingsConstants
+from seedsigner.views import tools_views
+
+
+class TestSmartcardSupportToggles(BaseTest):
+    def test_default_smartcard_backend_toggles_enabled(self):
+        assert self.settings.get_value(SettingsConstants.SETTING__SATOCHIP_SUPPORT) == SettingsConstants.OPTION__ENABLED
+        assert self.settings.get_value(SettingsConstants.SETTING__KEYCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED
+
+    def test_smartcard_menu_hides_keycard_when_disabled(self):
+        self.settings.set_value(SettingsConstants.SETTING__KEYCARD_SUPPORT, SettingsConstants.OPTION__DISABLED)
+        view = tools_views.ToolsSmartcardMenuView()
+
+        captured = {}
+
+        def fake_run_screen(screen_cls, **kwargs):
+            captured["button_data"] = kwargs["button_data"]
+            return 0
+
+        view.run_screen = fake_run_screen
+        view.run()
+
+        assert tools_views.ToolsSmartcardMenuView.KEYCARD not in captured["button_data"]
+
+    def test_smartcard_menu_hides_satochip_when_disabled(self):
+        self.settings.set_value(SettingsConstants.SETTING__SATOCHIP_SUPPORT, SettingsConstants.OPTION__DISABLED)
+        view = tools_views.ToolsSmartcardMenuView()
+
+        captured = {}
+
+        def fake_run_screen(screen_cls, **kwargs):
+            captured["button_data"] = kwargs["button_data"]
+            return 0
+
+        view.run_screen = fake_run_screen
+        view.run()
+
+        assert tools_views.ToolsSmartcardMenuView.SATOCHIP not in captured["button_data"]

--- a/tests/test_tools_smartcard_support_toggles.py
+++ b/tests/test_tools_smartcard_support_toggles.py
@@ -9,6 +9,9 @@ class TestSmartcardSupportToggles(BaseTest):
         assert self.settings.get_value(SettingsConstants.SETTING__SATOCHIP_SUPPORT) == SettingsConstants.OPTION__ENABLED
         assert self.settings.get_value(SettingsConstants.SETTING__KEYCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED
 
+    def test_default_specter_diy_toggle_disabled(self):
+        assert self.settings.get_value(SettingsConstants.SETTING__SPECTER_DIY_SUPPORT) == SettingsConstants.OPTION__DISABLED
+
     def test_smartcard_menu_hides_keycard_when_disabled(self):
         self.settings.set_value(SettingsConstants.SETTING__KEYCARD_SUPPORT, SettingsConstants.OPTION__DISABLED)
         view = tools_views.ToolsSmartcardMenuView()
@@ -38,3 +41,32 @@ class TestSmartcardSupportToggles(BaseTest):
         view.run()
 
         assert tools_views.ToolsSmartcardMenuView.SATOCHIP not in captured["button_data"]
+
+    def test_smartcard_menu_hides_specter_diy_by_default(self):
+        view = tools_views.ToolsSmartcardMenuView()
+
+        captured = {}
+
+        def fake_run_screen(screen_cls, **kwargs):
+            captured["button_data"] = kwargs["button_data"]
+            return 0
+
+        view.run_screen = fake_run_screen
+        view.run()
+
+        assert tools_views.ToolsSmartcardMenuView.SPECTER_DIY not in captured["button_data"]
+
+    def test_smartcard_menu_shows_specter_diy_when_enabled(self):
+        self.settings.set_value(SettingsConstants.SETTING__SPECTER_DIY_SUPPORT, SettingsConstants.OPTION__ENABLED)
+        view = tools_views.ToolsSmartcardMenuView()
+
+        captured = {}
+
+        def fake_run_screen(screen_cls, **kwargs):
+            captured["button_data"] = kwargs["button_data"]
+            return 0
+
+        view.run_screen = fake_run_screen
+        view.run()
+
+        assert tools_views.ToolsSmartcardMenuView.SPECTER_DIY in captured["button_data"]

--- a/tests/test_tools_smartcard_support_toggles.py
+++ b/tests/test_tools_smartcard_support_toggles.py
@@ -5,9 +5,9 @@ from seedsigner.views import tools_views
 
 
 class TestSmartcardSupportToggles(BaseTest):
-    def test_default_smartcard_backend_toggles_enabled(self):
+    def test_default_smartcard_backend_toggles(self):
         assert self.settings.get_value(SettingsConstants.SETTING__SATOCHIP_SUPPORT) == SettingsConstants.OPTION__ENABLED
-        assert self.settings.get_value(SettingsConstants.SETTING__KEYCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED
+        assert self.settings.get_value(SettingsConstants.SETTING__KEYCARD_SUPPORT) == SettingsConstants.OPTION__DISABLED
 
     def test_default_specter_diy_toggle_disabled(self):
         assert self.settings.get_value(SettingsConstants.SETTING__SPECTER_DIY_SUPPORT) == SettingsConstants.OPTION__DISABLED

--- a/tools/verify_keycard.py
+++ b/tools/verify_keycard.py
@@ -1,0 +1,62 @@
+"""
+Quick smoke-test for the KeycardSatochipConnector against a real card.
+
+Usage:
+    python tools/verify_keycard.py [PIN]      (default PIN: 123456)
+"""
+
+import sys
+import os
+
+# Resolve paths
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO, "src"))
+
+from seedsigner.helpers.keycard_connector import KeycardSatochipConnector
+
+PIN = sys.argv[1] if len(sys.argv) > 1 else "123456"
+
+print("=== Keycard smoke test ===")
+print(f"Default pairing password : {KeycardSatochipConnector.DEFAULT_PAIRING_PASSWORD!r}")
+print(f"PIN                      : {PIN}")
+print()
+
+# ── 1. Connect ────────────────────────────────────────────────────────────────
+print("[1] Connecting to card …")
+conn = KeycardSatochipConnector.create(card_filter=["satochip"])
+print(f"    UID SHA1 : {conn.UID_SHA1}")
+
+# ── 2. Get status ─────────────────────────────────────────────────────────────
+print("[2] card_get_status …")
+_, sw1, sw2, status = conn.card_get_status()
+print(f"    SW={sw1:02X}{sw2:02X}  status={status}")
+if not status.get("setup_done") and not status.get("key_initialized"):
+    print("    Card has no key loaded – stopping here.")
+    sys.exit(0)
+
+# ── 3. Verify PIN ─────────────────────────────────────────────────────────────
+print("[3] Verifying PIN …")
+conn.set_pin(0, PIN)
+resp, sw1, sw2 = conn.card_verify_PIN()
+if sw1 == 0x90 and sw2 == 0x00:
+    print("    PIN OK")
+else:
+    print(f"    PIN failed: SW={sw1:02X}{sw2:02X}")
+    sys.exit(1)
+
+# ── 4. Export xpub ───────────────────────────────────────────────────────────
+print("[4] Exporting xpub at m/44'/0'/0' …")
+xpub = conn.card_bip32_get_xpub("m/44'/0'/0'", "standard", is_mainnet=True)
+print(f"    xpub : {xpub}")
+
+# ── 5. Sign a dummy 32-byte hash ──────────────────────────────────────────────
+print("[5] Signing 32-byte hash at m/44'/0'/0'/0/0 …")
+dummy_hash = bytes(range(32))
+# Derive to leaf path so _last_path is set for keynbr=0xFF routing
+conn.card_bip32_get_xpub("m/44'/0'/0'/0/0", "standard", is_mainnet=True)
+sig_resp, sw1, sw2 = conn.card_sign_transaction_hash(0xFF, dummy_hash)
+print(f"    SW={sw1:02X}{sw2:02X}  DER sig ({len(sig_resp)} bytes): {bytes(sig_resp).hex()}")
+
+print()
+print("=== All checks passed ===")
+conn.card_disconnect()


### PR DESCRIPTION
This pull request introduces support for the Keycard backend as a compatibility layer for Satochip-style smartcard operations, improves QR scanning backend handling (including OpenCV fallback), and adds user-facing settings for enabling/disabling Satochip and Keycard support. It also refines UI logic to show smartcard options only when the relevant features are enabled, and improves error handling for missing QR scanning dependencies.

**Keycard Backend Integration and Smartcard Improvements:**
- Added Keycard backend support as a compatibility layer for Satochip flows, with environment variable controls and documentation updates. The backend selection logic now tries pysatochip first, then falls back to Keycard for Satochip flows if enabled (`src/seedsigner/helpers/seedkeeper_utils.py`, `src/seedsigner/helpers/keycard_connector.py`, `docs/smartcard_support_installation.md`, `requirements-desktop.txt`, `requirements-raspi.txt`). [[1]](diffhunk://#diff-c78d8efa598b9a9db0b21f22658b744eec1953b93d98d1ecb31bf02d4e90cd74R18) [[2]](diffhunk://#diff-c78d8efa598b9a9db0b21f22658b744eec1953b93d98d1ecb31bf02d4e90cd74R30-R77) [[3]](diffhunk://#diff-c78d8efa598b9a9db0b21f22658b744eec1953b93d98d1ecb31bf02d4e90cd74L148-R196) [[4]](diffhunk://#diff-c78d8efa598b9a9db0b21f22658b744eec1953b93d98d1ecb31bf02d4e90cd74R206-R208) [[5]](diffhunk://#diff-c78d8efa598b9a9db0b21f22658b744eec1953b93d98d1ecb31bf02d4e90cd74L187-R241) [[6]](diffhunk://#diff-c78d8efa598b9a9db0b21f22658b744eec1953b93d98d1ecb31bf02d4e90cd74R397-R406) [[7]](diffhunk://#diff-39803f7840a30d2aec6b9da5a3cf58542cdff4545a55d6fe8ec9194efede161eR83-R114) [[8]](diffhunk://#diff-d76436b048ca1d5c9ebd720898456f37f72df6ea99c337392136a59ec0351153R3) [[9]](diffhunk://#diff-3be24e137acd6e2b4f6de386ca088da467f1e2ccac0599d580d0baff348cf96aR4)
- Added new settings entries to enable or disable Satochip and Keycard support in the UI and codebase (`src/seedsigner/models/settings_definition.py`). [[1]](diffhunk://#diff-6763af84a0941388b23067bea258f34d437cce5f76d107fd33ceba3584fd4675R436-R437) [[2]](diffhunk://#diff-6763af84a0941388b23067bea258f34d437cce5f76d107fd33ceba3584fd4675R1060-R1073)
- UI logic for Satochip options now respects the new settings, so Satochip-related buttons only appear when the feature is enabled (`src/seedsigner/views/psbt_views.py`, `src/seedsigner/views/seed_views.py`, `src/seedsigner/views/tools_views.py`). [[1]](diffhunk://#diff-ecaa332c1175b0e40c3f391777ac713f92c5570da50f262490066ad2fb5a6577R86-R89) [[2]](diffhunk://#diff-763993aad0384d5ea02ea3307a20bd99c432637c886e50e15d55584bf2d16c9bL164-R167) [[3]](diffhunk://#diff-2e41a3c853a26b4979b1a935a7b45258f1432b0aa0f8d8ff060179852e066c17L1094-R1100)

**QR Code Scanning Backend Robustness:**
- Improved QR scanning backend selection: now attempts to use zbar if available, otherwise falls back to OpenCV on desktop. Added error reporting for missing dependencies and prevents QR scan flows if no backend is available (`src/seedsigner/models/decode_qr.py`, `src/seedsigner/views/scan_views.py`). [[1]](diffhunk://#diff-3a332b145e5a01d6757276b3166c9fd106cdd7c3e5a2fb9ad4025d78ac6d8577R11-R28) [[2]](diffhunk://#diff-3a332b145e5a01d6757276b3166c9fd106cdd7c3e5a2fb9ad4025d78ac6d8577R81-R115) [[3]](diffhunk://#diff-3a332b145e5a01d6757276b3166c9fd106cdd7c3e5a2fb9ad4025d78ac6d8577R512) [[4]](diffhunk://#diff-3a332b145e5a01d6757276b3166c9fd106cdd7c3e5a2fb9ad4025d78ac6d8577R523-R567) [[5]](diffhunk://#diff-c3440c27a11d58a168e79233abe1292e3d9e9bf7c62757024b8ddb85644719beR121-R144) [[6]](diffhunk://#diff-c3440c27a11d58a168e79233abe1292e3d9e9bf7c62757024b8ddb85644719beR420-R423)

**Satochip Signing Improvements:**
- Improved Satochip message signing logic to optionally use Bitcoin message digest depending on backend requirements (`src/seedsigner/helpers/satochip_signer.py`). [[1]](diffhunk://#diff-485f436ca7e6b62a9cd08b7a01d03584a2b076fcc2457f17a83b5e2567db3886R4) [[2]](diffhunk://#diff-485f436ca7e6b62a9cd08b7a01d03584a2b076fcc2457f17a83b5e2567db3886R161-R180) [[3]](diffhunk://#diff-485f436ca7e6b62a9cd08b7a01d03584a2b076fcc2457f17a83b5e2567db3886R351-R358)

**Other:**
- Minor refactoring and import cleanups for improved maintainability (`src/seedsigner/helpers/seedkeeper_utils.py`).

These changes make smartcard support more flexible and robust, improve user experience around QR scanning, and provide clearer configuration and error messaging for advanced features.## Description

_Describe the change simply. Provide a reason for the change._

_Include screenshots of any new or modified screens (or at least explain why they were omitted)_

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] I’ve run `pytest` and made sure all unit tests pass before sumbitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
