### PR TITLE
Fork translation overlay: pull upstream translations + agent-filled gaps

### DIFF
--- a/.claude/commands/translate-gaps.md
+++ b/.claude/commands/translate-gaps.md
@@ -12,19 +12,26 @@ overlap). Managed by `l10n/fork_translations.py`. See `l10n/README.md`.
 
 ## Procedure
 
-1. **Prepare.** Run `python l10n/fork_translations.py prune` then
-   `python l10n/fork_translations.py stub --locale <locale>`. Open
-   `l10n/fork/<locale>/messages.po` — every entry with an empty `msgstr` is a gap.
+1. **Prepare.** Run `python l10n/fork_translations.py prune`, then dump the gap
+   list: the msgids in `l10n/messages.pot` that the upstream catalog for the
+   locale hasn't translated and the overlay doesn't cover yet
+   (`fork_translations.py status` shows counts).
 
-2. **Build the glossary FIRST.** Read the upstream catalog at
+2. **Read `l10n/GLOSSARY.md` and the upstream catalog FIRST.** GLOSSARY.md holds
+   settled cross-locale decisions (never-translate list, SLIP-39 "share"
+   terminology per Trezor, per-locale conventions). The upstream catalog at
    `src/seedsigner/resources/seedsigner-translations/l10n/<locale>/LC_MESSAGES/messages.po`
-   and extract how upstream renders recurring terms before translating anything:
-   seed, mnemonic, passphrase, fingerprint, derivation path, descriptor,
-   multisig/single sig, script type, wallet, address, QR code, scan, verify,
-   backup, entropy, dice, coordinator/wallet software, and the names of
-   screens/buttons the fork strings extend. **Match upstream's choices exactly** —
-   including which terms upstream deliberately leaves in English (e.g. "xpub",
-   "SeedQR", "PSBT" typically stay untranslated).
+   is the primary glossary — extract how it renders recurring terms (seed,
+   mnemonic, passphrase, fingerprint, descriptor, multisig, wallet, address,
+   scan, verify, backup, entropy, dice) and **match its choices exactly**,
+   including which terms it deliberately leaves in English. Record any new
+   cross-locale decision back into GLOSSARY.md.
+
+   **Preferred mechanism:** write the translations as a
+   `TRANSLATIONS = {msgid: msgstr}` dict in `l10n/_tr_<locale>.py` (untracked
+   session file), then run `python -X utf8 l10n/apply_translations.py <locale>`
+   to build the overlay catalog with provenance comments, a typo guard on
+   msgids, and a report of what remains untranslated.
 
 3. **Translate every empty msgstr**, respecting:
    - Placeholders `{}` / `{name}` copied verbatim, same count and names.

--- a/.claude/commands/translate-gaps.md
+++ b/.claude/commands/translate-gaps.md
@@ -34,6 +34,9 @@ overlap). Managed by `l10n/fork_translations.py`. See `l10n/README.md`.
    msgids, and a report of what remains untranslated.
 
 3. **Translate every empty msgstr**, respecting:
+   - **BIP39/SLIP39 mnemonic words are NEVER translated** — never create an
+     entry whose msgid equals a wordlist word (`fork_translations.py check`
+     enforces this; rationale in GLOSSARY.md).
    - Placeholders `{}` / `{name}` copied verbatim, same count and names.
    - `\n` line structure preserved.
    - UI limits (see AGENTS.md): body copy ≤ ~120 chars over ≤ 2 lines; button

--- a/.claude/commands/translate-gaps.md
+++ b/.claude/commands/translate-gaps.md
@@ -1,0 +1,63 @@
+---
+description: Fill fork-translation gaps for a locale (agent-translated, upstream-glossary-consistent)
+argument-hint: <locale e.g. es, de, zh_Hans_CN> [--dry-run]
+---
+
+Fill the fork's translation overlay for locale **$ARGUMENTS**.
+
+The fork adds UI strings upstream never translates. Overlay catalogs live at
+`l10n/fork/<locale>/messages.po` and are merged into the upstream catalogs at
+build time by `python setup.py compile_catalog` (upstream always wins on
+overlap). Managed by `l10n/fork_translations.py`. See `l10n/README.md`.
+
+## Procedure
+
+1. **Prepare.** Run `python l10n/fork_translations.py prune` then
+   `python l10n/fork_translations.py stub --locale <locale>`. Open
+   `l10n/fork/<locale>/messages.po` — every entry with an empty `msgstr` is a gap.
+
+2. **Build the glossary FIRST.** Read the upstream catalog at
+   `src/seedsigner/resources/seedsigner-translations/l10n/<locale>/LC_MESSAGES/messages.po`
+   and extract how upstream renders recurring terms before translating anything:
+   seed, mnemonic, passphrase, fingerprint, derivation path, descriptor,
+   multisig/single sig, script type, wallet, address, QR code, scan, verify,
+   backup, entropy, dice, coordinator/wallet software, and the names of
+   screens/buttons the fork strings extend. **Match upstream's choices exactly** —
+   including which terms upstream deliberately leaves in English (e.g. "xpub",
+   "SeedQR", "PSBT" typically stay untranslated).
+
+3. **Translate every empty msgstr**, respecting:
+   - Placeholders `{}` / `{name}` copied verbatim, same count and names.
+   - `\n` line structure preserved.
+   - UI limits (see AGENTS.md): body copy ≤ ~120 chars over ≤ 2 lines; button
+     labels and titles as short as their English counterparts (the 240px screen
+     does not scroll horizontally).
+   - Sentence casing conventions of the target language; upstream's existing
+     style wins over textbook style.
+   - Brand/product names (SeedSigner, SeedKeeper, Satochip, Keycard, Specter,
+     BitBox02, Passport, TAPSIGNER, GPG, BIP39/BIP85/SLIP39) are never translated.
+   - Add `#. FORK: translated by Claude <YYYY-MM-DD>` above each entry you fill.
+
+4. **Doubt handling — ask, don't guess.** Collect ambiguous strings while
+   translating (polysemous words like "share" (SLIP39 share vs. verb),
+   "load" (from storage vs. onto card), terse fragments whose UI context is
+   unclear). Look up the source file/line from the entry's `#:` comment to get
+   context first; if still uncertain, mark the entry `#. FORK-REVIEW: <question>`
+   with msgstr left empty, and ask the user **in one batch** (AskUserQuestion)
+   at the end rather than one-at-a-time. Fill after answers arrive.
+
+5. **Verify.**
+   - `python l10n/fork_translations.py check` → 0 errors.
+   - `python setup.py compile_catalog` → look for `(+N fork overlay entries)`.
+   - Spot-check via gettext: load the locale and confirm 2–3 fork strings return
+     translations while an upstream string still returns upstream's text.
+   - `python -m pytest tests/test_flows_l10n.py` passes.
+   - Rendering (fonts/line lengths) is validated by the screenshot generator in
+     CI — locally Pillow lacks libraqm, don't attempt it.
+
+6. **Deliver.** `python l10n/fork_translations.py status` for the final coverage
+   number, then commit just this locale's overlay file on a dedicated branch and
+   report gap→coverage before/after. One locale per PR keeps diffs reviewable.
+
+If `--dry-run` was passed: do steps 1–2 and report the gap list and glossary,
+but don't write translations.

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,13 @@ src/seedsigner/models/settings_definition.json
 
 *.po
 *.mo
+# Fork translation overlay catalogs ARE tracked (see l10n/README.md);
+# the blanket *.po rule above is for the seedsigner-translations submodule.
+!l10n/fork/**/*.po
+# Working files used by translation sessions
+l10n/_*.py
+l10n/_*.json
+l10n/_*.txt
 jcardsim.jar
 settings.json
 /microsd

--- a/l10n/GLOSSARY.md
+++ b/l10n/GLOSSARY.md
@@ -1,0 +1,63 @@
+# Fork translation glossary & rules
+
+Shared decisions for filling the fork's translation overlays
+(`l10n/fork/<locale>/messages.po`). Used by the `/translate-gaps` workflow.
+The **upstream catalog for the locale is always the primary glossary** — match
+its terminology exactly, even when a textbook translation would differ. This
+file records decisions that upstream's catalogs don't settle.
+
+## Never translate (all locales)
+
+1. **Mis-extracted internal data keys** — these are GPG colon-format /
+   dict-lookup keys that Babel's extractor caught by accident. Translating
+   them is wrong; leave them out of every overlay (English fallback is a
+   no-op): `fpr`, `uid`, `uiduidfpr`, `fprcaps`, `fingerprintseed_type`, `.`
+2. **Brand / protocol names**: SeedSigner, SeedKeeper, Seedkeeper, Satochip,
+   Keycard, Specter, Specter-DIY, BitBox02, Passport, TAPSIGNER, Electrum,
+   LND, Diceware, SmartGPG, OpenGPG, GPG, NDEF, PCSC, NFC, PIN, PUK, RNG,
+   BIP39/BIP38/BIP32/BIP85, SLIP39, xpub, xprv, WIF, PSBT, SeedQR,
+   CompactSeedQR, EncryptedQR, QR.
+3. **Universal tokens**: `Base64`, `Base85`, `Hex` (unless the locale's
+   upstream catalog translates it), `microSD`, byte sizes (`64MB`, `4 KB`, …),
+   bit counts (`128 bits` — translate only the "bits" word if upstream does).
+
+## SLIP-39 "share"
+
+Follow Trezor firmware's per-language convention (checked at
+trezor-firmware `b235e018`):
+
+| locale | term |
+|--------|------|
+| es | parte / partes |
+| ca | part / parts (mirrors es; no Trezor ca) |
+| cs | podíl / podíly |
+| de | Share / Shares (Trezor de keeps English, capitalized noun) |
+| el | μερίδιο / μερίδια (no Trezor el; natural Greek) |
+| fr | fragment / fragments |
+| pt_BR | share / shares (Trezor pt keeps English) |
+
+For locales not listed: check Trezor first, else follow the pattern of the
+closest sibling language and note the decision here.
+
+## Per-locale conventions (from upstream catalogs)
+
+- **es**: seed = *semilla*; passphrase = *Passphrase* (kept); fingerprint =
+  *huella*; wallet = *billetera*; buttons in infinitive (*Cargar*, *Escanear*);
+  sentences address the user as *tú*.
+- **ca**: seed = *llavor*; passphrase = *Passphrase*; fingerprint = *empremta*;
+  wallet = *bitlletera*; mixes infinitive and imperative like upstream.
+- **cs**: seed = *seed* (kept, declined: *seedu*, *seedy*); passphrase =
+  *bezpečnostní fráze*; fingerprint = *otisk*; wallet = *peněženka*.
+- **de**: seed = *Seed* (kept); passphrase = *Passphrase*; fingerprint =
+  *Fingerabdruck*; wallet = *Wallet* (kept); Tools = *Tools* (kept); informal
+  *du*-form; verb-final button style (*Seed laden*, *… eingeben*).
+- **el**: seed = *seed* (kept); passphrase = *συνθηματική φράση*; fingerprint =
+  *αποτύπωμα*; wallet = *πορτοφόλι*; noun-style buttons (*Φόρτωση seed*).
+
+## Formatting rules
+
+- `{}` / `{name}` placeholders verbatim, same count and names.
+- Preserve `\n` counts and leading/trailing spaces exactly (icon-padded
+  labels like `" New seed"` and value labels like `"Voltage: "`).
+- Body copy ≤ ~120 chars over ≤ 2 lines; buttons/titles as short as English
+  (240px screen, no horizontal scroll — see AGENTS.md).

--- a/l10n/GLOSSARY.md
+++ b/l10n/GLOSSARY.md
@@ -6,6 +6,22 @@ The **upstream catalog for the locale is always the primary glossary** — match
 its terminology exactly, even when a textbook translation would differ. This
 file records decisions that upstream's catalogs don't settle.
 
+## BIP39 / SLIP39 mnemonic words are NEVER translated
+
+The seed words themselves (reading, backing up, entering, backup-test choices)
+must always render exactly as the English wordlist words. The code guarantees
+this — words are drawn directly (`SeedWordsScreen`), injected via `.format()`
+after template translation (calc-final-word), or use
+`ButtonOptionWithoutTranslation` (backup test) — so they never flow through
+gettext. To keep it that way:
+
+- Never add an overlay entry whose msgid exactly equals a BIP39/SLIP39 word
+  (`fork_translations.py check` errors on this). Upstream's "change"/"fee"
+  msgids are PSBT UI labels, not wordlist renderings — they're fine upstream
+  but must not be duplicated into overlays.
+- When touching seed/share word UI code, keep words out of `_()` and plain
+  `ButtonOption` labels; use `ButtonOptionWithoutTranslation`.
+
 ## Never translate (all locales)
 
 1. **Mis-extracted internal data keys** — these are GPG colon-format /

--- a/l10n/README.md
+++ b/l10n/README.md
@@ -12,6 +12,32 @@
 1. Python code retrieves a translation on demand.
 
 
+## Fork translation overlay (3rdIteration fork)
+This fork adds hundreds of UI strings (smartcard, GPG, password generator, SLIP39, …)
+that upstream's Transifex translators never see. Their translations live in
+**overlay catalogs** in this repo at `l10n/fork/<locale>/messages.po`, containing
+*only* the fork-gap entries.
+
+* **Merge rule:** at compile time the overridden `compile_catalog` command in
+  `setup.py` merges each upstream catalog (from the `seedsigner-translations`
+  submodule) with its overlay and writes a single combined `.mo`. **Upstream
+  always wins** for any msgid it has translated; the overlay only fills gaps.
+  No build system changes are needed anywhere — CI, seedsigner-os image builds,
+  and local dev all already run `python setup.py compile_catalog`.
+* **Management script:** `python l10n/fork_translations.py <status|stub|prune|check>`
+  * `status` — per-locale coverage (upstream + overlay vs `messages.pot`).
+  * `stub --locale <loc>` / `--all` — add missing msgids to the overlay with empty msgstr.
+  * `prune` — drop overlay entries that upstream has since translated, or that
+    left the pot. Run after every submodule bump and pot regeneration.
+  * `check` — validate catalogs (parse, `{}` placeholder consistency).
+* **Pulling upstream translations stays trivial:** bump the submodule pointer,
+  re-run `python setup.py extract_messages`, then `prune` + `status`.
+* **Filling gaps:** run the `/translate-gaps <locale>` Claude Code command
+  (`.claude/commands/translate-gaps.md`). The agent translates using the upstream
+  catalog as the terminology glossary, tags entries with `#. FORK:` provenance
+  comments, and asks (batched) about any string whose sense is ambiguous.
+
+
 ## "Wrapping" text for translation
 Any text that we want to be presented in multiple languages needs to "wrapped".
 
@@ -293,6 +319,10 @@ python setup.py compile_catalog
 # Or target a specific language code:
 python setup.py compile_catalog -l es
 ```
+
+Note: in this fork, `compile_catalog` also merges the fork overlay catalogs from
+`l10n/fork/<locale>/messages.po` into each `.mo` (see "Fork translation overlay"
+above). The log line per locale reports `(+N fork overlay entries)`.
 
 ### Unused babel commands
 Transifex eliminates the need for the `init_catalog` and `update_catalog` commands.

--- a/l10n/apply_translations.py
+++ b/l10n/apply_translations.py
@@ -1,0 +1,72 @@
+"""Build a fork overlay catalog from a translation dict.
+
+Part of the /translate-gaps workflow (see .claude/commands/translate-gaps.md
+and l10n/README.md):
+
+1. Create l10n/_tr_<locale>.py containing a ``TRANSLATIONS = {msgid: msgstr}``
+   dict (the leading underscore keeps it untracked; it's a session working file).
+2. Run:  python -X utf8 l10n/apply_translations.py <locale>
+3. The overlay at l10n/fork/<locale>/messages.po is rebuilt with every pot-gap
+   msgid found in the dict (ids upstream already translated are skipped, and a
+   ``FORK: translated by Claude <date>`` provenance comment is added to each).
+4. The script fails on dict keys that don't exist in messages.pot (typo guard)
+   and lists any gaps left untranslated so deliberate skips are visible.
+"""
+import datetime
+import importlib
+import sys
+
+sys.path.insert(0, "l10n")
+from babel.messages.catalog import Catalog
+
+from fork_translations import (
+    load_catalog, load_overlay, load_pot, save_overlay,
+    translated_ids, upstream_po_path,
+)
+
+
+def main(locale: str) -> int:
+    mod = importlib.import_module(f"_tr_{locale}")
+    translations = mod.TRANSLATIONS
+
+    pot = load_pot()
+    pot_ids = {m.id for m in pot if m.id}
+    upstream_done = translated_ids(load_catalog(upstream_po_path(locale), locale))
+    date = datetime.date.today().isoformat()
+
+    unknown = sorted(k for k in translations if k not in pot_ids)
+    if unknown:
+        print(f"ERROR: {len(unknown)} translation key(s) not in messages.pot:")
+        for key in unknown:
+            print("   ", repr(key))
+        return 1
+
+    catalog = Catalog(locale=locale, domain="messages", fuzzy=False)
+    catalog.header_comment = load_overlay(locale).header_comment
+
+    filled = 0
+    untranslated = []
+    for message in pot:
+        if not message.id or message.id in upstream_done:
+            continue
+        translation = translations.get(message.id)
+        if translation:
+            catalog.add(
+                message.id,
+                string=translation,
+                locations=message.locations,
+                auto_comments=[f"FORK: translated by Claude {date}"] + list(message.auto_comments),
+            )
+            filled += 1
+        else:
+            untranslated.append(message.id)
+
+    save_overlay(locale, catalog)
+    print(f"{locale}: filled {filled}; left untranslated: {len(untranslated)}")
+    for mid in untranslated:
+        print("   (gap)", repr(mid))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1]))

--- a/l10n/fork/ca/messages.po
+++ b/l10n/fork/ca/messages.po
@@ -1,0 +1,2493 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-10 23:02-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ca\n"
+"Language-Team: ca <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "Dades esborrades per inactivitat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "Iniciant la càmera..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "Desxifrar?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "Selecciona el tipus de QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "Clau de xifratge"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "Revisar la clau de xifratge"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "Número de compte"
+
+#. FORK: translated by Claude 2026-07-10
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "Xifrat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "Bits d'entropia xifrats"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "Ruta no estàndard!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "ID del mnemònic"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "Revisar l'ID del mnemònic"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "Els codis QR generats en els dos modes poden diferir, però tots dos són vàlids."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "Transcriure QR xifrat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "No hi ha opcions disponibles"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "Info. de la bateria"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "Info. del sistema"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Platform: {platform_name}"
+msgstr "Plataforma: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Variant: {platform_variant}"
+msgstr "Variant: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (CPU): {system_serial}"
+msgstr "Sèrie (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "Sèrie (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "Filtre de dispositius"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "Info. de xarxa"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "Calibratge de la bateria"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "Carrega la bateria del tot. Prem Següent per començar la prova de descàrrega."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "Inicia"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "La prova dura fins a esgotar-la. Deixa el dispositiu desendollat."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "Càrrega detectada"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "Descarregant"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "Transcorregut: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "Voltatge: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "Corrent: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "Estat: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "ENTROPIA BAIXA"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "ENTROPIA BONA"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "Text a codificar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "Establir PIN de coacció"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "Càmera 0"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "Càmera 1"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "Càmera 2"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "Càmera 3"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 minuts"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 minuts"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 minuts"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 minuts"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Passphrase Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "Preferir CompactSeedQR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "Preferir EncryptedQR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "Preguntar cada vegada"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "Intents de PIN de la targeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "Temporitzador d'esborrat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "Longituds de la llavor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "Preguntar compte BIP32"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "QR ambigu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "Tipus de clau GPG"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "Versió GPG de BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 és la més recent; usa v2 per recrear claus B9-B10"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "Llavors SLIP39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Llavors Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "Compatible amb LND, 24 paraules"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "Parts SLIP39 extensibles"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "Còpies de BitBox02"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Còpies de Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "Còpies de TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "Suport de targeta intel·ligent"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Suport de Satochip"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Suport de Keycard"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Suport de Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "Font de la càmera"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "Mode escriptori"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "No és segur!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Aquesta versió d'escriptori és només per a proves.\n"
+"NO la usis amb llavors o claus privades reals."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "Ho entenc"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "Compilació de desenvolupament"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Aquesta compilació de desenvolupament de SeedSignerOS és només per a proves.\n"
+"NO la usis amb llavors o claus privades reals."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "Operacions amb fitxers"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "Importar claus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "Exportar claus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "Veure claus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "Missatgeria segura"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "Eines GPG"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "Falten paquets"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "Requerit però no instal·lat:\n"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "Operacions amb subclaus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "Operacions amb ID d'usuari"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "Certificació creuada de claus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "Exportar paquet de clau pública"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "Metadades BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "Subclaus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "Enrere"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "Exportar paquet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "QR animat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "Desar dades BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "Carregar dades BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "Reconstruir clau BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "A MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "A QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "A Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "Des de MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "Des de QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Des de Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "Afegir subclaus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "Revocar subclaus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "Eliminar subclaus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "Canviar caducitat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "Exportar secrets de subclau"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 any"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 anys"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 anys"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "Mai"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "Fitxer"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "Targeta intel·ligent"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "Afegir ID d'usuari"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "Editar IDs d'usuari"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "Fixar ID d'usuari principal"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "Revocar ID d'usuari"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "Eliminar ID d'usuari"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "Xifrar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "Desxifrar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "Signar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "Verificar signatura"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "Crear missatge"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "Carregar missatge"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "Manifest"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "Escriure missatge"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Carregar Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "Escanejar QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "Carregar fitxer"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "Carregar clau"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Desar a Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "Mostrar com a QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "Clau pública"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "Clau privada"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "Veure info. de la targeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "Generar clau a la targeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "Canviar PIN d'administrador"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "Canviar PIN d'usuari"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "Xifrant el fitxer"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(Pot trigar una estona)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "Desxifrant el fitxer"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "Comprovar SHA256Sum"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "Actualitzar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "Des de fitxer"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "Generar nova"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "Derivar BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "Targeta OpenGPG"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "Editar text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "Descartar text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "Descartar el text?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "Generar codi QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "Mode transcripció"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "Mode pantalla completa"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "Mode transcripció?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "Confirmar codi QR de text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "Confirmar QR de text?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "Escanejar codi QR de text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "Confirmar codi QR de text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "El QR de text transcrit no coincideix amb el teu text original!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "Revisar codi QR de text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "El teu QR de text transcrit s'ha escanejat correctament i ha produït el mateix text."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "Confirmar QR de text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "No s'ha pogut llegir el teu QR de text transcrit!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "Editar i generar codi QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "Text descodificat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "Executar prova"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "Gravar imatge"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "Verificar MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "Esborrar (zeros)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "Esborrar (aleatori)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "Ometre verificació"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "Tots"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "Personalitzat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF curta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF llarga"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "Tirades de daus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "Tipus de contrasenya"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 bits"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 bits"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 bits"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "Robustesa de la contrasenya"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "Sí"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "No"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "Seleccionar opcions"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "Tria almenys un conjunt de caràcters."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "Ha fallat la comprovació de l'RNG del sistema."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "Error de l'RNG del sistema"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "Càmera"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "Daus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "RNG del sistema"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "Font d'entropia"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "No compatible"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 admet Diceware, tirades de daus, Hex, Base64 i Base85."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "Cap"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "Majúscula inicial"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "Espai"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "Separador"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 cares"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 cares"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 cares"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "Cares del dau"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "Nombre de tirades"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "Entrada no vàlida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "El nombre de tirades ha de ser com a mínim 1."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "Entropia pobra"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "Les tirades no han semblat prou aleatòries. Torna-ho a provar."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "L'entropia de la càmera no ha semblat prou aleatòria. Torna-ho a provar."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "ADVERTÈNCIA"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "Carrega una llavor abans d'usar BIP85."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "Seleccionar llavor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "Tria la llavor per a BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "Índex BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "Longitud no vàlida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex admet 128 o 256 bits."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 necessita 120+ bits."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 necessita 64-512 bits."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "Nom de la contrasenya"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "Espai insuficient"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"Desant el secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "Èxit"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "Contrasenya desada a Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "No hi ha prou espai a Seedkeeper per a la contrasenya"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "Ha fallat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "No s'ha pogut desar la contrasenya"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "Editar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "Contrasenya"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "Desar contrasenya"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Usar targeta Satochip"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Usar Keycard"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "Introduïr 15 paraules"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "Introduïr 18 paraules"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "Introduïr 21 paraules"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "Introduir WIF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "Escanejar WIF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "Introduir BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "Escanejar BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "L'empremta no coincideix"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "La targeta no pot signar el PSBT"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "L'empremta de la targeta ({}) no és entre els signants del PSBT."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "Clau privada (WIF)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "WIF no vàlid!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "No és una clau privada WIF vàlida."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "Clau BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "Passphrase BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "BIP38 no vàlid!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "No s'ha pogut desxifrar la clau BIP38."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "El descriptor no coincideix"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "Descriptor esborrat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "El descriptor multisig carregat no coincideix amb aquest PSBT. Carrega el descriptor correcte o omet la verificació per continuar."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "Signant el PSBT..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "Temps de signatura esgotat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "Reintentar (més temps)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Saved as {}."
+msgstr "Desat com a {}."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Failed to save PSBT: {}"
+msgstr "No s'ha pogut desar el PSBT: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "Codificant el PSBT..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "Escàner QR no disponible"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "Falta el motor d'escaneig QR. Instal·la zbar (o OpenCV a l'escriptori) i reinicia."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "Selecciona el tipus de llavor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "Hora fixada a:"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "No s'ha pogut fixar l'hora"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "Hora no vàlida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "No s'ha pogut llegir l'hora del QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "Escanejar part SLIP-39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "S'esperava un QR de part SLIP-39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "S'esperava una clau privada WIF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "S'esperava una clau privada BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "Escaneja l'adreça de recepció {} de la bitlletera que acabes d'exportar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"Les dades coincideixen amb\n"
+"diversos tipus de QR."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "Escriure clau de xifratge"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "Escanejar clau de xifratge"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "Editar clau de xifratge"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "Descartar clau de xifratge"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "Continuar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "Escanejar i afegir-ne un altre"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "Text desxifrat"
+
+#. FORK: translated by Claude 2026-07-10
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "Un fork no oficial de:"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "Còpia de BitBox02"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Còpia de Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "Còpia de TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Introduir llavor Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "Parts SLIP-39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " Escanejar un SeedQR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "Des de SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Des de Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " Generar una llavor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "Targeta microSD no detectada."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "No s'han trobat còpies"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "No s'han trobat còpies de BitBox02 (.bin, .bb02, .dat, .backup) a la targeta microSD."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "Selecciona la còpia de BitBox02"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup name: {}"
+msgstr "Nom de la còpia: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Created: {}"
+msgstr "Creada: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Firmware: {}"
+msgstr "Firmware: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Birthdate: {}"
+msgstr "Data d'origen: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Seed length: {} words"
+msgstr "Longitud de la llavor: {} paraules"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "Llavor carregada"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "No s'han trobat còpies de Passport (.7z) a la targeta microSD."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Selecciona la còpia de Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Codi de la còpia de Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "El codi de la còpia no pot estar buit."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Chain: {}"
+msgstr "Cadena: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "No s'han trobat còpies de TAPSIGNER (.aes) a la targeta microSD."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "Selecciona la còpia de TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "Clau de la còpia (hex)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "xprv carregada des de la còpia de TAPSIGNER."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Path: {}"
+msgstr "Ruta: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "Carregar Passphrase"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "Escriure Passphrase"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "Escanejar Passphrase"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "Carregar des de SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Passphrase Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"Aquest mnemònic requereix\n"
+"Passphrase."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "Passphrase no vàlida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Cal la Passphrase Aezeed.\n"
+"Torna-ho a provar."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Passphrase Aezeed incorrecta.\n"
+"Torna-ho a provar."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "QR de text no vàlid"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "S'han detectat dades no UTF-8."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Suport d'Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"L'entrada Aezeed és experimental.\n"
+"Usa-la només amb còpies verificades."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "Introduir 20 paraules"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "Introduir 33 paraules"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "Carregar part"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Share Word #{}"
+msgstr "Paraula #{} de la part"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "Introduir part"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "Escanejar part"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "Combinar parts"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "{} of {} needed"
+msgstr "Calen {} de {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "Reintentar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "Part SLIP-39 no vàlida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "Suma de comprovació fallida; no és una part SLIP-39 vàlida."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Llavor no extensible"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Aquesta llavor SLIP-39 no pot regenerar noves parts."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "Exportar com a QR sense xifrar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "A SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "A Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "Regenerar parts"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "Obre {} i mostra una adreça de recepció de la bitlletera que acabes d'exportar."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "el teu programari de bitlletera"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"Es va usar Passphrase.\n"
+"Necessitaràs paraules + Passphrase."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 paraules"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "Revisar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "Finalitzar llavor filla"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "Introduir clau de xifratge"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "Descartar la clau de xifratge?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "La clau introduïda s'esborrarà"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "Clau no vàlida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "La clau és massa llarga."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "Entrada des de la càmera"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "Usar empremta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "Assignar ID personalitzat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "Introduir ID del mnemònic"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "Editar ID del mnemònic"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "Descartar ID del mnemònic"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "Descartar l'ID del mnemònic?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "L'ID del mnemònic introduït s'esborrarà"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "Processant..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "Fallada de xifratge"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "Següents 100"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "Cerca ampliada"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "No trobat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "Adreça no verificada"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses with no match."
+msgstr "S'han comprovat {} adreces sense coincidència."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "Comprovar 10 més"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses per path with no match."
+msgstr "S'han comprovat {} adreces per ruta sense coincidència."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "Exportació de bitlletera"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "Bitlletera exportada correctament."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "El format d'adreça no coincideix amb el tipus de script exportat. L'exportació ha fallat."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "No s'ha pogut associar la bitlletera amb la llavor actual. L'exportació ha fallat."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "Exportació fallida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "Carregar SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "Exportant xpub..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "Signant el missatge..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "Verificació fallida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "Provar targeta intel·ligent"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "Llistar lectors de targetes"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "Provar escaneig NFC"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "Reiniciar PCSC"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "Info. de la bateria"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "Info. del sistema"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "Carregar fitxers de còpia"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "No s'ha detectat cap monitor de bateria compatible"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "No disponible"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "Funcions comunes"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Funcions de Satochip"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Funcions de Keycard"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "Funcions de SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Funcions de Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "Eines DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "Info. de la targeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "Comprovar autenticitat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "Canviar PIN"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "Canviar etiqueta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "Canviar política NFC"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "Configurar NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "Restablir targeta de fàbrica"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "Veure NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Usar enllaç de l'app Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "Esborrar NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "Definir NDEF personalitzat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "Desar NDEF a SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "Carregar NDEF des de SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "Registre de text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "Registre URI"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Llançar app Android"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "Personalitzat (HEX)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "Descodificar NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC activat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC desactivat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC bloquejat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "Targeta reinserida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "Veure espai lliure"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "Veure secrets de la targeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "Desar contrasenya a la targeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "Eliminar secret de la targeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "Carregar descriptor multisig"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "Desar descriptor multisig"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "Clonar secrets de la targeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "Sortir a l'inici"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "Inicialitzar amb llavor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "Carregar com a descriptor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "Carregar PSBT"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "Establir PUK"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "Desbloquejar PIN amb PUK"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "Establir nom"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "Treure llavor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "Prova de rendiment de signatura"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "Rendiment de signatura de missatges"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "Comprovar biaix de signatura"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "Treure"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "Restablir"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "Activar 2FA"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "Ja té llavor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"Una xprv no pot inicialitzar Satochip.\n"
+"Usa BIP39, SLIP39 o Electrum."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "Canviar PIN de la targeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "Carregar mnemònic"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "Desar mnemònic"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "Esborrar llavor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "Claus de la targeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "Compilar applets"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "Instal·lar applet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "Desinstal·lar applet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "Introduir un altre PIN"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "Carregar claus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "Desar claus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "Desbloquejar targeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "Bloquejar targeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "Esborrar claus carregades"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "Sobreescriure"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "Cancel·lar el desat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "Introduir clau única"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "Introduir joc de claus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "Generar clau única"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "Generar joc de claus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (predeterminat)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "Entropia de l'RNG del sistema massa baixa. Torna-ho a provar més tard."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "L'entropia derivada de l'RNG del sistema no ha passat les comprovacions."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Nova llavor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "Llavor SLIP39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "QR de text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "Generador de contrasenyes"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "Eines de targeta intel·ligent"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "Eines MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Esborrar descriptor multisig"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "Targeta microSD no detectada"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "Insereix una targeta microSD per desar el registre de descàrrega."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "No s'ha pogut carregar la informació de xarxa."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 paraules"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 paraules"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 paraules"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 paraules"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 paraules"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "20 words ({} rolls)"
+msgstr "20 paraules ({} tirades)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "33 words ({} rolls)"
+msgstr "33 paraules ({} tirades)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Descriptor multisig carregat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Carregar des de Satochip"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Llavor Electrum"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "Codificar text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "Descodificar codi QR"
+

--- a/l10n/fork/cs/messages.po
+++ b/l10n/fork/cs/messages.po
@@ -1,0 +1,2578 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-10 23:07-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cs\n"
+"Language-Team: cs <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "Data smazána po nečinnosti"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "Spouštím kameru..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "Dešifrovat?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "Vyberte typ QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "Šifrovací klíč"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "Zkontrolovat šifrovací klíč"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "Číslo účtu"
+
+#. FORK: translated by Claude 2026-07-10
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "Šifrováno"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "Šifrované bity entropie"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "Nestandardní cesta!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "ID mnemoniky"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "Zkontrolovat ID mnemoniky"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "QR kódy z obou režimů se mohou lišit, ale oba jsou platné."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "Přepsat šifrovaný QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "Žádné možnosti k dispozici"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "Info o baterii"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "Info o systému"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Platform: {platform_name}"
+msgstr "Platforma: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Variant: {platform_variant}"
+msgstr "Varianta: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (CPU): {system_serial}"
+msgstr "Sériové č. (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "Sériové č. (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "Filtr zařízení"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "Info o síti"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "Kalibrace baterie"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "Plně nabijte baterii. Zvolte Další pro spuštění vybíjecího testu."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "Spustit"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "Test běží do vybití. Nechte zařízení odpojené."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "Zjištěno nabíjení"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "Vybíjení"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "Uplynulo: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "Napětí: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "Proud: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "Stav: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "NÍZKÁ ENTROPIE"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "DOBRÁ ENTROPIE"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "Text ke kódování"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "Nastavit nátlakový PIN"
+
+#. FORK: translated by Claude 2026-07-10
+#. QR code format option; "default" = this is the format most wallets use
+#: src/seedsigner/models/settings_definition.py
+msgid "Animated (default)"
+msgstr "Animovaný (výchozí)"
+
+#. FORK: translated by Claude 2026-07-10
+#. QR code format option (static = single frame, not animated)
+#: src/seedsigner/models/settings_definition.py
+msgid "Static"
+msgstr "Statický"
+
+#. FORK: translated by Claude 2026-07-10
+#. QR code format option: old format that Specter Desktop used to use
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter legacy"
+msgstr "Specter legacy"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "Kamera 0"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "Kamera 1"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "Kamera 2"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "Kamera 3"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 minut"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 minut"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 minut"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 minut"
+
+#. FORK: translated by Claude 2026-07-10
+#. MicroSD notification duration setting - Display notification for 5 seconds
+#: src/seedsigner/models/settings_definition.py
+msgid "5 seconds"
+msgstr "5 sekund"
+
+#. FORK: translated by Claude 2026-07-10
+#. MicroSD notification duration setting - Display notification until the SD
+#. card is removed
+#: src/seedsigner/models/settings_definition.py
+msgid "Until SD removed"
+msgstr "Do vyjmutí SD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Aezeed bezpečnostní fráze"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "Preferovat CompactSeedQR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "Preferovat EncryptedQR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "Ptát se pokaždé"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "Pokusy o PIN karty"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "Časovač smazání"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "Délky seedu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Xpub QR format"
+msgstr "Formát QR pro xpub"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "Dotaz na účet BIP32"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "Nejednoznačný QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "Typy GPG klíčů"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "Verze GPG pro BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 je nejnovější; použijte v2 pro obnovu klíčů B9-B10"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "SLIP39 seedy"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Aezeed seedy"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "Kompatibilní s LND, 24 slov"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "Rozšiřitelné podíly SLIP39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "MicroSD notification duration"
+msgstr "Doba oznámení MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "Zálohy BitBox02"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Zálohy Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "Zálohy TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "Podpora chytrých karet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Podpora Satochip"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Podpora Keycard"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Podpora Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "Zdroj kamery"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "Režim desktop"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "Není bezpečné!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Tato desktopová verze slouží jen k testování.\n"
+"NEPOUŽÍVEJTE se skutečnými seedy či klíči."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "Rozumím"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "Vývojové sestavení"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Toto vývojové sestavení SeedSignerOS slouží jen k testování.\n"
+"NEPOUŽÍVEJTE se skutečnými seedy či klíči."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "Operace se soubory"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "Importovat klíče"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "Exportovat klíče"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "Zobrazit klíče"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "Zabezpečené zprávy"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "Nástroje GPG"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "Chybějící balíčky"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "Vyžadováno, ale nenainstalováno:\n"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "Operace s podklíči"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "Operace s ID uživatele"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "Křížová certifikace klíčů"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "Exportovat balík veřejného klíče"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "Metadata BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "Podklíče"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "Zpět"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "Exportovat balík"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "Animovaný QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "Uložit data BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "Nahrát data BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "Znovu vytvořit klíč BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "Na MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "Do QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "Na Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "Z MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "Z QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Ze Seedkeeperu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "Přidat podklíče"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "Odvolat podklíče"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "Smazat podklíče"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "Změnit platnost"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "Exportovat tajemství podklíčů"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 rok"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 roky"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 let"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "Nikdy"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "Soubor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "Chytrá karta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "Přidat ID uživatele"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "Upravit ID uživatele"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "Nastavit primární ID uživatele"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "Odvolat ID uživatele"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "Smazat ID uživatele"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "Šifrovat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "Dešifrovat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "Podepsat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "Ověřit podpis"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "Vytvořit zprávu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "Nahrát zprávu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "Manifest"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "Napsat zprávu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Nahrát Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "Naskenovat QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "Nahrát soubor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "Nahrát klíč"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Uložit na Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "Zobrazit jako QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "Veřejný klíč"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "Soukromý klíč"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "Zobrazit info o kartě"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "Vygenerovat klíč na kartě"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "Změnit admin PIN"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "Změnit uživatelský PIN"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "Šifruji soubor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(Může chvíli trvat)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "Dešifruji soubor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "Zkontrolovat SHA256Sum"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "Aktualizovat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "Ze souboru"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "Vygenerovat nový"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "Odvodit BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "Karta OpenGPG"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "Upravit text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "Zahodit text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "Zahodit text?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "Vygenerovat QR kód"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "Režim přepisu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "Režim celé obrazovky"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "Režim přepisu?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "Potvrdit textový QR kód"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "Potvrdit textový QR?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "Naskenovat textový QR kód"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "Potvrdit textový QR kód"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "Přepsaný textový QR kód neodpovídá původnímu textu!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "Zkontrolovat textový QR kód"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "Přepsaný textový QR kód byl úspěšně naskenován a obsahuje stejný text."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "Potvrdit textový QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "Přepsaný textový QR kód nelze přečíst!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "Upravit a vygenerovat QR kód"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "Dekódovaný text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "Spustit test"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "Zapsat image"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "Ověřit MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "Smazat (nuly)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "Smazat (náhodně)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "Přeskočit ověření"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "Vše"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "Vlastní"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF krátký"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF dlouhý"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "Hody kostkou"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "Typ hesla"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 bitů"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 bitů"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 bitů"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "Síla hesla"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "Ano"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "Ne"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "Vybrat možnosti"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "Vyberte alespoň jednu sadu znaků."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "Kontrola systémového RNG selhala."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "Chyba systémového RNG"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "Kamera"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "Kostky"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "Systémový RNG"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "Zdroj entropie"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "Nepodporováno"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 podporuje Diceware, hody kostkou, Hex, Base64 a Base85."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "Žádný"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "Velká písmena"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "Mezera"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "Oddělovač"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 stěn"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 stěn"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 stěn"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "Stěny kostky"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "Počet hodů"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "Neplatný vstup"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "Počet hodů musí být alespoň 1."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "Slabá entropie"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "Hody nevypadaly dostatečně náhodně. Zkuste to znovu."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "Entropie z kamery nevypadala dostatečně náhodně. Zkuste to znovu."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "VAROVÁNÍ"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "Před použitím BIP85 nahrajte seed."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "Vybrat seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "Vyberte seed pro BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "Index BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "Neplatná délka"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex podporuje 128 nebo 256 bitů."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 vyžaduje 120+ bitů."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 vyžaduje 64-512 bitů."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "Název hesla"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "Nedostatek místa"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"Ukládám tajemství\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "Povedlo se"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "Heslo uloženo na Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "Na Seedkeeperu není pro heslo dost místa"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "Selhalo"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "Heslo se nepodařilo uložit"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "Upravit"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "Heslo"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "Uložit heslo"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Použít kartu Satochip"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Použít Keycard"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "Vložit seed o 15 slovech"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "Vložit seed o 18 slovech"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "Vložit seed o 21 slovech"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "Vložit WIF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "Naskenovat WIF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "Vložit BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "Naskenovat BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "Otisk nesouhlasí"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "Karta nemůže podepsat PSBT"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "Otisk karty ({}) není mezi podepisujícími PSBT."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "Soukromý klíč (WIF)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "Neplatný WIF!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "Není platný soukromý klíč ve formátu WIF."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "Klíč BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "BIP38 bezpečnostní fráze"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "Neplatný BIP38!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "Klíč BIP38 se nepodařilo dešifrovat."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "Deskriptor nesouhlasí"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "Deskriptor smazán"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "Nahraný multisig deskriptor neodpovídá tomuto PSBT. Nahrajte správný deskriptor, nebo přeskočte ověření."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "Podepisuji PSBT..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "Vypršel čas podpisu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "Zkusit znovu (delší čas)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Saved as {}."
+msgstr "Uloženo jako {}."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Failed to save PSBT: {}"
+msgstr "PSBT se nepodařilo uložit: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "Kóduji PSBT..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "QR skener není k dispozici"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "Chybí backend pro skenování QR. Nainstalujte zbar (nebo OpenCV na desktopu) a restartujte."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "Vyberte typ seedu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "Čas nastaven na:"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "Čas se nepodařilo nastavit"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "Neplatný čas"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "Čas z QR se nepodařilo přečíst"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "Naskenovat podíl SLIP-39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "Očekáván QR podílu SLIP-39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "Očekáván soukromý klíč WIF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "Očekáván soukromý klíč BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "Naskenujte přijímací adresu {} z právě exportované peněženky"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"Data odpovídají více\n"
+"typům QR."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "Napsat šifrovací klíč"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "Naskenovat šifrovací klíč"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "Upravit šifrovací klíč"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "Zahodit šifrovací klíč"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "Pokračovat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "Naskenovat a přidat další"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "Dešifrovaný text"
+
+#. FORK: translated by Claude 2026-07-10
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "Neoficiální fork projektu:"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "Záloha BitBox02"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Záloha Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "Záloha TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Vložit Aezeed seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "Podíly SLIP-39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " Naskenovat SeedQR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "Ze SeedKeeperu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Ze Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " Vytvořit seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "Karta microSD nenalezena."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "Žádné zálohy nenalezeny"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "Na kartě microSD nebyly nalezeny žádné zálohy BitBox02 (.bin, .bb02, .dat, .backup)."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "Vyberte zálohu BitBox02"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup name: {}"
+msgstr "Název zálohy: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Created: {}"
+msgstr "Vytvořeno: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Firmware: {}"
+msgstr "Firmware: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Birthdate: {}"
+msgstr "Datum vzniku: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Seed length: {} words"
+msgstr "Délka seedu: {} slov"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "Seed nahrán"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "Na kartě microSD nebyly nalezeny žádné zálohy Passport (.7z)."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Vyberte zálohu Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Kód zálohy Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "Kód zálohy nesmí být prázdný."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Chain: {}"
+msgstr "Řetězec: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "Na kartě microSD nebyly nalezeny žádné zálohy TAPSIGNER (.aes)."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "Vyberte zálohu TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "Klíč zálohy (hex)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "xprv nahráno ze zálohy TAPSIGNER."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Path: {}"
+msgstr "Cesta: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "Nahrát bezpečnostní frázi"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "Napsat bezpečnostní frázi"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "Naskenovat bezpečnostní frázi"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "Nahrát ze SeedKeeperu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Aezeed bezpečnostní fráze"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"Tato mnemonika vyžaduje\n"
+"bezpečnostní frázi."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "Neplatná bezpečnostní fráze"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Je vyžadována Aezeed bezpečnostní fráze.\n"
+"Zkuste to znovu."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Nesprávná Aezeed bezpečnostní fráze.\n"
+"Zkuste to znovu."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "Neplatný textový QR kód"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "Zjištěna data mimo UTF-8."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Podpora Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"Vkládání Aezeed je experimentální.\n"
+"Používejte jen s ověřenými zálohami."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "Vložit 20 slov"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "Vložit 33 slov"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "Nahrát podíl"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Share Word #{}"
+msgstr "Slovo podílu #{}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "Vložit podíl"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "Naskenovat podíl"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "Zkombinovat podíly"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "{} of {} needed"
+msgstr "Potřeba {} z {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "Zkusit znovu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "Neplatný podíl SLIP-39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "Kontrolní součet selhal; není platný podíl SLIP-39."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Nerozšiřitelný seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Tento SLIP-39 seed nemůže vytvářet nové podíly."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "Exportovat jako nešifrovaný QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "Na SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "Na Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "Znovu vytvořit podíly"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Xpub QR Format"
+msgstr "Formát QR pro xpub"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "Otevřete {} a zobrazte přijímací adresu právě exportované peněženky."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "váš peněženkový software"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"Byla použita bezpečnostní fráze.\n"
+"Budete potřebovat slova + frázi."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 slov"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "Zkontrolovat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "Dokončit odvozený seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "Zadat šifrovací klíč"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "Zahodit šifrovací klíč?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "Zadaný klíč bude vymazán"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "Neplatný klíč"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "Klíč je příliš dlouhý."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "Vstup z kamery"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "Použít otisk"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "Přiřadit vlastní ID"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "Zadat ID mnemoniky"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "Upravit ID mnemoniky"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "Zahodit ID mnemoniky"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "Zahodit ID mnemoniky?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "Zadané ID mnemoniky bude vymazáno"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "Zpracovávám..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "Šifrování selhalo"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "Dalších 100"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "Rozšířené hledání"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "Nenalezeno"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "Adresa neověřena"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses with no match."
+msgstr "Zkontrolováno {} adres bez shody."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "Zkontrolovat dalších 10"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses per path with no match."
+msgstr "Zkontrolováno {} adres na cestu bez shody."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "Export peněženky"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "Peněženka úspěšně exportována."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "Formát adresy neodpovídá exportovanému typu skriptu. Export peněženky selhal."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "Peněženku se nepodařilo přiřadit k aktuálnímu seedu. Export selhal."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "Export selhal"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "Nahrát SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#. Multisig policy. For a "2 of 3" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/seed_views.py
+msgid "{threshold} of {n}"
+msgstr "{threshold} z {n}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "Exportuji xpub..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "Podepisuji zprávu..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "Ověření selhalo"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "Otestovat chytrou kartu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "Vypsat čtečky karet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "Otestovat NFC skenování"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "Restartovat PCSC"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "Info o baterii"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "Info o systému"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "Nahrát soubory záloh"
+
+#. FORK: translated by Claude 2026-07-10
+#. Title of a warning dialog when configuring a setting that requires at least
+#. one option to be selected.
+#: src/seedsigner/views/settings_views.py
+msgid "Selection Required"
+msgstr "Je vyžadován výběr"
+
+#. FORK: translated by Claude 2026-07-10
+#. The name of the setting being configured (e.g. "Script types") will be
+#. inserted.
+#: src/seedsigner/views/settings_views.py
+msgid "At least one option must be selected for \"{}\"."
+msgstr "Pro \"{}\" musí být vybrána alespoň jedna možnost."
+
+#. FORK: translated by Claude 2026-07-10
+#. Text for the button that returns the user to the setting configuration
+#. screen.
+#: src/seedsigner/views/settings_views.py
+msgid "Return to setting"
+msgstr "Zpět na nastavení"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "Nenalezen kompatibilní monitor baterie"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "Není k dispozici"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "Společné funkce"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Funkce Satochip"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Funkce Keycard"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "Funkce SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Funkce Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "Nástroje DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "Info o kartě"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "Kontrola pravosti"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "Změnit PIN"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "Změnit popisek"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "Změnit zásady NFC"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "Nastavit NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "Tovární reset karty"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "Zobrazit NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Použít odkaz aplikace Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "Smazat NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "Nastavit vlastní NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "Uložit NDEF na SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "Nahrát NDEF ze SeedKeeperu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "Textový záznam"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "Záznam URI"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Spuštění Android aplikace"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "Vlastní (HEX)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "Dekódovat NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC zapnuto"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC vypnuto"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC blokováno"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "Karta znovu vložena"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "Zobrazit volné místo"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "Zobrazit tajemství na kartě"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "Uložit heslo na kartu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "Smazat tajemství z karty"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "Nahrát multisig deskriptor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "Uložit multisig deskriptor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "Klonovat tajemství karty"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "Zpět na úvod"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "Inicializovat seedem"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "Nahrát jako deskriptor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "Nahrát PSBT"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "Nastavit PUK"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "Odblokovat PIN pomocí PUK"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "Nastavit název"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "Odebrat seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "Test rychlosti podpisu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "Test rychlosti podpisu zpráv"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "Zkontrolovat vychýlení podpisů"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "Odebrat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "Reset"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "Zapnout 2FA"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "Seed už je nahrán"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"xprv nemůže inicializovat Satochip.\n"
+"Použijte BIP39, SLIP39 nebo Electrum."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "Změnit PIN karty"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "Nahrát mnemoniku"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "Uložit mnemoniku"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "Smazat seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "Klíče karty"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "Sestavit applety"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "Nainstalovat applet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "Odinstalovat applet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "Zadat jiný PIN"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "Nahrát klíče"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "Uložit klíče"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "Odemknout kartu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "Zamknout kartu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "Smazat nahrané klíče"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "Přepsat"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "Zrušit ukládání"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "Zadat jeden klíč"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "Zadat sadu klíčů"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "Vygenerovat jeden klíč"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "Vygenerovat sadu klíčů"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (výchozí)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "Entropie systémového RNG je příliš nízká. Zkuste to později."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "Entropie ze systémového RNG neprošla kontrolami."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Nový seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "SLIP39 seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "Textový QR kód"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "Generátor hesel"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "Nástroje chytrých karet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "Nástroje MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Smazat multisig deskriptor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "Karta microSD nenalezena"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "Vložte kartu microSD pro uložení záznamu vybíjení."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "Informace o síti se nepodařilo načíst."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 slov"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 slov"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 slov"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 slov"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 slov"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "20 words ({} rolls)"
+msgstr "20 slov ({} hodů)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "33 words ({} rolls)"
+msgstr "33 slov ({} hodů)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Multisig deskriptor nahrán"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Nahrát ze Satochipu"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Electrum seed"
+
+#. FORK: translated by Claude 2026-07-10
+#. Multisig policy. For a "2 / 3 multisig" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/tools_views.py
+msgid "{threshold} / {n} multisig"
+msgstr "{threshold} / {n} multisig"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "Kódovat text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "Dekódovat QR kód"
+
+#. FORK: translated by Claude 2026-07-10
+#. "network" will be mainnet/testnet/regtest.
+#: src/seedsigner/views/view.py
+msgid "Current network setting ({network}) doesn't match {derivation_path}."
+msgstr "Aktuální nastavení sítě ({network}) neodpovídá {derivation_path}."
+

--- a/l10n/fork/de/messages.po
+++ b/l10n/fork/de/messages.po
@@ -1,0 +1,2493 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-10 23:05-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: de\n"
+"Language-Team: de <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "Daten nach Inaktivität gelöscht"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "Kamera wird gestartet..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "Entschlüsseln?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "QR-Typ wählen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "Verschlüsselungsschlüssel"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "Schlüssel überprüfen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "Kontonummer"
+
+#. FORK: translated by Claude 2026-07-10
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "Verschlüsselt"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "Verschlüsselte Entropie-Bits"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "Kein Standardpfad!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "Mnemonic-ID"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "Mnemonic-ID überprüfen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "Die QR-Codes der beiden Modi können sich unterscheiden, sind aber beide gültig."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "Verschlüsselten QR abschreiben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "Keine Optionen verfügbar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "Akku-Info"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "System-Info"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Platform: {platform_name}"
+msgstr "Plattform: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Variant: {platform_variant}"
+msgstr "Variante: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (CPU): {system_serial}"
+msgstr "Seriennr. (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "Seriennr. (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "Gerätefilter"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "Netzwerk-Info"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "Akku-Kalibrierung"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "Lade den Akku vollständig. Wähle Weiter, um den Entladetest zu starten."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "Start"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "Der Test läuft bis der Akku leer ist. Gerät nicht anschließen."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "Ladevorgang erkannt"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "Entlädt"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "Vergangen: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "Spannung: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "Strom: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "Status: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "NIEDRIGE ENTROPIE"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "GUTE ENTROPIE"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "Zu kodierender Text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "Duress-PIN festlegen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "Kamera 0"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "Kamera 1"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "Kamera 2"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "Kamera 3"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 Minuten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 Minuten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 Minuten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 Minuten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Aezeed Passphrase"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "CompactSeedQR bevorzugen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "EncryptedQR bevorzugen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "Jedes Mal fragen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "Smartcard-PIN-Versuche"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "Lösch-Timer"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "Seed-Wortlängen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "BIP32-Konto abfragen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "Mehrdeutiger QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "GPG-Schlüsseltypen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "BIP85-GPG-Version"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 ist die neueste; nutze v2, um B9-B10-Schlüssel nachzubilden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "SLIP39 Seeds"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Aezeed Seeds"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "LND-kompatibel, 24 Wörter"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "Erweiterbare SLIP39 Shares"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "BitBox02-Backups"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Passport-Backups"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "TAPSIGNER-Backups"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "Smartcard-Unterstützung"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Satochip-Unterstützung"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Keycard-Unterstützung"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Specter-DIY-Unterstützung"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "Kameraquelle"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "Desktop-Modus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "Nicht sicher!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Diese Desktop-Version ist nur zum Testen.\n"
+"NICHT mit echten Seeds oder privaten Schlüsseln verwenden."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "Verstanden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "Entwicklungs-Build"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Dieser SeedSignerOS-Entwicklungs-Build ist nur zum Testen.\n"
+"NICHT mit echten Seeds oder privaten Schlüsseln verwenden."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "Dateioperationen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "Schlüssel importieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "Schlüssel exportieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "Schlüssel anzeigen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "Sichere Nachrichten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "GPG Tools"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "Fehlende Pakete"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "Erforderlich, aber nicht installiert:\n"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "Unterschlüssel-Operationen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "User-ID-Operationen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "Schlüssel kreuzzertifizieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "Öffentliches Schlüsselpaket exportieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "BIP85-Metadaten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "Unterschlüssel"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "Zurück"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "Paket exportieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "Animierter QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "BIP85-Daten speichern"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "BIP85-Daten laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "BIP85-Schlüssel neu erzeugen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "Auf MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "Als QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "Auf Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "Von MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "Von QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Von Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "Unterschlüssel hinzufügen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "Unterschlüssel widerrufen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "Unterschlüssel löschen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "Ablaufdatum ändern"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "Unterschlüssel-Geheimnisse exportieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 Jahr"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 Jahre"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 Jahre"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "Nie"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "Datei"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "Smartcard"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "User-ID hinzufügen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "User-IDs bearbeiten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "Primäre User-ID festlegen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "User-ID widerrufen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "User-ID löschen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "Verschlüsseln"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "Entschlüsseln"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "Signieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "Signatur verifizieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "Nachricht erstellen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "Nachricht laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "Manifest"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "Nachricht eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Seedkeeper laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "QR scannen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "Datei laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "Schlüssel laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Auf Seedkeeper speichern"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "Als QR anzeigen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "Öffentlicher Schlüssel"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "Privater Schlüssel"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "Karteninfo anzeigen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "Schlüssel auf der Karte erzeugen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "Admin-PIN ändern"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "Benutzer-PIN ändern"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "Datei wird verschlüsselt"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(Kann etwas dauern)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "Datei wird entschlüsselt"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "SHA256-Summe prüfen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "Aktualisieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "Aus Datei"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "Neu erzeugen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "BIP85 ableiten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "OpenGPG-Karte"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "Text bearbeiten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "Text verwerfen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "Text verwerfen?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "QR-Code erzeugen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "Abschreibmodus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "Vollbildmodus"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "Abschreibmodus?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "Text-QR-Code bestätigen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "Text-QR bestätigen?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "Text-QR-Code scannen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "Text-QR-Code bestätigen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "Dein abgeschriebener Text-QR-Code stimmt nicht mit dem Originaltext überein!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "Text-QR-Code überprüfen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "Dein abgeschriebener Text-QR-Code wurde erfolgreich gescannt und ergab denselben Text."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "Text-QR bestätigen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "Dein abgeschriebener Text-QR-Code konnte nicht gelesen werden!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "Bearbeiten & QR-Code erzeugen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "Dekodierter Text"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "Test starten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "Image flashen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "MicroSD verifizieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "Löschen (Nullen)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "Löschen (Zufall)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "Verifizierung überspringen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "Alle"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF kurz"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF lang"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "Würfelwürfe"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "Passworttyp"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 Bits"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 Bits"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 Bits"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "Passwortstärke"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "Ja"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "Nein"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "Optionen wählen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "Wähle mindestens einen Zeichensatz."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "System-RNG-Prüfung fehlgeschlagen."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "System-RNG-Fehler"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "Kamera"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "Würfel"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "System-RNG"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "Entropiequelle"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "Nicht unterstützt"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 unterstützt Diceware, Würfelwürfe, Hex, Base64 und Base85."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "Keiner"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "Großschreibung"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "Leerzeichen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "Trennzeichen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 Seiten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 Seiten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 Seiten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "Würfelseiten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "Anzahl der Würfe"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "Ungültige Eingabe"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "Die Anzahl der Würfe muss mindestens 1 sein."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "Schwache Entropie"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "Die Würfe wirkten nicht zufällig genug. Bitte erneut versuchen."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "Die Kamera-Entropie wirkte nicht zufällig genug. Bitte erneut versuchen."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "WARNUNG"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "Lade einen Seed, bevor du BIP85 nutzt."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "Seed wählen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "Seed für BIP85 wählen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "BIP85-Index"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "Ungültige Länge"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex unterstützt 128 oder 256 Bits."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 benötigt 120+ Bits."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 benötigt 64-512 Bits."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "Passwortname"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "Nicht genug Speicherplatz"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"Geheimnis wird gespeichert\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "Erfolg"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "Passwort auf Seedkeeper gespeichert"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "Nicht genug Platz auf dem Seedkeeper für das Passwort"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "Fehlgeschlagen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "Passwort konnte nicht gespeichert werden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "Passwort"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "Passwort speichern"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Satochip-Karte verwenden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Keycard verwenden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "15-Wort Seed eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "18-Wort Seed eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "21-Wort Seed eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "WIF eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "WIF scannen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "BIP38 eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "BIP38 scannen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "Fingerabdruck stimmt nicht überein"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "Karte kann PSBT nicht signieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "Kartenfingerabdruck ({}) nicht unter den PSBT-Signierern."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "Privater Schlüssel (WIF)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "Ungültiger WIF!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "Kein gültiger WIF-kodierter privater Schlüssel."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "BIP38-Schlüssel"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "BIP38 Passphrase"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "Ungültiger BIP38!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "BIP38-Schlüssel konnte nicht entschlüsselt werden."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "Descriptor stimmt nicht überein"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "Descriptor gelöscht"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "Der geladene Multisig-Wallet-Descriptor passt nicht zu diesem PSBT. Lade den richtigen Descriptor oder überspringe die Verifizierung."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "PSBT wird signiert..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "Zeitüberschreitung beim Signieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "Erneut (längeres Timeout)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Saved as {}."
+msgstr "Gespeichert als {}."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Failed to save PSBT: {}"
+msgstr "PSBT konnte nicht gespeichert werden: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "PSBT wird kodiert..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "QR-Scanner nicht verfügbar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "QR-Scan-Backend fehlt. Installiere zbar (oder OpenCV am Desktop) und starte neu."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "Seed-Typ wählen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "Zeit gesetzt auf:"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "Zeit konnte nicht gesetzt werden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "Ungültige Zeit"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "Zeit konnte nicht aus dem QR gelesen werden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "SLIP-39 Share scannen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "SLIP-39-Share-QR erwartet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "Privater WIF-Schlüssel erwartet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "Privater BIP38-Schlüssel erwartet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "Scanne die Empfangsadresse {} der gerade exportierten Wallet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"Daten passen auf mehrere\n"
+"QR-Typen."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "Schlüssel eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "Schlüssel scannen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "Schlüssel bearbeiten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "Schlüssel verwerfen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "Fortfahren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "Weiteren scannen & anhängen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "Entschlüsselter Text"
+
+#. FORK: translated by Claude 2026-07-10
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "Ein inoffizieller Fork von:"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "BitBox02-Backup"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Passport-Backup"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "TAPSIGNER-Backup"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Aezeed Seed eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "SLIP-39 Shares"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " SeedQR scannen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "Von SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Von Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " Seed erstellen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "Keine microSD-Karte erkannt."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "Keine Backups gefunden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "Keine BitBox02-Backups (.bin, .bb02, .dat, .backup) auf der microSD-Karte gefunden."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "BitBox02-Backup wählen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup name: {}"
+msgstr "Backup-Name: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Created: {}"
+msgstr "Erstellt: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Firmware: {}"
+msgstr "Firmware: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Birthdate: {}"
+msgstr "Erstellungsdatum: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Seed length: {} words"
+msgstr "Seed-Länge: {} Wörter"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "Seed geladen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "Keine Passport-Backups (.7z) auf der microSD-Karte gefunden."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Passport-Backup wählen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Passport-Backup-Code"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "Der Backup-Code darf nicht leer sein."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Chain: {}"
+msgstr "Chain: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "Keine TAPSIGNER-Backups (.aes) auf der microSD-Karte gefunden."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "TAPSIGNER-Backup wählen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "Backup-Schlüssel (hex)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "xprv aus TAPSIGNER-Backup geladen."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Path: {}"
+msgstr "Pfad: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "Passphrase laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "Passphrase eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "Passphrase scannen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "Von SeedKeeper laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Aezeed Passphrase"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"Für diesen Seed ist eine\n"
+"Passphrase erforderlich."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "Ungültige Passphrase"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Aezeed Passphrase erforderlich.\n"
+"Erneut versuchen."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Falsche Aezeed Passphrase.\n"
+"Erneut versuchen."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "Ungültiger Text-QR-Code"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "Nicht-UTF-8-Daten erkannt."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Aezeed-Unterstützung"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"Die Aezeed-Eingabe ist experimentell.\n"
+"Nur mit geprüften Backups verwenden."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "20 Wörter eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "33 Wörter eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "Share laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Share Word #{}"
+msgstr "Share-Wort #{}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "Share eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "Share scannen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "Shares kombinieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "{} of {} needed"
+msgstr "{} von {} erforderlich"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "Erneut versuchen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "Ungültiger SLIP-39 Share"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "Prüfsumme fehlerhaft; kein gültiger SLIP-39 Share."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Nicht erweiterbarer Seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Dieser SLIP-39 Seed kann keine neuen Shares erzeugen."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "Als Klartext-QR exportieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "Auf SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "Auf Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "Shares neu erzeugen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "Öffne {} und zeige eine Empfangsadresse der gerade exportierten Wallet an."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "deine Wallet-Software"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"Es wurde eine Passphrase genutzt.\n"
+"Du brauchst Wörter + Passphrase."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 Wörter"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "Überprüfen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "Child-Seed abschließen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "Schlüssel eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "Schlüssel verwerfen?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "Deine aktuelle Schlüsseleingabe wird gelöscht"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "Ungültiger Schlüssel"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "Der Schlüssel ist zu lang."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "Eingabe per Kamera"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "Fingerabdruck verwenden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "Eigene ID vergeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "Mnemonic-ID eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "Mnemonic-ID bearbeiten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "Mnemonic-ID verwerfen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "Mnemonic-ID verwerfen?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "Deine aktuelle Mnemonic-ID-Eingabe wird gelöscht"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "Verarbeitung..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "Verschlüsselung fehlgeschlagen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "Nächste 100"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "Erweiterte Suche"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "Nicht gefunden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "Adresse nicht verifiziert"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses with no match."
+msgstr "{} Adressen geprüft, keine Übereinstimmung."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "Nächste 10 prüfen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses per path with no match."
+msgstr "{} Adressen pro Pfad geprüft, keine Übereinstimmung."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "Wallet-Export"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "Wallet erfolgreich exportiert."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "Das Adressformat passt nicht zum exportierten Skripttyp. Wallet-Export fehlgeschlagen."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "Wallet passt nicht zum aktuellen Seed. Wallet-Export fehlgeschlagen."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "Export fehlgeschlagen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "SeedKeeper laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "xpub wird exportiert..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "Nachricht wird signiert..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "Verifizierung fehlgeschlagen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "Smartcard testen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "Kartenleser auflisten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "NFC-Scan testen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "PCSC neu starten"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "Akku-Info"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "System-Info"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "Backup-Dateien laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "Kein kompatibler Akku-Monitor erkannt"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "Nicht verfügbar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "Allgemeine Funktionen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Satochip-Funktionen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Keycard-Funktionen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "SeedKeeper-Funktionen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Specter-DIY-Funktionen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "DIY Tools"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "Karteninfo"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "Echtheitsprüfung"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "PIN ändern"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "Label ändern"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "NFC-Richtlinie ändern"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "NDEF konfigurieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "Karte auf Werkszustand zurücksetzen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "NDEF anzeigen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Seedkeeper-App-Link verwenden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "NDEF löschen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "Eigenes NDEF festlegen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "NDEF auf SeedKeeper speichern"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "NDEF von SeedKeeper laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "Text-Eintrag"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "URI-Eintrag"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Android-App-Start"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "Benutzerdefiniert (HEX)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "NDEF dekodieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC aktiviert"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC deaktiviert"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC blockiert"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "Karte erneut eingelegt"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "Freien Speicher anzeigen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "Geheimnisse auf der Karte anzeigen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "Passwort auf der Karte speichern"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "Geheimnis von der Karte löschen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "Multisig-Descriptor laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "Multisig-Descriptor speichern"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "Kartengeheimnisse klonen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "Zum Startmenü"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "Mit Seed initialisieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "Als Descriptor laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "PSBT laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "PUK festlegen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "PIN mit PUK entsperren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "Namen festlegen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "Seed entfernen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "Signier-Benchmark"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "Nachrichtensignatur-Benchmark"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "Signatur-Bias prüfen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "Entfernen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "Zurücksetzen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "2FA aktivieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "Bereits mit Seed initialisiert"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"xprv kann Satochip nicht initialisieren.\n"
+"Nutze BIP39, SLIP39 oder Electrum."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "Karten-PIN ändern"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "Mnemonic laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "Mnemonic speichern"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "Seed löschen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "Kartenschlüssel"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "Applets bauen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "Applet installieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "Applet deinstallieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "Andere PIN eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "Schlüssel laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "Schlüssel speichern"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "Karte entsperren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "Karte sperren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "Geladene Schlüssel löschen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "Überschreiben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "Speichern abbrechen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "Einzelnen Schlüssel eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "Schlüsselsatz eingeben"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "Einzelnen Schlüssel erzeugen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "Schlüsselsatz erzeugen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (Standard)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "System-RNG-Entropie zu niedrig. Später erneut versuchen."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "Die vom System-RNG abgeleitete Entropie bestand die Prüfungen nicht."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Neuer Seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "SLIP39 Seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "Text-QR-Code"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "Passwortgenerator"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "Smartcard Tools"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "MicroSD Tools"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Multisig-Descriptor löschen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "Keine microSD-Karte erkannt"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "Lege eine microSD-Karte ein, um das Entladeprotokoll zu speichern."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "Netzwerkinformationen konnten nicht geladen werden."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 Wörter"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 Wörter"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 Wörter"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 Wörter"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 Wörter"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "20 words ({} rolls)"
+msgstr "20 Wörter ({} Würfe)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "33 words ({} rolls)"
+msgstr "33 Wörter ({} Würfe)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Multisig-Descriptor geladen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Von Satochip laden"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Electrum Seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "Text kodieren"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "QR-Code dekodieren"
+

--- a/l10n/fork/el/messages.po
+++ b/l10n/fork/el/messages.po
@@ -1,0 +1,2870 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-10 23:11-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: el\n"
+"Language-Team: el <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "Τα δεδομένα διαγράφηκαν λόγω αδράνειας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Review Transaction"
+msgstr "Έλεγχος συναλλαγής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Review details"
+msgstr "Έλεγχος λεπτομερειών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Transaction Math"
+msgstr "Υπολογισμοί συναλλαγής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Review recipients"
+msgstr "Έλεγχος παραληπτών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Sign Transaction"
+msgstr "Υπογραφή συναλλαγής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "Εκκίνηση κάμερας..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "Αποκρυπτογράφηση;"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "Επιλογή τύπου QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "Κλειδί κρυπτογράφησης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "Έλεγχος κλειδιού κρυπτογράφησης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/screen.py
+msgid "I understand"
+msgstr "Κατανοώ"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "Αριθμός λογαριασμού"
+
+#. FORK: translated by Claude 2026-07-10
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "Κρυπτογραφημένο"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "Κρυπτογραφημένα bits εντροπίας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "Μη τυπική διαδρομή!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Sign message"
+msgstr "Υπογραφή μηνύματος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "ID μνημονικού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "Έλεγχος ID μνημονικού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "Οι κωδικοί QR των δύο λειτουργιών μπορεί να διαφέρουν, αλλά είναι και οι δύο έγκυροι."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "Μεταγραφή κρυπτογραφημένου QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "Δεν υπάρχουν διαθέσιμες επιλογές"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "Πληροφορίες μπαταρίας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "Πληροφορίες συστήματος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Platform: {platform_name}"
+msgstr "Πλατφόρμα: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Variant: {platform_variant}"
+msgstr "Παραλλαγή: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (CPU): {system_serial}"
+msgstr "Σειριακός (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "Σειριακός (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "Φίλτρο συσκευών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "Πληροφορίες δικτύου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "Βαθμονόμηση μπαταρίας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "Φόρτισε πλήρως τη μπαταρία. Επίλεξε Επόμενο για έναρξη του τεστ εκφόρτισης."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "Έναρξη"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "Το τεστ τρέχει μέχρι να αδειάσει. Άφησε τη συσκευή αποσυνδεδεμένη."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "Εντοπίστηκε φόρτιση"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "Εκφόρτιση"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "Διάρκεια: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "Τάση: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "Ρεύμα: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "Κατάσταση: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "ΧΑΜΗΛΗ ΕΝΤΡΟΠΙΑ"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "ΚΑΛΗ ΕΝΤΡΟΠΙΑ"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "Κείμενο προς κωδικοποίηση"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "Ορισμός PIN εξαναγκασμού"
+
+#. FORK: translated by Claude 2026-07-10
+#. QR code format option; "default" = this is the format most wallets use
+#: src/seedsigner/models/settings_definition.py
+msgid "Animated (default)"
+msgstr "Κινούμενο (προεπιλογή)"
+
+#. FORK: translated by Claude 2026-07-10
+#. QR code format option (static = single frame, not animated)
+#: src/seedsigner/models/settings_definition.py
+msgid "Static"
+msgstr "Στατικό"
+
+#. FORK: translated by Claude 2026-07-10
+#. QR code format option: old format that Specter Desktop used to use
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter legacy"
+msgstr "Specter legacy"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "Κάμερα 0"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "Κάμερα 1"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "Κάμερα 2"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "Κάμερα 3"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 λεπτά"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 λεπτά"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 λεπτά"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 λεπτά"
+
+#. FORK: translated by Claude 2026-07-10
+#. MicroSD notification duration setting - Display notification for 5 seconds
+#: src/seedsigner/models/settings_definition.py
+msgid "5 seconds"
+msgstr "5 δευτερόλεπτα"
+
+#. FORK: translated by Claude 2026-07-10
+#. MicroSD notification duration setting - Display notification until the SD
+#. card is removed
+#: src/seedsigner/models/settings_definition.py
+msgid "Until SD removed"
+msgstr "Μέχρι την αφαίρεση της SD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Συνθηματική φράση Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "Προτίμηση CompactSeedQR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "Προτίμηση EncryptedQR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "Ερώτηση κάθε φορά"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "Προσπάθειες PIN κάρτας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "Χρονοδιακόπτης διαγραφής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "Μήκη seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Xpub QR format"
+msgstr "Μορφή QR για xpub"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "Ερώτηση λογαριασμού BIP32"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "Ασαφές QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "Τύποι κλειδιών GPG"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "Έκδοση GPG του BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "Η v3 είναι η νεότερη· χρησιμοποίησε v2 για κλειδιά B9-B10"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "Seeds SLIP39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Seeds Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "Συμβατό με LND, 24 λέξεις"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "Επεκτάσιμα μερίδια SLIP39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "MicroSD notification duration"
+msgstr "Διάρκεια ειδοποίησης MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "Αντίγραφα BitBox02"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Αντίγραφα Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "Αντίγραφα TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "Υποστήριξη έξυπνης κάρτας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Υποστήριξη Satochip"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Υποστήριξη Keycard"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Υποστήριξη Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#. Hardware settings option to specify the screen driver (e.g. st7789 vs
+#. ili9341)
+#: src/seedsigner/models/settings_definition.py
+msgid "Display type"
+msgstr "Τύπος οθόνης"
+
+#. FORK: translated by Claude 2026-07-10
+#. Hardware settings option to invert how the screen driver displays colors.
+#: src/seedsigner/models/settings_definition.py
+msgid "Invert colors"
+msgstr "Αντιστροφή χρωμάτων"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "Πηγή κάμερας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "Λειτουργία desktop"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "Μη ασφαλές!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Αυτή η έκδοση desktop είναι μόνο για δοκιμές.\n"
+"ΜΗΝ τη χρησιμοποιείς με αληθινά seeds ή κλειδιά."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "Κατανοώ"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "Έκδοση ανάπτυξης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Αυτή η έκδοση ανάπτυξης του SeedSignerOS είναι μόνο για δοκιμές.\n"
+"ΜΗΝ τη χρησιμοποιείς με αληθινά seeds ή κλειδιά."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "Λειτουργίες αρχείων"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "Εισαγωγή κλειδιών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "Εξαγωγή κλειδιών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "Προβολή κλειδιών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "Ασφαλή μηνύματα"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "Εργαλεία GPG"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "Λείπουν πακέτα"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "Απαιτείται αλλά δεν είναι εγκατεστημένο:\n"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "Λειτουργίες υποκλειδιών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "Λειτουργίες ID χρήστη"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "Διασταυρούμενη πιστοποίηση κλειδιών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "Εξαγωγή πακέτου δημόσιου κλειδιού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "Μεταδεδομένα BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "Υποκλειδιά"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "Πίσω"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "Εξαγωγή πακέτου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "Κινούμενο QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "Αποθήκευση δεδομένων BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "Φόρτωση δεδομένων BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "Αναδημιουργία κλειδιού BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "Σε MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "Σε QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "Σε Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "Από MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "Από QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Από Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "Προσθήκη υποκλειδιών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "Ανάκληση υποκλειδιών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "Διαγραφή υποκλειδιών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "Αλλαγή λήξης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "Εξαγωγή μυστικών υποκλειδιών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 έτος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 έτη"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 έτη"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "Ποτέ"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "Αρχείο"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "Έξυπνη κάρτα"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "Προσθήκη ID χρήστη"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "Επεξεργασία ID χρήστη"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "Ορισμός κύριου ID χρήστη"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "Ανάκληση ID χρήστη"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "Διαγραφή ID χρήστη"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "Κρυπτογράφηση"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "Αποκρυπτογράφηση"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "Υπογραφή"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "Επαλήθευση υπογραφής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "Δημιουργία μηνύματος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "Φόρτωση μηνύματος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "Manifest"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "Πληκτρολόγηση μηνύματος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Φόρτωση Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "Σάρωση QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "Φόρτωση αρχείου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "Φόρτωση κλειδιού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Αποθήκευση σε Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "Εμφάνιση ως QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "Δημόσιο κλειδί"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "Ιδιωτικό κλειδί"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "Πληροφορίες κάρτας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "Δημιουργία κλειδιού στην κάρτα"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "Αλλαγή PIN διαχειριστή"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "Αλλαγή PIN χρήστη"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "Κρυπτογράφηση αρχείου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(Μπορεί να διαρκέσει)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "Αποκρυπτογράφηση αρχείου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "Έλεγχος SHA256Sum"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "Ενημέρωση"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "Από αρχείο"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "Δημιουργία νέου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "Παραγώγιση BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "Κάρτα OpenGPG"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "Επεξεργασία κειμένου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "Απόρριψη κειμένου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "Απόρριψη κειμένου;"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "Δημιουργία κωδικού QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "Λειτουργία μεταγραφής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "Λειτουργία πλήρους οθόνης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "Λειτουργία μεταγραφής;"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "Επιβεβαίωση QR κειμένου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "Επιβεβαίωση QR κειμένου;"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "Σάρωση QR κειμένου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "Επιβεβαίωση QR κειμένου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "Το μεταγεγραμμένο QR κειμένου δεν ταιριάζει με το αρχικό σου κείμενο!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "Έλεγχος QR κειμένου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "Το μεταγεγραμμένο QR κειμένου σαρώθηκε επιτυχώς και έδωσε το ίδιο κείμενο."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "Επιβεβαίωση QR κειμένου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "Το μεταγεγραμμένο QR κειμένου δεν μπόρεσε να διαβαστεί!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "Επεξεργασία & δημιουργία QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "Αποκωδικοποιημένο κείμενο"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "Εκτέλεση τεστ"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "Εγγραφή image"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "Επαλήθευση MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "Διαγραφή (μηδενικά)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "Διαγραφή (τυχαία)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "Παράλειψη επαλήθευσης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "Όλα"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "Προσαρμοσμένο"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF σύντομη"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF μεγάλη"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "Ρίψεις ζαριών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "Τύπος κωδικού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 bits"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 bits"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 bits"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "Ισχύς κωδικού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "Ναι"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "Όχι"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "Επιλογές"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "Επίλεξε τουλάχιστον ένα σύνολο χαρακτήρων."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "Ο έλεγχος του RNG συστήματος απέτυχε."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "Σφάλμα RNG συστήματος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "Κάμερα"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "Ζάρια"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "RNG συστήματος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "Πηγή εντροπίας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "Δεν υποστηρίζεται"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "Το BIP85 υποστηρίζει Diceware, ρίψεις ζαριών, Hex, Base64 και Base85."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "Κανένα"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "Κεφαλαίο αρχικό"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "Κενό"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "Διαχωριστικό"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 πλευρές"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 πλευρές"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 πλευρές"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "Πλευρές ζαριού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "Αριθμός ρίψεων"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "Μη έγκυρη είσοδος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "Ο αριθμός ρίψεων πρέπει να είναι τουλάχιστον 1."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "Φτωχή εντροπία"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "Οι ρίψεις δεν φάνηκαν αρκετά τυχαίες. Δοκίμασε ξανά."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "Η εντροπία της κάμερας δεν φάνηκε αρκετά τυχαία. Δοκίμασε ξανά."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "ΠΡΟΕΙΔΟΠΟΙΗΣΗ"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "Φόρτωσε ένα seed πριν χρησιμοποιήσεις το BIP85."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "Επιλογή seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "Επίλεξε seed για BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "Δείκτης BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "Μη έγκυρο μήκος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "Το BIP85 Hex υποστηρίζει 128 ή 256 bits."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "Το BIP85 Base64 χρειάζεται 120+ bits."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "Το BIP85 Base85 χρειάζεται 64-512 bits."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "Όνομα κωδικού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "Ανεπαρκής χώρος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"Αποθήκευση μυστικού\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "Επιτυχία"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "Ο κωδικός αποθηκεύτηκε στο Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "Δεν υπάρχει αρκετός χώρος στο Seedkeeper για τον κωδικό"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "Απέτυχε"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "Η αποθήκευση του κωδικού απέτυχε"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "Επεξεργασία"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "Κωδικός"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "Αποθήκευση κωδικού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Χρήση κάρτας Satochip"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Χρήση Keycard"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "Εισαγωγή seed 15 λέξεων"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "Εισαγωγή seed 18 λέξεων"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "Εισαγωγή seed 21 λέξεων"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "Εισαγωγή WIF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "Σάρωση WIF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "Εισαγωγή BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "Σάρωση BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "Ασυμφωνία αποτυπώματος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "Η κάρτα δεν μπορεί να υπογράψει το PSBT"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "Το αποτύπωμα της κάρτας ({}) δεν είναι στους υπογράφοντες του PSBT."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "Ιδιωτικό κλειδί (WIF)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "Μη έγκυρο WIF!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "Δεν είναι έγκυρο ιδιωτικό κλειδί WIF."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "Κλειδί BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "Συνθηματική φράση BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "Μη έγκυρο BIP38!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "Αδύνατη η αποκρυπτογράφηση του κλειδιού BIP38."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction has unsupported input script type, please verify your change addresses."
+msgstr "Η συναλλαγή έχει μη υποστηριζόμενο τύπο script εισόδου· επαλήθευσε τις διευθύνσεις ρέστων."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "This transaction spends its entire input value. No change is coming back to your wallet."
+msgstr "Η συναλλαγή ξοδεύει όλο το ποσό εισόδου. Δεν επιστρέφουν ρέστα στο πορτοφόλι σου."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Next recipient"
+msgstr "Επόμενος παραλήπτης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Skip verification"
+msgstr "Παράλειψη επαλήθευσης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Verify multisig change"
+msgstr "Επαλήθευση ρέστων πολυυπογραφής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Verify multisig addr"
+msgstr "Επαλήθευση διεύθ. πολυυπογραφής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "Ασυμφωνία περιγραφέα"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "Ο περιγραφέας διαγράφηκε"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "Ο φορτωμένος περιγραφέας πολυυπογραφής δεν ταιριάζει με αυτό το PSBT. Φόρτωσε τον σωστό ή παράλειψε την επαλήθευση."
+
+#. FORK: translated by Claude 2026-07-10
+#. Variable is either "change" or "self-transfer".
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction's {} address could not be verified from wallet descriptor."
+msgstr "Η διεύθυνση {} της συναλλαγής δεν επαληθεύτηκε από τον περιγραφέα πορτοφολιού."
+
+#. FORK: translated by Claude 2026-07-10
+#. Variable is either "change" or "self-transfer".
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction's {} address could not be generated from your seed."
+msgstr "Η διεύθυνση {} της συναλλαγής δεν μπόρεσε να παραχθεί από το seed σου."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Suspicious Transaction"
+msgstr "Ύποπτη συναλλαγή"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Discard transaction"
+msgstr "Απόρριψη συναλλαγής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Approve transaction"
+msgstr "Έγκριση συναλλαγής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "Υπογραφή PSBT..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "Λήξη χρόνου υπογραφής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "Επανάληψη (περισσότερος χρόνος)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Saved as {}."
+msgstr "Αποθηκεύτηκε ως {}."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Failed to save PSBT: {}"
+msgstr "Αποτυχία αποθήκευσης PSBT: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "Κωδικοποίηση PSBT..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Select different seed"
+msgstr "Επιλογή άλλου seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction Error"
+msgstr "Σφάλμα συναλλαγής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "Ο σαρωτής QR δεν είναι διαθέσιμος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "Λείπει το backend σάρωσης QR. Εγκατέστησε zbar (ή OpenCV σε desktop) και επανεκκίνησε."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "Επιλογή τύπου seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "Η ώρα ορίστηκε σε:"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "Αποτυχία ορισμού ώρας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "Μη έγκυρη ώρα"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "Αδύνατη η ανάγνωση ώρας από το QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Scan Transaction"
+msgstr "Σάρωση συναλλαγής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a transaction"
+msgstr "Αναμενόταν συναλλαγή"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "Σάρωση μεριδίου SLIP-39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "Αναμενόταν QR μεριδίου SLIP-39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "Αναμενόταν ιδιωτικό κλειδί WIF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "Αναμενόταν ιδιωτικό κλειδί BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "Σάρωσε τη διεύθυνση λήψης {} από το πορτοφόλι που μόλις εξήγαγες"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"Τα δεδομένα ταιριάζουν με\n"
+"πολλούς τύπους QR."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "Πληκτρολόγηση κλειδιού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "Σάρωση κλειδιού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "Επεξεργασία κλειδιού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "Απόρριψη κλειδιού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "Συνέχεια"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "Σάρωση & προσθήκη άλλου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/view.py
+msgid "Back to Main Menu"
+msgstr "Πίσω στο κύριο μενού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "Αποκρυπτογραφημένο κείμενο"
+
+#. FORK: translated by Claude 2026-07-10
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "Ανεπίσημο fork του:"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "Αντίγραφο BitBox02"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Αντίγραφο Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "Αντίγραφο TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Εισαγωγή seed Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "Μερίδια SLIP-39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " Σάρωση SeedQR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "Από SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Από Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " Δημιουργία seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load a Seed"
+msgstr "Φόρτωση seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "Δεν εντοπίστηκε κάρτα microSD."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "Δεν βρέθηκαν αντίγραφα"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "Δεν βρέθηκαν αντίγραφα BitBox02 (.bin, .bb02, .dat, .backup) στην κάρτα microSD."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "Επιλογή αντιγράφου BitBox02"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup name: {}"
+msgstr "Όνομα αντιγράφου: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Created: {}"
+msgstr "Δημιουργήθηκε: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Firmware: {}"
+msgstr "Firmware: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Birthdate: {}"
+msgstr "Ημερομηνία δημιουργίας: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Seed length: {} words"
+msgstr "Μήκος seed: {} λέξεις"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "Το seed φορτώθηκε"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "Δεν βρέθηκαν αντίγραφα Passport (.7z) στην κάρτα microSD."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Επιλογή αντιγράφου Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Κωδικός αντιγράφου Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "Ο κωδικός αντιγράφου δεν μπορεί να είναι κενός."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Chain: {}"
+msgstr "Αλυσίδα: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "Δεν βρέθηκαν αντίγραφα TAPSIGNER (.aes) στην κάρτα microSD."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "Επιλογή αντιγράφου TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "Κλειδί αντιγράφου (hex)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "Το xprv φορτώθηκε από αντίγραφο TAPSIGNER."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Path: {}"
+msgstr "Διαδρομή: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Review & edit"
+msgstr "Έλεγχος & επεξεργασία"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "Φόρτωση συνθηματικής φράσης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "Πληκτρολόγηση συνθηματικής φράσης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "Σάρωση συνθηματικής φράσης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "Φόρτωση από SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Συνθηματική φράση Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"Απαιτείται συνθηματική φράση\n"
+"για αυτό το μνημονικό."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "Μη έγκυρη συνθηματική φράση"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Απαιτείται συνθηματική φράση Aezeed.\n"
+"Δοκίμασε ξανά."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Λάθος συνθηματική φράση Aezeed.\n"
+"Δοκίμασε ξανά."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Skip passphrase"
+msgstr "Παράλειψη συνθηματικής φράσης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Your current passphrase entry will be erased."
+msgstr "Η τρέχουσα συνθηματική φράση θα διαγραφεί."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Skip passphrase?"
+msgstr "Παράλειψη συνθηματικής φράσης;"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "You have not entered a passphrase yet."
+msgstr "Δεν έχεις εισαγάγει ακόμη συνθηματική φράση."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "Μη έγκυρο QR κειμένου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "Εντοπίστηκαν δεδομένα εκτός UTF-8."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Keep seed"
+msgstr "Διατήρηση seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Υποστήριξη Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"Η εισαγωγή Aezeed είναι πειραματική.\n"
+"Μόνο με επαληθευμένα αντίγραφα."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Electrum Warning"
+msgstr "Προειδοποίηση Electrum"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "Εισαγωγή 20 λέξεων"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "Εισαγωγή 33 λέξεων"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "Φόρτωση μεριδίου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Share Word #{}"
+msgstr "Λέξη μεριδίου #{}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "Εισαγωγή μεριδίου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "Σάρωση μεριδίου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "Συνδυασμός μεριδίων"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "{} of {} needed"
+msgstr "Χρειάζονται {} από {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "Δοκίμασε ξανά"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "Μη έγκυρο μερίδιο SLIP-39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "Σφάλμα checksum· μη έγκυρο μερίδιο SLIP-39."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Μη επεκτάσιμο seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Αυτό το seed SLIP-39 δεν μπορεί να δημιουργήσει νέα μερίδια."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Scan transaction"
+msgstr "Σάρωση συναλλαγής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Export xpub"
+msgstr "Εξαγωγή xpub"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Address explorer"
+msgstr "Εξερεύνηση διευθύνσεων"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup seed"
+msgstr "Αντίγραφο seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "BIP-85 child seed"
+msgstr "Παράγωγο seed BIP-85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard seed"
+msgstr "Απόρριψη seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "View seed words"
+msgstr "Προβολή λέξεων seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "Εξαγωγή ως μη κρυπτογραφημένο QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "Σε SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "Σε Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "Αναδημιουργία μεριδίων"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Xpub QR Format"
+msgstr "Μορφή QR για xpub"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "Άνοιξε το {} και εμφάνισε μια διεύθυνση λήψης από το πορτοφόλι που μόλις εξήγαγες."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "το λογισμικό πορτοφολιού σου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"Χρησιμοποιήθηκε συνθηματική φράση.\n"
+"Θα χρειαστείς λέξεις + φράση."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 λέξεις"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Try again"
+msgstr "Δοκίμασε ξανά"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "Έλεγχος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "Ολοκλήρωση παράγωγου seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Review seed words"
+msgstr "Έλεγχος λέξεων seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "Εισαγωγή κλειδιού κρυπτογράφησης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "Απόρριψη κλειδιού κρυπτογράφησης;"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "Το κλειδί που εισήγαγες θα διαγραφεί"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "Μη έγκυρο κλειδί"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "Το κλειδί είναι υπερβολικά μεγάλο."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "Είσοδος από κάμερα"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "Χρήση αποτυπώματος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "Ορισμός προσαρμοσμένου ID"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "Εισαγωγή ID μνημονικού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "Επεξεργασία ID μνημονικού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "Απόρριψη ID μνημονικού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "Απόρριψη ID μνημονικού;"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "Το ID μνημονικού που εισήγαγες θα διαγραφεί"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "Επεξεργασία..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "Αποτυχία κρυπτογράφησης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "Επόμενες 100"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "Εκτεταμένη αναζήτηση"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "Δεν βρέθηκε"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "Η διεύθυνση δεν επαληθεύτηκε"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses with no match."
+msgstr "Ελέγχθηκαν {} διευθύνσεις χωρίς αντιστοιχία."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "Έλεγχος επόμενων 10"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses per path with no match."
+msgstr "Ελέγχθηκαν {} διευθύνσεις ανά διαδρομή χωρίς αντιστοιχία."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "Εξαγωγή πορτοφολιού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "Επιτυχής εξαγωγή πορτοφολιού."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "Η μορφή διεύθυνσης δεν ταιριάζει με τον εξαγόμενο τύπο script. Η εξαγωγή απέτυχε."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "Αδύνατη η αντιστοίχιση πορτοφολιού με το τρέχον seed. Η εξαγωγή απέτυχε."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "Η εξαγωγή απέτυχε"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "Φόρτωση SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Return to transaction"
+msgstr "Επιστροφή στη συναλλαγή"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Verify addr"
+msgstr "Επαλήθευση διεύθ."
+
+#. FORK: translated by Claude 2026-07-10
+#. Multisig policy. For a "2 of 3" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/seed_views.py
+msgid "{threshold} of {n}"
+msgstr "{threshold} από {n}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "Εξαγωγή xpub..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "Υπογραφή μηνύματος..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "Η επαλήθευση απέτυχε"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Hardware"
+msgstr "Υλικό"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "Δοκιμή έξυπνης κάρτας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "Λίστα αναγνωστών καρτών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "Δοκιμή σάρωσης NFC"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "Επανεκκίνηση PCSC"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "Πληροφορίες μπαταρίας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "Πληροφορίες συστήματος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "Φόρτωση αρχείων αντιγράφων"
+
+#. FORK: translated by Claude 2026-07-10
+#. Title of a warning dialog when configuring a setting that requires at least
+#. one option to be selected.
+#: src/seedsigner/views/settings_views.py
+msgid "Selection Required"
+msgstr "Απαιτείται επιλογή"
+
+#. FORK: translated by Claude 2026-07-10
+#. The name of the setting being configured (e.g. "Script types") will be
+#. inserted.
+#: src/seedsigner/views/settings_views.py
+msgid "At least one option must be selected for \"{}\"."
+msgstr "Πρέπει να επιλεγεί τουλάχιστον μία επιλογή για \"{}\"."
+
+#. FORK: translated by Claude 2026-07-10
+#. Text for the button that returns the user to the setting configuration
+#. screen.
+#: src/seedsigner/views/settings_views.py
+msgid "Return to setting"
+msgstr "Επιστροφή στη ρύθμιση"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "Δεν εντοπίστηκε συμβατός μετρητής μπαταρίας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "Μη διαθέσιμο"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "Κοινές λειτουργίες"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Λειτουργίες Satochip"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Λειτουργίες Keycard"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "Λειτουργίες SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Λειτουργίες Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "Εργαλεία DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "Πληροφορίες κάρτας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "Έλεγχος γνησιότητας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "Αλλαγή PIN"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "Αλλαγή ετικέτας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "Αλλαγή πολιτικής NFC"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "Ρύθμιση NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "Επαναφορά κάρτας στα εργοστασιακά"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "Προβολή NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Χρήση συνδέσμου εφαρμογής Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "Διαγραφή NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "Ορισμός προσαρμοσμένου NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "Αποθήκευση NDEF σε SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "Φόρτωση NDEF από SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "Εγγραφή κειμένου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "Εγγραφή URI"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Εκκίνηση εφαρμογής Android"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "Προσαρμοσμένο (HEX)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "Αποκωδικοποίηση NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC ενεργό"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC ανενεργό"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC αποκλεισμένο"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "Η κάρτα επανατοποθετήθηκε"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "Προβολή ελεύθερου χώρου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "Προβολή μυστικών της κάρτας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "Αποθήκευση κωδικού στην κάρτα"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "Διαγραφή μυστικού από την κάρτα"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "Φόρτωση περιγραφέα πολυυπογραφής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "Αποθήκευση περιγραφέα πολυυπογραφής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "Κλωνοποίηση μυστικών κάρτας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "Έξοδος στην αρχική"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "Αρχικοποίηση με seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "Φόρτωση ως περιγραφέα"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "Φόρτωση PSBT"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "Ορισμός PUK"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "Ξεκλείδωμα PIN με PUK"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "Ορισμός ονόματος"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "Αφαίρεση seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "Μέτρηση ταχύτητας υπογραφής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "Μέτρηση υπογραφής μηνυμάτων"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "Έλεγχος μεροληψίας υπογραφών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "Αφαίρεση"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "Επαναφορά"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "Ενεργοποίηση 2FA"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "Έχει ήδη seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"Το xprv δεν μπορεί να αρχικοποιήσει Satochip.\n"
+"Χρησιμοποίησε BIP39, SLIP39 ή Electrum."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "Αλλαγή PIN κάρτας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "Φόρτωση μνημονικού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "Αποθήκευση μνημονικού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "Διαγραφή seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "Κλειδιά κάρτας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "Δημιουργία applets"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "Εγκατάσταση applet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "Απεγκατάσταση applet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "Εισαγωγή άλλου PIN"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "Φόρτωση κλειδιών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "Αποθήκευση κλειδιών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "Ξεκλείδωμα κάρτας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "Κλείδωμα κάρτας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "Διαγραφή φορτωμένων κλειδιών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "Αντικατάσταση"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "Ακύρωση αποθήκευσης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "Εισαγωγή ενός κλειδιού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "Εισαγωγή σετ κλειδιών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "Δημιουργία ενός κλειδιού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "Δημιουργία σετ κλειδιών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (προεπιλογή)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "Πολύ χαμηλή εντροπία RNG συστήματος. Δοκίμασε αργότερα."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "Η εντροπία από το RNG συστήματος απέτυχε στους ελέγχους."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Νέο seed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "Seed SLIP39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Verify address"
+msgstr "Επαλήθευση διεύθυνσης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "QR κειμένου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "Γεννήτρια κωδικών"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "Εργαλεία έξυπνης κάρτας"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "Εργαλεία MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Διαγραφή περιγραφέα πολυυπογραφής"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "Δεν εντοπίστηκε κάρτα microSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "Τοποθέτησε κάρτα microSD για αποθήκευση του αρχείου εκφόρτισης."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "Αδύνατη η φόρτωση πληροφοριών δικτύου."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 λέξεις"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 λέξεις"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 λέξεις"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 λέξεις"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 λέξεις"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "20 words ({} rolls)"
+msgstr "20 λέξεις ({} ρίψεις)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "33 words ({} rolls)"
+msgstr "33 λέξεις ({} ρίψεις)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Ο περιγραφέας πολυυπογραφής φορτώθηκε"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Φόρτωση από Satochip"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Seed Electrum"
+
+#. FORK: translated by Claude 2026-07-10
+#. label for addresses where others send us incoming payments
+#: src/seedsigner/views/tools_views.py
+msgid "Receive addresses"
+msgstr "Διευθύνσεις λήψης"
+
+#. FORK: translated by Claude 2026-07-10
+#. label for addresses that collect the change from our own outgoing payments
+#: src/seedsigner/views/tools_views.py
+msgid "Change addresses"
+msgstr "Διευθύνσεις ρέστων"
+
+#. FORK: translated by Claude 2026-07-10
+#. Multisig policy. For a "2 / 3 multisig" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/tools_views.py
+msgid "{threshold} / {n} multisig"
+msgstr "{threshold} / {n} πολυυπογραφή"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "Κωδικοποίηση κειμένου"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "Αποκωδικοποίηση QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/view.py
+msgid "Power off"
+msgstr "Απενεργοποίηση"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/view.py
+msgid "Back to main menu"
+msgstr "Πίσω στο κύριο μενού"
+
+#. FORK: translated by Claude 2026-07-10
+#. "network" will be mainnet/testnet/regtest.
+#: src/seedsigner/views/view.py
+msgid "Current network setting ({network}) doesn't match {derivation_path}."
+msgstr "Η τρέχουσα ρύθμιση δικτύου ({network}) δεν ταιριάζει με {derivation_path}."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/view.py
+msgid "Hardware Error"
+msgstr "Σφάλμα υλικού"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/view.py
+msgid "Cannot access camera"
+msgstr "Αδύνατη η πρόσβαση στην κάμερα"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/view.py
+msgid "Disconnect power and check for a loose camera connection."
+msgstr "Αποσύνδεσε το ρεύμα και έλεγξε για χαλαρή σύνδεση κάμερας."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/view.py
+msgid "Update setting"
+msgstr "Ενημέρωση ρύθμισης"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/view.py
+msgid "Action Required"
+msgstr "Απαιτείται ενέργεια"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/view.py
+msgid ""
+"You must remove the\n"
+"MicroSD card to continue."
+msgstr ""
+"Πρέπει να αφαιρέσεις την\n"
+"κάρτα MicroSD για να συνεχίσεις."
+

--- a/l10n/fork/es/messages.po
+++ b/l10n/fork/es/messages.po
@@ -1,0 +1,2493 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-10 22:56-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "Datos borrados por inactividad"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "Iniciando cámara..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "¿Descifrar?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "Selecciona el tipo de QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "Clave de cifrado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "Revisar clave de cifrado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "Número de cuenta"
+
+#. FORK: translated by Claude 2026-07-10
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "Cifrado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "Bits de entropía cifrados"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "¡Ruta no estándar!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "ID del mnemónico"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "Revisar ID del mnemónico"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "Los códigos QR generados en ambos modos pueden diferir, pero ambos son válidos."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "Transcribir QR cifrado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "No hay opciones disponibles"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "Info. de batería"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "Info. del sistema"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Platform: {platform_name}"
+msgstr "Plataforma: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Variant: {platform_variant}"
+msgstr "Variante: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (CPU): {system_serial}"
+msgstr "Serie (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "Serie (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "Filtro de dispositivos"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "Info. de red"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "Calibración de batería"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "Carga la batería por completo. Pulsa Siguiente para iniciar la prueba de descarga."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "Iniciar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "La prueba dura hasta agotarla. Deja el dispositivo desenchufado."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "Carga detectada"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "Descargando"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "Transcurrido: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "Voltaje: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "Corriente: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "Estado: "
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "ENTROPÍA BAJA"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "ENTROPÍA BUENA"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "Texto a codificar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "Establecer PIN de coacción"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "Cámara 0"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "Cámara 1"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "Cámara 2"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "Cámara 3"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 minutos"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 minutos"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Passphrase Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "Preferir CompactSeedQR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "Preferir EncryptedQR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "Preguntar cada vez"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "Intentos de PIN de la tarjeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "Temporizador de borrado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "Longitudes de semilla"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "Preguntar cuenta BIP32"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "QR ambiguo"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "Tipos de clave GPG"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "Versión GPG de BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 es la más reciente; usa v2 para recrear claves B9-B10"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "Semillas SLIP39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Semillas Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "Compatible con LND, 24 palabras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "Partes SLIP39 extensibles"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "Copias de BitBox02"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Copias de Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "Copias de TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "Soporte de tarjeta inteligente"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Soporte de Satochip"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Soporte de Keycard"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Soporte de Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "Fuente de cámara"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "Modo escritorio"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "¡No es seguro!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Esta versión de escritorio es solo para pruebas.\n"
+"NO la uses con semillas o claves privadas reales."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "Entiendo"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "Compilación de desarrollo"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Esta compilación de desarrollo de SeedSignerOS es solo para pruebas.\n"
+"NO la uses con semillas o claves privadas reales."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "Operaciones con archivos"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "Importar claves"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "Exportar claves"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "Ver claves"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "Mensajería segura"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "Herramientas GPG"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "Faltan paquetes"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "Requerido pero no instalado:\n"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "Operaciones con subclaves"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "Operaciones con ID de usuario"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "Certificación cruzada de claves"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "Exportar paquete de clave pública"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "Metadatos BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "Subclaves"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "Atrás"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "Exportar paquete"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "QR animado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "Guardar datos BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "Cargar datos BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "Reconstruir clave BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "A MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "A QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "A Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "Desde MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "Desde QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Desde Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "Añadir subclaves"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "Revocar subclaves"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "Eliminar subclaves"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "Cambiar caducidad"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "Exportar secretos de subclave"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 año"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 años"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 años"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "Nunca"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "Archivo"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "Tarjeta inteligente"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "Añadir ID de usuario"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "Editar IDs de usuario"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "Fijar ID de usuario principal"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "Revocar ID de usuario"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "Eliminar ID de usuario"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "Cifrar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "Descifrar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "Firmar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "Verificar firma"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "Crear mensaje"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "Cargar mensaje"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "Manifiesto"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "Escribir mensaje"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Cargar Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "Escanear QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "Cargar archivo"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "Cargar clave"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Guardar en Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "Mostrar como QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "Clave pública"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "Clave privada"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "Ver info. de la tarjeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "Generar clave en la tarjeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "Cambiar PIN de administrador"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "Cambiar PIN de usuario"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "Cifrando archivo"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(Puede tardar un poco)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "Descifrando archivo"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "Comprobar SHA256Sum"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "Actualizar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "Desde archivo"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "Generar nueva"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "Derivar BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "Tarjeta OpenGPG"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "Editar texto"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "Descartar texto"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "¿Descartar texto?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "Generar código QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "Modo transcripción"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "Modo pantalla completa"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "¿Modo transcripción?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "Confirmar código QR de texto"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "¿Confirmar QR de texto?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "Escanear código QR de texto"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "Confirmar código QR de texto"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "¡El QR de texto transcrito no coincide con tu texto original!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "Revisar código QR de texto"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "Tu QR de texto transcrito se escaneó correctamente y produjo el mismo texto."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "Confirmar QR de texto"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "¡No se pudo leer tu QR de texto transcrito!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "Editar y generar código QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "Texto decodificado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "Ejecutar prueba"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "Grabar imagen"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "Verificar MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "Borrar (ceros)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "Borrar (aleatorio)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "Omitir verificación"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "Todos"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "Personalizado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF corta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF larga"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "Tiradas de dados"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "Tipo de contraseña"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 bits"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 bits"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 bits"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "Fortaleza de la contraseña"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "Sí"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "No"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "Seleccionar opciones"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "Elige al menos un conjunto de caracteres."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "Falló la comprobación del RNG del sistema."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "Error del RNG del sistema"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "Cámara"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "Dados"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "RNG del sistema"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "Fuente de entropía"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "No compatible"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 admite Diceware, tiradas de dados, Hex, Base64 y Base85."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "Ninguno"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "Mayúscula inicial"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "Espacio"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "Separador"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 caras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 caras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 caras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "Caras del dado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "Número de tiradas"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "Entrada no válida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "El número de tiradas debe ser al menos 1."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "Entropía pobre"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "Las tiradas no parecieron lo bastante aleatorias. Inténtalo de nuevo."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "La entropía de la cámara no pareció lo bastante aleatoria. Inténtalo de nuevo."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "ADVERTENCIA"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "Carga una semilla antes de usar BIP85."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "Seleccionar semilla"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "Elige la semilla para BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "Índice BIP85"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "Longitud no válida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex admite 128 o 256 bits."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 necesita 120+ bits."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 necesita 64-512 bits."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "Nombre de la contraseña"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "Espacio insuficiente"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"Guardando secreto\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "Éxito"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "Contraseña guardada en Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "No hay espacio suficiente en Seedkeeper para la contraseña"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "Falló"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "No se pudo guardar la contraseña"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "Editar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "Contraseña"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "Guardar contraseña"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Usar tarjeta Satochip"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Usar Keycard"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "Cargar semilla de 15 palabras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "Cargar semilla de 18 palabras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "Cargar semilla de 21 palabras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "Introducir WIF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "Escanear WIF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "Introducir BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "Escanear BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "La huella no coincide"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "La tarjeta no puede firmar el PSBT"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "La huella de la tarjeta ({}) no está entre los firmantes del PSBT."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "Clave privada (WIF)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "¡WIF no válido!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "No es una clave privada WIF válida."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "Clave BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "Passphrase BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "¡BIP38 no válido!"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "No se pudo descifrar la clave BIP38."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "El descriptor no coincide"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "Descriptor borrado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "El descriptor multifirma cargado no coincide con este PSBT. Carga el descriptor correcto u omite la verificación para continuar."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "Firmando PSBT..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "Tiempo de firma agotado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "Reintentar (más tiempo)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Saved as {}."
+msgstr "Guardado como {}."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Failed to save PSBT: {}"
+msgstr "No se pudo guardar el PSBT: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "Codificando PSBT..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "Escáner QR no disponible"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "Falta el motor de escaneo QR. Instala zbar (u OpenCV en escritorio) y reinicia."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "Selecciona el tipo de semilla"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "Hora fijada a:"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "No se pudo fijar la hora"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "Hora no válida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "No se pudo leer la hora del QR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "Escanear parte SLIP-39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "Se esperaba un QR de parte SLIP-39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "Se esperaba una clave privada WIF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "Se esperaba una clave privada BIP38"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "Escanea la dirección de recepción {} de la billetera que acabas de exportar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"Los datos coinciden con\n"
+"varios tipos de QR."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "Escribir clave de cifrado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "Escanear clave de cifrado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "Editar clave de cifrado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "Descartar clave de cifrado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "Continuar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "Escanear y añadir otro"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "Texto descifrado"
+
+#. FORK: translated by Claude 2026-07-10
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "Un fork no oficial de:"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "Copia de BitBox02"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Copia de Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "Copia de TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Cargar semilla Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "Partes SLIP-39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " Escanear un SeedQR"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "Desde SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Desde Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " Crear una semilla"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "Tarjeta microSD no detectada."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "No se encontraron copias"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "No se encontraron copias de BitBox02 (.bin, .bb02, .dat, .backup) en la tarjeta microSD."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "Selecciona la copia de BitBox02"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup name: {}"
+msgstr "Nombre de la copia: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Created: {}"
+msgstr "Creada: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Firmware: {}"
+msgstr "Firmware: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Birthdate: {}"
+msgstr "Fecha de origen: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Seed length: {} words"
+msgstr "Longitud de semilla: {} palabras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "Semilla cargada"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "No se encontraron copias de Passport (.7z) en la tarjeta microSD."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Selecciona la copia de Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Código de la copia de Passport"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "El código de la copia no puede estar vacío."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Chain: {}"
+msgstr "Cadena: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "No se encontraron copias de TAPSIGNER (.aes) en la tarjeta microSD."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "Selecciona la copia de TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "Clave de la copia (hex)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "xprv cargada desde la copia de TAPSIGNER."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Path: {}"
+msgstr "Ruta: {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "Cargar Passphrase"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "Escribir Passphrase"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "Escanear Passphrase"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "Cargar desde SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Passphrase Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"Este mnemónico requiere\n"
+"Passphrase."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "Passphrase no válida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Se requiere la Passphrase Aezeed.\n"
+"Inténtalo de nuevo."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Passphrase Aezeed incorrecta.\n"
+"Inténtalo de nuevo."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "QR de texto no válido"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "Se detectaron datos no UTF-8."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Soporte de Aezeed"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"La entrada Aezeed es experimental.\n"
+"Úsala solo con copias verificadas."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "Introducir 20 palabras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "Introducir 33 palabras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "Cargar parte"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Share Word #{}"
+msgstr "Palabra #{} de la parte"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "Introducir parte"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "Escanear parte"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "Combinar partes"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "{} of {} needed"
+msgstr "Se necesitan {} de {}"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "Reintentar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "Parte SLIP-39 no válida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "Fallo en la suma de comprobación; no es una parte SLIP-39 válida."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Semilla no extensible"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Esta semilla SLIP-39 no puede regenerar nuevas partes."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "Exportar como QR sin cifrar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "A SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "A Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "Regenerar partes"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "Abre {} y muestra una dirección de recepción de la billetera que acabas de exportar."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "tu software de billetera"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"Se usó Passphrase.\n"
+"Necesitarás palabras + Passphrase."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 palabras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "Revisar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "Finalizar semilla hija"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "Introducir clave de cifrado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "¿Descartar clave de cifrado?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "La clave introducida se borrará"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "Clave no válida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "La clave es demasiado larga."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "Entrada desde cámara"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "Usar huella"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "Asignar ID personalizado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "Introducir ID del mnemónico"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "Editar ID del mnemónico"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "Descartar ID del mnemónico"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "¿Descartar ID del mnemónico?"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "El ID del mnemónico introducido se borrará"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "Procesando..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "Fallo de cifrado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "Siguientes 100"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "Búsqueda ampliada"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "No encontrado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "Dirección no verificada"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses with no match."
+msgstr "Se comprobaron {} direcciones sin coincidencia."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "Comprobar 10 más"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses per path with no match."
+msgstr "Se comprobaron {} direcciones por ruta sin coincidencia."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "Exportación de billetera"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "Billetera exportada correctamente."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "El formato de dirección no coincide con el tipo de script exportado. La exportación falló."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "No se pudo asociar la billetera con la semilla actual. La exportación falló."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "Exportación fallida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "Cargar SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "Exportando xpub..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "Firmando mensaje..."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "Verificación fallida"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "Probar tarjeta inteligente"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "Listar lectores de tarjetas"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "Probar escaneo NFC"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "Reiniciar PCSC"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "Info. de batería"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "Info. del sistema"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "Cargar archivos de copia"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "No se detectó un monitor de batería compatible"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "No disponible"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "Funciones comunes"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Funciones de Satochip"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Funciones de Keycard"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "Funciones de SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Funciones de Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "Herramientas DIY"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "Info. de la tarjeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "Comprobar autenticidad"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "Cambiar PIN"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "Cambiar etiqueta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "Cambiar política NFC"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "Configurar NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "Restablecer tarjeta de fábrica"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "Ver NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Usar enlace de la app Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "Borrar NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "Definir NDEF personalizado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "Guardar NDEF en SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "Cargar NDEF desde SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "Registro de texto"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "Registro URI"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Lanzar app Android"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "Personalizado (HEX)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "Decodificar NDEF"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC activado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC desactivado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC bloqueado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "Tarjeta reinsertada"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "Ver espacio libre"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "Ver secretos de la tarjeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "Guardar contraseña en la tarjeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "Eliminar secreto de la tarjeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "Cargar descriptor multifirma"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "Guardar descriptor multifirma"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "Clonar secretos de la tarjeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "Salir al inicio"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "Inicializar con semilla"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "Cargar como descriptor"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "Cargar PSBT"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "Establecer PUK"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "Desbloquear PIN con PUK"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "Establecer nombre"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "Quitar semilla"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "Prueba de rendimiento de firma"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "Rendimiento de firma de mensajes"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "Comprobar sesgo de firma"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "Quitar"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "Restablecer"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "Activar 2FA"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "Ya tiene semilla"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"Una xprv no puede inicializar Satochip.\n"
+"Usa BIP39, SLIP39 o Electrum."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "Cambiar PIN de la tarjeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "Cargar mnemónico"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "Guardar mnemónico"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "Borrar semilla"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "Claves de la tarjeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "Compilar applets"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "Instalar applet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "Desinstalar applet"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "Introducir otro PIN"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "Cargar claves"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "Guardar claves"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "Desbloquear tarjeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "Bloquear tarjeta"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "Borrar claves cargadas"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "Sobrescribir"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "Cancelar guardado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "Introducir clave única"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "Introducir juego de claves"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "Generar clave única"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "Generar juego de claves"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (predeterminado)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "Entropía del RNG del sistema demasiado baja. Inténtalo más tarde."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "La entropía derivada del RNG del sistema no pasó las comprobaciones."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Nueva semilla"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "Semilla SLIP39"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "QR de texto"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "Generador de contraseñas"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "Herramientas de tarjeta inteligente"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "Herramientas MicroSD"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Borrar descriptor multifirma"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "Tarjeta microSD no detectada"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "Inserta una tarjeta microSD para guardar el registro de descarga."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "No se pudo cargar la información de red."
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 palabras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 palabras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 palabras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 palabras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 palabras"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "20 words ({} rolls)"
+msgstr "20 palabras ({} tiradas)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "33 words ({} rolls)"
+msgstr "33 palabras ({} tiradas)"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Descriptor multifirma cargado"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Cargar desde Satochip"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Semilla Electrum"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "Codificar texto"
+
+#. FORK: translated by Claude 2026-07-10
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "Decodificar código QR"
+

--- a/l10n/fork/fa/messages.po
+++ b/l10n/fork/fa/messages.po
@@ -1,0 +1,2516 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-12 08:16-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: fa\n"
+"Language-Team: fa <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "داده‌ها پس از بی‌کاری پاک شد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "در حال راه‌اندازی دوربین..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "رمزگشایی شود؟"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "نوع QR را انتخاب کنید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "کلید رمزنگاری"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "بررسی کلید رمزنگاری"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "شماره حساب"
+
+#. FORK: translated by Claude 2026-07-12
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "رمزنگاری‌شده"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "بیت‌های آنتروپی رمزنگاری‌شده"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "مسیر غیراستاندارد!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "شناسه Mnemonic"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "بررسی شناسه Mnemonic"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "کدهای QR خروجی در دو حالت ممکن است متفاوت باشند، اما هر دو معتبرند."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "رونویسی QR رمزنگاری‌شده"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "گزینه‌ای موجود نیست"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "اطلاعات باتری"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "اطلاعات سیستم"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Platform: {platform_name}"
+msgstr "پلتفرم: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Variant: {platform_variant}"
+msgstr "گونه: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Serial (CPU): {system_serial}"
+msgstr "سریال (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "سریال (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "فیلتر دستگاه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "اطلاعات شبکه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "کالیبراسیون باتری"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "باتری را کامل شارژ کنید. برای شروع آزمون تخلیه، بعدی را انتخاب کنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "شروع"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "آزمون تا خالی‌شدن ادامه می‌یابد. دستگاه را به برق وصل نکنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "شارژ تشخیص داده شد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "در حال تخلیه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "سپری‌شده: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "ولتاژ: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "جریان: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "وضعیت: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "آنتروپی کم"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "آنتروپی خوب"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "متن برای رمزگذاری"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "تنظیم PIN اضطراری"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "دوربین ۰"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "دوربین ۱"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "دوربین ۲"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "دوربین ۳"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "۵ دقیقه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "۱۰ دقیقه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "۱۵ دقیقه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "۳۰ دقیقه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "گذرواژه Aezeed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "ترجیح CompactSeedQR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "ترجیح EncryptedQR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "هر بار بپرس"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "تعداد تلاش PIN اسمارت‌کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "زمان‌سنج پاک‌سازی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "تعداد کلمات عبارت بازیابی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "درخواست حساب BIP32"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "QR مبهم"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "انواع کلید GPG"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "نسخه GPG برای BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 جدیدترین است؛ برای بازسازی کلیدهای B9-B10 از v2 استفاده کنید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "عبارت‌های بازیابی SLIP39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "عبارت‌های بازیابی Aezeed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "سازگار با LND، ۲۴ کلمه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "سهم‌های قابل‌گسترش SLIP39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "پشتیبان‌های BitBox02"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "پشتیبان‌های Passport"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "پشتیبان‌های TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "پشتیبانی از اسمارت‌کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "پشتیبانی از Satochip"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "پشتیبانی از Keycard"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "پشتیبانی از Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "منبع دوربین"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "حالت دسکتاپ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "امن نیست!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"این نسخه دسکتاپ فقط برای آزمایش است.\n"
+"با عبارت بازیابی یا کلید خصوصی واقعی استفاده نکنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "متوجه شدم"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "نسخه توسعه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"این نسخه توسعه SeedSignerOS فقط برای آزمایش است.\n"
+"با عبارت بازیابی یا کلید خصوصی واقعی استفاده نکنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "عملیات فایل"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "درون‌ریزی کلیدها"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "برون‌ریزی کلیدها"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "مشاهده کلیدها"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "پیام‌رسانی امن"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "ابزارهای GPG"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "بسته‌های ناموجود"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "لازم اما نصب‌نشده:\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "عملیات زیرکلید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "عملیات شناسه کاربر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "گواهی متقابل کلیدها"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "برون‌ریزی بستهٔ کلید عمومی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "فراداده BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "زیرکلیدها"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "بازگشت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "برون‌ریزی بسته"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "QR متحرک"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "ذخیره داده BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "بارگذاری داده BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "بازسازی کلید BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "به MicroSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "به QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "به Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "از MicroSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "از QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "از Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "افزودن زیرکلید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "ابطال زیرکلید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "حذف زیرکلید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "تغییر انقضا"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "برون‌ریزی رازهای زیرکلید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "۱ سال"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "۲ سال"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "۵ سال"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "هرگز"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "فایل"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "اسمارت‌کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "افزودن شناسه کاربر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "ویرایش شناسه‌های کاربر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "تنظیم شناسه کاربر اصلی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "ابطال شناسه کاربر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "حذف شناسه کاربر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "رمزنگاری"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "رمزگشایی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "امضا"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "تأیید امضا"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "ایجاد پیام"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "بارگذاری پیام"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "فهرست"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "تایپ پیام"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "بارگذاری Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "اسکن QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "بارگذاری فایل"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "بارگذاری کلید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "ذخیره در Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "نمایش به‌صورت QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "کلید عمومی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "کلید خصوصی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "مشاهده اطلاعات کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "تولید کلید روی کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "تغییر PIN مدیر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "تغییر PIN کاربر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "در حال رمزنگاری فایل"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(ممکن است کمی طول بکشد)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "در حال رمزگشایی فایل"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "بررسی SHA256Sum"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "به‌روزرسانی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "از فایل"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "تولید جدید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "استخراج BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "کارت OpenGPG"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "ویرایش متن"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "دور انداختن متن"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "متن دور انداخته شود؟"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "تولید کد QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "حالت رونویسی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "حالت تمام‌صفحه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "حالت رونویسی؟"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "تأیید کد QR متن"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "تأیید QR متن؟"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "اسکن کد QR متن"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "تأیید کد QR متن"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "کد QR متن رونویسی‌شده با متن اصلی مطابقت ندارد!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "بررسی کد QR متن"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "کد QR متن رونویسی‌شده با موفقیت اسکن شد و همان متن به دست آمد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "تأیید QR متن"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "کد QR متن رونویسی‌شده خوانده نشد!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "ویرایش و تولید کد QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "متن رمزگشایی‌شده"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "اجرای آزمون"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "فلش تصویر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "تأیید MicroSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "پاک‌سازی (صفر)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "پاک‌سازی (تصادفی)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "رد کردن تأیید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "همه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "سفارشی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF کوتاه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF بلند"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "پرتاب تاس"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "نوع گذرواژه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "۶۴ بیت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "۱۲۸ بیت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "۲۵۶ بیت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "قدرت گذرواژه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "بله"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "خیر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "انتخاب گزینه‌ها"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "حداقل یک مجموعه نویسه انتخاب کنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "بررسی سلامت RNG سیستم ناموفق بود."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "خطای RNG سیستم"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "دوربین"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "تاس"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "RNG سیستم"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "منبع آنتروپی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "پشتیبانی نمی‌شود"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 از Diceware، پرتاب تاس، Hex، Base64 و Base85 پشتیبانی می‌کند."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "هیچ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "بزرگ‌کردن حرف اول"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "فاصله"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "جداکننده"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "۶ وجه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "۱۰ وجه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "۲۰ وجه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "وجوه تاس"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "تعداد پرتاب‌ها"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "ورودی نامعتبر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "تعداد پرتاب‌ها باید حداقل ۱ باشد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "آنتروپی ضعیف"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "پرتاب تاس به‌اندازه کافی تصادفی نبود. لطفاً دوباره تلاش کنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "آنتروپی دوربین به‌اندازه کافی تصادفی نبود. لطفاً دوباره تلاش کنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "هشدار"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "پیش از استفاده از BIP85 یک عبارت بازیابی بارگذاری کنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "انتخاب عبارت بازیابی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "انتخاب عبارت بازیابی برای BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "شاخص BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "طول نامعتبر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex از ۱۲۸ یا ۲۵۶ بیت پشتیبانی می‌کند."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 به ۱۲۰ بیت یا بیشتر نیاز دارد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 به ۶۴ تا ۵۱۲ بیت نیاز دارد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "نام گذرواژه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "فضای کافی نیست"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"در حال ذخیره راز\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "موفق"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "گذرواژه در Seedkeeper ذخیره شد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "فضای کافی روی Seedkeeper برای گذرواژه نیست"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "ناموفق"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "ذخیره گذرواژه ناموفق بود"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "ویرایش"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "گذرواژه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "ذخیره گذرواژه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "استفاده از کارت Satochip"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "استفاده از Keycard"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "ورود عبارت بازیابی ۱۵ کلمه‌ای"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "ورود عبارت بازیابی ۱۸ کلمه‌ای"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "ورود عبارت بازیابی ۲۱ کلمه‌ای"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "ورود WIF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "اسکن WIF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "ورود BIP38"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "اسکن BIP38"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "عدم تطابق اثر انگشت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "کارت نمی‌تواند این PSBT را امضا کند"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "اثر انگشت کارت ({}) در امضاکنندگان PSBT نیست."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "کلید خصوصی (WIF)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "WIF نامعتبر!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "کلید خصوصی معتبر با کدگذاری WIF نیست."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "کلید BIP38"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "گذرواژه BIP38"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "BIP38 نامعتبر!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "کلید BIP38 رمزگشایی نشد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "عدم تطابق descriptor"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "descriptor پاک شد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "descriptor کیف‌پول چندامضایی بارگذاری‌شده با این PSBT مطابقت ندارد. descriptor درست را بارگذاری کنید یا برای ادامه تأیید را رد کنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "در حال امضای PSBT..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "مهلت امضا تمام شد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "تلاش دوباره (مهلت بیشتر)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Saved as {}."
+msgstr "با نام {} ذخیره شد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Failed to save PSBT: {}"
+msgstr "ذخیره PSBT ناموفق بود: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "در حال کدگذاری PSBT..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "اسکنر QR در دسترس نیست"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "بک‌اند اسکن QR موجود نیست. zbar (یا OpenCV روی دسکتاپ) را نصب و دستگاه را دوباره راه‌اندازی کنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "انتخاب نوع عبارت بازیابی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "زمان تنظیم شد به:"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "تنظیم زمان ناموفق بود"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "زمان نامعتبر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "زمان از QR خوانده نشد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "اسکن سهم SLIP-39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "QR سهم SLIP-39 انتظار می‌رفت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "کلید خصوصی WIF انتظار می‌رفت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "کلید خصوصی BIP38 انتظار می‌رفت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+#, python-brace-format
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "نشانی دریافت {} را از کیف‌پولی که تازه برون‌ریزی کردید اسکن کنید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"داده با چند نوع\n"
+"QR مطابقت دارد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "تایپ کلید رمزنگاری"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "اسکن کلید رمزنگاری"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "ویرایش کلید رمزنگاری"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "دور انداختن کلید رمزنگاری"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "ادامه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "اسکن و افزودن مورد دیگر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "متن رمزگشایی‌شده"
+
+#. FORK: translated by Claude 2026-07-12
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "یک fork غیررسمی از:"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "پشتیبان BitBox02"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "پشتیبان Passport"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "پشتیبان TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "ورود عبارت بازیابی Aezeed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "سهم‌های SLIP-39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " اسکن SeedQR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "از SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "از Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " ساخت عبارت بازیابی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "کارت microSD شناسایی نشد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "پشتیبانی یافت نشد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "هیچ پشتیبان BitBox02 (‎.bin، .bb02، .dat، .backup) روی کارت microSD یافت نشد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "انتخاب پشتیبان BitBox02"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Backup name: {}"
+msgstr "نام پشتیبان: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Created: {}"
+msgstr "ایجاد شد: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Firmware: {}"
+msgstr "میان‌افزار: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Birthdate: {}"
+msgstr "تاریخ ایجاد: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Seed length: {} words"
+msgstr "طول عبارت بازیابی: {} کلمه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "عبارت بازیابی بارگذاری شد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "هیچ پشتیبان Passport (‎.7z) روی کارت microSD یافت نشد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "انتخاب پشتیبان Passport"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "کد پشتیبان Passport"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "کد پشتیبان نمی‌تواند خالی باشد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Chain: {}"
+msgstr "زنجیره: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "هیچ پشتیبان TAPSIGNER (‎.aes) روی کارت microSD یافت نشد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "انتخاب پشتیبان TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "کلید پشتیبان (hex)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "xprv از پشتیبان TAPSIGNER بارگذاری شد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Path: {}"
+msgstr "مسیر: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "بارگذاری گذرواژه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "تایپ گذرواژه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "اسکن گذرواژه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "بارگذاری از SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "گذرواژه Aezeed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"برای این mnemonic\n"
+"گذرواژه لازم است."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "گذرواژه نامعتبر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"گذرواژه Aezeed لازم است.\n"
+"دوباره تلاش کنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"گذرواژه Aezeed اشتباه است.\n"
+"دوباره تلاش کنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "کد QR متن نامعتبر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "داده غیر UTF-8 شناسایی شد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "پشتیبانی از Aezeed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"ورود Aezeed آزمایشی است.\n"
+"فقط با پشتیبان‌های سالمِ شناخته‌شده استفاده کنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "ورود ۲۰ کلمه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "ورود ۳۳ کلمه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "بارگذاری سهم"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Share Word #{}"
+msgstr "کلمه سهم #{}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "ورود سهم"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "اسکن سهم"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "ترکیب سهم‌ها"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "{} of {} needed"
+msgstr "{} از {} لازم است"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "دوباره تلاش کنید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "سهم SLIP-39 نامعتبر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "خطای کنترل‌جمع؛ سهم SLIP-39 معتبر نیست."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "عبارت بازیابی غیرقابل‌گسترش"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "این عبارت بازیابی SLIP-39 نمی‌تواند سهم‌های جدید بسازد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "برون‌ریزی به‌صورت QR متن ساده"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "به SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "به Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "بازتولید سهم‌ها"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "{} را باز کنید و یک نشانی دریافت از کیف‌پولی که تازه برون‌ریزی کردید نمایش دهید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "نرم‌افزار کیف‌پول شما"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"گذرواژه استفاده شد.\n"
+"به کلمات + گذرواژه نیاز خواهید داشت."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "۱۸ کلمه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "بررسی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "نهایی‌سازی عبارت بازیابی فرزند"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "ورود کلید رمزنگاری"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "کلید رمزنگاری دور انداخته شود؟"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "ورودی کلید کنونی شما پاک خواهد شد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "کلید نامعتبر"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "طول کلید بیش از حد است."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "ورود از دوربین"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "استفاده از اثر انگشت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "اختصاص شناسه سفارشی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "ورود شناسه Mnemonic"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "ویرایش شناسه Mnemonic"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "دور انداختن شناسه Mnemonic"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "شناسه Mnemonic دور انداخته شود؟"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "ورودی شناسه Mnemonic کنونی شما پاک خواهد شد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "در حال پردازش..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "خطای رمزنگاری"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "۱۰۰ بعدی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "جستجوی گسترده"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "یافت نشد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "نشانی تأیید نشد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Checked {} addresses with no match."
+msgstr "{} نشانی بررسی شد، بدون تطابق."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "بررسی ۱۰ بعدی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Checked {} addresses per path with no match."
+msgstr "{} نشانی در هر مسیر بررسی شد، بدون تطابق."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "برون‌ریزی کیف‌پول"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "برون‌ریزی کیف‌پول موفق بود."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "قالب نشانی با نوع اسکریپت برون‌ریزی‌شده مطابقت ندارد. برون‌ریزی کیف‌پول ناموفق بود."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "تطبیق کیف‌پول با عبارت بازیابی کنونی ممکن نشد. برون‌ریزی کیف‌پول ناموفق بود."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "برون‌ریزی ناموفق"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "بارگذاری SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "در حال برون‌ریزی xpub..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "در حال امضای پیام..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "تأیید ناموفق بود"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "آزمون اسمارت‌کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "فهرست کارت‌خوان‌ها"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "آزمون اسکن NFC"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "راه‌اندازی مجدد PCSC"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "اطلاعات باتری"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "اطلاعات سیستم"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "بارگذاری فایل‌های پشتیبان"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "هیچ پایشگر باتری سازگاری شناسایی نشد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "در دسترس نیست"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "توابع مشترک"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "توابع Satochip"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "توابع Keycard"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "توابع SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "توابع Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "ابزارهای DIY"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "اطلاعات کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "بررسی اصالت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "تغییر PIN"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "تغییر برچسب"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "تغییر سیاست NFC"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "پیکربندی NDEF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "بازنشانی کارخانه‌ای کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "مشاهده NDEF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "استفاده از پیوند برنامه Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "پاک‌کردن NDEF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "تنظیم NDEF سفارشی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "ذخیره NDEF در SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "بارگذاری NDEF از SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "رکورد متن"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "رکورد URI"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "اجرای برنامه اندروید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "سفارشی (HEX)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "رمزگشایی NDEF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC فعال"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC غیرفعال"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC مسدود"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "کارت دوباره وارد شد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "مشاهده فضای خالی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "مشاهده رازها روی کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "ذخیره گذرواژه در کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "حذف راز از کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "بارگذاری descriptor چندامضایی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "ذخیره descriptor چندامضایی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "همانندسازی رازهای کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "خروج به خانه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "مقداردهی اولیه با عبارت بازیابی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "بارگذاری به‌صورت descriptor"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "بارگذاری PSBT"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "تنظیم PUK"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "رفع انسداد PIN با PUK"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "تنظیم نام"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "حذف عبارت بازیابی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "محک امضا"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "محک امضای پیام"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "بررسی اریبی امضا"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "حذف"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "بازنشانی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "فعال‌سازی 2FA"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "از قبل عبارت بازیابی دارد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"xprv نمی‌تواند Satochip را مقداردهی کند.\n"
+"از BIP39، SLIP39 یا Electrum استفاده کنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "تغییر PIN کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "بارگذاری Mnemonic"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "ذخیره Mnemonic"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "پاک‌کردن عبارت بازیابی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "کلیدهای کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "ساخت اپلت‌ها"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "نصب اپلت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "حذف اپلت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "ورود PIN متفاوت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "بارگذاری کلیدها"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "ذخیره کلیدها"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "باز کردن قفل کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "قفل کردن کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "پاک‌کردن کلیدهای بارگذاری‌شده"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "بازنویسی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "لغو ذخیره"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "ورود کلید تکی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "ورود مجموعه کلید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "تولید کلید تکی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "تولید مجموعه کلید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "۸ KB (پیش‌فرض)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "آنتروپی RNG سیستم بسیار کم است. بعداً دوباره تلاش کنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "آنتروپی استخراج‌شده از RNG سیستم در بررسی سلامت رد شد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " عبارت بازیابی جدید"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "عبارت بازیابی SLIP39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "کد QR متن"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "تولیدکننده گذرواژه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "ابزارهای اسمارت‌کارت"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "ابزارهای MicroSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "پاک‌کردن descriptor چندامضایی"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "کارت microSD شناسایی نشد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "برای ذخیره گزارش تخلیه یک کارت microSD وارد کنید."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "بارگذاری اطلاعات شبکه ممکن نشد."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "۱۵ کلمه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "۱۸ کلمه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "۲۱ کلمه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "۲۰ کلمه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "۳۳ کلمه"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+#, python-brace-format
+msgid "20 words ({} rolls)"
+msgstr "۲۰ کلمه ({} پرتاب)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+#, python-brace-format
+msgid "33 words ({} rolls)"
+msgstr "۳۳ کلمه ({} پرتاب)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "descriptor چندامضایی بارگذاری شد"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "بارگذاری از Satochip"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "عبارت بازیابی Electrum"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "کدگذاری متن"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "رمزگشایی کد QR"
+

--- a/l10n/fork/fr/messages.po
+++ b/l10n/fork/fr/messages.po
@@ -1,0 +1,2493 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-11 08:17-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: fr\n"
+"Language-Team: fr <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "Données effacées après inactivité"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "Démarrage de la caméra..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "Déchiffrer ?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "Choisir le type de QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "Clé de chiffrement"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "Vérifier la clé de chiffrement"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "Numéro de compte"
+
+#. FORK: translated by Claude 2026-07-11
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "Chiffré"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "Bits d'entropie chiffrés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "Chemin non standard !"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "ID du mnémonique"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "Vérifier l'ID du mnémonique"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "Les QR codes produits par les deux modes peuvent différer, mais tous deux sont valides."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "Transcrire le QR chiffré"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "Aucune option disponible"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "Infos batterie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "Infos système"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Platform: {platform_name}"
+msgstr "Plateforme : {platform_name}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Variant: {platform_variant}"
+msgstr "Variante : {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (CPU): {system_serial}"
+msgstr "N° de série (CPU) : {system_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "N° de série (MicroSD) : {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "Filtre d'appareils"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "Infos réseau"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "Calibrage de la batterie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "Chargez la batterie à fond. Choisissez Suivant pour lancer le test de décharge."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "Démarrer"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "Le test dure jusqu'à la décharge complète. Laissez l'appareil débranché."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "Charge détectée"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "Décharge en cours"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "Écoulé : "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "Tension : "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "Courant : "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "État : "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "ENTROPIE FAIBLE"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "BONNE ENTROPIE"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "Texte à encoder"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "Définir le PIN de contrainte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "Caméra 0"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "Caméra 1"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "Caméra 2"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "Caméra 3"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 minutes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 minutes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 minutes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Phrase secrète Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "Préférer CompactSeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "Préférer EncryptedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "Demander à chaque fois"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "Essais de PIN de la carte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "Minuteur d'effacement"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "Longueurs de seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "Demander le compte BIP32"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "QR ambigu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "Types de clés GPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "Version GPG de BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 est la plus récente ; utilisez v2 pour recréer les clés B9-B10"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "Seeds SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Seeds Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "Compatible LND, 24 mots"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "Fragments SLIP39 extensibles"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "Sauvegardes BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Sauvegardes Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "Sauvegardes TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "Prise en charge des cartes à puce"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Prise en charge Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Prise en charge Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Prise en charge Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "Source de la caméra"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "Mode bureau"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "Non sécurisé !"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Cette version bureau sert uniquement aux tests.\n"
+"NE PAS utiliser avec de vraies seeds ou clés privées."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "J'ai compris"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "Version de développement"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Cette version de développement de SeedSignerOS sert uniquement aux tests.\n"
+"NE PAS utiliser avec de vraies seeds ou clés privées."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "Opérations sur fichiers"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "Importer des clés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "Exporter des clés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "Voir les clés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "Messagerie sécurisée"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "Outils GPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "Paquets manquants"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "Requis mais non installé :\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "Opérations sur sous-clés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "Opérations sur ID utilisateur"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "Certification croisée des clés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "Exporter le paquet de clé publique"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "Métadonnées BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "Sous-clés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "Retour"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "Exporter le paquet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "QR animé"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "Enregistrer les données BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "Charger les données BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "Reconstruire la clé BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "Vers MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "Vers QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "Vers Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "Depuis MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "Depuis QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Depuis Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "Ajouter des sous-clés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "Révoquer des sous-clés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "Supprimer des sous-clés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "Changer l'expiration"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "Exporter les secrets des sous-clés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 an"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 ans"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 ans"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "Jamais"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "Fichier"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "Carte à puce"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "Ajouter un ID utilisateur"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "Modifier les ID utilisateur"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "Définir l'ID utilisateur principal"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "Révoquer un ID utilisateur"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "Supprimer un ID utilisateur"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "Chiffrer"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "Déchiffrer"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "Signer"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "Vérifier la signature"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "Créer un message"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "Charger un message"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "Manifeste"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "Saisir un message"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Charger Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "Scanner le QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "Charger un fichier"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "Charger une clé"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Enregistrer sur Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "Afficher en QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "Clé publique"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "Clé privée"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "Voir les infos de la carte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "Générer la clé sur la carte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "Changer le PIN admin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "Changer le PIN utilisateur"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "Chiffrement du fichier"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(Peut prendre du temps)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "Déchiffrement du fichier"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "Vérifier le SHA256Sum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "Mettre à jour"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "Depuis un fichier"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "Générer une nouvelle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "Dériver BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "Carte OpenGPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "Modifier le texte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "Rejeter le texte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "Rejeter le texte ?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "Générer le QR code"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "Mode transcription"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "Mode plein écran"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "Mode transcription ?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "Confirmer le QR code de texte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "Confirmer le QR de texte ?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "Scanner le QR code de texte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "Confirmer le QR code de texte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "Votre QR de texte transcrit ne correspond pas au texte original !"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "Vérifier le QR code de texte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "Votre QR de texte transcrit a été scanné avec succès et donne le même texte."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "Confirmer le QR de texte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "Votre QR de texte transcrit n'a pas pu être lu !"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "Modifier et générer le QR code"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "Texte décodé"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "Lancer le test"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "Flasher l'image"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "Vérifier la MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "Effacer (zéros)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "Effacer (aléatoire)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "Sauter la vérification"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "Tout"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "Personnalisé"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF courte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF longue"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "Lancers de dés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "Type de mot de passe"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 bits"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 bits"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 bits"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "Robustesse du mot de passe"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "Oui"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "Non"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "Choisir les options"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "Choisissez au moins un jeu de caractères."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "Échec du contrôle du RNG système."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "Erreur du RNG système"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "Caméra"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "Dés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "RNG système"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "Source d'entropie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "Non pris en charge"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 prend en charge Diceware, lancers de dés, Hex, Base64 et Base85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "Aucun"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "Majuscule initiale"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "Espace"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "Séparateur"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 faces"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 faces"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 faces"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "Faces du dé"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "Nombre de lancers"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "Saisie invalide"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "Le nombre de lancers doit être d'au moins 1."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "Entropie faible"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "Les lancers n'ont pas semblé assez aléatoires. Veuillez réessayer."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "L'entropie de la caméra n'a pas semblé assez aléatoire. Veuillez réessayer."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "ATTENTION"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "Chargez une seed avant d'utiliser BIP85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "Choisir la seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "Choisissez la seed pour BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "Index BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "Longueur invalide"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex prend en charge 128 ou 256 bits."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 nécessite 120+ bits."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 nécessite 64-512 bits."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "Nom du mot de passe"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "Espace insuffisant"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"Enregistrement du secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "Succès"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "Mot de passe enregistré sur Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "Pas assez d'espace sur le Seedkeeper pour le mot de passe"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "Échec"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "Échec de l'enregistrement du mot de passe"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "Modifier"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "Mot de passe"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "Enregistrer le mot de passe"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Utiliser la carte Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Utiliser la Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "Entrer la seed 15 mots"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "Entrer la seed 18 mots"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "Entrer la seed 21 mots"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "Entrer un WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "Scanner un WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "Entrer un BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "Scanner un BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "Empreinte non concordante"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "La carte ne peut pas signer le PSBT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "L'empreinte de la carte ({}) n'est pas parmi les signataires du PSBT."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "Clé privée (WIF)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "WIF invalide !"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "Clé privée WIF invalide."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "Clé BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "Phrase secrète BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "BIP38 invalide !"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "Impossible de déchiffrer la clé BIP38."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "Descripteur non concordant"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "Descripteur effacé"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "Le descripteur multisig chargé ne correspond pas à ce PSBT. Chargez le bon descripteur ou sautez la vérification."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "Signature du PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "Délai de signature dépassé"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "Réessayer (délai plus long)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Saved as {}."
+msgstr "Enregistré sous {}."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Failed to save PSBT: {}"
+msgstr "Échec de l'enregistrement du PSBT : {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "Encodage du PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "Scanner QR indisponible"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "Backend de scan QR manquant. Installez zbar (ou OpenCV sur bureau) et redémarrez."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "Choisir le type de seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "Heure réglée sur :"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "Échec du réglage de l'heure"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "Heure invalide"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "Impossible de lire l'heure du QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "Scanner un fragment SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "QR de fragment SLIP-39 attendu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "Clé privée WIF attendue"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "Clé privée BIP38 attendue"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "Scannez l'adresse de réception {} du portefeuille que vous venez d'exporter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"Les données correspondent à\n"
+"plusieurs types de QR."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "Saisir la clé de chiffrement"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "Scanner la clé de chiffrement"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "Modifier la clé de chiffrement"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "Rejeter la clé de chiffrement"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "Continuer"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "Scanner et ajouter un autre"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "Texte déchiffré"
+
+#. FORK: translated by Claude 2026-07-11
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "Un fork non officiel de :"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "Sauvegarde BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Sauvegarde Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "Sauvegarde TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Entrer la seed Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "Fragments SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " Scanner un SeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "Depuis SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Depuis Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " Créer une seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "Carte microSD non détectée."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "Aucune sauvegarde trouvée"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "Aucune sauvegarde BitBox02 (.bin, .bb02, .dat, .backup) trouvée sur la carte microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "Choisir la sauvegarde BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup name: {}"
+msgstr "Nom de la sauvegarde : {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Created: {}"
+msgstr "Créée : {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Firmware: {}"
+msgstr "Firmware : {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Birthdate: {}"
+msgstr "Date de création : {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed length: {} words"
+msgstr "Longueur de la seed : {} mots"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "Seed chargée"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "Aucune sauvegarde Passport (.7z) trouvée sur la carte microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Choisir la sauvegarde Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Code de la sauvegarde Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "Le code de sauvegarde ne peut pas être vide."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Chain: {}"
+msgstr "Chaîne : {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "XFP: {}"
+msgstr "XFP : {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "Aucune sauvegarde TAPSIGNER (.aes) trouvée sur la carte microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "Choisir la sauvegarde TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "Clé de sauvegarde (hex)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "xprv chargée depuis la sauvegarde TAPSIGNER."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Path: {}"
+msgstr "Chemin : {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "Charger la phrase secrète"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "Saisir la phrase secrète"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "Scanner la phrase secrète"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "Charger depuis SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Phrase secrète Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"Phrase secrète requise\n"
+"pour ce mnémonique."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "Phrase secrète invalide"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Phrase secrète Aezeed requise.\n"
+"Réessayez."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Phrase secrète Aezeed erronée.\n"
+"Réessayez."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "QR de texte invalide"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "Données non UTF-8 détectées."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Prise en charge Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"La saisie Aezeed est expérimentale.\n"
+"Uniquement avec des sauvegardes fiables."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "Entrer 20 mots"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "Entrer 33 mots"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "Charger un fragment"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Share Word #{}"
+msgstr "Mot du fragment n°{}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "Saisir un fragment"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "Scanner un fragment"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "Combiner les fragments"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "{} of {} needed"
+msgstr "{} sur {} requis"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "Réessayer"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "Fragment SLIP-39 invalide"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "Somme de contrôle erronée ; fragment SLIP-39 invalide."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Seed non extensible"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Cette seed SLIP-39 ne peut pas régénérer de nouveaux fragments."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "Exporter en QR non chiffré"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "Vers SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "Vers Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "Régénérer les fragments"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "Ouvrez {} et affichez une adresse de réception du portefeuille que vous venez d'exporter."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "votre logiciel de portefeuille"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"Une phrase secrète a été utilisée.\n"
+"Il faudra mots + phrase secrète."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 mots"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "Vérifier"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "Finaliser la seed enfant"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "Saisir la clé de chiffrement"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "Rejeter la clé de chiffrement ?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "La clé saisie sera effacée"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "Clé invalide"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "La clé est trop longue."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "Saisie par caméra"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "Utiliser l'empreinte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "Attribuer un ID personnalisé"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "Saisir l'ID du mnémonique"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "Modifier l'ID du mnémonique"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "Rejeter l'ID du mnémonique"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "Rejeter l'ID du mnémonique ?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "L'ID du mnémonique saisi sera effacé"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "Traitement..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "Échec du chiffrement"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "100 suivantes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "Recherche étendue"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "Introuvable"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "Adresse non vérifiée"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses with no match."
+msgstr "{} adresses vérifiées sans correspondance."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "Vérifier les 10 suivantes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses per path with no match."
+msgstr "{} adresses vérifiées par chemin sans correspondance."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "Export du portefeuille"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "Portefeuille exporté avec succès."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "Le format d'adresse ne correspond pas au type de script exporté. Échec de l'export."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "Impossible d'associer le portefeuille à la seed actuelle. Échec de l'export."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "Échec de l'export"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "Charger SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "Export de la xpub..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "Signature du message..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "Échec de la vérification"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "Tester la carte à puce"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "Lister les lecteurs de cartes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "Tester le scan NFC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "Redémarrer PCSC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "Infos batterie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "Infos système"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "Charger des fichiers de sauvegarde"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "Aucun moniteur de batterie compatible détecté"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "Indisponible"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "Fonctions communes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Fonctions Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Fonctions Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "Fonctions SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Fonctions Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "Outils DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "Infos de la carte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "Contrôle d'authenticité"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "Changer le PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "Changer l'étiquette"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "Changer la politique NFC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "Configurer NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "Réinitialiser la carte (usine)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "Voir le NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Utiliser le lien de l'app Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "Effacer le NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "Définir un NDEF personnalisé"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "Enregistrer le NDEF sur SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "Charger le NDEF depuis SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "Enregistrement texte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "Enregistrement URI"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Lancement d'app Android"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "Personnalisé (HEX)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "Décoder le NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC activé"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC désactivé"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC bloqué"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "Carte réinsérée"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "Voir l'espace libre"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "Voir les secrets de la carte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "Enregistrer le mot de passe sur la carte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "Supprimer un secret de la carte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "Charger un descripteur multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "Enregistrer le descripteur multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "Cloner les secrets de la carte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "Retour à l'accueil"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "Initialiser avec une seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "Charger comme descripteur"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "Charger un PSBT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "Définir le PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "Débloquer le PIN avec le PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "Définir le nom"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "Retirer la seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "Benchmark de signature"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "Benchmark de signature de messages"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "Vérifier le biais de signature"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "Retirer"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "Réinitialiser"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "Activer la 2FA"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "Seed déjà présente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"Une xprv ne peut pas initialiser Satochip.\n"
+"Utilisez BIP39, SLIP39 ou Electrum."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "Changer le PIN de la carte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "Charger le mnémonique"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "Enregistrer le mnémonique"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "Effacer la seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "Clés de la carte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "Compiler les applets"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "Installer l'applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "Désinstaller l'applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "Saisir un autre PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "Charger les clés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "Enregistrer les clés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "Déverrouiller la carte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "Verrouiller la carte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "Effacer les clés chargées"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "Écraser"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "Annuler l'enregistrement"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "Saisir une clé unique"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "Saisir un jeu de clés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "Générer une clé unique"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "Générer un jeu de clés"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (par défaut)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "Entropie du RNG système trop faible. Réessayez plus tard."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "L'entropie dérivée du RNG système a échoué aux contrôles."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Nouvelle seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "Seed SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "QR code de texte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "Générateur de mots de passe"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "Outils carte à puce"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "Outils MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Effacer le descripteur multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "Carte microSD non détectée"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "Insérez une carte microSD pour enregistrer le journal de décharge."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "Impossible de charger les informations réseau."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 mots"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 mots"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 mots"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 mots"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 mots"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words ({} rolls)"
+msgstr "20 mots ({} lancers)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words ({} rolls)"
+msgstr "33 mots ({} lancers)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Descripteur multisig chargé"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Charger depuis Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Seed Electrum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "Encoder le texte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "Décoder le QR code"
+

--- a/l10n/fork/hi/messages.po
+++ b/l10n/fork/hi/messages.po
@@ -1,0 +1,2516 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-12 08:13-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: hi\n"
+"Language-Team: hi <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "निष्क्रियता के बाद डेटा मिटाया गया"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "कैमरा शुरू हो रहा है..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "डिक्रिप्ट करें?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "QR प्रकार चुनें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "एन्क्रिप्शन कुंजी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "एन्क्रिप्शन कुंजी जाँचें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "खाता संख्या"
+
+#. FORK: translated by Claude 2026-07-12
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "एन्क्रिप्टेड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "एन्क्रिप्टेड एन्ट्रॉपी बिट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "गैर-मानक पथ!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "मेमोनिक ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "मेमोनिक ID जाँचें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "दोनों मोड के QR कोड अलग हो सकते हैं, पर दोनों मान्य हैं।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "एन्क्रिप्टेड QR उतारें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "कोई विकल्प उपलब्ध नहीं"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "बैटरी जानकारी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "सिस्टम जानकारी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Platform: {platform_name}"
+msgstr "प्लेटफ़ॉर्म: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Variant: {platform_variant}"
+msgstr "वेरिएंट: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Serial (CPU): {system_serial}"
+msgstr "सीरियल (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "सीरियल (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "डिवाइस फ़िल्टर"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "नेटवर्क जानकारी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "बैटरी कैलिब्रेशन"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "बैटरी पूरी चार्ज करें। डिस्चार्ज परीक्षण शुरू करने के लिए अगला चुनें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "शुरू करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "परीक्षण बैटरी खत्म होने तक चलता है। डिवाइस को अनप्लग रखें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "चार्जिंग का पता चला"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "डिस्चार्ज हो रहा है"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "बीता समय: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "वोल्टेज: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "करंट: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "स्थिति: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "कम एन्ट्रॉपी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "अच्छी एन्ट्रॉपी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "एन्कोड करने का टेक्स्ट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "ड्यूरेस PIN सेट करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "कैमरा 0"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "कैमरा 1"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "कैमरा 2"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "कैमरा 3"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 मिनट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 मिनट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 मिनट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 मिनट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Aezeed पासफ़्रेज़"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "CompactSeedQR को प्राथमिकता"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "EncryptedQR को प्राथमिकता"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "हर बार पूछें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "स्मार्टकार्ड PIN प्रयास"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "वाइप टाइमर"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "सीड शब्द संख्या"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "BIP32 खाता संकेत"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "अस्पष्ट QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "GPG कुंजी प्रकार"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "BIP85 GPG संस्करण"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 नवीनतम है; B9-B10 कुंजियाँ फिर बनाने के लिए v2 का उपयोग करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "SLIP39 सीड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Aezeed सीड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "LND-संगत, 24 शब्द"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "विस्तारयोग्य SLIP39 शेयर"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "BitBox02 बैकअप"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Passport बैकअप"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "TAPSIGNER बैकअप"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "स्मार्टकार्ड समर्थन"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Satochip समर्थन"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Keycard समर्थन"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Specter-DIY समर्थन"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "कैमरा स्रोत"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "डेस्कटॉप मोड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "सुरक्षित नहीं!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"यह डेस्कटॉप संस्करण केवल परीक्षण के लिए है।\n"
+"वास्तविक सीड या निजी कुंजियों के साथ उपयोग न करें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "मैं समझता हूँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "डेवलपमेंट बिल्ड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"यह SeedSignerOS डेवलपमेंट बिल्ड केवल परीक्षण के लिए है।\n"
+"वास्तविक सीड या निजी कुंजियों के साथ उपयोग न करें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "फ़ाइल संचालन"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "कुंजियाँ आयात करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "कुंजियाँ निर्यात करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "कुंजियाँ देखें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "सुरक्षित संदेश"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "GPG टूल्स"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "अनुपस्थित पैकेज"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "आवश्यक पर स्थापित नहीं:\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "उपकुंजी संचालन"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "यूज़र ID संचालन"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "कुंजियों का पारस्परिक प्रमाणन"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "सार्वजनिक कुंजी बंडल निर्यात करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "BIP85 मेटाडेटा"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "उपकुंजियाँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "पीछे"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "बंडल निर्यात करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "एनिमेटेड QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "BIP85 डेटा सहेजें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "BIP85 डेटा लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "BIP85 कुंजी फिर बनाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "MicroSD पर"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "QR पर"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "Seedkeeper पर"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "MicroSD से"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "QR से"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Seedkeeper से"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "उपकुंजियाँ जोड़ें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "उपकुंजियाँ रद्द करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "उपकुंजियाँ हटाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "समाप्ति बदलें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "उपकुंजी रहस्य निर्यात करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 वर्ष"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 वर्ष"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 वर्ष"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "कभी नहीं"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "फ़ाइल"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "स्मार्टकार्ड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "यूज़र ID जोड़ें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "यूज़र ID संपादित करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "प्राथमिक यूज़र ID सेट करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "यूज़र ID रद्द करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "यूज़र ID हटाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "एन्क्रिप्ट करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "डिक्रिप्ट करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "साइन करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "हस्ताक्षर सत्यापित करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "संदेश बनाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "संदेश लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "मैनिफ़ेस्ट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "संदेश टाइप करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Seedkeeper लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "QR स्कैन करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "फ़ाइल लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "कुंजी लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Seedkeeper में सहेजें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "QR के रूप में दिखाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "सार्वजनिक कुंजी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "निजी कुंजी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "कार्ड जानकारी देखें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "कार्ड पर कुंजी बनाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "एडमिन PIN बदलें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "यूज़र PIN बदलें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "फ़ाइल एन्क्रिप्ट हो रही है"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(कुछ समय लग सकता है)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "फ़ाइल डिक्रिप्ट हो रही है"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "SHA256Sum जाँचें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "अपडेट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "फ़ाइल से"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "नया बनाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "BIP85 व्युत्पन्न करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "OpenGPG कार्ड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "टेक्स्ट संपादित करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "टेक्स्ट छोड़ें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "टेक्स्ट छोड़ें?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "QR कोड बनाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "उतारने का मोड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "फ़ुलस्क्रीन मोड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "उतारने का मोड?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "टेक्स्ट QR कोड पुष्टि करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "टेक्स्ट QR पुष्टि करें?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "टेक्स्ट QR कोड स्कैन करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "टेक्स्ट QR कोड पुष्टि करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "आपका उतारा गया टेक्स्ट QR कोड मूल टेक्स्ट से मेल नहीं खाता!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "टेक्स्ट QR कोड जाँचें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "आपका उतारा गया टेक्स्ट QR कोड सफलतापूर्वक स्कैन हुआ और वही टेक्स्ट मिला।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "टेक्स्ट QR पुष्टि करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "आपका उतारा गया टेक्स्ट QR कोड पढ़ा नहीं जा सका!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "संपादित करें और QR कोड बनाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "डिकोड किया गया टेक्स्ट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "परीक्षण चलाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "इमेज फ़्लैश करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "MicroSD सत्यापित करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "वाइप (शून्य)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "वाइप (यादृच्छिक)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "सत्यापन छोड़ें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "सभी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "कस्टम"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF छोटा"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF लंबा"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "पासा फेंक"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "पासवर्ड प्रकार"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 बिट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 बिट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 बिट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "पासवर्ड मज़बूती"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "हाँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "नहीं"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "विकल्प चुनें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "कम से कम एक वर्ण सेट चुनें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "सिस्टम RNG स्वास्थ्य जाँच विफल।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "सिस्टम RNG त्रुटि"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "कैमरा"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "पासा"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "सिस्टम RNG"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "एन्ट्रॉपी स्रोत"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "समर्थित नहीं"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 Diceware, पासा फेंक, Hex, Base64 और Base85 का समर्थन करता है।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "कोई नहीं"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "पहला अक्षर बड़ा"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "स्पेस"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "विभाजक"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 भुजा"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 भुजा"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 भुजा"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "पासे की भुजाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "फेंकने की संख्या"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "अमान्य इनपुट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "फेंकने की संख्या कम से कम 1 होनी चाहिए।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "कमज़ोर एन्ट्रॉपी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "पासा फेंक पर्याप्त यादृच्छिक नहीं लगे। कृपया फिर प्रयास करें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "कैमरा एन्ट्रॉपी पर्याप्त यादृच्छिक नहीं लगी। कृपया फिर प्रयास करें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "चेतावनी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "BIP85 उपयोग करने से पहले सीड लोड करें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "सीड चुनें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "BIP85 के लिए सीड चुनें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "BIP85 इंडेक्स"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "अमान्य लंबाई"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex 128 या 256 बिट का समर्थन करता है।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 को 120+ बिट चाहिए।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 को 64-512 बिट चाहिए।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "पासवर्ड नाम"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "पर्याप्त जगह नहीं"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"रहस्य सहेजा जा रहा है\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "सफल"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "पासवर्ड Seedkeeper में सहेजा गया"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "पासवर्ड के लिए Seedkeeper पर पर्याप्त जगह नहीं"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "विफल"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "पासवर्ड सहेजना विफल"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "संपादित करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "पासवर्ड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "पासवर्ड सहेजें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Satochip कार्ड उपयोग करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Keycard उपयोग करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "15-शब्द सीड दर्ज करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "18-शब्द सीड दर्ज करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "21-शब्द सीड दर्ज करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "WIF दर्ज करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "WIF स्कैन करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "BIP38 दर्ज करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "BIP38 स्कैन करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "फ़िंगरप्रिंट बेमेल"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "कार्ड इस PSBT को साइन नहीं कर सकता"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "कार्ड फ़िंगरप्रिंट ({}) PSBT साइनर में नहीं है।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "निजी कुंजी (WIF)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "अमान्य WIF!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "मान्य WIF-एन्कोडेड निजी कुंजी नहीं है।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "BIP38 कुंजी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "BIP38 पासफ़्रेज़"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "अमान्य BIP38!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "BIP38 कुंजी डिक्रिप्ट नहीं हो सकी।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "descriptor बेमेल"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "descriptor साफ़ किया गया"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "लोड किया गया multisig वॉलेट descriptor इस PSBT से मेल नहीं खाता। सही descriptor लोड करें या जारी रखने के लिए सत्यापन छोड़ें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "PSBT साइन हो रहा है..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "साइनिंग टाइमआउट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "पुनः प्रयास (अधिक समय)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Saved as {}."
+msgstr "{} के रूप में सहेजा गया।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Failed to save PSBT: {}"
+msgstr "PSBT सहेजना विफल: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "PSBT एन्कोड हो रहा है..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "QR स्कैनर अनुपलब्ध"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "QR स्कैनिंग बैकएंड अनुपस्थित। zbar (डेस्कटॉप पर OpenCV) स्थापित करें और पुनः शुरू करें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "सीड प्रकार चुनें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "समय सेट किया गया:"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "समय सेट करना विफल"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "अमान्य समय"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "QR से समय पढ़ा नहीं जा सका"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "SLIP-39 शेयर स्कैन करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "SLIP-39 शेयर QR अपेक्षित था"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "WIF निजी कुंजी अपेक्षित थी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "BIP38 निजी कुंजी अपेक्षित थी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+#, python-brace-format
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "अभी निर्यात किए वॉलेट से {} प्राप्ति पता स्कैन करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"डेटा कई QR प्रकारों\n"
+"से मेल खाता है।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "एन्क्रिप्शन कुंजी टाइप करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "एन्क्रिप्शन कुंजी स्कैन करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "एन्क्रिप्शन कुंजी संपादित करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "एन्क्रिप्शन कुंजी छोड़ें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "आगे बढ़ें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "स्कैन करें और एक और जोड़ें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "डिक्रिप्ट किया गया टेक्स्ट"
+
+#. FORK: translated by Claude 2026-07-12
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "इसका अनौपचारिक fork:"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "BitBox02 बैकअप"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Passport बैकअप"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "TAPSIGNER बैकअप"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Aezeed सीड दर्ज करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "SLIP-39 शेयर"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " SeedQR स्कैन करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "SeedKeeper से"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Specter-DIY से"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " सीड बनाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "microSD कार्ड नहीं मिला।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "कोई बैकअप नहीं मिला"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "microSD कार्ड पर कोई BitBox02 बैकअप (.bin, .bb02, .dat, .backup) नहीं मिला।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "BitBox02 बैकअप चुनें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Backup name: {}"
+msgstr "बैकअप नाम: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Created: {}"
+msgstr "बनाया गया: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Firmware: {}"
+msgstr "फ़र्मवेयर: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Birthdate: {}"
+msgstr "जन्मतिथि: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Seed length: {} words"
+msgstr "सीड लंबाई: {} शब्द"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "सीड लोड हुआ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "microSD कार्ड पर कोई Passport बैकअप (.7z) नहीं मिला।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Passport बैकअप चुनें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Passport बैकअप कोड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "बैकअप कोड खाली नहीं हो सकता।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Chain: {}"
+msgstr "चेन: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "microSD कार्ड पर कोई TAPSIGNER बैकअप (.aes) नहीं मिला।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "TAPSIGNER बैकअप चुनें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "बैकअप कुंजी (hex)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "TAPSIGNER बैकअप से xprv लोड हुआ।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Path: {}"
+msgstr "पथ: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "पासफ़्रेज़ लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "पासफ़्रेज़ टाइप करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "पासफ़्रेज़ स्कैन करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "SeedKeeper से लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Aezeed पासफ़्रेज़"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"इस मेमोनिक के लिए\n"
+"पासफ़्रेज़ आवश्यक है।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "अमान्य पासफ़्रेज़"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Aezeed पासफ़्रेज़ आवश्यक है।\n"
+"फिर प्रयास करें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"गलत Aezeed पासफ़्रेज़।\n"
+"फिर प्रयास करें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "अमान्य टेक्स्ट QR कोड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "गैर UTF-8 डेटा मिला।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Aezeed समर्थन"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"Aezeed प्रविष्टि प्रयोगात्मक है।\n"
+"केवल ज्ञात-अच्छे बैकअप के साथ उपयोग करें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "20 शब्द दर्ज करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "33 शब्द दर्ज करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "शेयर लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Share Word #{}"
+msgstr "शेयर शब्द #{}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "शेयर दर्ज करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "शेयर स्कैन करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "शेयर जोड़ें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "{} of {} needed"
+msgstr "{} में से {} आवश्यक"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "फिर प्रयास करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "अमान्य SLIP-39 शेयर"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "चेकसम विफल; मान्य SLIP-39 शेयर नहीं है।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "गैर-विस्तारयोग्य सीड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "यह SLIP-39 सीड नए शेयर फिर से नहीं बना सकता।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "प्लेनटेक्स्ट QR के रूप में निर्यात करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "SeedKeeper पर"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "Specter-DIY पर"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "शेयर फिर से बनाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "{} खोलें और अभी निर्यात किए वॉलेट से प्राप्ति पता दिखाएँ।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "आपका वॉलेट सॉफ़्टवेयर"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"पासफ़्रेज़ उपयोग हुआ था।\n"
+"आपको शब्द + पासफ़्रेज़ चाहिए होंगे।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 शब्द"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "जाँचें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "चाइल्ड सीड अंतिम करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "एन्क्रिप्शन कुंजी दर्ज करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "एन्क्रिप्शन कुंजी छोड़ें?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "आपकी वर्तमान कुंजी प्रविष्टि मिटा दी जाएगी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "अमान्य कुंजी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "कुंजी बहुत लंबी है।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "कैमरा से इनपुट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "फ़िंगरप्रिंट उपयोग करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "कस्टम ID निर्धारित करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "मेमोनिक ID दर्ज करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "मेमोनिक ID संपादित करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "मेमोनिक ID छोड़ें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "मेमोनिक ID छोड़ें?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "आपकी वर्तमान मेमोनिक ID प्रविष्टि मिटा दी जाएगी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "प्रसंस्करण हो रहा है..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "एन्क्रिप्शन विफल"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "अगले 100"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "विस्तारित खोज"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "नहीं मिला"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "पता सत्यापित नहीं"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Checked {} addresses with no match."
+msgstr "{} पते जाँचे, कोई मेल नहीं।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "अगले 10 जाँचें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Checked {} addresses per path with no match."
+msgstr "प्रति पथ {} पते जाँचे, कोई मेल नहीं।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "वॉलेट निर्यात"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "वॉलेट निर्यात सफल।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "पता प्रारूप निर्यात किए स्क्रिप्ट प्रकार से मेल नहीं खाता। वॉलेट निर्यात असफल।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "वॉलेट को वर्तमान सीड से मिलाने में असमर्थ। वॉलेट निर्यात असफल।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "निर्यात विफल"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "SeedKeeper लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "xpub निर्यात हो रहा है..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "संदेश साइन हो रहा है..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "सत्यापन विफल"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "स्मार्टकार्ड परीक्षण करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "कार्ड रीडर सूची"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "NFC स्कैन परीक्षण करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "PCSC पुनः शुरू करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "बैटरी जानकारी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "सिस्टम जानकारी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "बैकअप फ़ाइलें लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "कोई संगत बैटरी मॉनिटर नहीं मिला"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "अनुपलब्ध"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "सामान्य फ़ंक्शन"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Satochip फ़ंक्शन"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Keycard फ़ंक्शन"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "SeedKeeper फ़ंक्शन"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Specter-DIY फ़ंक्शन"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "DIY टूल्स"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "कार्ड जानकारी"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "असली जाँच"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "PIN बदलें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "लेबल बदलें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "NFC नीति बदलें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "NDEF कॉन्फ़िगर करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "कार्ड फ़ैक्टरी रीसेट करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "NDEF देखें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Seedkeeper ऐप लिंक उपयोग करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "NDEF साफ़ करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "कस्टम NDEF सेट करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "NDEF को SeedKeeper में सहेजें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "SeedKeeper से NDEF लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "टेक्स्ट रिकॉर्ड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "URI रिकॉर्ड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Android ऐप लॉन्च"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "कस्टम (HEX)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "NDEF डिकोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC सक्षम"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC अक्षम"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC अवरुद्ध"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "कार्ड फिर से डाला गया"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "खाली जगह देखें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "कार्ड पर रहस्य देखें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "पासवर्ड कार्ड में सहेजें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "कार्ड से रहस्य हटाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "MultiSig descriptor लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "MultiSig descriptor सहेजें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "कार्ड रहस्यों की क्लोन बनाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "होम पर जाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "सीड से आरंभ करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "descriptor के रूप में लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "PSBT लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "PUK सेट करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "PUK से PIN अनब्लॉक करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "नाम सेट करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "सीड हटाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "साइनिंग बेंचमार्क"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "संदेश साइनिंग बेंचमार्क"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "साइनिंग पूर्वाग्रह जाँचें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "हटाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "रीसेट"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "2FA सक्षम करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "पहले से सीड सेट है"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"xprv Satochip आरंभ नहीं कर सकता।\n"
+"BIP39, SLIP39 या Electrum उपयोग करें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "कार्ड PIN बदलें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "मेमोनिक लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "मेमोनिक सहेजें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "सीड वाइप करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "कार्ड कुंजियाँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "ऐपलेट बनाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "ऐपलेट स्थापित करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "ऐपलेट अनइंस्टॉल करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "अलग PIN दर्ज करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "कुंजियाँ लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "कुंजियाँ सहेजें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "कार्ड अनलॉक करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "कार्ड लॉक करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "लोड की कुंजियाँ साफ़ करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "अधिलेखित करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "सहेजना रद्द करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "एकल कुंजी दर्ज करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "कुंजी सेट दर्ज करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "एकल कुंजी बनाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "कुंजी सेट बनाएँ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (डिफ़ॉल्ट)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "सिस्टम RNG एन्ट्रॉपी बहुत कम। बाद में फिर प्रयास करें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "सिस्टम RNG से व्युत्पन्न एन्ट्रॉपी स्वास्थ्य जाँच में विफल।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " नया सीड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "SLIP39 सीड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "टेक्स्ट QR कोड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "पासवर्ड जनरेटर"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "स्मार्टकार्ड टूल्स"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "MicroSD टूल्स"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Multisig descriptor साफ़ करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "microSD कार्ड नहीं मिला"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "डिस्चार्ज लॉग सहेजने के लिए microSD कार्ड डालें।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "नेटवर्क जानकारी लोड करने में असमर्थ।"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 शब्द"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 शब्द"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 शब्द"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 शब्द"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 शब्द"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+#, python-brace-format
+msgid "20 words ({} rolls)"
+msgstr "20 शब्द ({} फेंक)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+#, python-brace-format
+msgid "33 words ({} rolls)"
+msgstr "33 शब्द ({} फेंक)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Multisig descriptor लोड हुआ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Satochip से लोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Electrum सीड"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "टेक्स्ट एन्कोड करें"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "QR कोड डिकोड करें"
+

--- a/l10n/fork/id/messages.po
+++ b/l10n/fork/id/messages.po
@@ -1,0 +1,2578 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-11 13:43-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: id\n"
+"Language-Team: id <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "Data dihapus setelah tidak aktif"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "Memulai kamera..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "Dekripsi?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "Pilih jenis QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "Kunci enkripsi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "Tinjau kunci enkripsi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "Nomor akun"
+
+#. FORK: translated by Claude 2026-07-11
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "Terenkripsi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "Bit entropi terenkripsi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "Jalur tidak standar!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "ID mnemonik"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "Tinjau ID mnemonik"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "Kode QR dari kedua mode bisa berbeda, tetapi keduanya valid."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "Salin QR terenkripsi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "Tidak ada opsi tersedia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "Info baterai"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "Info sistem"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Platform: {platform_name}"
+msgstr "Platform: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Variant: {platform_variant}"
+msgstr "Varian: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (CPU): {system_serial}"
+msgstr "Serial (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "Serial (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "Filter perangkat"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "Info jaringan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "Kalibrasi baterai"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "Isi penuh baterai. Pilih Berikutnya untuk memulai uji pengosongan."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "Mulai"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "Uji berjalan sampai baterai habis. Biarkan perangkat tidak tercolok."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "Pengisian terdeteksi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "Mengosongkan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "Berlalu: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "Tegangan: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "Arus: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "Status: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "ENTROPI RENDAH"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "ENTROPI BAIK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "Teks untuk dikodekan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "Atur PIN darurat"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option; "default" = this is the format most wallets use
+#: src/seedsigner/models/settings_definition.py
+msgid "Animated (default)"
+msgstr "Animasi (bawaan)"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option (static = single frame, not animated)
+#: src/seedsigner/models/settings_definition.py
+msgid "Static"
+msgstr "Statis"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option: old format that Specter Desktop used to use
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter legacy"
+msgstr "Specter legacy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "Kamera 0"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "Kamera 1"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "Kamera 2"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "Kamera 3"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 menit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 menit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 menit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 menit"
+
+#. FORK: translated by Claude 2026-07-11
+#. MicroSD notification duration setting - Display notification for 5 seconds
+#: src/seedsigner/models/settings_definition.py
+msgid "5 seconds"
+msgstr "5 detik"
+
+#. FORK: translated by Claude 2026-07-11
+#. MicroSD notification duration setting - Display notification until the SD
+#. card is removed
+#: src/seedsigner/models/settings_definition.py
+msgid "Until SD removed"
+msgstr "Sampai SD dilepas"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Passphrase Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "Utamakan CompactSeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "Utamakan EncryptedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "Tanyakan setiap kali"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "Percobaan PIN kartu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "Pewaktu penghapusan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "Panjang seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Xpub QR format"
+msgstr "Format QR xpub"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "Tanyakan akun BIP32"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "QR ambigu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "Jenis kunci GPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "Versi GPG BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 adalah yang terbaru; gunakan v2 untuk membuat ulang kunci B9-B10"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "Seed SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Seed Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "Kompatibel LND, 24 kata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "Bagian SLIP39 yang dapat diperluas"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "MicroSD notification duration"
+msgstr "Durasi notifikasi MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "Cadangan BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Cadangan Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "Cadangan TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "Dukungan kartu pintar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Dukungan Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Dukungan Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Dukungan Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "Sumber kamera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "Mode desktop"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "Tidak aman!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Versi desktop ini hanya untuk pengujian.\n"
+"JANGAN gunakan seed atau kunci privat asli."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "Saya mengerti"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "Build pengembangan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Build pengembangan SeedSignerOS ini hanya untuk pengujian.\n"
+"JANGAN gunakan seed atau kunci privat asli."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "Operasi berkas"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "Impor kunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "Ekspor kunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "Lihat kunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "Pesan aman"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "Alat GPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "Paket tidak ada"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "Diperlukan tetapi belum terpasang:\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "Operasi subkunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "Operasi ID pengguna"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "Sertifikasi silang kunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "Ekspor bundel kunci publik"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "Metadata BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "Subkunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "Kembali"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "Ekspor bundel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "QR animasi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "Simpan data BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "Muat data BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "Bangun ulang kunci BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "Ke MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "Ke QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "Ke Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "Dari MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "Dari QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Dari Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "Tambah subkunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "Cabut subkunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "Hapus subkunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "Ubah masa berlaku"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "Ekspor rahasia subkunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 tahun"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 tahun"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 tahun"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "Tidak pernah"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "Berkas"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "Kartu pintar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "Tambah ID pengguna"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "Sunting ID pengguna"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "Atur ID pengguna utama"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "Cabut ID pengguna"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "Hapus ID pengguna"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "Enkripsi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "Dekripsi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "Tanda tangani"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "Verifikasi tanda tangan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "Buat pesan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "Muat pesan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "Manifes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "Ketik pesan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Muat Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "Pindai QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "Muat berkas"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "Muat kunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Simpan ke Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "Tampilkan sebagai QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "Kunci publik"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "Kunci privat"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "Lihat info kartu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "Buat kunci di kartu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "Ubah PIN admin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "Ubah PIN pengguna"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "Mengenkripsi berkas"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(Mungkin butuh waktu)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "Mendekripsi berkas"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "Periksa SHA256Sum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "Perbarui"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "Dari berkas"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "Buat baru"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "Turunkan BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "Kartu OpenGPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "Sunting teks"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "Buang teks"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "Buang teks?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "Buat kode QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "Mode salin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "Mode layar penuh"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "Mode salin?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "Konfirmasi kode QR teks"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "Konfirmasi QR teks?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "Pindai kode QR teks"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "Konfirmasi kode QR teks"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "Kode QR teks salinan Anda tidak cocok dengan teks asli!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "Tinjau kode QR teks"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "Kode QR teks salinan Anda berhasil dipindai dan menghasilkan teks yang sama."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "Konfirmasi QR teks"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "Kode QR teks salinan Anda tidak dapat dibaca!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "Sunting & buat kode QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "Teks hasil dekode"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "Jalankan uji"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "Tulis image"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "Verifikasi MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "Hapus (nol)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "Hapus (acak)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "Lewati verifikasi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "Semua"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "Kustom"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF pendek"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF panjang"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "Lemparan dadu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "Jenis kata sandi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 bit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 bit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 bit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "Kekuatan kata sandi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "Ya"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "Tidak"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "Pilih opsi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "Pilih setidaknya satu set karakter."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "Pemeriksaan RNG sistem gagal."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "Kesalahan RNG sistem"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "Kamera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "Dadu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "RNG sistem"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "Sumber entropi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "Tidak didukung"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 mendukung Diceware, lemparan dadu, Hex, Base64, dan Base85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "Tidak ada"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "Huruf besar awal"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "Spasi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "Pemisah"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 sisi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 sisi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 sisi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "Sisi dadu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "Jumlah lemparan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "Masukan tidak valid"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "Jumlah lemparan minimal 1."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "Entropi buruk"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "Lemparan dadu tampak kurang acak. Silakan coba lagi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "Entropi kamera tampak kurang acak. Silakan coba lagi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "PERINGATAN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "Muat seed sebelum menggunakan BIP85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "Pilih seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "Pilih seed untuk BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "Indeks BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "Panjang tidak valid"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex mendukung 128 atau 256 bit."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 membutuhkan 120+ bit."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 membutuhkan 64-512 bit."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "Nama kata sandi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "Ruang tidak cukup"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"Menyimpan rahasia\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "Sukses"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "Kata sandi disimpan ke Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "Ruang di Seedkeeper tidak cukup untuk kata sandi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "Gagal"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "Gagal menyimpan kata sandi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "Sunting"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "Kata sandi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "Simpan kata sandi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Gunakan kartu Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Gunakan Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "Masukkan seed 15 kata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "Masukkan seed 18 kata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "Masukkan seed 21 kata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "Masukkan WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "Pindai WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "Masukkan BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "Pindai BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "Sidik jari tidak cocok"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "Kartu tidak dapat menandatangani PSBT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "Sidik jari kartu ({}) tidak ada di penandatangan PSBT."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "Kunci privat (WIF)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "WIF tidak valid!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "Bukan kunci privat WIF yang valid."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "Kunci BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "Passphrase BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "BIP38 tidak valid!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "Tidak dapat mendekripsi kunci BIP38."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "Deskriptor tidak cocok"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "Deskriptor dihapus"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "Deskriptor dompet multisig yang dimuat tidak cocok dengan PSBT ini. Muat deskriptor yang benar atau lewati verifikasi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "Menandatangani PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "Waktu tanda tangan habis"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "Coba lagi (waktu lebih lama)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Saved as {}."
+msgstr "Disimpan sebagai {}."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Failed to save PSBT: {}"
+msgstr "Gagal menyimpan PSBT: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "Mengodekan PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "Pemindai QR tidak tersedia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "Backend pemindaian QR tidak ada. Pasang zbar (atau OpenCV di desktop) lalu mulai ulang."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "Pilih jenis seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "Waktu diatur ke:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "Gagal mengatur waktu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "Waktu tidak valid"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "Tidak dapat membaca waktu dari QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "Pindai bagian SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "Diharapkan QR bagian SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "Diharapkan kunci privat WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "Diharapkan kunci privat BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "Pindai alamat penerimaan {} dari dompet yang baru Anda ekspor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"Data cocok dengan beberapa\n"
+"jenis QR."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "Ketik kunci enkripsi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "Pindai kunci enkripsi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "Sunting kunci enkripsi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "Buang kunci enkripsi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "Lanjutkan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "Pindai & tambahkan lagi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "Teks terdekripsi"
+
+#. FORK: translated by Claude 2026-07-11
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "Fork tidak resmi dari:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "Cadangan BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Cadangan Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "Cadangan TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Masukkan seed Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "Bagian SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " Pindai SeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "Dari SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Dari Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " Buat seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "Kartu microSD tidak terdeteksi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "Cadangan tidak ditemukan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "Tidak ada cadangan BitBox02 (.bin, .bb02, .dat, .backup) di kartu microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "Pilih cadangan BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup name: {}"
+msgstr "Nama cadangan: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Created: {}"
+msgstr "Dibuat: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Firmware: {}"
+msgstr "Firmware: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Birthdate: {}"
+msgstr "Tanggal pembuatan: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed length: {} words"
+msgstr "Panjang seed: {} kata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "Seed dimuat"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "Tidak ada cadangan Passport (.7z) di kartu microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Pilih cadangan Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Kode cadangan Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "Kode cadangan tidak boleh kosong."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Chain: {}"
+msgstr "Jaringan: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "Tidak ada cadangan TAPSIGNER (.aes) di kartu microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "Pilih cadangan TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "Kunci cadangan (hex)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "xprv dimuat dari cadangan TAPSIGNER."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Path: {}"
+msgstr "Jalur: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "Muat passphrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "Ketik passphrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "Pindai passphrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "Muat dari SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Passphrase Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"Mnemonik ini memerlukan\n"
+"passphrase."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "Passphrase tidak valid"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Passphrase Aezeed diperlukan.\n"
+"Coba lagi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Passphrase Aezeed salah.\n"
+"Coba lagi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "Kode QR teks tidak valid"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "Terdeteksi data non-UTF-8."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Dukungan Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"Input Aezeed bersifat eksperimental.\n"
+"Gunakan hanya dengan cadangan teruji."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "Masukkan 20 kata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "Masukkan 33 kata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "Muat bagian"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Share Word #{}"
+msgstr "Kata bagian #{}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "Masukkan bagian"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "Pindai bagian"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "Gabungkan bagian"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "{} of {} needed"
+msgstr "Perlu {} dari {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "Coba lagi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "Bagian SLIP-39 tidak valid"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "Checksum gagal; bukan bagian SLIP-39 yang valid."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Seed tidak dapat diperluas"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Seed SLIP-39 ini tidak dapat membuat bagian baru."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "Ekspor sebagai QR tanpa enkripsi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "Ke SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "Ke Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "Buat ulang bagian"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Xpub QR Format"
+msgstr "Format QR xpub"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "Buka {} dan tampilkan alamat penerimaan dari dompet yang baru Anda ekspor."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "perangkat lunak dompet Anda"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"Passphrase digunakan.\n"
+"Anda perlu kata-kata + passphrase."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 kata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "Tinjau"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "Selesaikan seed turunan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "Masukkan kunci enkripsi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "Buang kunci enkripsi?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "Kunci yang dimasukkan akan dihapus"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "Kunci tidak valid"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "Kunci terlalu panjang."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "Masukan dari kamera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "Gunakan sidik jari"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "Tetapkan ID kustom"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "Masukkan ID mnemonik"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "Sunting ID mnemonik"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "Buang ID mnemonik"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "Buang ID mnemonik?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "ID mnemonik yang dimasukkan akan dihapus"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "Memproses..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "Enkripsi gagal"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "100 berikutnya"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "Pencarian diperluas"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "Tidak ditemukan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "Alamat tidak terverifikasi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses with no match."
+msgstr "Memeriksa {} alamat tanpa kecocokan."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "Periksa 10 berikutnya"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses per path with no match."
+msgstr "Memeriksa {} alamat per jalur tanpa kecocokan."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "Ekspor dompet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "Ekspor dompet berhasil."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "Format alamat tidak cocok dengan jenis skrip yang diekspor. Ekspor dompet gagal."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "Tidak dapat mencocokkan dompet dengan seed saat ini. Ekspor dompet gagal."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "Ekspor gagal"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "Muat SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#. Multisig policy. For a "2 of 3" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/seed_views.py
+msgid "{threshold} of {n}"
+msgstr "{threshold} dari {n}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "Mengekspor xpub..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "Menandatangani pesan..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "Verifikasi gagal"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "Uji kartu pintar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "Daftar pembaca kartu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "Uji pemindaian NFC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "Mulai ulang PCSC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "Info baterai"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "Info sistem"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "Muat berkas cadangan"
+
+#. FORK: translated by Claude 2026-07-11
+#. Title of a warning dialog when configuring a setting that requires at least
+#. one option to be selected.
+#: src/seedsigner/views/settings_views.py
+msgid "Selection Required"
+msgstr "Pilihan diperlukan"
+
+#. FORK: translated by Claude 2026-07-11
+#. The name of the setting being configured (e.g. "Script types") will be
+#. inserted.
+#: src/seedsigner/views/settings_views.py
+msgid "At least one option must be selected for \"{}\"."
+msgstr "Setidaknya satu opsi harus dipilih untuk \"{}\"."
+
+#. FORK: translated by Claude 2026-07-11
+#. Text for the button that returns the user to the setting configuration
+#. screen.
+#: src/seedsigner/views/settings_views.py
+msgid "Return to setting"
+msgstr "Kembali ke pengaturan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "Monitor baterai yang kompatibel tidak terdeteksi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "Tidak tersedia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "Fungsi umum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Fungsi Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Fungsi Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "Fungsi SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Fungsi Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "Alat DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "Info kartu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "Pemeriksaan keaslian"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "Ubah PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "Ubah label"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "Ubah kebijakan NFC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "Konfigurasi NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "Reset pabrik kartu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "Lihat NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Gunakan tautan aplikasi Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "Bersihkan NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "Atur NDEF kustom"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "Simpan NDEF ke SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "Muat NDEF dari SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "Rekaman teks"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "Rekaman URI"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Peluncuran aplikasi Android"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "Kustom (HEX)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "Dekode NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC aktif"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC nonaktif"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC diblokir"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "Kartu dimasukkan kembali"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "Lihat ruang kosong"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "Lihat rahasia di kartu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "Simpan kata sandi ke kartu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "Hapus rahasia dari kartu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "Muat deskriptor multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "Simpan deskriptor multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "Klon rahasia kartu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "Keluar ke beranda"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "Inisialisasi dengan seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "Muat sebagai deskriptor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "Muat PSBT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "Atur PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "Buka blokir PIN dengan PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "Atur nama"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "Hapus seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "Uji kecepatan tanda tangan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "Uji tanda tangan pesan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "Periksa bias tanda tangan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "Hapus"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "Reset"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "Aktifkan 2FA"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "Sudah ada seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"xprv tidak dapat menginisialisasi Satochip.\n"
+"Gunakan BIP39, SLIP39, atau Electrum."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "Ubah PIN kartu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "Muat mnemonik"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "Simpan mnemonik"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "Hapus seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "Kunci kartu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "Bangun applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "Pasang applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "Copot applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "Masukkan PIN lain"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "Muat kunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "Simpan kunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "Buka kunci kartu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "Kunci kartu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "Bersihkan kunci yang dimuat"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "Timpa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "Batalkan penyimpanan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "Masukkan satu kunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "Masukkan set kunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "Buat satu kunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "Buat set kunci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (bawaan)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "Entropi RNG sistem terlalu rendah. Coba lagi nanti."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "Entropi dari RNG sistem gagal pemeriksaan."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Seed baru"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "Seed SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "Kode QR teks"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "Pembuat kata sandi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "Alat kartu pintar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "Alat MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Bersihkan deskriptor multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "Kartu microSD tidak terdeteksi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "Masukkan kartu microSD untuk menyimpan log pengosongan."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "Tidak dapat memuat informasi jaringan."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 kata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 kata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 kata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 kata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 kata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words ({} rolls)"
+msgstr "20 kata ({} lemparan)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words ({} rolls)"
+msgstr "33 kata ({} lemparan)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Deskriptor multisig dimuat"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Muat dari Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Seed Electrum"
+
+#. FORK: translated by Claude 2026-07-11
+#. Multisig policy. For a "2 / 3 multisig" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/tools_views.py
+msgid "{threshold} / {n} multisig"
+msgstr "Multisig {threshold} / {n}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "Kodekan teks"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "Dekode kode QR"
+
+#. FORK: translated by Claude 2026-07-11
+#. "network" will be mainnet/testnet/regtest.
+#: src/seedsigner/views/view.py
+msgid "Current network setting ({network}) doesn't match {derivation_path}."
+msgstr "Pengaturan jaringan saat ini ({network}) tidak cocok dengan {derivation_path}."
+

--- a/l10n/fork/it/messages.po
+++ b/l10n/fork/it/messages.po
@@ -1,0 +1,2870 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-11 08:43-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: it\n"
+"Language-Team: it <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "Dati cancellati per inattività"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Review Transaction"
+msgstr "Rivedi la transazione"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Review details"
+msgstr "Rivedi i dettagli"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Transaction Math"
+msgstr "Calcoli della transazione"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Review recipients"
+msgstr "Rivedi i destinatari"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Sign Transaction"
+msgstr "Firma la transazione"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "Avvio fotocamera..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "Decifrare?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "Seleziona il tipo di QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "Chiave di cifratura"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "Rivedi la chiave di cifratura"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/screen.py
+msgid "I understand"
+msgstr "Ho capito"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "Numero di account"
+
+#. FORK: translated by Claude 2026-07-11
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "Cifrato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "Bit di entropia cifrati"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "Percorso non standard!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Sign message"
+msgstr "Firma messaggio"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "ID del mnemonico"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "Rivedi l'ID del mnemonico"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "I codici QR prodotti nelle due modalità possono differire, ma entrambi sono validi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "Trascrivi QR cifrato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "Nessuna opzione disponibile"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "Info batteria"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "Info sistema"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Platform: {platform_name}"
+msgstr "Piattaforma: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Variant: {platform_variant}"
+msgstr "Variante: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (CPU): {system_serial}"
+msgstr "Seriale (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "Seriale (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "Filtro dispositivi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "Info rete"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "Calibrazione batteria"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "Carica completamente la batteria. Seleziona Avanti per avviare il test di scarica."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "Avvia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "Il test dura fino allo scaricamento. Lascia il dispositivo scollegato."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "Ricarica rilevata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "In scarica"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "Trascorso: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "Tensione: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "Corrente: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "Stato: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "ENTROPIA BASSA"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "ENTROPIA BUONA"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "Testo da codificare"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "Imposta PIN di coercizione"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option; "default" = this is the format most wallets use
+#: src/seedsigner/models/settings_definition.py
+msgid "Animated (default)"
+msgstr "Animato (predefinito)"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option (static = single frame, not animated)
+#: src/seedsigner/models/settings_definition.py
+msgid "Static"
+msgstr "Statico"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option: old format that Specter Desktop used to use
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter legacy"
+msgstr "Specter legacy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "Fotocamera 0"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "Fotocamera 1"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "Fotocamera 2"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "Fotocamera 3"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 minuti"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 minuti"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 minuti"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 minuti"
+
+#. FORK: translated by Claude 2026-07-11
+#. MicroSD notification duration setting - Display notification for 5 seconds
+#: src/seedsigner/models/settings_definition.py
+msgid "5 seconds"
+msgstr "5 secondi"
+
+#. FORK: translated by Claude 2026-07-11
+#. MicroSD notification duration setting - Display notification until the SD
+#. card is removed
+#: src/seedsigner/models/settings_definition.py
+msgid "Until SD removed"
+msgstr "Fino alla rimozione della SD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Passphrase Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "Preferisci CompactSeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "Preferisci EncryptedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "Chiedi ogni volta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "Tentativi PIN della smartcard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "Timer di cancellazione"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "Lunghezze del Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Xpub QR format"
+msgstr "Formato QR della xpub"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "Richiedi account BIP32"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "QR ambiguo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "Tipi di chiavi GPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "Versione GPG di BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 è la più recente; usa v2 per ricreare le chiavi B9-B10"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "Seed SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Seed Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "Compatibile con LND, 24 parole"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "Quote SLIP39 estensibili"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "MicroSD notification duration"
+msgstr "Durata della notifica MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "Backup BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Backup Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "Backup TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "Supporto smartcard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Supporto Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Supporto Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Supporto Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#. Hardware settings option to specify the screen driver (e.g. st7789 vs
+#. ili9341)
+#: src/seedsigner/models/settings_definition.py
+msgid "Display type"
+msgstr "Tipo di display"
+
+#. FORK: translated by Claude 2026-07-11
+#. Hardware settings option to invert how the screen driver displays colors.
+#: src/seedsigner/models/settings_definition.py
+msgid "Invert colors"
+msgstr "Inverti i colori"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "Sorgente fotocamera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "Modalità desktop"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "Non sicuro!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Questa versione desktop è solo per test.\n"
+"NON usarla con seed o chiavi private reali."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "Ho capito"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "Build di sviluppo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Questa build di sviluppo di SeedSignerOS è solo per test.\n"
+"NON usarla con seed o chiavi private reali."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "Operazioni sui file"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "Importa chiavi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "Esporta chiavi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "Visualizza chiavi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "Messaggistica sicura"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "Strumenti GPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "Pacchetti mancanti"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "Richiesto ma non installato:\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "Operazioni sulle sottochiavi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "Operazioni sugli ID utente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "Certificazione incrociata delle chiavi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "Esporta pacchetto di chiave pubblica"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "Metadati BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "Sottochiavi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "Indietro"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "Esporta pacchetto"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "QR animato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "Salva dati BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "Carica dati BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "Ricostruisci chiave BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "Su MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "In QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "Su Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "Da MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "Da QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Da Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "Aggiungi sottochiavi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "Revoca sottochiavi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "Elimina sottochiavi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "Cambia scadenza"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "Esporta segreti delle sottochiavi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 anno"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 anni"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 anni"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "Mai"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "File"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "Smartcard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "Aggiungi ID utente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "Modifica ID utente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "Imposta ID utente primario"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "Revoca ID utente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "Elimina ID utente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "Cifra"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "Decifra"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "Firma"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "Verifica firma"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "Crea messaggio"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "Carica messaggio"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "Manifest"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "Scrivi messaggio"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Carica Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "Scansiona QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "Carica file"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "Carica chiave"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Salva su Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "Mostra come QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "Chiave pubblica"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "Chiave privata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "Info della carta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "Genera chiave sulla carta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "Cambia PIN admin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "Cambia PIN utente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "Cifratura del file"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(Può richiedere tempo)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "Decifratura del file"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "Verifica SHA256Sum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "Aggiorna"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "Da file"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "Genera nuova"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "Deriva BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "Carta OpenGPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "Modifica testo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "Scarta testo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "Scartare il testo?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "Genera codice QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "Modalità trascrizione"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "Modalità schermo intero"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "Modalità trascrizione?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "Conferma il QR di testo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "Confermare il QR di testo?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "Scansiona il QR di testo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "Conferma il QR di testo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "Il QR di testo trascritto non corrisponde al testo originale!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "Rivedi il QR di testo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "Il QR di testo trascritto è stato scansionato con successo e ha prodotto lo stesso testo."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "Conferma QR di testo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "Impossibile leggere il QR di testo trascritto!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "Modifica e genera codice QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "Testo decodificato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "Esegui test"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "Scrivi immagine"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "Verifica MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "Cancella (zeri)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "Cancella (casuale)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "Salta verifica"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "Tutti"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "Personalizzato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF corta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF lunga"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "Lanci di dadi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "Tipo di password"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 bit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 bit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 bit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "Robustezza della password"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "Sì"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "No"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "Seleziona opzioni"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "Scegli almeno un set di caratteri."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "Controllo dell'RNG di sistema fallito."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "Errore RNG di sistema"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "Fotocamera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "Dadi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "RNG di sistema"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "Sorgente di entropia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "Non supportato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 supporta Diceware, lanci di dadi, Hex, Base64 e Base85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "Nessuno"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "Iniziale maiuscola"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "Spazio"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "Separatore"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 facce"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 facce"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 facce"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "Facce del dado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "Numero di lanci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "Input non valido"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "Il numero di lanci deve essere almeno 1."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "Entropia scarsa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "I lanci non sono sembrati abbastanza casuali. Riprova."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "L'entropia della fotocamera non è sembrata abbastanza casuale. Riprova."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "ATTENZIONE"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "Importa un Seed prima di usare BIP85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "Seleziona Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "Scegli il Seed per BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "Indice BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "Lunghezza non valida"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex supporta 128 o 256 bit."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 richiede 120+ bit."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 richiede 64-512 bit."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "Nome della password"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "Spazio insufficiente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"Salvataggio del segreto\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "Successo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "Password salvata su Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "Spazio insufficiente sul Seedkeeper per la password"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "Fallito"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "Salvataggio della password fallito"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "Modifica"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "Password"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "Salva password"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Usa carta Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Usa Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "Inserisci un seed di 15 parole"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "Inserisci un seed di 18 parole"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "Inserisci un seed di 21 parole"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "Inserisci WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "Scansiona WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "Inserisci BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "Scansiona BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "Fingerprint non corrispondente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "La carta non può firmare il PSBT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "Il fingerprint della carta ({}) non è tra i firmatari del PSBT."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "Chiave privata (WIF)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "WIF non valido!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "Non è una chiave privata WIF valida."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "Chiave BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "Passphrase BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "BIP38 non valido!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "Impossibile decifrare la chiave BIP38."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction has unsupported input script type, please verify your change addresses."
+msgstr "La transazione ha un tipo di script di input non supportato; verifica gli indirizzi di resto."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "This transaction spends its entire input value. No change is coming back to your wallet."
+msgstr "Questa transazione spende tutto il valore in input. Nessun resto tornerà al tuo wallet."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Next recipient"
+msgstr "Destinatario successivo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Skip verification"
+msgstr "Salta verifica"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Verify multisig change"
+msgstr "Verifica il resto multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Verify multisig addr"
+msgstr "Verifica indirizzo multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "Descriptor non corrispondente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "Descriptor cancellato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "Il wallet descriptor multisig caricato non corrisponde a questo PSBT. Carica quello corretto o salta la verifica."
+
+#. FORK: translated by Claude 2026-07-11
+#. Variable is either "change" or "self-transfer".
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction's {} address could not be verified from wallet descriptor."
+msgstr "Impossibile verificare l'indirizzo {} della transazione dal wallet descriptor."
+
+#. FORK: translated by Claude 2026-07-11
+#. Variable is either "change" or "self-transfer".
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction's {} address could not be generated from your seed."
+msgstr "Impossibile generare l'indirizzo {} della transazione dal tuo Seed."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Suspicious Transaction"
+msgstr "Transazione sospetta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Discard transaction"
+msgstr "Scarta la transazione"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Approve transaction"
+msgstr "Approva la transazione"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "Firma del PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "Timeout di firma"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "Riprova (timeout maggiore)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Saved as {}."
+msgstr "Salvato come {}."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Failed to save PSBT: {}"
+msgstr "Salvataggio del PSBT fallito: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "Codifica del PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Select different seed"
+msgstr "Seleziona un altro Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction Error"
+msgstr "Errore della transazione"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "Scanner QR non disponibile"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "Backend di scansione QR mancante. Installa zbar (o OpenCV su desktop) e riavvia."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "Seleziona il tipo di Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "Ora impostata su:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "Impostazione dell'ora fallita"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "Ora non valida"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "Impossibile leggere l'ora dal QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan Transaction"
+msgstr "Scansiona la transazione"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a transaction"
+msgstr "Attesa una transazione"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "Scansiona quota SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "Atteso un QR di quota SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "Attesa una chiave privata WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "Attesa una chiave privata BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "Scansiona l'indirizzo di ricezione {} del wallet appena esportato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"I dati corrispondono a\n"
+"più tipi di QR."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "Digita la chiave di cifratura"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "Scansiona la chiave di cifratura"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "Modifica la chiave di cifratura"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "Scarta la chiave di cifratura"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "Procedi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "Scansiona e aggiungi un altro"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/view.py
+msgid "Back to Main Menu"
+msgstr "Torna al menu principale"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "Testo decifrato"
+
+#. FORK: translated by Claude 2026-07-11
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "Un fork non ufficiale di:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "Backup BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Backup Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "Backup TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Inserisci un seed Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "Quote SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " Scansiona un SeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "Da SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Da Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " Crea nuovo Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load a Seed"
+msgstr "Importa un Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "Scheda microSD non rilevata."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "Nessun backup trovato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "Nessun backup BitBox02 (.bin, .bb02, .dat, .backup) trovato sulla scheda microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "Seleziona il backup BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup name: {}"
+msgstr "Nome del backup: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Created: {}"
+msgstr "Creato: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Firmware: {}"
+msgstr "Firmware: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Birthdate: {}"
+msgstr "Data di creazione: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed length: {} words"
+msgstr "Lunghezza del Seed: {} parole"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "Seed caricato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "Nessun backup Passport (.7z) trovato sulla scheda microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Seleziona il backup Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Codice del backup Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "Il codice del backup non può essere vuoto."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Chain: {}"
+msgstr "Chain: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "Nessun backup TAPSIGNER (.aes) trovato sulla scheda microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "Seleziona il backup TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "Chiave del backup (hex)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "xprv caricata dal backup TAPSIGNER."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Path: {}"
+msgstr "Percorso: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review & edit"
+msgstr "Rivedi e modifica"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "Carica passphrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "Digita passphrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "Scansiona passphrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "Carica da SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Passphrase Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"Questo mnemonico richiede\n"
+"una passphrase."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "Passphrase non valida"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Passphrase Aezeed richiesta.\n"
+"Riprova."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Passphrase Aezeed errata.\n"
+"Riprova."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Skip passphrase"
+msgstr "Salta passphrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current passphrase entry will be erased."
+msgstr "La passphrase inserita verrà cancellata."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Skip passphrase?"
+msgstr "Saltare la passphrase?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "You have not entered a passphrase yet."
+msgstr "Non hai ancora inserito una passphrase."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "QR di testo non valido"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "Rilevati dati non UTF-8."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Keep seed"
+msgstr "Mantieni il Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Supporto Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"L'inserimento Aezeed è sperimentale.\n"
+"Solo con backup verificati."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Electrum Warning"
+msgstr "Avviso Electrum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "Inserisci 20 parole"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "Inserisci 33 parole"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "Carica quota"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Share Word #{}"
+msgstr "Parola della quota n. {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "Inserisci quota"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "Scansiona quota"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "Combina quote"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "{} of {} needed"
+msgstr "Servono {} di {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "Riprova"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "Quota SLIP-39 non valida"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "Checksum errato; quota SLIP-39 non valida."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Seed non estensibile"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Questo Seed SLIP-39 non può rigenerare nuove quote."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan transaction"
+msgstr "Scansiona transazione"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export xpub"
+msgstr "Esporta xpub"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Address explorer"
+msgstr "Esplora indirizzi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup seed"
+msgstr "Backup del Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "BIP-85 child seed"
+msgstr "Seed derivato BIP-85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard seed"
+msgstr "Scarta il Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "View seed words"
+msgstr "Visualizza le parole del Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "Esporta come QR in chiaro"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "Su SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "Su Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "Rigenera quote"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Xpub QR Format"
+msgstr "Formato QR della xpub"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "Apri {} e mostra un indirizzo di ricezione del wallet appena esportato."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "il tuo software wallet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"È stata usata una passphrase.\n"
+"Serviranno parole + passphrase."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 parole"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Try again"
+msgstr "Riprova"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "Rivedi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "Finalizza il seed derivato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review seed words"
+msgstr "Rivedi le parole del Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "Inserisci la chiave di cifratura"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "Scartare la chiave di cifratura?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "La chiave inserita verrà cancellata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "Chiave non valida"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "La chiave è troppo lunga."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "Input dalla fotocamera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "Usa il fingerprint"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "Assegna ID personalizzato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "Inserisci l'ID del mnemonico"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "Modifica l'ID del mnemonico"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "Scarta l'ID del mnemonico"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "Scartare l'ID del mnemonico?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "L'ID del mnemonico inserito verrà cancellato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "Elaborazione..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "Cifratura fallita"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "Successivi 100"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "Ricerca estesa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "Non trovato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "Indirizzo non verificato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses with no match."
+msgstr "Controllati {} indirizzi senza corrispondenza."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "Controlla i prossimi 10"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses per path with no match."
+msgstr "Controllati {} indirizzi per percorso senza corrispondenza."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "Esportazione wallet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "Wallet esportato con successo."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "Il formato dell'indirizzo non corrisponde al tipo di script esportato. Esportazione fallita."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "Impossibile associare il wallet al Seed attuale. Esportazione fallita."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "Esportazione fallita"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "Carica SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Return to transaction"
+msgstr "Torna alla transazione"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Verify addr"
+msgstr "Verifica indir."
+
+#. FORK: translated by Claude 2026-07-11
+#. Multisig policy. For a "2 of 3" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/seed_views.py
+msgid "{threshold} of {n}"
+msgstr "{threshold} di {n}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "Esportazione xpub..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "Firma del messaggio..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "Verifica fallita"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Hardware"
+msgstr "Hardware"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "Testa la smartcard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "Elenca i lettori di carte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "Testa la scansione NFC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "Riavvia PCSC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "Info batteria"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "Info sistema"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "Carica file di backup"
+
+#. FORK: translated by Claude 2026-07-11
+#. Title of a warning dialog when configuring a setting that requires at least
+#. one option to be selected.
+#: src/seedsigner/views/settings_views.py
+msgid "Selection Required"
+msgstr "Selezione richiesta"
+
+#. FORK: translated by Claude 2026-07-11
+#. The name of the setting being configured (e.g. "Script types") will be
+#. inserted.
+#: src/seedsigner/views/settings_views.py
+msgid "At least one option must be selected for \"{}\"."
+msgstr "Va selezionata almeno un'opzione per \"{}\"."
+
+#. FORK: translated by Claude 2026-07-11
+#. Text for the button that returns the user to the setting configuration
+#. screen.
+#: src/seedsigner/views/settings_views.py
+msgid "Return to setting"
+msgstr "Torna all'impostazione"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "Nessun monitor batteria compatibile rilevato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "Non disponibile"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "Funzioni comuni"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Funzioni Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Funzioni Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "Funzioni SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Funzioni Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "Strumenti DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "Info carta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "Verifica di autenticità"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "Cambia PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "Cambia etichetta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "Cambia policy NFC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "Configura NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "Ripristino di fabbrica della carta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "Visualizza NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Usa il link dell'app Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "Cancella NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "Imposta NDEF personalizzato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "Salva NDEF su SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "Carica NDEF da SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "Record di testo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "Record URI"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Avvio app Android"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "Personalizzato (HEX)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "Decodifica NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC attivo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC disattivato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC bloccato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "Carta reinserita"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "Visualizza spazio libero"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "Visualizza i segreti sulla carta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "Salva la password sulla carta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "Elimina un segreto dalla carta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "Carica descriptor multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "Salva descriptor multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "Clona i segreti della carta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "Torna alla home"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "Inizializza con un Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "Carica come descriptor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "Carica PSBT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "Imposta PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "Sblocca il PIN con il PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "Imposta nome"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "Rimuovi Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "Benchmark di firma"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "Benchmark firma messaggi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "Verifica il bias di firma"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "Rimuovi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "Reset"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "Attiva 2FA"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "Seed già presente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"Una xprv non può inizializzare Satochip.\n"
+"Usa BIP39, SLIP39 o Electrum."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "Cambia il PIN della carta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "Carica mnemonico"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "Salva mnemonico"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "Cancella Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "Chiavi della carta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "Compila applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "Installa applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "Disinstalla applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "Inserisci un PIN diverso"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "Carica chiavi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "Salva chiavi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "Sblocca carta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "Blocca carta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "Cancella le chiavi caricate"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "Sovrascrivi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "Annulla salvataggio"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "Inserisci chiave singola"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "Inserisci set di chiavi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "Genera chiave singola"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "Genera set di chiavi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (predefinito)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "Entropia dell'RNG di sistema troppo bassa. Riprova più tardi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "L'entropia derivata dall'RNG di sistema non ha superato i controlli."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Nuovo Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "Seed SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Verify address"
+msgstr "Verifica indirizzo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "QR di testo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "Generatore di password"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "Strumenti smartcard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "Strumenti MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Cancella descriptor multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "Scheda microSD non rilevata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "Inserisci una scheda microSD per salvare il log di scarica."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "Impossibile caricare le informazioni di rete."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 parole"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 parole"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 parole"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 parole"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 parole"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words ({} rolls)"
+msgstr "20 parole ({} lanci)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words ({} rolls)"
+msgstr "33 parole ({} lanci)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Descriptor multisig caricato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Carica da Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Seed Electrum"
+
+#. FORK: translated by Claude 2026-07-11
+#. label for addresses where others send us incoming payments
+#: src/seedsigner/views/tools_views.py
+msgid "Receive addresses"
+msgstr "Indirizzi di ricezione"
+
+#. FORK: translated by Claude 2026-07-11
+#. label for addresses that collect the change from our own outgoing payments
+#: src/seedsigner/views/tools_views.py
+msgid "Change addresses"
+msgstr "Indirizzi di resto"
+
+#. FORK: translated by Claude 2026-07-11
+#. Multisig policy. For a "2 / 3 multisig" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/tools_views.py
+msgid "{threshold} / {n} multisig"
+msgstr "Multisig {threshold} / {n}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "Codifica testo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "Decodifica codice QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Power off"
+msgstr "Spegni"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Back to main menu"
+msgstr "Torna al menu principale"
+
+#. FORK: translated by Claude 2026-07-11
+#. "network" will be mainnet/testnet/regtest.
+#: src/seedsigner/views/view.py
+msgid "Current network setting ({network}) doesn't match {derivation_path}."
+msgstr "L'impostazione di rete attuale ({network}) non corrisponde a {derivation_path}."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Hardware Error"
+msgstr "Errore hardware"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Cannot access camera"
+msgstr "Impossibile accedere alla fotocamera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Disconnect power and check for a loose camera connection."
+msgstr "Scollega l'alimentazione e controlla il collegamento della fotocamera."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Update setting"
+msgstr "Aggiorna impostazione"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Action Required"
+msgstr "Azione richiesta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid ""
+"You must remove the\n"
+"MicroSD card to continue."
+msgstr ""
+"Devi rimuovere la scheda\n"
+"MicroSD per continuare."
+

--- a/l10n/fork/ja/messages.po
+++ b/l10n/fork/ja/messages.po
@@ -1,0 +1,2516 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-12 08:03-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "無操作のためﾃﾞｰﾀを消去しました"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "ｶﾒﾗを起動中..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "復号しますか?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "QRの種類を選択"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "暗号鍵"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "暗号鍵を確認"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "ｱｶｳﾝﾄ番号"
+
+#. FORK: translated by Claude 2026-07-12
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "暗号化済み"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "暗号化されたｴﾝﾄﾛﾋﾟｰﾋﾞｯﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "非標準のﾊﾟｽです!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "ﾆｰﾓﾆｯｸID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "ﾆｰﾓﾆｯｸIDを確認"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "両ﾓｰﾄﾞのQRｺｰﾄﾞは異なる場合がありますが､どちらも有効です｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "暗号化QRを書き写す"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "選択肢がありません"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "ﾊﾞｯﾃﾘｰ情報"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "ｼｽﾃﾑ情報"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Platform: {platform_name}"
+msgstr "ﾌﾟﾗｯﾄﾌｫｰﾑ: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Variant: {platform_variant}"
+msgstr "ﾊﾞﾘｱﾝﾄ: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Serial (CPU): {system_serial}"
+msgstr "ｼﾘｱﾙ(CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "ｼﾘｱﾙ(MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "ﾃﾞﾊﾞｲｽﾌｨﾙﾀｰ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "ﾈｯﾄﾜｰｸ情報"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "ﾊﾞｯﾃﾘｰ較正"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "ﾊﾞｯﾃﾘｰを満充電にし､｢次｣で放電ﾃｽﾄを開始します｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "開始"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "ﾃｽﾄは空になるまで続きます｡電源は接続しないでください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "充電を検出"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "放電中"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "経過: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "電圧: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "電流: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "状態: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "ｴﾝﾄﾛﾋﾟｰ不足"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "ｴﾝﾄﾛﾋﾟｰ良好"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "ｴﾝｺｰﾄﾞするﾃｷｽﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "強要時PINを設定"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "ｶﾒﾗ0"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "ｶﾒﾗ1"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "ｶﾒﾗ2"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "ｶﾒﾗ3"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5分"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10分"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15分"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30分"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Aezeedﾊﾟｽﾌﾚｰｽﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "CompactSeedQRを優先"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "EncryptedQRを優先"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "毎回確認"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "ｶｰﾄﾞPIN試行回数"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "消去ﾀｲﾏｰ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "ｼｰﾄﾞのﾜｰﾄﾞ数"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "BIP32ｱｶｳﾝﾄを確認"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "曖昧なQR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "GPG鍵の種類"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "BIP85のGPGﾊﾞｰｼﾞｮﾝ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3が最新｡B9-B10の鍵を再現するにはv2を使用"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "SLIP39ｼｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Aezeedｼｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "LND互換､24ﾜｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "拡張可能なSLIP39ｼｪｱ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "BitBox02ﾊﾞｯｸｱｯﾌﾟ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Passportﾊﾞｯｸｱｯﾌﾟ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "TAPSIGNERﾊﾞｯｸｱｯﾌﾟ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "ｽﾏｰﾄｶｰﾄﾞ対応"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Satochip対応"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Keycard対応"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Specter-DIY対応"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "ｶﾒﾗ入力元"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "ﾃﾞｽｸﾄｯﾌﾟﾓｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "安全ではありません!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"このﾃﾞｽｸﾄｯﾌﾟ版はﾃｽﾄ専用です｡\n"
+"実際のｼｰﾄﾞや秘密鍵は使用しないでください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "了解しました"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "開発ﾋﾞﾙﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"このSeedSignerOS開発ﾋﾞﾙﾄﾞはﾃｽﾄ専用です｡\n"
+"実際のｼｰﾄﾞや秘密鍵は使用しないでください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "ﾌｧｲﾙ操作"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "鍵をｲﾝﾎﾟｰﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "鍵をｴｸｽﾎﾟｰﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "鍵を表示"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "ｾｷｭｱﾒｯｾｰｼﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "GPG道具箱"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "ﾊﾟｯｹｰｼﾞ不足"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "必要ですが未ｲﾝｽﾄｰﾙ:\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "副鍵の操作"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "ﾕｰｻﾞｰIDの操作"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "鍵の相互証明"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "公開鍵ﾊﾞﾝﾄﾞﾙをｴｸｽﾎﾟｰﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "BIP85ﾒﾀﾃﾞｰﾀ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "副鍵"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "戻る"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "ﾊﾞﾝﾄﾞﾙをｴｸｽﾎﾟｰﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "動くQR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "BIP85ﾃﾞｰﾀを保存"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "BIP85ﾃﾞｰﾀを読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "BIP85鍵を再構築"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "MicroSDへ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "QRへ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "Seedkeeperへ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "MicroSDから"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "QRから"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Seedkeeperから"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "副鍵を追加"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "副鍵を失効"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "副鍵を削除"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "有効期限を変更"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "副鍵の秘密をｴｸｽﾎﾟｰﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1年"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2年"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5年"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "無期限"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "ﾌｧｲﾙ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "ｽﾏｰﾄｶｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "ﾕｰｻﾞｰIDを追加"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "ﾕｰｻﾞｰIDを編集"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "主ﾕｰｻﾞｰIDを設定"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "ﾕｰｻﾞｰIDを失効"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "ﾕｰｻﾞｰIDを削除"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "暗号化"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "復号"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "署名"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "署名を確認"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "ﾒｯｾｰｼﾞを作成"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "ﾒｯｾｰｼﾞを読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "ﾏﾆﾌｪｽﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "ﾒｯｾｰｼﾞを入力"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Seedkeeperを読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "QRを読み取る"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "ﾌｧｲﾙを読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "鍵を読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Seedkeeperに保存"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "QRで表示"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "公開鍵"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "秘密鍵"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "ｶｰﾄﾞ情報を表示"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "ｶｰﾄﾞ上で鍵を生成"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "管理者PINを変更"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "ﾕｰｻﾞｰPINを変更"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "ﾌｧｲﾙを暗号化中"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(時間がかかる場合があります)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "ﾌｧｲﾙを復号中"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "SHA256Sumを確認"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "更新"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "ﾌｧｲﾙから"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "新規生成"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "BIP85を導出"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "OpenGPGｶｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "ﾃｷｽﾄを編集"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "ﾃｷｽﾄを破棄"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "ﾃｷｽﾄを破棄しますか?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "QRｺｰﾄﾞを生成"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "書き写しﾓｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "全画面ﾓｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "書き写しﾓｰﾄﾞ?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "ﾃｷｽﾄQRｺｰﾄﾞを確認"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "ﾃｷｽﾄQRを確認しますか?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "ﾃｷｽﾄQRｺｰﾄﾞを読み取る"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "ﾃｷｽﾄQRｺｰﾄﾞを確認"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "書き写したﾃｷｽﾄQRが元のﾃｷｽﾄと一致しません!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "ﾃｷｽﾄQRｺｰﾄﾞを確認"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "書き写したﾃｷｽﾄQRの読み取りに成功し､同じﾃｷｽﾄが得られました｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "ﾃｷｽﾄQRを確認"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "書き写したﾃｷｽﾄQRを読み取れませんでした!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "編集してQRｺｰﾄﾞを生成"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "復号したﾃｷｽﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "ﾃｽﾄを実行"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "ｲﾒｰｼﾞを書き込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "MicroSDを検証"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "消去(ｾﾞﾛ)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "消去(ﾗﾝﾀﾞﾑ)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "検証を省略"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "すべて"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "ｶｽﾀﾑ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF短"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF長"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "ｻｲｺﾛ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "ﾊﾟｽﾜｰﾄﾞの種類"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64ﾋﾞｯﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128ﾋﾞｯﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256ﾋﾞｯﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "ﾊﾟｽﾜｰﾄﾞ強度"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "はい"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "いいえ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "ｵﾌﾟｼｮﾝを選択"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "文字種を1つ以上選んでください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "ｼｽﾃﾑRNGの検査に失敗しました｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "ｼｽﾃﾑRNGｴﾗｰ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "ｶﾒﾗ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "ｻｲｺﾛ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "ｼｽﾃﾑRNG"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "ｴﾝﾄﾛﾋﾟｰ源"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "非対応"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85はDiceware､ｻｲｺﾛ､Hex､Base64､Base85に対応｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "なし"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "頭文字を大文字に"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "ｽﾍﾟｰｽ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "区切り文字"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6面"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10面"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20面"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "ｻｲｺﾛの面数"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "振る回数"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "無効な入力"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "振る回数は1以上にしてください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "ｴﾝﾄﾛﾋﾟｰ不足"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "ｻｲｺﾛの出目が十分ﾗﾝﾀﾞﾑではないようです｡もう一度お試しください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "ｶﾒﾗのｴﾝﾄﾛﾋﾟｰが十分ﾗﾝﾀﾞﾑではないようです｡もう一度お試しください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "警告"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "BIP85を使う前にｼｰﾄﾞを読み込んでください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "ｼｰﾄﾞを選択"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "BIP85に使うｼｰﾄﾞを選択"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "BIP85ｲﾝﾃﾞｯｸｽ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "無効な長さ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hexは128または256ﾋﾞｯﾄ対応｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64は120ﾋﾞｯﾄ以上が必要｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85は64-512ﾋﾞｯﾄが必要｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "ﾊﾟｽﾜｰﾄﾞ名"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "空き容量不足"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"ｼｰｸﾚｯﾄを保存中\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "成功"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "ﾊﾟｽﾜｰﾄﾞをSeedkeeperに保存しました"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "Seedkeeperにﾊﾟｽﾜｰﾄﾞ用の空きがありません"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "失敗"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "ﾊﾟｽﾜｰﾄﾞの保存に失敗しました"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "編集"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "ﾊﾟｽﾜｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "ﾊﾟｽﾜｰﾄﾞを保存"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Satochipｶｰﾄﾞを使う"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Keycardを使う"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "15ﾜｰﾄﾞのｼｰﾄﾞを記入"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "18ﾜｰﾄﾞのｼｰﾄﾞを記入"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "21ﾜｰﾄﾞのｼｰﾄﾞを記入"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "WIFを入力"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "WIFを読み取る"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "BIP38を入力"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "BIP38を読み取る"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "ﾌｨﾝｶﾞｰﾌﾟﾘﾝﾄ値が不一致"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "ｶｰﾄﾞはこのPSBTに署名できません"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "ｶｰﾄﾞのﾌｨﾝｶﾞｰﾌﾟﾘﾝﾄ値({})がPSBT署名者にありません｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "秘密鍵(WIF)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "無効なWIF!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "有効なWIF形式の秘密鍵ではありません｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "BIP38鍵"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "BIP38ﾊﾟｽﾌﾚｰｽﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "無効なBIP38!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "BIP38鍵を復号できませんでした｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "descriptorが不一致"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "descriptorを消去しました"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "読み込んだﾏﾙﾁｼｸﾞdescriptorがこのPSBTと一致しません｡正しいdescriptorを読み込むか検証を省略してください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "PSBTに署名中..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "署名ﾀｲﾑｱｳﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "再試行(時間を延長)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Saved as {}."
+msgstr "{}として保存しました｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Failed to save PSBT: {}"
+msgstr "PSBTの保存に失敗: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "PSBTをｴﾝｺｰﾄﾞ中..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "QRｽｷｬﾅｰが使用不可"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "QR読み取り機能がありません｡zbar(ﾃﾞｽｸﾄｯﾌﾟではOpenCV)を入れて再起動してください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "ｼｰﾄﾞの種類を選択"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "時刻を設定:"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "時刻設定に失敗"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "無効な時刻"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "QRから時刻を読み取れませんでした"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "SLIP-39ｼｪｱを読み取る"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "SLIP-39ｼｪｱのQRが必要です"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "WIF秘密鍵が必要です"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "BIP38秘密鍵が必要です"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+#, python-brace-format
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "ｴｸｽﾎﾟｰﾄしたｳｫﾚｯﾄの受取ｱﾄﾞﾚｽ{}を読み取ってください"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"ﾃﾞｰﾀが複数のQR種別に\n"
+"一致します｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "暗号鍵を入力"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "暗号鍵を読み取る"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "暗号鍵を編集"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "暗号鍵を破棄"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "続行"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "読み取ってさらに追加"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "復号したﾃｷｽﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "以下の非公式ﾌｫｰｸ:"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "BitBox02ﾊﾞｯｸｱｯﾌﾟ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Passportﾊﾞｯｸｱｯﾌﾟ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "TAPSIGNERﾊﾞｯｸｱｯﾌﾟ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Aezeedｼｰﾄﾞを記入"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "SLIP-39ｼｪｱ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " SeedQRを読み取る"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "SeedKeeperから"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Specter-DIYから"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " ｼｰﾄﾞを作る"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "microSDｶｰﾄﾞ未検出｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "ﾊﾞｯｸｱｯﾌﾟが見つかりません"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "microSDｶｰﾄﾞにBitBox02ﾊﾞｯｸｱｯﾌﾟ(.bin, .bb02, .dat, .backup)が見つかりません｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "BitBox02ﾊﾞｯｸｱｯﾌﾟを選択"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Backup name: {}"
+msgstr "ﾊﾞｯｸｱｯﾌﾟ名: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Created: {}"
+msgstr "作成: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Firmware: {}"
+msgstr "ﾌｧｰﾑｳｪｱ: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Birthdate: {}"
+msgstr "作成日: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Seed length: {} words"
+msgstr "ｼｰﾄﾞ長: {}ﾜｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "ｼｰﾄﾞを読み込みました"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "microSDｶｰﾄﾞにPassportﾊﾞｯｸｱｯﾌﾟ(.7z)が見つかりません｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Passportﾊﾞｯｸｱｯﾌﾟを選択"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Passportﾊﾞｯｸｱｯﾌﾟｺｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "ﾊﾞｯｸｱｯﾌﾟｺｰﾄﾞは空にできません｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Chain: {}"
+msgstr "ﾁｪｰﾝ: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "microSDｶｰﾄﾞにTAPSIGNERﾊﾞｯｸｱｯﾌﾟ(.aes)が見つかりません｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "TAPSIGNERﾊﾞｯｸｱｯﾌﾟを選択"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "ﾊﾞｯｸｱｯﾌﾟ鍵(hex)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "TAPSIGNERﾊﾞｯｸｱｯﾌﾟからxprvを読み込みました｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Path: {}"
+msgstr "ﾊﾟｽ: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "ﾊﾟｽﾌﾚｰｽﾞを読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "ﾊﾟｽﾌﾚｰｽﾞを入力"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "ﾊﾟｽﾌﾚｰｽﾞを読み取る"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "SeedKeeperから読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Aezeedﾊﾟｽﾌﾚｰｽﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"このﾆｰﾓﾆｯｸには\n"
+"ﾊﾟｽﾌﾚｰｽﾞが必要です｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "無効なﾊﾟｽﾌﾚｰｽﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Aezeedﾊﾟｽﾌﾚｰｽﾞが必要です｡\n"
+"もう一度お試しください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Aezeedﾊﾟｽﾌﾚｰｽﾞが違います｡\n"
+"もう一度お試しください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "無効なﾃｷｽﾄQRｺｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "UTF-8以外のﾃﾞｰﾀを検出｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Aezeed対応"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"Aezeed入力は実験的機能です｡\n"
+"検証済みﾊﾞｯｸｱｯﾌﾟのみで使用してください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "20ﾜｰﾄﾞを記入"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "33ﾜｰﾄﾞを記入"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "ｼｪｱを読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Share Word #{}"
+msgstr "ｼｪｱのﾜｰﾄﾞ#{}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "ｼｪｱを記入"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "ｼｪｱを読み取る"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "ｼｪｱを結合"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "{} of {} needed"
+msgstr "{}個必要(全{}個中)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "もう一度"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "無効なSLIP-39ｼｪｱ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "ﾁｪｯｸｻﾑ不一致｡有効なSLIP-39ｼｪｱではありません｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "拡張不可のｼｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "このSLIP-39ｼｰﾄﾞは新しいｼｪｱを再生成できません｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "平文QRとしてｴｸｽﾎﾟｰﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "SeedKeeperへ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "Specter-DIYへ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "ｼｪｱを再生成"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "{}を開き､ｴｸｽﾎﾟｰﾄしたｳｫﾚｯﾄの受取ｱﾄﾞﾚｽを表示してください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "お使いのｳｫﾚｯﾄｿﾌﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"ﾊﾟｽﾌﾚｰｽﾞを使用しました｡\n"
+"ﾜｰﾄﾞ+ﾊﾟｽﾌﾚｰｽﾞが必要です｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18ﾜｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "確認"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "子ｼｰﾄﾞを確定"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "暗号鍵を入力"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "暗号鍵を破棄しますか?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "入力中の鍵は消去されます"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "無効な鍵"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "鍵が長すぎます｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "ｶﾒﾗから入力"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "ﾌｨﾝｶﾞｰﾌﾟﾘﾝﾄ値を使う"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "ｶｽﾀﾑIDを割り当てる"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "ﾆｰﾓﾆｯｸIDを入力"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "ﾆｰﾓﾆｯｸIDを編集"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "ﾆｰﾓﾆｯｸIDを破棄"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "ﾆｰﾓﾆｯｸIDを破棄しますか?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "入力中のﾆｰﾓﾆｯｸIDは消去されます"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "処理中..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "暗号化失敗"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "次の100件"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "拡張検索"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "見つかりません"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "ｱﾄﾞﾚｽ未確認"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Checked {} addresses with no match."
+msgstr "{}件のｱﾄﾞﾚｽを確認しましたが一致なし｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "次の10件を確認"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Checked {} addresses per path with no match."
+msgstr "各ﾊﾟｽで{}件のｱﾄﾞﾚｽを確認しましたが一致なし｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "ｳｫﾚｯﾄのｴｸｽﾎﾟｰﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "ｳｫﾚｯﾄのｴｸｽﾎﾟｰﾄに成功しました｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "ｱﾄﾞﾚｽ形式がｴｸｽﾎﾟｰﾄしたｽｸﾘﾌﾟﾄ種別と不一致｡ｴｸｽﾎﾟｰﾄ失敗｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "ｳｫﾚｯﾄを現在のｼｰﾄﾞと照合できません｡ｴｸｽﾎﾟｰﾄ失敗｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "ｴｸｽﾎﾟｰﾄ失敗"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "SeedKeeperを読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "xpubをｴｸｽﾎﾟｰﾄ中..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "ﾒｯｾｰｼﾞに署名中..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "検証失敗"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "ｽﾏｰﾄｶｰﾄﾞをﾃｽﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "ｶｰﾄﾞﾘｰﾀﾞｰ一覧"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "NFC読み取りをﾃｽﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "PCSCを再起動"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "ﾊﾞｯﾃﾘｰ情報"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "ｼｽﾃﾑ情報"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "ﾊﾞｯｸｱｯﾌﾟﾌｧｲﾙを読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "対応するﾊﾞｯﾃﾘｰﾓﾆﾀｰが見つかりません"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "利用不可"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "共通機能"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Satochip機能"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Keycard機能"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "SeedKeeper機能"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Specter-DIY機能"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "DIY道具箱"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "ｶｰﾄﾞ情報"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "真正性確認"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "PINを変更"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "ﾗﾍﾞﾙを変更"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "NFCﾎﾟﾘｼｰを変更"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "NDEFを設定"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "ｶｰﾄﾞを初期化"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "NDEFを表示"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Seedkeeperｱﾌﾟﾘﾘﾝｸを使う"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "NDEFを消去"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "ｶｽﾀﾑNDEFを設定"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "NDEFをSeedKeeperに保存"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "NDEFをSeedKeeperから読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "ﾃｷｽﾄﾚｺｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "URIﾚｺｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Androidｱﾌﾟﾘ起動"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "ｶｽﾀﾑ(HEX)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "NDEFをﾃﾞｺｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC有効"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC無効"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC遮断"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "ｶｰﾄﾞ再挿入"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "空き容量を表示"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "ｶｰﾄﾞ内のｼｰｸﾚｯﾄを表示"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "ﾊﾟｽﾜｰﾄﾞをｶｰﾄﾞに保存"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "ｶｰﾄﾞからｼｰｸﾚｯﾄを削除"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "ﾏﾙﾁｼｸﾞdescriptorを読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "ﾏﾙﾁｼｸﾞdescriptorを保存"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "ｶｰﾄﾞのｼｰｸﾚｯﾄを複製"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "ﾎｰﾑへ戻る"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "ｼｰﾄﾞで初期化"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "descriptorとして読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "PSBTを読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "PUKを設定"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "PUKでPINを解除"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "名前を設定"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "ｼｰﾄﾞを削除"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "署名速度ﾃｽﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "ﾒｯｾｰｼﾞ署名速度ﾃｽﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "署名の偏りを確認"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "削除"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "ﾘｾｯﾄ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "2FAを有効化"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "ｼｰﾄﾞ設定済み"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"xprvではSatochipを初期化できません｡\n"
+"BIP39､SLIP39またはElectrumを使用してください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "ｶｰﾄﾞPINを変更"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "ﾆｰﾓﾆｯｸを読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "ﾆｰﾓﾆｯｸを保存"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "ｼｰﾄﾞを消去"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "ｶｰﾄﾞの鍵"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "ｱﾌﾟﾚｯﾄをﾋﾞﾙﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "ｱﾌﾟﾚｯﾄをｲﾝｽﾄｰﾙ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "ｱﾌﾟﾚｯﾄをｱﾝｲﾝｽﾄｰﾙ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "別のPINを入力"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "鍵を読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "鍵を保存"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "ｶｰﾄﾞをｱﾝﾛｯｸ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "ｶｰﾄﾞをﾛｯｸ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "読み込んだ鍵を消去"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "上書き"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "保存を中止"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "単一の鍵を入力"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "鍵ｾｯﾄを入力"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "単一の鍵を生成"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "鍵ｾｯﾄを生成"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB(既定)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "ｼｽﾃﾑRNGのｴﾝﾄﾛﾋﾟｰが不足しています｡後でお試しください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "ｼｽﾃﾑRNG由来のｴﾝﾄﾛﾋﾟｰが検査に不合格でした｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " 新しいｼｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "SLIP39ｼｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "ﾃｷｽﾄQRｺｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "ﾊﾟｽﾜｰﾄﾞ生成"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "ｽﾏｰﾄｶｰﾄﾞ道具箱"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "MicroSD道具箱"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "ﾏﾙﾁｼｸﾞdescriptorを消去"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "microSDｶｰﾄﾞ未検出"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "放電ﾛｸﾞを保存するにはmicroSDｶｰﾄﾞを挿入してください｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "ﾈｯﾄﾜｰｸ情報を読み込めません｡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15ﾜｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18ﾜｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21ﾜｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20ﾜｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33ﾜｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+#, python-brace-format
+msgid "20 words ({} rolls)"
+msgstr "20ﾜｰﾄﾞ({}回)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+#, python-brace-format
+msgid "33 words ({} rolls)"
+msgstr "33ﾜｰﾄﾞ({}回)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "ﾏﾙﾁｼｸﾞdescriptor読み込み済み"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Satochipから読み込む"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Electrumｼｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "ﾃｷｽﾄをｴﾝｺｰﾄﾞ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "QRｺｰﾄﾞをﾃﾞｺｰﾄﾞ"
+

--- a/l10n/fork/ko/messages.po
+++ b/l10n/fork/ko/messages.po
@@ -1,0 +1,2516 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-12 08:05-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ko\n"
+"Language-Team: ko <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "비활성으로 데이터가 지워짐"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "카메라 시작 중..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "복호화할까요?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "QR 유형 선택"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "암호화 키"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "암호화 키 확인"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "계정 번호"
+
+#. FORK: translated by Claude 2026-07-12
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "암호화됨"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "암호화된 엔트로피 비트"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "비표준 경로!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "니모닉 ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "니모닉 ID 확인"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "두 모드의 QR 코드는 다를 수 있지만 모두 유효합니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "암호화 QR 옮겨 적기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "사용 가능한 옵션 없음"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "배터리 정보"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "시스템 정보"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Platform: {platform_name}"
+msgstr "플랫폼: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Variant: {platform_variant}"
+msgstr "변형: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Serial (CPU): {system_serial}"
+msgstr "시리얼(CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "시리얼(MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "장치 필터"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "네트워크 정보"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "배터리 보정"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "배터리를 완전히 충전하세요. 다음을 눌러 방전 테스트를 시작합니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "시작"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "테스트는 방전될 때까지 진행됩니다. 전원을 연결하지 마세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "충전 감지됨"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "방전 중"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "경과: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "전압: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "전류: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "상태: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "엔트로피 부족"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "엔트로피 양호"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "인코딩할 텍스트"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "강압용 PIN 설정"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "카메라 0"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "카메라 1"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "카메라 2"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "카메라 3"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5분"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10분"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15분"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30분"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Aezeed 패스프레이즈"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "CompactSeedQR 선호"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "EncryptedQR 선호"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "매번 묻기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "스마트카드 PIN 시도 횟수"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "삭제 타이머"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "시드 단어 수"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "BIP32 계정 확인"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "모호한 QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "GPG 키 유형"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "BIP85 GPG 버전"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3가 최신입니다. B9-B10 키를 재생성하려면 v2 사용"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "SLIP39 시드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Aezeed 시드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "LND 호환, 24단어"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "확장 가능한 SLIP39 조각"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "BitBox02 백업"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Passport 백업"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "TAPSIGNER 백업"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "스마트카드 지원"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Satochip 지원"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Keycard 지원"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Specter-DIY 지원"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "카메라 입력원"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "데스크톱 모드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "안전하지 않음!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"이 데스크톱 버전은 테스트 전용입니다.\n"
+"실제 시드나 개인키에 사용하지 마세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "이해했습니다"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "개발 빌드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"이 SeedSignerOS 개발 빌드는 테스트 전용입니다.\n"
+"실제 시드나 개인키에 사용하지 마세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "파일 작업"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "키 가져오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "키 내보내기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "키 보기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "보안 메시징"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "GPG 도구"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "누락된 패키지"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "필요하지만 설치되지 않음:\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "하위 키 작업"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "사용자 ID 작업"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "키 상호 인증"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "공개키 번들 내보내기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "BIP85 메타데이터"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "하위 키"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "뒤로"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "번들 내보내기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "애니메이션 QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "BIP85 데이터 저장"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "BIP85 데이터 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "BIP85 키 재구성"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "MicroSD로"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "QR로"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "Seedkeeper로"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "MicroSD에서"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "QR에서"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Seedkeeper에서"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "하위 키 추가"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "하위 키 폐기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "하위 키 삭제"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "만료일 변경"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "하위 키 비밀 내보내기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1년"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2년"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5년"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "안 함"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "파일"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "스마트카드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "사용자 ID 추가"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "사용자 ID 편집"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "기본 사용자 ID 설정"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "사용자 ID 폐기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "사용자 ID 삭제"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "암호화"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "복호화"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "서명"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "서명 확인"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "메시지 작성"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "메시지 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "매니페스트"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "메시지 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Seedkeeper 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "QR 스캔"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "파일 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "키 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Seedkeeper에 저장"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "QR로 표시"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "공개키"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "개인키"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "카드 정보 보기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "카드 내 키 생성"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "관리자 PIN 변경"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "사용자 PIN 변경"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "파일 암호화 중"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(시간이 걸릴 수 있음)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "파일 복호화 중"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "SHA256Sum 확인"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "업데이트"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "파일에서"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "새로 생성"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "BIP85 파생"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "OpenGPG 카드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "텍스트 편집"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "텍스트 버리기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "텍스트를 버릴까요?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "QR 코드 생성"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "옮겨 적기 모드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "전체 화면 모드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "옮겨 적기 모드?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "텍스트 QR 코드 확인"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "텍스트 QR 확인?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "텍스트 QR 코드 스캔"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "텍스트 QR 코드 확인"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "옮겨 적은 텍스트 QR 코드가 원본 텍스트와 일치하지 않습니다!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "텍스트 QR 코드 확인"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "옮겨 적은 텍스트 QR 코드가 정상 스캔되어 동일한 텍스트가 나왔습니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "텍스트 QR 확인"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "옮겨 적은 텍스트 QR 코드를 읽을 수 없습니다!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "편집 후 QR 코드 생성"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "디코딩된 텍스트"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "테스트 실행"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "이미지 플래시"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "MicroSD 검증"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "삭제(0으로)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "삭제(랜덤)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "검증 건너뛰기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "전체"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "사용자 지정"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF 짧게"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF 길게"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "주사위"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "비밀번호 유형"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64비트"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128비트"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256비트"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "비밀번호 강도"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "예"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "아니요"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "옵션 선택"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "문자 종류를 하나 이상 선택하세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "시스템 RNG 상태 점검 실패."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "시스템 RNG 오류"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "카메라"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "주사위"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "시스템 RNG"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "엔트로피 원천"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "지원되지 않음"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85는 Diceware, 주사위, Hex, Base64, Base85를 지원합니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "없음"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "첫 글자 대문자"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "공백"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "구분 문자"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6면"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10면"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20면"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "주사위 면 수"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "굴리는 횟수"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "잘못된 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "굴리는 횟수는 1 이상이어야 합니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "엔트로피 부족"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "주사위 결과가 충분히 무작위하지 않습니다. 다시 시도하세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "카메라 엔트로피가 충분히 무작위하지 않습니다. 다시 시도하세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "경고"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "BIP85를 사용하기 전에 시드를 불러오세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "시드 선택"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "BIP85에 사용할 시드 선택"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "BIP85 인덱스"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "잘못된 길이"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex는 128 또는 256비트를 지원합니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64는 120비트 이상이 필요합니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85는 64-512비트가 필요합니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "비밀번호 이름"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "공간 부족"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"비밀 저장 중\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "성공"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "비밀번호를 Seedkeeper에 저장함"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "Seedkeeper에 비밀번호를 저장할 공간이 부족합니다"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "실패"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "비밀번호 저장 실패"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "편집"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "비밀번호"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "비밀번호 저장"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Satochip 카드 사용"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Keycard 사용"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "15단어 시드 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "18단어 시드 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "21단어 시드 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "WIF 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "WIF 스캔"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "BIP38 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "BIP38 스캔"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "지문 불일치"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "카드가 이 PSBT에 서명할 수 없음"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "카드 지문({})이 PSBT 서명자 목록에 없습니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "개인키(WIF)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "잘못된 WIF!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "유효한 WIF 형식 개인키가 아닙니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "BIP38 키"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "BIP38 패스프레이즈"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "잘못된 BIP38!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "BIP38 키를 복호화할 수 없습니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "descriptor 불일치"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "descriptor 지움"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "불러온 멀티시그 지갑 descriptor가 이 PSBT와 일치하지 않습니다. 올바른 descriptor를 불러오거나 검증을 건너뛰어 계속하세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "PSBT 서명 중..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "서명 시간 초과"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "재시도(시간 연장)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Saved as {}."
+msgstr "{}(으)로 저장함."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Failed to save PSBT: {}"
+msgstr "PSBT 저장 실패: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "PSBT 인코딩 중..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "QR 스캐너 사용 불가"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "QR 스캔 백엔드가 없습니다. zbar(데스크톱은 OpenCV)를 설치하고 재시작하세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "시드 유형 선택"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "설정된 시간:"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "시간 설정 실패"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "잘못된 시간"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "QR에서 시간을 읽을 수 없습니다"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "SLIP-39 조각 스캔"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "SLIP-39 조각 QR이 필요합니다"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "WIF 개인키가 필요합니다"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "BIP38 개인키가 필요합니다"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+#, python-brace-format
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "방금 내보낸 지갑의 수신 주소 {}을(를) 스캔하세요"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"데이터가 여러 QR\n"
+"유형과 일치합니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "암호화 키 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "암호화 키 스캔"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "암호화 키 편집"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "암호화 키 버리기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "계속"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "스캔하여 추가"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "복호화된 텍스트"
+
+#. FORK: translated by Claude 2026-07-12
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "다음의 비공식 포크:"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "BitBox02 백업"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Passport 백업"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "TAPSIGNER 백업"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Aezeed 시드 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "SLIP-39 조각"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " SeedQR 스캔"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "SeedKeeper에서"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Specter-DIY에서"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " 시드 만들기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "microSD 카드가 감지되지 않음."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "백업을 찾을 수 없음"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "microSD 카드에서 BitBox02 백업(.bin, .bb02, .dat, .backup)을 찾을 수 없습니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "BitBox02 백업 선택"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Backup name: {}"
+msgstr "백업 이름: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Created: {}"
+msgstr "생성됨: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Firmware: {}"
+msgstr "펌웨어: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Birthdate: {}"
+msgstr "생성일: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Seed length: {} words"
+msgstr "시드 길이: {}단어"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "시드 불러옴"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "microSD 카드에서 Passport 백업(.7z)을 찾을 수 없습니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Passport 백업 선택"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Passport 백업 코드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "백업 코드는 비워둘 수 없습니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Chain: {}"
+msgstr "체인: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "microSD 카드에서 TAPSIGNER 백업(.aes)을 찾을 수 없습니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "TAPSIGNER 백업 선택"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "백업 키(hex)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "TAPSIGNER 백업에서 xprv를 불러왔습니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Path: {}"
+msgstr "경로: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "패스프레이즈 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "패스프레이즈 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "패스프레이즈 스캔"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "SeedKeeper에서 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Aezeed 패스프레이즈"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"이 니모닉에는\n"
+"패스프레이즈가 필요합니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "잘못된 패스프레이즈"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Aezeed 패스프레이즈가 필요합니다.\n"
+"다시 시도하세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Aezeed 패스프레이즈가 틀렸습니다.\n"
+"다시 시도하세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "잘못된 텍스트 QR 코드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "UTF-8이 아닌 데이터가 감지됨."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Aezeed 지원"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"Aezeed 입력은 실험적 기능입니다.\n"
+"검증된 백업에만 사용하세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "20단어 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "33단어 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "조각 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Share Word #{}"
+msgstr "조각 단어 #{}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "조각 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "조각 스캔"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "조각 결합"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "{} of {} needed"
+msgstr "{}개 중 {}개 필요"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "다시 시도"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "잘못된 SLIP-39 조각"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "체크섬 오류. 유효한 SLIP-39 조각이 아닙니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "확장 불가 시드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "이 SLIP-39 시드는 새 조각을 재생성할 수 없습니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "평문 QR로 내보내기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "SeedKeeper로"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "Specter-DIY로"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "조각 재생성"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "{}을(를) 열고 방금 내보낸 지갑의 수신 주소를 표시하세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "사용 중인 지갑 소프트웨어"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"패스프레이즈를 사용했습니다.\n"
+"단어 + 패스프레이즈가 필요합니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18단어"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "확인"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "자식 시드 확정"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "암호화 키 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "암호화 키를 버릴까요?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "입력 중인 키가 지워집니다"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "잘못된 키"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "키가 너무 깁니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "카메라로 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "지문 사용"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "사용자 지정 ID 할당"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "니모닉 ID 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "니모닉 ID 편집"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "니모닉 ID 버리기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "니모닉 ID를 버릴까요?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "입력 중인 니모닉 ID가 지워집니다"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "처리 중..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "암호화 실패"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "다음 100개"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "확장 검색"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "찾을 수 없음"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "주소 미확인"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Checked {} addresses with no match."
+msgstr "{}개 주소를 확인했으나 일치 없음."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "다음 10개 확인"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Checked {} addresses per path with no match."
+msgstr "경로당 {}개 주소를 확인했으나 일치 없음."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "지갑 내보내기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "지갑 내보내기 성공."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "주소 형식이 내보낸 스크립트 유형과 일치하지 않습니다. 지갑 내보내기 실패."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "지갑을 현재 시드와 일치시킬 수 없습니다. 지갑 내보내기 실패."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "내보내기 실패"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "SeedKeeper 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "xpub 내보내는 중..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "메시지 서명 중..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "검증 실패"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "스마트카드 테스트"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "카드 리더 목록"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "NFC 스캔 테스트"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "PCSC 재시작"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "배터리 정보"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "시스템 정보"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "백업 파일 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "호환되는 배터리 모니터를 찾을 수 없음"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "사용 불가"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "공통 기능"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Satochip 기능"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Keycard 기능"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "SeedKeeper 기능"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Specter-DIY 기능"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "DIY 도구"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "카드 정보"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "정품 확인"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "PIN 변경"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "라벨 변경"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "NFC 정책 변경"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "NDEF 설정"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "카드 공장 초기화"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "NDEF 보기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Seedkeeper 앱 링크 사용"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "NDEF 지우기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "사용자 지정 NDEF 설정"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "NDEF를 SeedKeeper에 저장"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "SeedKeeper에서 NDEF 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "텍스트 레코드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "URI 레코드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Android 앱 실행"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "사용자 지정(HEX)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "NDEF 디코딩"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC 사용"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC 사용 안 함"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC 차단됨"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "카드 재삽입됨"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "여유 공간 보기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "카드의 비밀 보기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "비밀번호를 카드에 저장"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "카드에서 비밀 삭제"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "멀티시그 descriptor 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "멀티시그 descriptor 저장"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "카드 비밀 복제"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "홈으로 나가기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "시드로 초기화"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "descriptor로 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "PSBT 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "PUK 설정"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "PUK로 PIN 잠금 해제"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "이름 설정"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "시드 제거"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "서명 벤치마크"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "메시지 서명 벤치마크"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "서명 편향 확인"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "제거"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "초기화"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "2FA 사용"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "이미 시드 설정됨"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"xprv로는 Satochip를 초기화할 수 없습니다.\n"
+"BIP39, SLIP39 또는 Electrum을 사용하세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "카드 PIN 변경"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "니모닉 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "니모닉 저장"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "시드 삭제"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "카드 키"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "애플릿 빌드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "애플릿 설치"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "애플릿 제거"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "다른 PIN 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "키 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "키 저장"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "카드 잠금 해제"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "카드 잠금"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "불러온 키 지우기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "덮어쓰기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "저장 중단"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "단일 키 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "키 세트 입력"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "단일 키 생성"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "키 세트 생성"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB(기본값)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "시스템 RNG 엔트로피가 너무 낮습니다. 나중에 다시 시도하세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "시스템 RNG에서 파생된 엔트로피가 상태 점검에 실패했습니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " 새 시드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "SLIP39 시드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "텍스트 QR 코드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "비밀번호 생성기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "스마트카드 도구"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "MicroSD 도구"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "멀티시그 descriptor 지우기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "microSD 카드가 감지되지 않음"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "방전 로그를 저장하려면 microSD 카드를 삽입하세요."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "네트워크 정보를 불러올 수 없습니다."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15단어"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18단어"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21단어"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20단어"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33단어"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+#, python-brace-format
+msgid "20 words ({} rolls)"
+msgstr "20단어({}회)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+#, python-brace-format
+msgid "33 words ({} rolls)"
+msgstr "33단어({}회)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "멀티시그 descriptor 불러옴"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Satochip에서 불러오기"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Electrum 시드"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "텍스트 인코딩"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "QR 코드 디코딩"
+

--- a/l10n/fork/nl/messages.po
+++ b/l10n/fork/nl/messages.po
@@ -1,0 +1,2493 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-11 08:46-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: nl\n"
+"Language-Team: nl <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "Gegevens gewist na inactiviteit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "Camera wordt gestart..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "Ontsleutelen?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "Kies het QR-type"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "Versleutelingssleutel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "Controleer de versleutelingssleutel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "Accountnummer"
+
+#. FORK: translated by Claude 2026-07-11
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "Versleuteld"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "Versleutelde entropie-bits"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "Geen standaardpad!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "Mnemonic-ID"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "Controleer de mnemonic-ID"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "De QR-codes van beide modi kunnen verschillen, maar beide zijn geldig."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "Versleutelde QR overschrijven"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "Geen opties beschikbaar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "Batterij-info"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "Systeeminfo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Platform: {platform_name}"
+msgstr "Platform: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Variant: {platform_variant}"
+msgstr "Variant: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (CPU): {system_serial}"
+msgstr "Serienr. (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "Serienr. (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "Apparaatfilter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "Netwerkinfo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "Batterijkalibratie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "Laad de batterij volledig op. Kies Volgende om de ontlaadtest te starten."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "Start"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "De test loopt tot de batterij leeg is. Laat het apparaat losgekoppeld."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "Opladen gedetecteerd"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "Ontladen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "Verstreken: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "Spanning: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "Stroom: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "Status: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "LAGE ENTROPIE"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "GOEDE ENTROPIE"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "Te coderen tekst"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "Dwang-PIN instellen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "Camera 0"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "Camera 1"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "Camera 2"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "Camera 3"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 minuten"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 minuten"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 minuten"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 minuten"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Aezeed-wachtwoordzin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "Voorkeur voor CompactSeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "Voorkeur voor EncryptedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "Elke keer vragen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "PIN-pogingen smartcard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "Wis-timer"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "Seed-woordlengtes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "BIP32-account vragen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "Dubbelzinnige QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "GPG-sleuteltypen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "BIP85-GPG-versie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 is de nieuwste; gebruik v2 om B9-B10-sleutels na te maken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "SLIP39-seeds"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Aezeed-seeds"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "LND-compatibel, 24 woorden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "Uitbreidbare SLIP39-shares"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "BitBox02-back-ups"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Passport-back-ups"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "TAPSIGNER-back-ups"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "Smartcard-ondersteuning"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Satochip-ondersteuning"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Keycard-ondersteuning"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Specter-DIY-ondersteuning"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "Camerabron"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "Desktopmodus"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "Niet veilig!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Deze desktopversie is alleen voor tests.\n"
+"Gebruik GEEN echte seeds of privésleutels."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "Ik begrijp het"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "Ontwikkelbuild"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Deze SeedSignerOS-ontwikkelbuild is alleen voor tests.\n"
+"Gebruik GEEN echte seeds of privésleutels."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "Bestandsbewerkingen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "Sleutels importeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "Sleutels exporteren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "Sleutels bekijken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "Beveiligde berichten"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "GPG-gereedschap"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "Ontbrekende pakketten"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "Vereist maar niet geïnstalleerd:\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "Subsleutel-bewerkingen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "Gebruikers-ID-bewerkingen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "Sleutels kruiscertificeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "Publieke-sleutelbundel exporteren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "BIP85-metadata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "Subsleutels"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "Terug"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "Bundel exporteren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "Geanimeerde QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "BIP85-gegevens opslaan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "BIP85-gegevens laden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "BIP85-sleutel opnieuw opbouwen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "Naar MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "Naar QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "Naar Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "Van MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "Van QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Van Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "Subsleutels toevoegen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "Subsleutels intrekken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "Subsleutels verwijderen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "Vervaldatum wijzigen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "Subsleutelgeheimen exporteren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 jaar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 jaar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 jaar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "Nooit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "Bestand"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "Smartcard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "Gebruikers-ID toevoegen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "Gebruikers-ID's bewerken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "Primaire gebruikers-ID instellen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "Gebruikers-ID intrekken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "Gebruikers-ID verwijderen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "Versleutelen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "Ontsleutelen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "Ondertekenen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "Handtekening verifiëren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "Bericht maken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "Bericht laden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "Manifest"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "Bericht typen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Seedkeeper laden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "QR scannen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "Bestand laden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "Sleutel laden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Opslaan op Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "Tonen als QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "Publieke sleutel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "Privésleutel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "Kaartinfo bekijken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "Sleutel op de kaart genereren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "Admin-PIN wijzigen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "Gebruikers-PIN wijzigen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "Bestand wordt versleuteld"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(Kan even duren)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "Bestand wordt ontsleuteld"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "SHA256Sum controleren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "Bijwerken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "Uit bestand"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "Nieuwe genereren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "BIP85 afleiden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "OpenGPG-kaart"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "Tekst bewerken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "Tekst weggooien"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "Tekst weggooien?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "QR-code genereren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "Overschrijfmodus"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "Volledig-schermmodus"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "Overschrijfmodus?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "Tekst-QR-code bevestigen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "Tekst-QR bevestigen?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "Tekst-QR-code scannen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "Tekst-QR-code bevestigen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "Je overgeschreven tekst-QR komt niet overeen met je originele tekst!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "Tekst-QR-code controleren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "Je overgeschreven tekst-QR is gescand en leverde dezelfde tekst op."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "Tekst-QR bevestigen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "Je overgeschreven tekst-QR kon niet worden gelezen!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "Bewerken en QR-code genereren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "Gedecodeerde tekst"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "Test uitvoeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "Image flashen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "MicroSD verifiëren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "Wissen (nullen)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "Wissen (willekeurig)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "Verificatie overslaan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "Alles"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "Aangepast"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF kort"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF lang"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "Dobbelworpen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "Wachtwoordtype"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 bits"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 bits"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 bits"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "Wachtwoordsterkte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "Ja"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "Nee"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "Opties kiezen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "Kies minstens één tekenset."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "Controle van de systeem-RNG mislukt."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "Systeem-RNG-fout"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "Camera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "Dobbelstenen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "Systeem-RNG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "Entropiebron"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "Niet ondersteund"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 ondersteunt Diceware, dobbelworpen, Hex, Base64 en Base85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "Geen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "Beginhoofdletter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "Spatie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "Scheidingsteken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 zijden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 zijden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 zijden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "Dobbelsteenzijden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "Aantal worpen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "Ongeldige invoer"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "Het aantal worpen moet minstens 1 zijn."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "Zwakke entropie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "De worpen leken niet willekeurig genoeg. Probeer opnieuw."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "De camera-entropie leek niet willekeurig genoeg. Probeer opnieuw."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "WAARSCHUWING"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "Laad een seed voordat je BIP85 gebruikt."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "Seed kiezen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "Kies de seed voor BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "BIP85-index"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "Ongeldige lengte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex ondersteunt 128 of 256 bits."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 vereist 120+ bits."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 vereist 64-512 bits."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "Wachtwoordnaam"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "Onvoldoende ruimte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"Geheim wordt opgeslagen\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "Gelukt"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "Wachtwoord opgeslagen op Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "Onvoldoende ruimte op de Seedkeeper voor het wachtwoord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "Mislukt"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "Wachtwoord opslaan mislukt"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "Bewerken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "Wachtwoord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "Wachtwoord opslaan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Satochip-kaart gebruiken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Keycard gebruiken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "15-woorden-seed invoeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "18-woorden-seed invoeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "21-woorden-seed invoeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "WIF invoeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "WIF scannen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "BIP38 invoeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "BIP38 scannen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "Vingerafdruk komt niet overeen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "Kaart kan de PSBT niet ondertekenen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "Kaartvingerafdruk ({}) zit niet bij de PSBT-ondertekenaars."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "Privésleutel (WIF)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "Ongeldige WIF!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "Geen geldige WIF-gecodeerde privésleutel."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "BIP38-sleutel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "BIP38-wachtwoordzin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "Ongeldige BIP38!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "Kon de BIP38-sleutel niet ontsleutelen."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "Descriptor komt niet overeen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "Descriptor gewist"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "De geladen multisig-wallet-descriptor past niet bij deze PSBT. Laad de juiste descriptor of sla verificatie over."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "PSBT wordt ondertekend..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "Time-out bij ondertekenen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "Opnieuw (langere time-out)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Saved as {}."
+msgstr "Opgeslagen als {}."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Failed to save PSBT: {}"
+msgstr "PSBT opslaan mislukt: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "PSBT wordt gecodeerd..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "QR-scanner niet beschikbaar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "QR-scanbackend ontbreekt. Installeer zbar (of OpenCV op desktop) en herstart."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "Kies het seed-type"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "Tijd ingesteld op:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "Tijd instellen mislukt"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "Ongeldige tijd"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "Kon de tijd niet uit de QR lezen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "SLIP-39-share scannen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "SLIP-39-share-QR verwacht"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "WIF-privésleutel verwacht"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "BIP38-privésleutel verwacht"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "Scan ontvangstadres {} van de zojuist geëxporteerde wallet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"Gegevens passen bij meerdere\n"
+"QR-typen."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "Sleutel typen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "Sleutel scannen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "Sleutel bewerken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "Sleutel weggooien"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "Doorgaan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "Scan en voeg nog een toe"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "Ontsleutelde tekst"
+
+#. FORK: translated by Claude 2026-07-11
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "Een onofficiële fork van:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "BitBox02-back-up"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Passport-back-up"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "TAPSIGNER-back-up"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Aezeed-seed invoeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "SLIP-39-shares"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " SeedQR scannen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "Van SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Van Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " Maak een seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "Geen microSD-kaart gedetecteerd."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "Geen back-ups gevonden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "Geen BitBox02-back-ups (.bin, .bb02, .dat, .backup) gevonden op de microSD-kaart."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "Kies de BitBox02-back-up"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup name: {}"
+msgstr "Back-upnaam: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Created: {}"
+msgstr "Gemaakt: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Firmware: {}"
+msgstr "Firmware: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Birthdate: {}"
+msgstr "Aanmaakdatum: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed length: {} words"
+msgstr "Seed-lengte: {} woorden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "Seed geladen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "Geen Passport-back-ups (.7z) gevonden op de microSD-kaart."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Kies de Passport-back-up"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Passport-back-upcode"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "De back-upcode mag niet leeg zijn."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Chain: {}"
+msgstr "Chain: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "Geen TAPSIGNER-back-ups (.aes) gevonden op de microSD-kaart."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "Kies de TAPSIGNER-back-up"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "Back-upsleutel (hex)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "xprv geladen uit TAPSIGNER-back-up."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Path: {}"
+msgstr "Pad: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "Wachtwoordzin laden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "Wachtwoordzin typen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "Wachtwoordzin scannen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "Laden van SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Aezeed-wachtwoordzin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"Wachtwoordzin vereist\n"
+"voor deze mnemonic."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "Ongeldige wachtwoordzin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Aezeed-wachtwoordzin vereist.\n"
+"Probeer opnieuw."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Onjuiste Aezeed-wachtwoordzin.\n"
+"Probeer opnieuw."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "Ongeldige tekst-QR-code"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "Niet-UTF-8-gegevens gedetecteerd."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Aezeed-ondersteuning"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"Aezeed-invoer is experimenteel.\n"
+"Alleen met gecontroleerde back-ups."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "20 woorden invoeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "33 woorden invoeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "Share laden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Share Word #{}"
+msgstr "Share-woord #{}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "Share invoeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "Share scannen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "Shares combineren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "{} of {} needed"
+msgstr "{} van {} nodig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "Opnieuw proberen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "Ongeldige SLIP-39-share"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "Controlesom onjuist; geen geldige SLIP-39-share."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Niet-uitbreidbare seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Deze SLIP-39-seed kan geen nieuwe shares genereren."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "Exporteren als onversleutelde QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "Naar SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "Naar Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "Shares opnieuw genereren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "Open {} en toon een ontvangstadres van de zojuist geëxporteerde wallet."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "je walletsoftware"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"Er is een wachtwoordzin gebruikt.\n"
+"Je hebt woorden + wachtwoordzin nodig."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 woorden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "Controleren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "Child-seed afronden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "Versleutelingssleutel invoeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "Sleutel weggooien?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "De ingevoerde sleutel wordt gewist"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "Ongeldige sleutel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "De sleutel is te lang."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "Invoer via camera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "Vingerafdruk gebruiken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "Eigen ID toewijzen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "Mnemonic-ID invoeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "Mnemonic-ID bewerken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "Mnemonic-ID weggooien"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "Mnemonic-ID weggooien?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "De ingevoerde mnemonic-ID wordt gewist"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "Verwerken..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "Versleuteling mislukt"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "Volgende 100"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "Uitgebreide zoekopdracht"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "Niet gevonden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "Adres niet geverifieerd"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses with no match."
+msgstr "{} adressen gecontroleerd zonder match."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "Volgende 10 controleren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses per path with no match."
+msgstr "{} adressen per pad gecontroleerd zonder match."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "Wallet-export"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "Wallet succesvol geëxporteerd."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "Adresformaat past niet bij het geëxporteerde scripttype. Wallet-export mislukt."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "Kan de wallet niet koppelen aan de huidige seed. Wallet-export mislukt."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "Export mislukt"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "SeedKeeper laden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "Xpub wordt geëxporteerd..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "Bericht wordt ondertekend..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "Verificatie mislukt"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "Smartcard testen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "Kaartlezers weergeven"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "NFC-scan testen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "PCSC herstarten"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "Batterij-info"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "Systeeminfo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "Back-upbestanden laden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "Geen compatibele batterijmonitor gedetecteerd"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "Niet beschikbaar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "Algemene functies"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Satochip-functies"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Keycard-functies"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "SeedKeeper-functies"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Specter-DIY-functies"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "DIY-gereedschap"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "Kaartinfo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "Echtheidscontrole"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "PIN wijzigen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "Label wijzigen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "NFC-beleid wijzigen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "NDEF configureren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "Kaart terugzetten naar fabrieksinstellingen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "NDEF bekijken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Seedkeeper-app-link gebruiken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "NDEF wissen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "Eigen NDEF instellen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "NDEF opslaan op SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "NDEF laden van SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "Tekstrecord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "URI-record"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Android-app starten"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "Aangepast (HEX)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "NDEF decoderen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC ingeschakeld"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC uitgeschakeld"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC geblokkeerd"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "Kaart opnieuw geplaatst"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "Vrije ruimte bekijken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "Geheimen op de kaart bekijken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "Wachtwoord opslaan op de kaart"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "Geheim verwijderen van de kaart"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "Multisig-descriptor laden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "Multisig-descriptor opslaan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "Kaartgeheimen klonen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "Terug naar start"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "Initialiseren met seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "Laden als descriptor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "PSBT laden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "PUK instellen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "PIN deblokkeren met PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "Naam instellen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "Seed verwijderen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "Ondertekenings-benchmark"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "Berichtondertekenings-benchmark"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "Ondertekeningsbias controleren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "Verwijderen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "Resetten"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "2FA inschakelen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "Al voorzien van een seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"Een xprv kan Satochip niet initialiseren.\n"
+"Gebruik BIP39, SLIP39 of Electrum."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "Kaart-PIN wijzigen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "Mnemonic laden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "Mnemonic opslaan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "Seed wissen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "Kaartsleutels"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "Applets bouwen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "Applet installeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "Applet de-installeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "Andere PIN invoeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "Sleutels laden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "Sleutels opslaan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "Kaart ontgrendelen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "Kaart vergrendelen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "Geladen sleutels wissen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "Overschrijven"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "Opslaan afbreken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "Eén sleutel invoeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "Sleutelset invoeren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "Eén sleutel genereren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "Sleutelset genereren"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (standaard)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "Entropie van de systeem-RNG te laag. Probeer later opnieuw."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "De van de systeem-RNG afgeleide entropie doorstond de controles niet."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Nieuwe seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "SLIP39-seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "Tekst-QR-code"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "Wachtwoordgenerator"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "Smartcard-gereedschap"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "MicroSD-gereedschap"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Multisig-descriptor wissen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "Geen microSD-kaart gedetecteerd"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "Plaats een microSD-kaart om het ontlaadlog op te slaan."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "Kan netwerkinformatie niet laden."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 woorden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 woorden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 woorden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 woorden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 woorden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words ({} rolls)"
+msgstr "20 woorden ({} worpen)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words ({} rolls)"
+msgstr "33 woorden ({} worpen)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Multisig-descriptor geladen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Laden van Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Electrum-seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "Tekst coderen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "QR-code decoderen"
+

--- a/l10n/fork/no/messages.po
+++ b/l10n/fork/no/messages.po
@@ -1,0 +1,2870 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-11 13:46-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: no\n"
+"Language-Team: no <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "Data slettet etter inaktivitet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Review Transaction"
+msgstr "Kontroller transaksjonen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Review details"
+msgstr "Kontroller detaljene"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Transaction Math"
+msgstr "Transaksjonsregnskap"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Review recipients"
+msgstr "Kontroller mottakerne"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Sign Transaction"
+msgstr "Signer transaksjonen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "Starter kamera..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "Dekryptere?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "Velg QR-type"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "Krypteringsnøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "Kontroller krypteringsnøkkelen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/screen.py
+msgid "I understand"
+msgstr "Jeg forstår"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "Kontonummer"
+
+#. FORK: translated by Claude 2026-07-11
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "Kryptert"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "Krypterte entropibiter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "Ikke-standard sti!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Sign message"
+msgstr "Signer melding"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "Mnemonisk ID"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "Kontroller mnemonisk ID"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "QR-kodene fra de to modusene kan variere, men begge er gyldige."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "Skriv av kryptert QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "Ingen alternativer tilgjengelig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "Batteriinfo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "Systeminfo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Platform: {platform_name}"
+msgstr "Plattform: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Variant: {platform_variant}"
+msgstr "Variant: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (CPU): {system_serial}"
+msgstr "Serienr. (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "Serienr. (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "Enhetsfilter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "Nettverksinfo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "Batterikalibrering"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "Lad batteriet helt opp. Velg Neste for å starte utladingstesten."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "Start"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "Testen kjører til batteriet er tomt. La enheten være frakoblet."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "Lading oppdaget"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "Lader ut"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "Forløpt: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "Spenning: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "Strøm: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "Status: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "LAV ENTROPI"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "GOD ENTROPI"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "Tekst som skal kodes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "Angi tvangs-PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option; "default" = this is the format most wallets use
+#: src/seedsigner/models/settings_definition.py
+msgid "Animated (default)"
+msgstr "Animert (standard)"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option (static = single frame, not animated)
+#: src/seedsigner/models/settings_definition.py
+msgid "Static"
+msgstr "Statisk"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option: old format that Specter Desktop used to use
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter legacy"
+msgstr "Specter legacy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "Kamera 0"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "Kamera 1"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "Kamera 2"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "Kamera 3"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 minutter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 minutter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 minutter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 minutter"
+
+#. FORK: translated by Claude 2026-07-11
+#. MicroSD notification duration setting - Display notification for 5 seconds
+#: src/seedsigner/models/settings_definition.py
+msgid "5 seconds"
+msgstr "5 sekunder"
+
+#. FORK: translated by Claude 2026-07-11
+#. MicroSD notification duration setting - Display notification until the SD
+#. card is removed
+#: src/seedsigner/models/settings_definition.py
+msgid "Until SD removed"
+msgstr "Til SD fjernes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Aezeed-passordfrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "Foretrekk CompactSeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "Foretrekk EncryptedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "Spør hver gang"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "PIN-forsøk for kortet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "Slettetimer"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "Seedlengder"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Xpub QR format"
+msgstr "Xpub-QR-format"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "Spør om BIP32-konto"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "Tvetydig QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "GPG-nøkkeltyper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "BIP85-GPG-versjon"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 er nyest; bruk v2 for å gjenskape B9-B10-nøkler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "SLIP39-seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Aezeed-seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "LND-kompatibel, 24 ord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "Utvidbare SLIP39-deler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "MicroSD notification duration"
+msgstr "Varighet for MicroSD-varsel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "BitBox02-sikkerhetskopier"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Passport-sikkerhetskopier"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "TAPSIGNER-sikkerhetskopier"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "Smartkortstøtte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Satochip-støtte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Keycard-støtte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Specter-DIY-støtte"
+
+#. FORK: translated by Claude 2026-07-11
+#. Hardware settings option to specify the screen driver (e.g. st7789 vs
+#. ili9341)
+#: src/seedsigner/models/settings_definition.py
+msgid "Display type"
+msgstr "Skjermtype"
+
+#. FORK: translated by Claude 2026-07-11
+#. Hardware settings option to invert how the screen driver displays colors.
+#: src/seedsigner/models/settings_definition.py
+msgid "Invert colors"
+msgstr "Inverter farger"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "Kamerakilde"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "Skrivebordsmodus"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "Ikke sikkert!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Denne skrivebordsversjonen er kun for testing.\n"
+"IKKE bruk ekte seed eller private nøkler."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "Jeg forstår"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "Utviklingsversjon"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Denne SeedSignerOS-utviklingsversjonen er kun for testing.\n"
+"IKKE bruk ekte seed eller private nøkler."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "Filoperasjoner"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "Importer nøkler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "Eksporter nøkler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "Vis nøkler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "Sikre meldinger"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "GPG-verktøy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "Manglende pakker"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "Kreves, men er ikke installert:\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "Undernøkkeloperasjoner"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "Bruker-ID-operasjoner"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "Krysssertifiser nøkler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "Eksporter offentlig nøkkelpakke"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "BIP85-metadata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "Undernøkler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "Tilbake"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "Eksporter pakke"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "Animert QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "Lagre BIP85-data"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "Last inn BIP85-data"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "Gjenoppbygg BIP85-nøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "Til MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "Til QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "Til Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "Fra MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "Fra QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Fra Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "Legg til undernøkler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "Tilbakekall undernøkler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "Slett undernøkler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "Endre utløpsdato"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "Eksporter undernøkkelhemmeligheter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 år"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 år"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 år"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "Aldri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "Fil"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "Smartkort"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "Legg til bruker-ID"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "Rediger bruker-ID-er"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "Angi primær bruker-ID"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "Tilbakekall bruker-ID"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "Slett bruker-ID"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "Krypter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "Dekrypter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "Signer"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "Verifiser signatur"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "Opprett melding"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "Last inn melding"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "Manifest"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "Skriv melding"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Last inn Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "Skann QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "Last inn fil"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "Last inn nøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Lagre på Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "Vis som QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "Offentlig nøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "Privat nøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "Vis kortinfo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "Generer nøkkel på kortet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "Endre admin-PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "Endre bruker-PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "Krypterer fil"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(Kan ta litt tid)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "Dekrypterer fil"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "Sjekk SHA256Sum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "Oppdater"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "Fra fil"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "Generer ny"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "Utled BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "OpenGPG-kort"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "Rediger tekst"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "Forkast tekst"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "Forkaste teksten?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "Generer QR-kode"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "Avskrivingsmodus"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "Fullskjermmodus"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "Avskrivingsmodus?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "Bekreft tekst-QR-kode"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "Bekrefte tekst-QR?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "Skann tekst-QR-kode"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "Bekreft tekst-QR-kode"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "Den avskrevne tekst-QR-koden samsvarer ikke med originalteksten!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "Kontroller tekst-QR-koden"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "Den avskrevne tekst-QR-koden ble skannet og ga samme tekst."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "Bekreft tekst-QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "Den avskrevne tekst-QR-koden kunne ikke leses!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "Rediger og generer QR-kode"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "Dekodet tekst"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "Kjør test"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "Skriv image"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "Verifiser MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "Slett (nuller)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "Slett (tilfeldig)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "Hopp over verifisering"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "Alle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "Egendefinert"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF kort"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF lang"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "Terningkast"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "Passordtype"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 biter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 biter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 biter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "Passordstyrke"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "Ja"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "Nei"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "Velg alternativer"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "Velg minst ett tegnsett."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "Systemets RNG-sjekk feilet."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "System-RNG-feil"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "Kamera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "Terninger"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "System-RNG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "Entropikilde"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "Støttes ikke"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 støtter Diceware, terningkast, Hex, Base64 og Base85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "Ingen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "Stor forbokstav"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "Mellomrom"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "Skilletegn"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 sider"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 sider"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 sider"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "Terningsider"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "Antall kast"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "Ugyldig inndata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "Antall kast må være minst 1."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "Svak entropi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "Kastene virket ikke tilfeldige nok. Prøv igjen."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "Kameraentropien virket ikke tilfeldig nok. Prøv igjen."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "ADVARSEL"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "Last inn et seed før du bruker BIP85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "Velg seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "Velg seed for BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "BIP85-indeks"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "Ugyldig lengde"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex støtter 128 eller 256 biter."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 krever 120+ biter."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 krever 64-512 biter."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "Passordnavn"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "Ikke nok plass"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"Lagrer hemmelighet\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "Suksess"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "Passord lagret på Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "Ikke nok plass på Seedkeeper til passordet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "Mislyktes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "Kunne ikke lagre passordet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "Rediger"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "Passord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "Lagre passord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Bruk Satochip-kort"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Bruk Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "Skriv inn 15-ords seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "Skriv inn 18-ords seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "Skriv inn 21-ords seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "Skriv inn WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "Skann WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "Skriv inn BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "Skann BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "Fingeravtrykket samsvarer ikke"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "Kortet kan ikke signere PSBT-en"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "Kortets fingeravtrykk ({}) er ikke blant PSBT-signatarene."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "Privat nøkkel (WIF)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "Ugyldig WIF!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "Ikke en gyldig WIF-kodet privat nøkkel."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "BIP38-nøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "BIP38-passordfrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "Ugyldig BIP38!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "Kunne ikke dekryptere BIP38-nøkkelen."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction has unsupported input script type, please verify your change addresses."
+msgstr "Transaksjonen har en skripttype som ikke støttes; verifiser veksleadressene dine."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "This transaction spends its entire input value. No change is coming back to your wallet."
+msgstr "Denne transaksjonen bruker hele inngangsbeløpet. Ingen veksel kommer tilbake til lommeboken."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Next recipient"
+msgstr "Neste mottaker"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Skip verification"
+msgstr "Hopp over verifisering"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Verify multisig change"
+msgstr "Verifiser multisig-veksel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Verify multisig addr"
+msgstr "Verifiser multisig-adresse"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "Deskriptoren samsvarer ikke"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "Deskriptor slettet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "Den innlastede multisig-deskriptoren samsvarer ikke med denne PSBT-en. Last inn riktig deskriptor eller hopp over verifiseringen."
+
+#. FORK: translated by Claude 2026-07-11
+#. Variable is either "change" or "self-transfer".
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction's {} address could not be verified from wallet descriptor."
+msgstr "Transaksjonens {}-adresse kunne ikke verifiseres fra lommebokdeskriptoren."
+
+#. FORK: translated by Claude 2026-07-11
+#. Variable is either "change" or "self-transfer".
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction's {} address could not be generated from your seed."
+msgstr "Transaksjonens {}-adresse kunne ikke genereres fra seedet ditt."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Suspicious Transaction"
+msgstr "Mistenkelig transaksjon"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Discard transaction"
+msgstr "Forkast transaksjonen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Approve transaction"
+msgstr "Godkjenn transaksjonen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "Signerer PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "Tidsavbrudd ved signering"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "Prøv igjen (lengre tidsfrist)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Saved as {}."
+msgstr "Lagret som {}."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Failed to save PSBT: {}"
+msgstr "Kunne ikke lagre PSBT: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "Koder PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Select different seed"
+msgstr "Velg et annet seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction Error"
+msgstr "Transaksjonsfeil"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "QR-skanner utilgjengelig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "QR-skannemotor mangler. Installer zbar (eller OpenCV på skrivebord) og start på nytt."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "Velg seedtype"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "Tid satt til:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "Kunne ikke stille klokken"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "Ugyldig tid"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "Kunne ikke lese tid fra QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan Transaction"
+msgstr "Skann transaksjon"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a transaction"
+msgstr "Forventet en transaksjon"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "Skann SLIP-39-del"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "Forventet en SLIP-39-del-QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "Forventet en privat WIF-nøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "Forventet en privat BIP38-nøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "Skann mottaksadresse {} fra lommeboken du nettopp eksporterte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"Dataene samsvarer med\n"
+"flere QR-typer."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "Skriv inn krypteringsnøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "Skann krypteringsnøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "Rediger krypteringsnøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "Forkast krypteringsnøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "Fortsett"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "Skann og legg til enda en"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/view.py
+msgid "Back to Main Menu"
+msgstr "Tilbake til hovedmenyen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "Dekryptert tekst"
+
+#. FORK: translated by Claude 2026-07-11
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "En uoffisiell fork av:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "BitBox02-sikkerhetskopi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Passport-sikkerhetskopi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "TAPSIGNER-sikkerhetskopi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Skriv inn Aezeed-seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "SLIP-39-deler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " Skann en SeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "Fra SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Fra Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " Opprett et seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load a Seed"
+msgstr "Last inn et seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "MicroSD-kort ikke funnet."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "Ingen sikkerhetskopier funnet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "Ingen BitBox02-sikkerhetskopier (.bin, .bb02, .dat, .backup) ble funnet på microSD-kortet."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "Velg BitBox02-sikkerhetskopi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup name: {}"
+msgstr "Kopinavn: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Created: {}"
+msgstr "Opprettet: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Firmware: {}"
+msgstr "Fastvare: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Birthdate: {}"
+msgstr "Opprettelsesdato: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed length: {} words"
+msgstr "Seedlengde: {} ord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "Seed lastet inn"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "Ingen Passport-sikkerhetskopier (.7z) ble funnet på microSD-kortet."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Velg Passport-sikkerhetskopi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Passport-kopikode"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "Kopikoden kan ikke være tom."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Chain: {}"
+msgstr "Kjede: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "Ingen TAPSIGNER-sikkerhetskopier (.aes) ble funnet på microSD-kortet."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "Velg TAPSIGNER-sikkerhetskopi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "Kopinøkkel (hex)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "xprv lastet inn fra TAPSIGNER-sikkerhetskopi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Path: {}"
+msgstr "Sti: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review & edit"
+msgstr "Kontroller og rediger"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "Last inn passordfrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "Skriv inn passordfrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "Skann passordfrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "Last inn fra SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Aezeed-passordfrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"Passordfrase kreves\n"
+"for denne mnemonikken."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "Ugyldig passordfrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Aezeed-passordfrase kreves.\n"
+"Prøv igjen."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Feil Aezeed-passordfrase.\n"
+"Prøv igjen."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Skip passphrase"
+msgstr "Hopp over passordfrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current passphrase entry will be erased."
+msgstr "Den inntastede passordfrasen slettes."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Skip passphrase?"
+msgstr "Hoppe over passordfrasen?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "You have not entered a passphrase yet."
+msgstr "Du har ikke skrevet inn en passordfrase ennå."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "Ugyldig tekst-QR-kode"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "Ikke-UTF-8-data oppdaget."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Keep seed"
+msgstr "Behold seedet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Aezeed-støtte"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"Aezeed-inntasting er eksperimentell.\n"
+"Bruk kun med verifiserte kopier."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Electrum Warning"
+msgstr "Electrum-advarsel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "Skriv inn 20 ord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "Skriv inn 33 ord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "Last inn del"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Share Word #{}"
+msgstr "Delord nr. {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "Skriv inn del"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "Skann del"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "Kombiner deler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "{} of {} needed"
+msgstr "{} av {} kreves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "Prøv igjen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "Ugyldig SLIP-39-del"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "Sjekksumfeil; ikke en gyldig SLIP-39-del."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Ikke-utvidbart seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Dette SLIP-39-seedet kan ikke lage nye deler."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan transaction"
+msgstr "Skann transaksjon"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export xpub"
+msgstr "Eksporter xpub"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Address explorer"
+msgstr "Adresseutforsker"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup seed"
+msgstr "Sikkerhetskopier seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "BIP-85 child seed"
+msgstr "BIP-85-avledet seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard seed"
+msgstr "Forkast seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "View seed words"
+msgstr "Vis seedord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "Eksporter som ukryptert QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "Til SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "Til Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "Regenerer deler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Xpub QR Format"
+msgstr "Xpub-QR-format"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "Åpne {} og vis en mottaksadresse fra lommeboken du nettopp eksporterte."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "lommebokprogramvaren din"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"Passordfrase ble brukt.\n"
+"Du trenger ord + passordfrase."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 ord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Try again"
+msgstr "Prøv igjen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "Kontroller"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "Fullfør avledet seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review seed words"
+msgstr "Kontroller seedordene"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "Skriv inn krypteringsnøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "Forkaste krypteringsnøkkelen?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "Den inntastede nøkkelen slettes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "Ugyldig nøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "Nøkkelen er for lang."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "Inndata fra kamera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "Bruk fingeravtrykk"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "Tildel egendefinert ID"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "Skriv inn mnemonisk ID"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "Rediger mnemonisk ID"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "Forkast mnemonisk ID"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "Forkaste mnemonisk ID?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "Den inntastede mnemoniske ID-en slettes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "Behandler..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "Krypteringsfeil"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "Neste 100"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "Utvidet søk"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "Ikke funnet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "Adresse ikke verifisert"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses with no match."
+msgstr "Sjekket {} adresser uten treff."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "Sjekk de neste 10"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses per path with no match."
+msgstr "Sjekket {} adresser per sti uten treff."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "Lommebokeksport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "Lommeboken ble eksportert."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "Adresseformatet samsvarer ikke med den eksporterte skripttypen. Eksporten mislyktes."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "Kunne ikke knytte lommeboken til gjeldende seed. Eksporten mislyktes."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "Eksport mislyktes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "Last inn SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Return to transaction"
+msgstr "Tilbake til transaksjonen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Verify addr"
+msgstr "Verifiser adr."
+
+#. FORK: translated by Claude 2026-07-11
+#. Multisig policy. For a "2 of 3" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/seed_views.py
+msgid "{threshold} of {n}"
+msgstr "{threshold} av {n}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "Eksporterer xpub..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "Signerer melding..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "Verifisering mislyktes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Hardware"
+msgstr "Maskinvare"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "Test smartkort"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "List opp kortlesere"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "Test NFC-skanning"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "Start PCSC på nytt"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "Batteriinfo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "Systeminfo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "Last inn kopifiler"
+
+#. FORK: translated by Claude 2026-07-11
+#. Title of a warning dialog when configuring a setting that requires at least
+#. one option to be selected.
+#: src/seedsigner/views/settings_views.py
+msgid "Selection Required"
+msgstr "Valg kreves"
+
+#. FORK: translated by Claude 2026-07-11
+#. The name of the setting being configured (e.g. "Script types") will be
+#. inserted.
+#: src/seedsigner/views/settings_views.py
+msgid "At least one option must be selected for \"{}\"."
+msgstr "Minst ett alternativ må velges for \"{}\"."
+
+#. FORK: translated by Claude 2026-07-11
+#. Text for the button that returns the user to the setting configuration
+#. screen.
+#: src/seedsigner/views/settings_views.py
+msgid "Return to setting"
+msgstr "Tilbake til innstillingen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "Ingen kompatibel batterimonitor oppdaget"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "Utilgjengelig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "Fellesfunksjoner"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Satochip-funksjoner"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Keycard-funksjoner"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "SeedKeeper-funksjoner"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Specter-DIY-funksjoner"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "DIY-verktøy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "Kortinfo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "Ekthetskontroll"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "Endre PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "Endre etikett"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "Endre NFC-policy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "Konfigurer NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "Tilbakestill kortet til fabrikkinnstillinger"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "Vis NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Bruk Seedkeeper-applenke"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "Tøm NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "Angi egendefinert NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "Lagre NDEF på SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "Last inn NDEF fra SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "Tekstoppføring"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "URI-oppføring"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Android-appstart"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "Egendefinert (HEX)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "Dekod NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC på"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC av"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC blokkert"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "Kortet satt inn igjen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "Vis ledig plass"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "Vis hemmeligheter på kortet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "Lagre passord på kortet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "Slett hemmelighet fra kortet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "Last inn multisig-deskriptor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "Lagre multisig-deskriptor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "Klon kortets hemmeligheter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "Gå til startskjermen"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "Initialiser med seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "Last inn som deskriptor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "Last inn PSBT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "Angi PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "Lås opp PIN med PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "Angi navn"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "Fjern seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "Signeringsytelsestest"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "Ytelsestest for meldingssignering"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "Sjekk signaturskjevhet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "Fjern"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "Tilbakestill"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "Aktiver 2FA"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "Har allerede seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"xprv kan ikke initialisere Satochip.\n"
+"Bruk BIP39, SLIP39 eller Electrum."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "Endre kortets PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "Last inn mnemonikk"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "Lagre mnemonikk"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "Slett seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "Kortnøkler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "Bygg appleter"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "Installer applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "Avinstaller applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "Skriv inn en annen PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "Last inn nøkler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "Lagre nøkler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "Lås opp kortet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "Lås kortet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "Tøm innlastede nøkler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "Overskriv"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "Avbryt lagring"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "Skriv inn én nøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "Skriv inn nøkkelsett"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "Generer én nøkkel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "Generer nøkkelsett"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (standard)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "System-RNG-entropien er for lav. Prøv igjen senere."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "Entropi fra system-RNG besto ikke kontrollene."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Nytt seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "SLIP39-seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Verify address"
+msgstr "Verifiser adresse"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "Tekst-QR-kode"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "Passordgenerator"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "Smartkortverktøy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "MicroSD-verktøy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Tøm multisig-deskriptor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "MicroSD-kort ikke funnet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "Sett inn et microSD-kort for å lagre utladingsloggen."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "Kunne ikke laste inn nettverksinformasjon."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 ord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 ord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 ord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 ord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 ord"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words ({} rolls)"
+msgstr "20 ord ({} kast)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words ({} rolls)"
+msgstr "33 ord ({} kast)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Multisig-deskriptor lastet inn"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Last inn fra Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Electrum-seed"
+
+#. FORK: translated by Claude 2026-07-11
+#. label for addresses where others send us incoming payments
+#: src/seedsigner/views/tools_views.py
+msgid "Receive addresses"
+msgstr "Mottaksadresser"
+
+#. FORK: translated by Claude 2026-07-11
+#. label for addresses that collect the change from our own outgoing payments
+#: src/seedsigner/views/tools_views.py
+msgid "Change addresses"
+msgstr "Veksleadresser"
+
+#. FORK: translated by Claude 2026-07-11
+#. Multisig policy. For a "2 / 3 multisig" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/tools_views.py
+msgid "{threshold} / {n} multisig"
+msgstr "{threshold} / {n} multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "Kod tekst"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "Dekod QR-kode"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Power off"
+msgstr "Slå av"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Back to main menu"
+msgstr "Tilbake til hovedmenyen"
+
+#. FORK: translated by Claude 2026-07-11
+#. "network" will be mainnet/testnet/regtest.
+#: src/seedsigner/views/view.py
+msgid "Current network setting ({network}) doesn't match {derivation_path}."
+msgstr "Gjeldende nettverksinnstilling ({network}) samsvarer ikke med {derivation_path}."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Hardware Error"
+msgstr "Maskinvarefeil"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Cannot access camera"
+msgstr "Får ikke tilgang til kameraet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Disconnect power and check for a loose camera connection."
+msgstr "Koble fra strømmen og sjekk om kamerakontakten sitter løst."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Update setting"
+msgstr "Oppdater innstilling"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Action Required"
+msgstr "Handling kreves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid ""
+"You must remove the\n"
+"MicroSD card to continue."
+msgstr ""
+"Du må fjerne MicroSD-kortet\n"
+"for å fortsette."
+

--- a/l10n/fork/pl/messages.po
+++ b/l10n/fork/pl/messages.po
@@ -1,0 +1,2578 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-11 08:50-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pl\n"
+"Language-Team: pl <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "Dane wymazane po bezczynności"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "Uruchamianie kamery..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "Odszyfrować?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "Wybierz typ QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "Klucz szyfrowania"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "Sprawdź klucz szyfrowania"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "Numer konta"
+
+#. FORK: translated by Claude 2026-07-11
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "Zaszyfrowane"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "Zaszyfrowane bity entropii"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "Niestandardowa ścieżka!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "ID mnemonika"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "Sprawdź ID mnemonika"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "Kody QR z obu trybów mogą się różnić, ale oba są poprawne."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "Przepisz zaszyfrowany QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "Brak dostępnych opcji"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "Informacje o baterii"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "Informacje o systemie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Platform: {platform_name}"
+msgstr "Platforma: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Variant: {platform_variant}"
+msgstr "Wariant: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (CPU): {system_serial}"
+msgstr "Nr seryjny (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "Nr seryjny (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "Filtr urządzeń"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "Informacje o sieci"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "Kalibracja baterii"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "Naładuj baterię do pełna. Wybierz Dalej, aby rozpocząć test rozładowania."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "Start"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "Test trwa do rozładowania. Pozostaw urządzenie odłączone."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "Wykryto ładowanie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "Rozładowywanie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "Upłynęło: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "Napięcie: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "Prąd: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "Stan: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "NISKA ENTROPIA"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "DOBRA ENTROPIA"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "Tekst do zakodowania"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "Ustaw PIN przymusu"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option; "default" = this is the format most wallets use
+#: src/seedsigner/models/settings_definition.py
+msgid "Animated (default)"
+msgstr "Animowany (domyślnie)"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option (static = single frame, not animated)
+#: src/seedsigner/models/settings_definition.py
+msgid "Static"
+msgstr "Statyczny"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option: old format that Specter Desktop used to use
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter legacy"
+msgstr "Specter legacy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "Kamera 0"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "Kamera 1"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "Kamera 2"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "Kamera 3"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 minut"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 minut"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 minut"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 minut"
+
+#. FORK: translated by Claude 2026-07-11
+#. MicroSD notification duration setting - Display notification for 5 seconds
+#: src/seedsigner/models/settings_definition.py
+msgid "5 seconds"
+msgstr "5 sekund"
+
+#. FORK: translated by Claude 2026-07-11
+#. MicroSD notification duration setting - Display notification until the SD
+#. card is removed
+#: src/seedsigner/models/settings_definition.py
+msgid "Until SD removed"
+msgstr "Do wyjęcia karty SD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Hasło Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "Preferuj CompactSeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "Preferuj EncryptedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "Pytaj za każdym razem"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "Próby PIN karty"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "Licznik wymazywania"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "Długości Seeda"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Xpub QR format"
+msgstr "Format QR dla xpub"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "Pytaj o konto BIP32"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "Niejednoznaczny QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "Typy kluczy GPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "Wersja GPG dla BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 jest najnowsza; użyj v2, aby odtworzyć klucze B9-B10"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "Seedy SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Seedy Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "Zgodny z LND, 24 słowa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "Rozszerzalne udziały SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "MicroSD notification duration"
+msgstr "Czas powiadomienia MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "Kopie BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Kopie Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "Kopie TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "Obsługa kart inteligentnych"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Obsługa Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Obsługa Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Obsługa Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "Źródło kamery"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "Tryb desktop"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "Niebezpieczne!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Ta wersja desktopowa służy tylko do testów.\n"
+"NIE używaj prawdziwych Seedów ani kluczy."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "Rozumiem"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "Wersja deweloperska"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Ta deweloperska wersja SeedSignerOS służy tylko do testów.\n"
+"NIE używaj prawdziwych Seedów ani kluczy."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "Operacje na plikach"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "Importuj klucze"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "Eksportuj klucze"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "Pokaż klucze"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "Bezpieczne wiadomości"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "Narzędzia GPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "Brakujące pakiety"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "Wymagane, ale niezainstalowane:\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "Operacje na podkluczach"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "Operacje na ID użytkownika"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "Certyfikacja krzyżowa kluczy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "Eksportuj pakiet klucza publicznego"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "Metadane BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "Podklucze"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "Wstecz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "Eksportuj pakiet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "Animowany QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "Zapisz dane BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "Załaduj dane BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "Odtwórz klucz BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "Na MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "Do QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "Na Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "Z MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "Z QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Z Seedkeepera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "Dodaj podklucze"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "Odwołaj podklucze"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "Usuń podklucze"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "Zmień termin ważności"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "Eksportuj sekrety podkluczy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 rok"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 lata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 lat"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "Nigdy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "Plik"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "Karta inteligentna"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "Dodaj ID użytkownika"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "Edytuj ID użytkownika"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "Ustaw główny ID użytkownika"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "Odwołaj ID użytkownika"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "Usuń ID użytkownika"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "Zaszyfruj"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "Odszyfruj"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "Podpisz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "Zweryfikuj podpis"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "Utwórz wiadomość"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "Załaduj wiadomość"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "Manifest"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "Wpisz wiadomość"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Załaduj Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "Skanuj QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "Załaduj plik"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "Załaduj klucz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Zapisz na Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "Pokaż jako QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "Klucz publiczny"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "Klucz prywatny"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "Informacje o karcie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "Wygeneruj klucz na karcie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "Zmień PIN administratora"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "Zmień PIN użytkownika"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "Szyfrowanie pliku"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(Może chwilę potrwać)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "Odszyfrowywanie pliku"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "Sprawdź SHA256Sum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "Aktualizuj"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "Z pliku"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "Wygeneruj nowy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "Wyprowadź BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "Karta OpenGPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "Edytuj tekst"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "Odrzuć tekst"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "Odrzucić tekst?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "Wygeneruj kod QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "Tryb przepisywania"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "Tryb pełnoekranowy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "Tryb przepisywania?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "Potwierdź tekstowy kod QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "Potwierdzić tekstowy QR?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "Skanuj tekstowy kod QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "Potwierdź tekstowy kod QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "Przepisany tekstowy kod QR nie zgadza się z oryginalnym tekstem!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "Sprawdź tekstowy kod QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "Przepisany tekstowy kod QR został zeskanowany i dał ten sam tekst."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "Potwierdź tekstowy QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "Nie udało się odczytać przepisanego tekstowego kodu QR!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "Edytuj i wygeneruj kod QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "Odkodowany tekst"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "Uruchom test"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "Wgraj obraz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "Zweryfikuj MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "Wymaż (zera)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "Wymaż (losowo)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "Pomiń weryfikację"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "Wszystkie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "Własne"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF krótka"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF długa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "Rzuty kośćmi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "Typ hasła"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 bity"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 bitów"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 bitów"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "Siła hasła"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "Tak"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "Nie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "Wybierz opcje"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "Wybierz co najmniej jeden zestaw znaków."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "Kontrola systemowego RNG nie powiodła się."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "Błąd systemowego RNG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "Kamera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "Kości"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "Systemowy RNG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "Źródło entropii"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "Nieobsługiwane"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 obsługuje Diceware, rzuty kośćmi, Hex, Base64 i Base85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "Brak"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "Wielka litera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "Spacja"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "Separator"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 ścian"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 ścian"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 ścian"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "Ściany kości"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "Liczba rzutów"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "Nieprawidłowe dane"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "Liczba rzutów musi wynosić co najmniej 1."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "Słaba entropia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "Rzuty nie wyglądały na wystarczająco losowe. Spróbuj ponownie."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "Entropia z kamery nie wyglądała na wystarczająco losową. Spróbuj ponownie."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "OSTRZEŻENIE"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "Załaduj Seed przed użyciem BIP85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "Wybierz Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "Wybierz Seed dla BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "Indeks BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "Nieprawidłowa długość"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex obsługuje 128 lub 256 bitów."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 wymaga 120+ bitów."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 wymaga 64-512 bitów."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "Nazwa hasła"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "Za mało miejsca"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"Zapisywanie sekretu\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "Sukces"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "Hasło zapisane na Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "Za mało miejsca na Seedkeeperze na hasło"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "Niepowodzenie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "Nie udało się zapisać hasła"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "Edytuj"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "Hasło"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "Zapisz hasło"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Użyj karty Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Użyj Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "Podaj 15-wyrazowy Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "Podaj 18-wyrazowy Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "Podaj 21-wyrazowy Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "Podaj WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "Skanuj WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "Podaj BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "Skanuj BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "Fingerprint się nie zgadza"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "Karta nie może podpisać PSBT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "Fingerprint karty ({}) nie jest wśród podpisujących PSBT."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "Klucz prywatny (WIF)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "Nieprawidłowy WIF!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "To nie jest poprawny klucz prywatny w formacie WIF."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "Klucz BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "Hasło BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "Nieprawidłowy BIP38!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "Nie udało się odszyfrować klucza BIP38."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "Deskryptor się nie zgadza"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "Deskryptor wyczyszczony"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "Załadowany deskryptor multisig nie pasuje do tego PSBT. Załaduj poprawny deskryptor albo pomiń weryfikację."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "Podpisywanie PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "Przekroczono czas podpisywania"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "Ponów (dłuższy limit)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Saved as {}."
+msgstr "Zapisano jako {}."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Failed to save PSBT: {}"
+msgstr "Nie udało się zapisać PSBT: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "Kodowanie PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "Skaner QR niedostępny"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "Brak silnika skanowania QR. Zainstaluj zbar (lub OpenCV na desktopie) i uruchom ponownie."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "Wybierz typ Seeda"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "Czas ustawiony na:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "Nie udało się ustawić czasu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "Nieprawidłowy czas"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "Nie udało się odczytać czasu z QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "Skanuj udział SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "Oczekiwano QR z udziałem SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "Oczekiwano klucza prywatnego WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "Oczekiwano klucza prywatnego BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "Zeskanuj adres odbiorczy {} z właśnie wyeksportowanego portfela"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"Dane pasują do wielu\n"
+"typów QR."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "Wpisz klucz szyfrowania"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "Skanuj klucz szyfrowania"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "Edytuj klucz szyfrowania"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "Odrzuć klucz szyfrowania"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "Kontynuuj"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "Skanuj i dodaj kolejny"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "Odszyfrowany tekst"
+
+#. FORK: translated by Claude 2026-07-11
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "Nieoficjalny fork projektu:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "Kopia BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Kopia Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "Kopia TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Podaj Seed Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "Udziały SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " Skanuj SeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "Z SeedKeepera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Ze Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " Utwórz Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "Nie wykryto karty microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "Nie znaleziono kopii"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "Nie znaleziono kopii BitBox02 (.bin, .bb02, .dat, .backup) na karcie microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "Wybierz kopię BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup name: {}"
+msgstr "Nazwa kopii: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Created: {}"
+msgstr "Utworzono: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Firmware: {}"
+msgstr "Firmware: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Birthdate: {}"
+msgstr "Data utworzenia: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed length: {} words"
+msgstr "Długość Seeda: {} słów"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "Seed załadowany"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "Nie znaleziono kopii Passport (.7z) na karcie microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Wybierz kopię Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Kod kopii Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "Kod kopii nie może być pusty."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Chain: {}"
+msgstr "Sieć: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "Nie znaleziono kopii TAPSIGNER (.aes) na karcie microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "Wybierz kopię TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "Klucz kopii (hex)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "xprv załadowany z kopii TAPSIGNER."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Path: {}"
+msgstr "Ścieżka: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "Załaduj hasło"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "Wpisz hasło"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "Skanuj hasło"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "Załaduj z SeedKeepera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Hasło Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"Ten mnemonik wymaga\n"
+"hasła."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "Nieprawidłowe hasło"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Wymagane hasło Aezeed.\n"
+"Spróbuj ponownie."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Błędne hasło Aezeed.\n"
+"Spróbuj ponownie."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "Nieprawidłowy tekstowy kod QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "Wykryto dane spoza UTF-8."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Obsługa Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"Wprowadzanie Aezeed jest eksperymentalne.\n"
+"Tylko ze sprawdzonymi kopiami."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "Podaj 20 słów"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "Podaj 33 słowa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "Załaduj udział"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Share Word #{}"
+msgstr "Słowo udziału nr {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "Podaj udział"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "Skanuj udział"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "Połącz udziały"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "{} of {} needed"
+msgstr "Potrzeba {} z {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "Spróbuj ponownie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "Nieprawidłowy udział SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "Błąd sumy kontrolnej; to nie jest poprawny udział SLIP-39."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Nierozszerzalny Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Ten Seed SLIP-39 nie może generować nowych udziałów."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "Eksportuj jako niezaszyfrowany QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "Na SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "Na Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "Wygeneruj udziały ponownie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Xpub QR Format"
+msgstr "Format QR dla xpub"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "Otwórz {} i wyświetl adres odbiorczy właśnie wyeksportowanego portfela."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "twoje oprogramowanie portfela"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"Użyto hasła.\n"
+"Potrzebne będą słowa + hasło."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 słów"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "Sprawdź"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "Zakończ Seed pochodny"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "Podaj klucz szyfrowania"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "Odrzucić klucz szyfrowania?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "Wpisany klucz zostanie wymazany"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "Nieprawidłowy klucz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "Klucz jest za długi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "Wprowadzanie z kamery"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "Użyj fingerprinta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "Przypisz własne ID"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "Podaj ID mnemonika"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "Edytuj ID mnemonika"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "Odrzuć ID mnemonika"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "Odrzucić ID mnemonika?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "Wpisane ID mnemonika zostanie wymazane"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "Przetwarzanie..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "Błąd szyfrowania"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "Następne 100"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "Rozszerzone wyszukiwanie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "Nie znaleziono"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "Adres niezweryfikowany"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses with no match."
+msgstr "Sprawdzono {} adresów bez dopasowania."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "Sprawdź kolejne 10"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses per path with no match."
+msgstr "Sprawdzono {} adresów na ścieżkę bez dopasowania."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "Eksport portfela"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "Portfel wyeksportowany pomyślnie."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "Format adresu nie pasuje do eksportowanego typu skryptu. Eksport portfela nie powiódł się."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "Nie można dopasować portfela do bieżącego Seeda. Eksport nie powiódł się."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "Eksport nie powiódł się"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "Załaduj SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#. Multisig policy. For a "2 of 3" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/seed_views.py
+msgid "{threshold} of {n}"
+msgstr "{threshold} z {n}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "Eksportowanie xpub..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "Podpisywanie wiadomości..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "Weryfikacja nie powiodła się"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "Testuj kartę inteligentną"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "Lista czytników kart"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "Testuj skan NFC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "Restartuj PCSC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "Informacje o baterii"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "Informacje o systemie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "Załaduj pliki kopii"
+
+#. FORK: translated by Claude 2026-07-11
+#. Title of a warning dialog when configuring a setting that requires at least
+#. one option to be selected.
+#: src/seedsigner/views/settings_views.py
+msgid "Selection Required"
+msgstr "Wymagany wybór"
+
+#. FORK: translated by Claude 2026-07-11
+#. The name of the setting being configured (e.g. "Script types") will be
+#. inserted.
+#: src/seedsigner/views/settings_views.py
+msgid "At least one option must be selected for \"{}\"."
+msgstr "Dla \"{}\" trzeba wybrać co najmniej jedną opcję."
+
+#. FORK: translated by Claude 2026-07-11
+#. Text for the button that returns the user to the setting configuration
+#. screen.
+#: src/seedsigner/views/settings_views.py
+msgid "Return to setting"
+msgstr "Wróć do ustawienia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "Nie wykryto zgodnego monitora baterii"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "Niedostępne"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "Funkcje wspólne"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Funkcje Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Funkcje Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "Funkcje SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Funkcje Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "Narzędzia DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "Informacje o karcie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "Kontrola autentyczności"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "Zmień PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "Zmień etykietę"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "Zmień politykę NFC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "Skonfiguruj NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "Przywróć kartę do ustawień fabrycznych"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "Pokaż NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Użyj linku aplikacji Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "Wyczyść NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "Ustaw własny NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "Zapisz NDEF na SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "Załaduj NDEF z SeedKeepera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "Rekord tekstowy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "Rekord URI"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Uruchomienie aplikacji Android"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "Własny (HEX)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "Dekoduj NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC włączone"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC wyłączone"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC zablokowane"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "Kartę włożono ponownie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "Pokaż wolne miejsce"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "Pokaż sekrety na karcie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "Zapisz hasło na karcie"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "Usuń sekret z karty"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "Załaduj deskryptor multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "Zapisz deskryptor multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "Sklonuj sekrety karty"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "Wróć do ekranu głównego"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "Zainicjuj Seedem"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "Załaduj jako deskryptor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "Załaduj PSBT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "Ustaw PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "Odblokuj PIN kodem PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "Ustaw nazwę"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "Usuń Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "Test szybkości podpisywania"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "Test podpisywania wiadomości"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "Sprawdź odchylenie podpisów"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "Usuń"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "Reset"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "Włącz 2FA"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "Seed już załadowany"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"xprv nie może zainicjować Satochipa.\n"
+"Użyj BIP39, SLIP39 lub Electrum."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "Zmień PIN karty"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "Załaduj mnemonik"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "Zapisz mnemonik"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "Wymaż Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "Klucze karty"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "Zbuduj applety"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "Zainstaluj applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "Odinstaluj applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "Podaj inny PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "Załaduj klucze"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "Zapisz klucze"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "Odblokuj kartę"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "Zablokuj kartę"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "Wyczyść załadowane klucze"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "Nadpisz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "Przerwij zapis"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "Podaj jeden klucz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "Podaj zestaw kluczy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "Wygeneruj jeden klucz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "Wygeneruj zestaw kluczy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (domyślnie)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "Entropia systemowego RNG za niska. Spróbuj później."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "Entropia z systemowego RNG nie przeszła kontroli."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Nowy Seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "Seed SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "Tekstowy kod QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "Generator haseł"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "Narzędzia kart inteligentnych"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "Narzędzia MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Wyczyść deskryptor multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "Nie wykryto karty microSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "Włóż kartę microSD, aby zapisać log rozładowania."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "Nie można załadować informacji o sieci."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 słów"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 słów"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 słów"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 słów"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 słowa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words ({} rolls)"
+msgstr "20 słów ({} rzutów)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words ({} rolls)"
+msgstr "33 słowa ({} rzutów)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Deskryptor multisig załadowany"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Załaduj z Satochipa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Seed Electrum"
+
+#. FORK: translated by Claude 2026-07-11
+#. Multisig policy. For a "2 / 3 multisig" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/tools_views.py
+msgid "{threshold} / {n} multisig"
+msgstr "Multisig {threshold} / {n}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "Zakoduj tekst"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "Dekoduj kod QR"
+
+#. FORK: translated by Claude 2026-07-11
+#. "network" will be mainnet/testnet/regtest.
+#: src/seedsigner/views/view.py
+msgid "Current network setting ({network}) doesn't match {derivation_path}."
+msgstr "Bieżące ustawienie sieci ({network}) nie pasuje do {derivation_path}."
+

--- a/l10n/fork/pt_BR/messages.po
+++ b/l10n/fork/pt_BR/messages.po
@@ -1,0 +1,2493 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-11 08:48-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: pt_BR\n"
+"Language-Team: pt_BR <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "Dados apagados por inatividade"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "Iniciando a câmera..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "Descriptografar?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "Selecione o tipo de QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "Chave de criptografia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "Revisar chave de criptografia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "Número da conta"
+
+#. FORK: translated by Claude 2026-07-11
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "Criptografado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "Bits de entropia criptografados"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "Caminho fora do padrão!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "ID do mnemônico"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "Revisar ID do mnemônico"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "Os QR codes gerados nos dois modos podem diferir, mas ambos são válidos."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "Transcrever QR criptografado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "Nenhuma opção disponível"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "Info da bateria"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "Info do sistema"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Platform: {platform_name}"
+msgstr "Plataforma: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Variant: {platform_variant}"
+msgstr "Variante: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (CPU): {system_serial}"
+msgstr "Serial (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "Serial (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "Filtro de dispositivos"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "Info de rede"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "Calibração da bateria"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "Carregue a bateria totalmente. Selecione Continuar para iniciar o teste de descarga."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "Iniciar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "O teste dura até esgotar. Deixe o dispositivo desconectado."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "Carregamento detectado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "Descarregando"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "Decorrido: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "Tensão: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "Corrente: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "Status: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "ENTROPIA BAIXA"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "ENTROPIA BOA"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "Texto a codificar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "Definir PIN de coação"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "Câmera 0"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "Câmera 1"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "Câmera 2"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "Câmera 3"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 minutos"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 minutos"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 minutos"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 minutos"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Passphrase Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "Preferir CompactSeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "Preferir EncryptedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "Perguntar sempre"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "Tentativas de PIN do cartão"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "Temporizador de limpeza"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "Tamanhos de seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "Perguntar conta BIP32"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "QR ambíguo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "Tipos de chave GPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "Versão GPG do BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 é a mais recente; use v2 para recriar chaves B9-B10"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "Seeds SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Seeds Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "Compatível com LND, 24 palavras"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "Shares SLIP39 extensíveis"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "Backups BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Backups Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "Backups TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "Suporte a cartão inteligente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Suporte a Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Suporte a Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Suporte a Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "Fonte da câmera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "Modo desktop"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "Não é seguro!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Esta versão desktop é apenas para testes.\n"
+"NÃO use com seeds ou chaves privadas reais."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "Entendi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "Build de desenvolvimento"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Esta build de desenvolvimento do SeedSignerOS é apenas para testes.\n"
+"NÃO use com seeds ou chaves privadas reais."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "Operações com arquivos"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "Importar chaves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "Exportar chaves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "Ver chaves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "Mensagens seguras"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "Ferramentas GPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "Pacotes ausentes"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "Necessário, mas não instalado:\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "Operações com subchaves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "Operações com ID de usuário"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "Certificação cruzada de chaves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "Exportar pacote de chave pública"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "Metadados BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "Subchaves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "Voltar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "Exportar pacote"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "QR animado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "Salvar dados BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "Carregar dados BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "Reconstruir chave BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "Para MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "Para QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "Para Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "Do MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "Do QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Do Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "Adicionar subchaves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "Revogar subchaves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "Excluir subchaves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "Alterar validade"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "Exportar segredos das subchaves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 ano"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 anos"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 anos"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "Nunca"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "Arquivo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "Cartão inteligente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "Adicionar ID de usuário"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "Editar IDs de usuário"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "Definir ID de usuário principal"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "Revogar ID de usuário"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "Excluir ID de usuário"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "Criptografar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "Descriptografar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "Assinar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "Verificar assinatura"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "Criar mensagem"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "Carregar mensagem"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "Manifesto"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "Digitar mensagem"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Carregar Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "Ler QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "Carregar arquivo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "Carregar chave"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Salvar no Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "Mostrar como QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "Chave pública"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "Chave privada"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "Ver info do cartão"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "Gerar chave no cartão"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "Alterar PIN de admin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "Alterar PIN de usuário"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "Criptografando arquivo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(Pode demorar um pouco)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "Descriptografando arquivo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "Verificar SHA256Sum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "Atualizar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "De arquivo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "Gerar nova"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "Derivar BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "Cartão OpenGPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "Editar texto"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "Descartar texto"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "Descartar o texto?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "Gerar QR code"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "Modo transcrição"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "Modo tela cheia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "Modo transcrição?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "Confirmar QR code de texto"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "Confirmar QR de texto?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "Ler QR code de texto"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "Confirmar QR code de texto"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "Seu QR de texto transcrito não corresponde ao texto original!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "Revisar QR code de texto"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "Seu QR de texto transcrito foi lido com sucesso e produziu o mesmo texto."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "Confirmar QR de texto"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "Não foi possível ler seu QR de texto transcrito!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "Editar e gerar QR code"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "Texto decodificado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "Executar teste"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "Gravar imagem"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "Verificar MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "Apagar (zeros)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "Apagar (aleatório)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "Pular verificação"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "Todos"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "Personalizado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF curta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF longa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "Lançamentos de dados"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "Tipo de senha"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 bits"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 bits"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 bits"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "Força da senha"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "Sim"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "Não"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "Selecionar opções"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "Escolha ao menos um conjunto de caracteres."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "Falha na verificação do RNG do sistema."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "Erro do RNG do sistema"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "Câmera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "Dados"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "RNG do sistema"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "Fonte de entropia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "Não suportado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "O BIP85 suporta Diceware, lançamentos de dados, Hex, Base64 e Base85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "Nenhum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "Inicial maiúscula"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "Espaço"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "Separador"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 lados"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 lados"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 lados"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "Lados do dado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "Número de lançamentos"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "Entrada inválida"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "O número de lançamentos deve ser pelo menos 1."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "Entropia fraca"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "Os lançamentos não pareceram aleatórios o suficiente. Tente novamente."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "A entropia da câmera não pareceu aleatória o suficiente. Tente novamente."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "ATENÇÃO"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "Carregue uma seed antes de usar o BIP85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "Selecionar seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "Escolha a seed para o BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "Índice BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "Tamanho inválido"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex suporta 128 ou 256 bits."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 precisa de 120+ bits."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 precisa de 64-512 bits."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "Nome da senha"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "Espaço insuficiente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"Salvando segredo\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "Sucesso"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "Senha salva no Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "Espaço insuficiente no Seedkeeper para a senha"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "Falhou"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "Falha ao salvar a senha"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "Editar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "Senha"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "Salvar senha"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Usar cartão Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Usar Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "Inserir 15 palavras"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "Inserir 18 palavras"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "Inserir 21 palavras"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "Inserir WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "Ler WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "Inserir BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "Ler BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "Fingerprint não corresponde"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "O cartão não pode assinar o PSBT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "O fingerprint do cartão ({}) não está entre os signatários do PSBT."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "Chave privada (WIF)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "WIF inválido!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "Não é uma chave privada WIF válida."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "Chave BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "Passphrase BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "BIP38 inválido!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "Não foi possível descriptografar a chave BIP38."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "Descritor não corresponde"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "Descritor apagado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "O descritor multisig carregado não corresponde a este PSBT. Carregue o descritor correto ou pule a verificação."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "Assinando PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "Tempo de assinatura esgotado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "Tentar de novo (mais tempo)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Saved as {}."
+msgstr "Salvo como {}."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Failed to save PSBT: {}"
+msgstr "Falha ao salvar o PSBT: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "Codificando PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "Leitor de QR indisponível"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "Backend de leitura de QR ausente. Instale o zbar (ou OpenCV no desktop) e reinicie."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "Selecione o tipo de seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "Hora definida para:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "Falha ao definir a hora"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "Hora inválida"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "Não foi possível ler a hora do QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "Ler share SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "Esperado um QR de share SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "Esperada uma chave privada WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "Esperada uma chave privada BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "Leia o endereço de recebimento {} da carteira que você acabou de exportar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"Os dados correspondem a\n"
+"vários tipos de QR."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "Digitar chave de criptografia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "Ler chave de criptografia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "Editar chave de criptografia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "Descartar chave de criptografia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "Prosseguir"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "Ler e adicionar outro"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "Texto descriptografado"
+
+#. FORK: translated by Claude 2026-07-11
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "Um fork não oficial de:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "Backup BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Backup Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "Backup TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Inserir seed Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "Shares SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " Ler um SeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "Do SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Do Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " Criar uma seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "Cartão microSD não detectado."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "Nenhum backup encontrado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "Nenhum backup BitBox02 (.bin, .bb02, .dat, .backup) encontrado no cartão microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "Selecione o backup BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup name: {}"
+msgstr "Nome do backup: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Created: {}"
+msgstr "Criado: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Firmware: {}"
+msgstr "Firmware: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Birthdate: {}"
+msgstr "Data de criação: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed length: {} words"
+msgstr "Tamanho da seed: {} palavras"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "Seed carregada"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "Nenhum backup Passport (.7z) encontrado no cartão microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Selecione o backup Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Código do backup Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "O código do backup não pode ficar vazio."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Chain: {}"
+msgstr "Rede: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "Nenhum backup TAPSIGNER (.aes) encontrado no cartão microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "Selecione o backup TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "Chave do backup (hex)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "xprv carregada do backup TAPSIGNER."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Path: {}"
+msgstr "Caminho: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "Carregar passphrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "Digitar passphrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "Ler passphrase"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "Carregar do SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Passphrase Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"Este mnemônico requer\n"
+"uma passphrase."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "Passphrase inválida"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Passphrase Aezeed necessária.\n"
+"Tente novamente."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Passphrase Aezeed incorreta.\n"
+"Tente novamente."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "QR de texto inválido"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "Dados não UTF-8 detectados."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Suporte a Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"A entrada Aezeed é experimental.\n"
+"Use apenas com backups verificados."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "Inserir 20 palavras"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "Inserir 33 palavras"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "Carregar share"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Share Word #{}"
+msgstr "Palavra do share nº {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "Inserir share"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "Ler share"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "Combinar shares"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "{} of {} needed"
+msgstr "Necessários {} de {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "Tentar novamente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "Share SLIP-39 inválido"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "Falha no checksum; share SLIP-39 inválido."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Seed não extensível"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Esta seed SLIP-39 não pode regenerar novos shares."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "Exportar como QR sem criptografia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "Para SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "Para Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "Regenerar shares"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "Abra {} e exiba um endereço de recebimento da carteira que você acabou de exportar."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "seu software de carteira"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"Foi usada uma passphrase.\n"
+"Serão necessárias palavras + passphrase."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 palavras"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "Revisar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "Finalizar seed derivada"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "Inserir chave de criptografia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "Descartar chave de criptografia?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "A chave inserida será apagada"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "Chave inválida"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "A chave é longa demais."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "Entrada pela câmera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "Usar fingerprint"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "Atribuir ID personalizado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "Inserir ID do mnemônico"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "Editar ID do mnemônico"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "Descartar ID do mnemônico"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "Descartar ID do mnemônico?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "O ID do mnemônico inserido será apagado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "Processando..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "Falha na criptografia"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "Próximos 100"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "Busca ampliada"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "Não encontrado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "Endereço não verificado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses with no match."
+msgstr "{} endereços verificados sem correspondência."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "Verificar próximos 10"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses per path with no match."
+msgstr "{} endereços verificados por caminho sem correspondência."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "Exportação da carteira"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "Carteira exportada com sucesso."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "O formato do endereço não corresponde ao tipo de script exportado. Exportação da carteira falhou."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "Não foi possível associar a carteira à seed atual. Exportação da carteira falhou."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "Exportação falhou"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "Carregar SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "Exportando xpub..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "Assinando mensagem..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "Verificação falhou"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "Testar cartão inteligente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "Listar leitores de cartão"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "Testar leitura NFC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "Reiniciar PCSC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "Info da bateria"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "Info do sistema"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "Carregar arquivos de backup"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "Nenhum monitor de bateria compatível detectado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "Indisponível"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "Funções comuns"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Funções do Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Funções do Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "Funções do SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Funções do Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "Ferramentas DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "Info do cartão"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "Verificação de autenticidade"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "Alterar PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "Alterar etiqueta"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "Alterar política NFC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "Configurar NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "Restaurar cartão de fábrica"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "Ver NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Usar link do app Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "Limpar NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "Definir NDEF personalizado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "Salvar NDEF no SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "Carregar NDEF do SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "Registro de texto"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "Registro URI"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Abrir app Android"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "Personalizado (HEX)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "Decodificar NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC ativado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC desativado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC bloqueado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "Cartão reinserido"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "Ver espaço livre"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "Ver segredos no cartão"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "Salvar senha no cartão"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "Excluir segredo do cartão"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "Carregar descritor multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "Salvar descritor multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "Clonar segredos do cartão"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "Voltar ao início"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "Inicializar com seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "Carregar como descritor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "Carregar PSBT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "Definir PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "Desbloquear PIN com PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "Definir nome"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "Remover seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "Benchmark de assinatura"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "Benchmark de assinatura de mensagens"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "Verificar viés de assinatura"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "Remover"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "Redefinir"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "Ativar 2FA"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "Já tem seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"Uma xprv não pode inicializar o Satochip.\n"
+"Use BIP39, SLIP39 ou Electrum."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "Alterar PIN do cartão"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "Carregar mnemônico"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "Salvar mnemônico"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "Apagar seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "Chaves do cartão"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "Compilar applets"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "Instalar applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "Desinstalar applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "Inserir outro PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "Carregar chaves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "Salvar chaves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "Desbloquear cartão"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "Bloquear cartão"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "Limpar chaves carregadas"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "Sobrescrever"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "Cancelar salvamento"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "Inserir chave única"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "Inserir conjunto de chaves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "Gerar chave única"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "Gerar conjunto de chaves"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (padrão)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "Entropia do RNG do sistema muito baixa. Tente mais tarde."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "A entropia derivada do RNG do sistema falhou nas verificações."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Nova seed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "Seed SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "QR de texto"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "Gerador de senhas"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "Ferramentas de cartão inteligente"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "Ferramentas MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Limpar descritor multisig"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "Cartão microSD não detectado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "Insira um cartão microSD para salvar o log de descarga."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "Não foi possível carregar as informações de rede."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 palavras"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 palavras"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 palavras"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 palavras"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 palavras"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words ({} rolls)"
+msgstr "20 palavras ({} lançamentos)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words ({} rolls)"
+msgstr "33 palavras ({} lançamentos)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Descritor multisig carregado"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Carregar do Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Seed Electrum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "Codificar texto"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "Decodificar QR code"
+

--- a/l10n/fork/ru/messages.po
+++ b/l10n/fork/ru/messages.po
@@ -1,0 +1,2870 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-11 08:52-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ru\n"
+"Language-Team: ru <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "Данные стёрты из-за бездействия"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Review Transaction"
+msgstr "Проверка транзакции"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Review details"
+msgstr "Проверить детали"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Transaction Math"
+msgstr "Расчёты транзакции"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Review recipients"
+msgstr "Проверить получателей"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Sign Transaction"
+msgstr "Подписать транзакцию"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "Запуск камеры..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "Расшифровать?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "Выберите тип QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "Ключ шифрования"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "Проверить ключ шифрования"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/screen.py
+msgid "I understand"
+msgstr "Понимаю"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "Номер счёта"
+
+#. FORK: translated by Claude 2026-07-11
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "Зашифровано"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "Зашифрованные биты энтропии"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "Нестандартный путь!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Sign message"
+msgstr "Подписать сообщение"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "ID мнемоники"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "Проверить ID мнемоники"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "QR-коды двух режимов могут отличаться, но оба действительны."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "Перепись зашифрованного QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "Нет доступных вариантов"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "О батарее"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "О системе"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Platform: {platform_name}"
+msgstr "Платформа: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Variant: {platform_variant}"
+msgstr "Вариант: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (CPU): {system_serial}"
+msgstr "Серийный № (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "Серийный № (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "Фильтр устройств"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "О сети"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "Калибровка батареи"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "Полностью зарядите батарею. Нажмите Далее, чтобы начать тест разряда."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "Старт"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "Тест идёт до полного разряда. Не подключайте устройство к питанию."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "Обнаружена зарядка"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "Разрядка"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "Прошло: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "Напряжение: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "Ток: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "Статус: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "НИЗКАЯ ЭНТРОПИЯ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "ХОРОШАЯ ЭНТРОПИЯ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "Текст для кодирования"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "Задать PIN принуждения"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option; "default" = this is the format most wallets use
+#: src/seedsigner/models/settings_definition.py
+msgid "Animated (default)"
+msgstr "Анимированный (по умолчанию)"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option (static = single frame, not animated)
+#: src/seedsigner/models/settings_definition.py
+msgid "Static"
+msgstr "Статичный"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option: old format that Specter Desktop used to use
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter legacy"
+msgstr "Specter legacy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "Камера 0"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "Камера 1"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "Камера 2"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "Камера 3"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 минут"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 минут"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 минут"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 минут"
+
+#. FORK: translated by Claude 2026-07-11
+#. MicroSD notification duration setting - Display notification for 5 seconds
+#: src/seedsigner/models/settings_definition.py
+msgid "5 seconds"
+msgstr "5 секунд"
+
+#. FORK: translated by Claude 2026-07-11
+#. MicroSD notification duration setting - Display notification until the SD
+#. card is removed
+#: src/seedsigner/models/settings_definition.py
+msgid "Until SD removed"
+msgstr "До извлечения SD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Кодовая фраза Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "Предпочитать CompactSeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "Предпочитать EncryptedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "Спрашивать каждый раз"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "Попытки PIN карты"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "Таймер стирания"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "Длины сида"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Xpub QR format"
+msgstr "Формат QR для xpub"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "Запрашивать счёт BIP32"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "Неоднозначный QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "Типы ключей GPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "Версия GPG для BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 — новейшая; используйте v2 для воссоздания ключей B9-B10"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "Сиды SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Сиды Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "Совместимо с LND, 24 слова"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "Расширяемые доли SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "MicroSD notification duration"
+msgstr "Длительность уведомления MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "Резервные копии BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Резервные копии Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "Резервные копии TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "Поддержка смарт-карт"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Поддержка Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Поддержка Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Поддержка Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#. Hardware settings option to specify the screen driver (e.g. st7789 vs
+#. ili9341)
+#: src/seedsigner/models/settings_definition.py
+msgid "Display type"
+msgstr "Тип дисплея"
+
+#. FORK: translated by Claude 2026-07-11
+#. Hardware settings option to invert how the screen driver displays colors.
+#: src/seedsigner/models/settings_definition.py
+msgid "Invert colors"
+msgstr "Инвертировать цвета"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "Источник камеры"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "Режим ПК"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "Небезопасно!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Эта версия для ПК — только для тестов.\n"
+"НЕ используйте настоящие сиды и ключи."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "Понимаю"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "Тестовая сборка"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Эта тестовая сборка SeedSignerOS — только для тестов.\n"
+"НЕ используйте настоящие сиды и ключи."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "Операции с файлами"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "Импорт ключей"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "Экспорт ключей"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "Просмотр ключей"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "Защищённые сообщения"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "Инструменты GPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "Отсутствуют пакеты"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "Требуется, но не установлено:\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "Операции с подключами"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "Операции с ID пользователя"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "Перекрёстная сертификация ключей"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "Экспорт пакета открытого ключа"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "Метаданные BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "Подключи"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "Назад"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "Экспорт пакета"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "Анимированный QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "Сохранить данные BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "Загрузить данные BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "Восстановить ключ BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "На MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "В QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "На Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "С MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "Из QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Из Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "Добавить подключи"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "Отозвать подключи"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "Удалить подключи"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "Изменить срок действия"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "Экспорт секретов подключей"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 год"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 года"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 лет"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "Никогда"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "Файл"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "Смарт-карта"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "Добавить ID пользователя"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "Изменить ID пользователя"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "Назначить основной ID пользователя"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "Отозвать ID пользователя"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "Удалить ID пользователя"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "Зашифровать"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "Расшифровать"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "Подписать"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "Проверить подпись"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "Создать сообщение"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "Загрузить сообщение"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "Манифест"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "Ввести сообщение"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Загрузить Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "Сканировать QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "Загрузить файл"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "Загрузить ключ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Сохранить на Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "Показать как QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "Открытый ключ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "Закрытый ключ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "О карте"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "Создать ключ на карте"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "Сменить PIN админа"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "Сменить PIN пользователя"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "Шифрование файла"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(Может занять время)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "Расшифровка файла"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "Проверить SHA256Sum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "Обновить"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "Из файла"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "Создать новый"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "Вывести BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "Карта OpenGPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "Изменить текст"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "Сбросить текст"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "Сбросить текст?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "Создать QR-код"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "Режим переписи"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "Полноэкранный режим"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "Режим переписи?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "Подтвердить текстовый QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "Подтвердить текстовый QR?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "Сканировать текстовый QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "Подтвердить текстовый QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "Переписанный текстовый QR не совпадает с исходным текстом!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "Проверить текстовый QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "Переписанный текстовый QR успешно отсканирован и дал тот же текст."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "Подтвердить текстовый QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "Не удалось прочитать переписанный текстовый QR!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "Изменить и создать QR-код"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "Декодированный текст"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "Запустить тест"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "Записать образ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "Проверить MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "Стереть (нули)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "Стереть (случайно)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "Пропустить проверку"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "Все"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "Свой"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF короткий"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF длинный"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "Броски кубиков"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "Тип пароля"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 бита"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 бит"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 бит"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "Стойкость пароля"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "Да"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "Нет"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "Выбрать параметры"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "Выберите хотя бы один набор символов."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "Проверка системного ГСЧ не пройдена."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "Ошибка системного ГСЧ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "Камера"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "Кубики"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "Системный ГСЧ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "Источник энтропии"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "Не поддерживается"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 поддерживает Diceware, броски кубиков, Hex, Base64 и Base85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "Нет"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "С заглавной буквы"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "Пробел"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "Разделитель"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 граней"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 граней"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 граней"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "Грани кубика"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "Число бросков"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "Неверный ввод"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "Число бросков должно быть не меньше 1."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "Слабая энтропия"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "Броски выглядят недостаточно случайными. Попробуйте ещё раз."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "Энтропия камеры выглядит недостаточно случайной. Попробуйте ещё раз."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "ВНИМАНИЕ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "Загрузите сид перед использованием BIP85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "Выбрать сид"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "Выберите сид для BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "Индекс BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "Неверная длина"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex поддерживает 128 или 256 бит."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 требует 120+ бит."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 требует 64-512 бит."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "Имя пароля"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "Недостаточно места"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"Сохранение секрета\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "Успех"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "Пароль сохранён на Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "На Seedkeeper недостаточно места для пароля"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "Не удалось"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "Не удалось сохранить пароль"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "Изменить"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "Пароль"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "Сохранить пароль"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Использовать карту Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Использовать Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "Ввести сид из 15 слов"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "Ввести сид из 18 слов"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "Ввести сид из 21 слова"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "Ввести WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "Сканировать WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "Ввести BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "Сканировать BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "Отпечаток не совпадает"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "Карта не может подписать PSBT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "Отпечатка карты ({}) нет среди подписантов PSBT."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "Закрытый ключ (WIF)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "Неверный WIF!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "Это не корректный закрытый ключ в формате WIF."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "Ключ BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "Кодовая фраза BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "Неверный BIP38!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "Не удалось расшифровать ключ BIP38."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction has unsupported input script type, please verify your change addresses."
+msgstr "У транзакции неподдерживаемый тип входного скрипта; проверьте адреса сдачи."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "This transaction spends its entire input value. No change is coming back to your wallet."
+msgstr "Транзакция тратит всю входную сумму. Сдача в кошелёк не вернётся."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Next recipient"
+msgstr "Следующий получатель"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Skip verification"
+msgstr "Пропустить проверку"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Verify multisig change"
+msgstr "Проверить сдачу мультиподписи"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Verify multisig addr"
+msgstr "Проверить адрес мультиподписи"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "Дескриптор не совпадает"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "Дескриптор сброшен"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "Загруженный дескриптор мультиподписи не соответствует этому PSBT. Загрузите верный дескриптор или пропустите проверку."
+
+#. FORK: translated by Claude 2026-07-11
+#. Variable is either "change" or "self-transfer".
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction's {} address could not be verified from wallet descriptor."
+msgstr "Адрес {} транзакции не удалось проверить по дескриптору кошелька."
+
+#. FORK: translated by Claude 2026-07-11
+#. Variable is either "change" or "self-transfer".
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction's {} address could not be generated from your seed."
+msgstr "Адрес {} транзакции не удалось получить из вашего сида."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Suspicious Transaction"
+msgstr "Подозрительная транзакция"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Discard transaction"
+msgstr "Сбросить транзакцию"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Approve transaction"
+msgstr "Одобрить транзакцию"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "Подписание PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "Тайм-аут подписания"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "Повторить (больше времени)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Saved as {}."
+msgstr "Сохранено как {}."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Failed to save PSBT: {}"
+msgstr "Не удалось сохранить PSBT: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "Кодирование PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Select different seed"
+msgstr "Выбрать другой сид"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction Error"
+msgstr "Ошибка транзакции"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "Сканер QR недоступен"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "Отсутствует модуль сканирования QR. Установите zbar (или OpenCV на ПК) и перезапустите."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "Выберите тип сида"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "Время установлено:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "Не удалось установить время"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "Неверное время"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "Не удалось прочитать время из QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan Transaction"
+msgstr "Сканировать транзакцию"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a transaction"
+msgstr "Ожидалась транзакция"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "Сканировать долю SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "Ожидался QR доли SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "Ожидался закрытый ключ WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "Ожидался закрытый ключ BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "Отсканируйте адрес получения {} из только что экспортированного кошелька"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"Данные соответствуют\n"
+"нескольким типам QR."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "Ввести ключ шифрования"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "Сканировать ключ шифрования"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "Изменить ключ шифрования"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "Сбросить ключ шифрования"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "Продолжить"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "Сканировать и добавить ещё"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/view.py
+msgid "Back to Main Menu"
+msgstr "В главное меню"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "Расшифрованный текст"
+
+#. FORK: translated by Claude 2026-07-11
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "Неофициальный форк проекта:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "Резервная копия BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Резервная копия Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "Резервная копия TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Ввести сид Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "Доли SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " Сканировать SeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "Из SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Из Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " Создать сид"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load a Seed"
+msgstr "Загрузить сид"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "Карта microSD не обнаружена."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "Резервные копии не найдены"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "На карте microSD не найдены резервные копии BitBox02 (.bin, .bb02, .dat, .backup)."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "Выберите копию BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup name: {}"
+msgstr "Имя копии: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Created: {}"
+msgstr "Создана: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Firmware: {}"
+msgstr "Прошивка: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Birthdate: {}"
+msgstr "Дата создания: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed length: {} words"
+msgstr "Длина сида: {} слов"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "Сид загружен"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "На карте microSD не найдены резервные копии Passport (.7z)."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Выберите копию Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Код копии Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "Код копии не может быть пустым."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Chain: {}"
+msgstr "Сеть: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "На карте microSD не найдены резервные копии TAPSIGNER (.aes)."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "Выберите копию TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "Ключ копии (hex)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "xprv загружен из копии TAPSIGNER."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Path: {}"
+msgstr "Путь: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review & edit"
+msgstr "Проверить и изменить"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "Загрузить кодовую фразу"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "Ввести кодовую фразу"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "Сканировать кодовую фразу"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "Загрузить из SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Кодовая фраза Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"Для этой мнемоники требуется\n"
+"кодовая фраза."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "Неверная кодовая фраза"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Требуется кодовая фраза Aezeed.\n"
+"Попробуйте ещё раз."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Неверная кодовая фраза Aezeed.\n"
+"Попробуйте ещё раз."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Skip passphrase"
+msgstr "Пропустить кодовую фразу"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current passphrase entry will be erased."
+msgstr "Введённая кодовая фраза будет стёрта."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Skip passphrase?"
+msgstr "Пропустить кодовую фразу?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "You have not entered a passphrase yet."
+msgstr "Вы ещё не ввели кодовую фразу."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "Неверный текстовый QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "Обнаружены данные не в UTF-8."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Keep seed"
+msgstr "Оставить сид"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Поддержка Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"Ввод Aezeed — экспериментальный.\n"
+"Только с проверенными копиями."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Electrum Warning"
+msgstr "Предупреждение Electrum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "Ввести 20 слов"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "Ввести 33 слова"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "Загрузить долю"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Share Word #{}"
+msgstr "Слово доли №{}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "Ввести долю"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "Сканировать долю"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "Объединить доли"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "{} of {} needed"
+msgstr "Нужно {} из {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "Попробовать снова"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "Неверная доля SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "Ошибка контрольной суммы; это не корректная доля SLIP-39."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Нерасширяемый сид"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Этот сид SLIP-39 не может создавать новые доли."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan transaction"
+msgstr "Сканировать транзакцию"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export xpub"
+msgstr "Экспорт xpub"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Address explorer"
+msgstr "Обзор адресов"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup seed"
+msgstr "Резервная копия сида"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "BIP-85 child seed"
+msgstr "Дочерний сид BIP-85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard seed"
+msgstr "Сбросить сид"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "View seed words"
+msgstr "Показать слова сида"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "Экспорт как незашифрованный QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "На SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "На Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "Создать доли заново"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Xpub QR Format"
+msgstr "Формат QR для xpub"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "Откройте {} и выведите адрес получения из только что экспортированного кошелька."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "ваше кошелёк-приложение"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"Использовалась кодовая фраза.\n"
+"Понадобятся слова + фраза."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 слов"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Try again"
+msgstr "Попробовать снова"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "Проверить"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "Завершить дочерний сид"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review seed words"
+msgstr "Проверить слова сида"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "Ввести ключ шифрования"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "Сбросить ключ шифрования?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "Введённый ключ будет стёрт"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "Неверный ключ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "Ключ слишком длинный."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "Ввод с камеры"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "Использовать отпечаток"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "Назначить свой ID"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "Ввести ID мнемоники"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "Изменить ID мнемоники"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "Сбросить ID мнемоники"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "Сбросить ID мнемоники?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "Введённый ID мнемоники будет стёрт"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "Обработка..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "Сбой шифрования"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "Следующие 100"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "Расширенный поиск"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "Не найдено"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "Адрес не подтверждён"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses with no match."
+msgstr "Проверено {} адресов, совпадений нет."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "Проверить ещё 10"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses per path with no match."
+msgstr "Проверено {} адресов на путь, совпадений нет."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "Экспорт кошелька"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "Кошелёк успешно экспортирован."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "Формат адреса не соответствует экспортированному типу скрипта. Экспорт не удался."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "Не удалось сопоставить кошелёк с текущим сидом. Экспорт не удался."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "Экспорт не удался"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "Загрузить SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Return to transaction"
+msgstr "Вернуться к транзакции"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Verify addr"
+msgstr "Проверить адрес"
+
+#. FORK: translated by Claude 2026-07-11
+#. Multisig policy. For a "2 of 3" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/seed_views.py
+msgid "{threshold} of {n}"
+msgstr "{threshold} из {n}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "Экспорт xpub..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "Подписание сообщения..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "Проверка не пройдена"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Hardware"
+msgstr "Оборудование"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "Проверить смарт-карту"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "Список считывателей карт"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "Проверить сканирование NFC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "Перезапустить PCSC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "О батарее"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "О системе"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "Загрузить файлы копий"
+
+#. FORK: translated by Claude 2026-07-11
+#. Title of a warning dialog when configuring a setting that requires at least
+#. one option to be selected.
+#: src/seedsigner/views/settings_views.py
+msgid "Selection Required"
+msgstr "Требуется выбор"
+
+#. FORK: translated by Claude 2026-07-11
+#. The name of the setting being configured (e.g. "Script types") will be
+#. inserted.
+#: src/seedsigner/views/settings_views.py
+msgid "At least one option must be selected for \"{}\"."
+msgstr "Для \"{}\" нужно выбрать хотя бы один вариант."
+
+#. FORK: translated by Claude 2026-07-11
+#. Text for the button that returns the user to the setting configuration
+#. screen.
+#: src/seedsigner/views/settings_views.py
+msgid "Return to setting"
+msgstr "Вернуться к настройке"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "Совместимый монитор батареи не обнаружен"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "Недоступно"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "Общие функции"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Функции Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Функции Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "Функции SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Функции Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "Инструменты DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "О карте"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "Проверка подлинности"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "Сменить PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "Сменить метку"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "Сменить политику NFC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "Настроить NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "Сброс карты к заводским настройкам"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "Просмотр NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Использовать ссылку приложения Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "Очистить NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "Задать свой NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "Сохранить NDEF на SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "Загрузить NDEF из SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "Текстовая запись"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "Запись URI"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Запуск Android-приложения"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "Свой (HEX)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "Декодировать NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC включён"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC выключен"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC заблокирован"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "Карта вставлена заново"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "Свободное место"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "Секреты на карте"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "Сохранить пароль на карту"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "Удалить секрет с карты"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "Загрузить дескриптор мультиподписи"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "Сохранить дескриптор мультиподписи"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "Клонировать секреты карты"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "На главный экран"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "Инициализировать сидом"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "Загрузить как дескриптор"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "Загрузить PSBT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "Задать PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "Разблокировать PIN кодом PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "Задать имя"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "Убрать сид"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "Тест скорости подписи"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "Тест подписи сообщений"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "Проверить смещение подписей"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "Убрать"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "Сброс"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "Включить 2FA"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "Сид уже загружен"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"xprv не может инициализировать Satochip.\n"
+"Используйте BIP39, SLIP39 или Electrum."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "Сменить PIN карты"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "Загрузить мнемонику"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "Сохранить мнемонику"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "Стереть сид"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "Ключи карты"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "Собрать апплеты"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "Установить апплет"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "Удалить апплет"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "Ввести другой PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "Загрузить ключи"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "Сохранить ключи"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "Разблокировать карту"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "Заблокировать карту"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "Очистить загруженные ключи"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "Перезаписать"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "Отменить сохранение"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "Ввести один ключ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "Ввести набор ключей"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "Создать один ключ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "Создать набор ключей"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (по умолчанию)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "Энтропия системного ГСЧ слишком мала. Попробуйте позже."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "Энтропия системного ГСЧ не прошла проверки."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Новый сид"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "Сид SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Verify address"
+msgstr "Проверить адрес"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "Текстовый QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "Генератор паролей"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "Инструменты смарт-карт"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "Инструменты MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Сбросить дескриптор мультиподписи"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "Карта microSD не обнаружена"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "Вставьте карту microSD для сохранения журнала разряда."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "Не удалось загрузить сведения о сети."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 слов"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 слов"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 слово"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 слов"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 слова"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words ({} rolls)"
+msgstr "20 слов ({} бросков)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words ({} rolls)"
+msgstr "33 слова ({} бросков)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Дескриптор мультиподписи загружен"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Загрузить из Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Сид Electrum"
+
+#. FORK: translated by Claude 2026-07-11
+#. label for addresses where others send us incoming payments
+#: src/seedsigner/views/tools_views.py
+msgid "Receive addresses"
+msgstr "Адреса получения"
+
+#. FORK: translated by Claude 2026-07-11
+#. label for addresses that collect the change from our own outgoing payments
+#: src/seedsigner/views/tools_views.py
+msgid "Change addresses"
+msgstr "Адреса сдачи"
+
+#. FORK: translated by Claude 2026-07-11
+#. Multisig policy. For a "2 / 3 multisig" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/tools_views.py
+msgid "{threshold} / {n} multisig"
+msgstr "Мультиподпись {threshold} / {n}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "Закодировать текст"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "Декодировать QR-код"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Power off"
+msgstr "Выключить"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Back to main menu"
+msgstr "В главное меню"
+
+#. FORK: translated by Claude 2026-07-11
+#. "network" will be mainnet/testnet/regtest.
+#: src/seedsigner/views/view.py
+msgid "Current network setting ({network}) doesn't match {derivation_path}."
+msgstr "Текущая настройка сети ({network}) не соответствует {derivation_path}."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Hardware Error"
+msgstr "Аппаратная ошибка"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Cannot access camera"
+msgstr "Нет доступа к камере"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Disconnect power and check for a loose camera connection."
+msgstr "Отключите питание и проверьте подключение камеры."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Update setting"
+msgstr "Обновить настройку"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Action Required"
+msgstr "Требуется действие"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid ""
+"You must remove the\n"
+"MicroSD card to continue."
+msgstr ""
+"Извлеките карту MicroSD,\n"
+"чтобы продолжить."
+

--- a/l10n/fork/th/messages.po
+++ b/l10n/fork/th/messages.po
@@ -1,0 +1,2516 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-12 08:10-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: th\n"
+"Language-Team: th <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "ล้างข้อมูลหลังไม่มีการใช้งาน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "กำลังเริ่มกล้อง..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "ถอดรหัสหรือไม่?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "เลือกชนิด QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "กุญแจเข้ารหัส"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "ตรวจสอบกุญแจเข้ารหัส"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "หมายเลขบัญชี"
+
+#. FORK: translated by Claude 2026-07-12
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "เข้ารหัสแล้ว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "บิตเอนโทรปีที่เข้ารหัส"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "เส้นทางไม่มาตรฐาน!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "รหัส Mnemonic"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "ตรวจสอบรหัส Mnemonic"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "QR ที่ได้จากทั้งสองโหมดอาจต่างกัน แต่ทั้งคู่ใช้งานได้"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "คัดลอก QR ที่เข้ารหัส"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "ไม่มีตัวเลือก"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "ข้อมูลแบตเตอรี่"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "ข้อมูลระบบ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Platform: {platform_name}"
+msgstr "แพลตฟอร์ม: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Variant: {platform_variant}"
+msgstr "รุ่นย่อย: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Serial (CPU): {system_serial}"
+msgstr "ซีเรียล (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "ซีเรียล (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "ตัวกรองอุปกรณ์"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "ข้อมูลเครือข่าย"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "ปรับเทียบแบตเตอรี่"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "ชาร์จแบตเตอรี่ให้เต็ม เลือกถัดไปเพื่อเริ่มทดสอบการคายประจุ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "เริ่ม"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "ทดสอบจนแบตหมด อย่าเสียบสายไฟ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "ตรวจพบการชาร์จ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "กำลังคายประจุ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "เวลาที่ผ่าน: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "แรงดัน: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "กระแส: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "สถานะ: "
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "เอนโทรปีต่ำ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "เอนโทรปีดี"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "ข้อความที่จะเข้ารหัส"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "ตั้ง PIN ฉุกเฉิน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "กล้อง 0"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "กล้อง 1"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "กล้อง 2"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "กล้อง 3"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 นาที"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 นาที"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 นาที"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 นาที"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "รหัสเสริม Aezeed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "เลือก CompactSeedQR ก่อน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "เลือก EncryptedQR ก่อน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "ถามทุกครั้ง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "จำนวนครั้งใส่ PIN สมาร์ตการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "ตัวจับเวลาล้างข้อมูล"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "จำนวนคำ Seed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "แจ้งบัญชี BIP32"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "QR ไม่ชัดเจน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "ชนิดกุญแจ GPG"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "เวอร์ชัน GPG ของ BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 ล่าสุด; ใช้ v2 เพื่อสร้างกุญแจ B9-B10 ใหม่"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "Seed แบบ SLIP39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Seed แบบ Aezeed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "รองรับ LND, 24 คำ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "ส่วน SLIP39 ที่ขยายได้"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "ข้อมูลสำรอง BitBox02"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "ข้อมูลสำรอง Passport"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "ข้อมูลสำรอง TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "รองรับสมาร์ตการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "รองรับ Satochip"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "รองรับ Keycard"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "รองรับ Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "แหล่งกล้อง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "โหมดเดสก์ท็อป"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "ไม่ปลอดภัย!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"เวอร์ชันเดสก์ท็อปนี้ใช้ทดสอบเท่านั้น\n"
+"อย่าใช้กับ Seed หรือกุญแจส่วนตัวจริง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "ฉันเข้าใจ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "รุ่นสำหรับพัฒนา"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"รุ่นพัฒนา SeedSignerOS นี้ใช้ทดสอบเท่านั้น\n"
+"อย่าใช้กับ Seed หรือกุญแจส่วนตัวจริง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "การจัดการไฟล์"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "นำเข้ากุญแจ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "ส่งออกกุญแจ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "ดูกุญแจ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "การส่งข้อความแบบปลอดภัย"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "เครื่องมือ GPG"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "ขาดแพ็กเกจ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "จำเป็นแต่ยังไม่ได้ติดตั้ง:\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "การจัดการกุญแจย่อย"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "การจัดการ User ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "รับรองกุญแจข้ามกัน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "ส่งออกชุดกุญแจสาธารณะ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "ข้อมูลเมตา BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "กุญแจย่อย"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "ย้อนกลับ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "ส่งออกชุด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "QR แบบเคลื่อนไหว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "บันทึกข้อมูล BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "โหลดข้อมูล BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "สร้างกุญแจ BIP85 ใหม่"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "ไปยัง MicroSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "ไปยัง QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "ไปยัง Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "จาก MicroSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "จาก QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "จาก Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "เพิ่มกุญแจย่อย"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "เพิกถอนกุญแจย่อย"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "ลบกุญแจย่อย"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "เปลี่ยนวันหมดอายุ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "ส่งออกความลับกุญแจย่อย"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 ปี"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 ปี"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 ปี"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "ไม่มีวันหมดอายุ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "ไฟล์"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "สมาร์ตการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "เพิ่ม User ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "แก้ไข User ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "ตั้ง User ID หลัก"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "เพิกถอน User ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "ลบ User ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "เข้ารหัส"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "ถอดรหัส"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "เซ็น"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "ตรวจสอบลายเซ็น"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "สร้างข้อความ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "โหลดข้อความ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "รายการไฟล์"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "พิมพ์ข้อความ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "โหลด Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "สแกน QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "โหลดไฟล์"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "โหลดกุญแจ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "บันทึกไปยัง Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "แสดงเป็น QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "กุญแจสาธารณะ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "กุญแจส่วนตัว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "ดูข้อมูลการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "สร้างกุญแจบนการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "เปลี่ยน PIN ผู้ดูแล"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "เปลี่ยน PIN ผู้ใช้"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "กำลังเข้ารหัสไฟล์"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(อาจใช้เวลาสักครู่)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "กำลังถอดรหัสไฟล์"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "ตรวจสอบ SHA256Sum"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "อัปเดต"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "จากไฟล์"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "สร้างใหม่"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "สืบทอด BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "การ์ด OpenGPG"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "แก้ไขข้อความ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "ทิ้งข้อความ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "ทิ้งข้อความหรือไม่?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "สร้าง QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "โหมดคัดลอก"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "โหมดเต็มจอ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "โหมดคัดลอก?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "ยืนยัน QR ข้อความ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "ยืนยัน QR ข้อความ?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "สแกน QR ข้อความ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "ยืนยัน QR ข้อความ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "QR ข้อความที่คัดลอกไม่ตรงกับข้อความต้นฉบับ!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "ตรวจสอบ QR ข้อความ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "สแกน QR ข้อความที่คัดลอกสำเร็จและได้ข้อความเดิม"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "ยืนยัน QR ข้อความ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "อ่าน QR ข้อความที่คัดลอกไม่ได้!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "แก้ไขและสร้าง QR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "ข้อความที่ถอดรหัส"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "รันการทดสอบ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "แฟลชอิมเมจ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "ตรวจสอบ MicroSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "ล้าง (ศูนย์)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "ล้าง (สุ่ม)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "ข้ามการตรวจสอบ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "ทั้งหมด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "กำหนดเอง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF สั้น"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF ยาว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "ทอยลูกเต๋า"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "ชนิดรหัสผ่าน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 บิต"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 บิต"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 บิต"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "ความแข็งแรงของรหัสผ่าน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "ใช่"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "ไม่"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "เลือกตัวเลือก"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "เลือกชุดอักขระอย่างน้อยหนึ่งชุด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "การตรวจสอบ RNG ของระบบล้มเหลว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "ข้อผิดพลาด RNG ของระบบ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "กล้อง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "ลูกเต๋า"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "RNG ของระบบ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "แหล่งเอนโทรปี"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "ไม่รองรับ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 รองรับ Diceware, ทอยลูกเต๋า, Hex, Base64 และ Base85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "ไม่มี"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "ตัวพิมพ์ใหญ่นำหน้า"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "เว้นวรรค"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "ตัวคั่น"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 หน้า"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 หน้า"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 หน้า"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "จำนวนหน้าลูกเต๋า"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "จำนวนครั้งที่ทอย"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "ข้อมูลไม่ถูกต้อง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "จำนวนครั้งที่ทอยต้องอย่างน้อย 1"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "เอนโทรปีต่ำ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "การทอยลูกเต๋าดูสุ่มไม่พอ โปรดลองอีกครั้ง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "เอนโทรปีจากกล้องดูสุ่มไม่พอ โปรดลองอีกครั้ง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "คำเตือน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "โหลด Seed ก่อนใช้ BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "เลือก Seed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "เลือก Seed สำหรับ BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "ดัชนี BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "ความยาวไม่ถูกต้อง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex รองรับ 128 หรือ 256 บิต"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 ต้องการ 120 บิตขึ้นไป"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 ต้องการ 64-512 บิต"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "ชื่อรหัสผ่าน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "พื้นที่ไม่พอ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"กำลังบันทึกความลับ\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "สำเร็จ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "บันทึกรหัสผ่านไปยัง Seedkeeper แล้ว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "พื้นที่บน Seedkeeper ไม่พอสำหรับรหัสผ่าน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "ล้มเหลว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "บันทึกรหัสผ่านล้มเหลว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "แก้ไข"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "รหัสผ่าน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "บันทึกรหัสผ่าน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "ใช้การ์ด Satochip"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "ใช้ Keycard"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "ป้อน Seed 15 คำ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "ป้อน Seed 18 คำ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "ป้อน Seed 21 คำ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "ป้อน WIF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "สแกน WIF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "ป้อน BIP38"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "สแกน BIP38"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "ลายนิ้วมือไม่ตรงกัน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "การ์ดเซ็น PSBT นี้ไม่ได้"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "ลายนิ้วมือการ์ด ({}) ไม่อยู่ในผู้เซ็น PSBT"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "กุญแจส่วนตัว (WIF)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "WIF ไม่ถูกต้อง!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "ไม่ใช่กุญแจส่วนตัวรูปแบบ WIF ที่ถูกต้อง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "กุญแจ BIP38"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "รหัสเสริม BIP38"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "BIP38 ไม่ถูกต้อง!"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "ถอดรหัสกุญแจ BIP38 ไม่ได้"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "descriptor ไม่ตรงกัน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "ล้าง descriptor แล้ว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "descriptor กระเป๋าเงิน multisig ที่โหลดไม่ตรงกับ PSBT นี้ โหลด descriptor ที่ถูกต้องหรือข้ามการตรวจสอบเพื่อดำเนินต่อ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "กำลังเซ็น PSBT..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "หมดเวลาการเซ็น"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "ลองใหม่ (เพิ่มเวลา)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Saved as {}."
+msgstr "บันทึกเป็น {} แล้ว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Failed to save PSBT: {}"
+msgstr "บันทึก PSBT ล้มเหลว: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "กำลังเข้ารหัส PSBT..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "เครื่องสแกน QR ไม่พร้อมใช้"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "ไม่มีแบ็กเอนด์สแกน QR ติดตั้ง zbar (หรือ OpenCV บนเดสก์ท็อป) แล้วรีสตาร์ต"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "เลือกชนิด Seed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "ตั้งเวลาเป็น:"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "ตั้งเวลาล้มเหลว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "เวลาไม่ถูกต้อง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "อ่านเวลาจาก QR ไม่ได้"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "สแกนส่วน SLIP-39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "ต้องการ QR ส่วน SLIP-39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "ต้องการกุญแจส่วนตัว WIF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "ต้องการกุญแจส่วนตัว BIP38"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+#, python-brace-format
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "สแกนที่อยู่รับ {} จากกระเป๋าเงินที่คุณเพิ่งส่งออก"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"ข้อมูลตรงกับชนิด QR\n"
+"หลายแบบ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "พิมพ์กุญแจเข้ารหัส"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "สแกนกุญแจเข้ารหัส"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "แก้ไขกุญแจเข้ารหัส"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "ทิ้งกุญแจเข้ารหัส"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "ดำเนินการต่อ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "สแกนและเพิ่มอีก"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "ข้อความที่ถอดรหัส"
+
+#. FORK: translated by Claude 2026-07-12
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "fork ที่ไม่เป็นทางการของ:"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "ข้อมูลสำรอง BitBox02"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "ข้อมูลสำรอง Passport"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "ข้อมูลสำรอง TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "ป้อน Seed Aezeed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "ส่วน SLIP-39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " สแกน SeedQR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "จาก SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "จาก Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " สร้าง Seed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "ไม่พบการ์ด microSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "ไม่พบข้อมูลสำรอง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "ไม่พบข้อมูลสำรอง BitBox02 (.bin, .bb02, .dat, .backup) บนการ์ด microSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "เลือกข้อมูลสำรอง BitBox02"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Backup name: {}"
+msgstr "ชื่อข้อมูลสำรอง: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Created: {}"
+msgstr "สร้างเมื่อ: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Firmware: {}"
+msgstr "เฟิร์มแวร์: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Birthdate: {}"
+msgstr "วันที่สร้าง: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Seed length: {} words"
+msgstr "ความยาว Seed: {} คำ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "โหลด Seed แล้ว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "ไม่พบข้อมูลสำรอง Passport (.7z) บนการ์ด microSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "เลือกข้อมูลสำรอง Passport"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "รหัสข้อมูลสำรอง Passport"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "รหัสข้อมูลสำรองต้องไม่ว่าง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Chain: {}"
+msgstr "เชน: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "ไม่พบข้อมูลสำรอง TAPSIGNER (.aes) บนการ์ด microSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "เลือกข้อมูลสำรอง TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "กุญแจข้อมูลสำรอง (hex)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "โหลด xprv จากข้อมูลสำรอง TAPSIGNER แล้ว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Path: {}"
+msgstr "เส้นทาง: {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "โหลดรหัสเสริม"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "พิมพ์รหัสเสริม"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "สแกนรหัสเสริม"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "โหลดจาก SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "รหัสเสริม Aezeed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"mnemonic นี้ต้องใช้\n"
+"รหัสเสริม"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "รหัสเสริมไม่ถูกต้อง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"ต้องใช้รหัสเสริม Aezeed\n"
+"ลองอีกครั้ง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"รหัสเสริม Aezeed ผิด\n"
+"ลองอีกครั้ง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "QR ข้อความไม่ถูกต้อง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "ตรวจพบข้อมูลที่ไม่ใช่ UTF-8"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "รองรับ Aezeed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"การป้อน Aezeed เป็นฟีเจอร์ทดลอง\n"
+"ใช้กับข้อมูลสำรองที่ทราบว่าดีเท่านั้น"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "ป้อน 20 คำ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "ป้อน 33 คำ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "โหลดส่วน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Share Word #{}"
+msgstr "คำของส่วน #{}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "ป้อนส่วน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "สแกนส่วน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "รวมส่วน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "{} of {} needed"
+msgstr "ต้องการ {} จาก {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "ลองอีกครั้ง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "ส่วน SLIP-39 ไม่ถูกต้อง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "เช็กซัมล้มเหลว; ไม่ใช่ส่วน SLIP-39 ที่ถูกต้อง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Seed ที่ขยายไม่ได้"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Seed SLIP-39 นี้สร้างส่วนใหม่ไม่ได้"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "ส่งออกเป็น QR ข้อความธรรมดา"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "ไปยัง SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "ไปยัง Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "สร้างส่วนใหม่"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "เปิด {} และแสดงที่อยู่รับจากกระเป๋าเงินที่คุณเพิ่งส่งออก"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "ซอฟต์แวร์กระเป๋าเงินของคุณ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"มีการใช้รหัสเสริม\n"
+"คุณต้องใช้คำ + รหัสเสริม"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 คำ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "ตรวจสอบ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "สรุป Seed ลูก"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "ป้อนกุญแจเข้ารหัส"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "ทิ้งกุญแจเข้ารหัสหรือไม่?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "กุญแจที่กำลังป้อนจะถูกลบ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "กุญแจไม่ถูกต้อง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "กุญแจยาวเกินไป"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "ป้อนจากกล้อง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "ใช้ลายนิ้วมือ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "กำหนด ID เอง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "ป้อนรหัส Mnemonic"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "แก้ไขรหัส Mnemonic"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "ทิ้งรหัส Mnemonic"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "ทิ้งรหัส Mnemonic หรือไม่?"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "รหัส Mnemonic ที่กำลังป้อนจะถูกลบ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "กำลังประมวลผล..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "การเข้ารหัสล้มเหลว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "อีก 100 ถัดไป"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "ค้นหาแบบขยาย"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "ไม่พบ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "ที่อยู่ยังไม่ได้ตรวจสอบ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Checked {} addresses with no match."
+msgstr "ตรวจสอบ {} ที่อยู่แล้วไม่พบที่ตรงกัน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "ตรวจสอบ 10 ถัดไป"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Checked {} addresses per path with no match."
+msgstr "ตรวจสอบ {} ที่อยู่ต่อเส้นทางแล้วไม่พบที่ตรงกัน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "ส่งออกกระเป๋าเงิน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "ส่งออกกระเป๋าเงินสำเร็จ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "รูปแบบที่อยู่ไม่ตรงกับชนิดสคริปต์ที่ส่งออก ส่งออกกระเป๋าเงินไม่สำเร็จ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "จับคู่กระเป๋าเงินกับ Seed ปัจจุบันไม่ได้ ส่งออกกระเป๋าเงินไม่สำเร็จ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "ส่งออกล้มเหลว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "โหลด SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "กำลังส่งออก xpub..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "กำลังเซ็นข้อความ..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "การตรวจสอบล้มเหลว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "ทดสอบสมาร์ตการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "แสดงรายการเครื่องอ่านการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "ทดสอบสแกน NFC"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "รีสตาร์ต PCSC"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "ข้อมูลแบตเตอรี่"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "ข้อมูลระบบ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "โหลดไฟล์ข้อมูลสำรอง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "ไม่พบตัวตรวจสอบแบตเตอรี่ที่รองรับ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "ไม่พร้อมใช้"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "ฟังก์ชันทั่วไป"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "ฟังก์ชัน Satochip"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "ฟังก์ชัน Keycard"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "ฟังก์ชัน SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "ฟังก์ชัน Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "เครื่องมือ DIY"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "ข้อมูลการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "ตรวจสอบของแท้"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "เปลี่ยน PIN"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "เปลี่ยนป้ายชื่อ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "เปลี่ยนนโยบาย NFC"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "ตั้งค่า NDEF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "รีเซ็ตการ์ดเป็นค่าโรงงาน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "ดู NDEF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "ใช้ลิงก์แอป Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "ล้าง NDEF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "ตั้ง NDEF กำหนดเอง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "บันทึก NDEF ไปยัง SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "โหลด NDEF จาก SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "ระเบียนข้อความ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "ระเบียน URI"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "เปิดแอป Android"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "กำหนดเอง (HEX)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "ถอดรหัส NDEF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "เปิด NFC"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "ปิด NFC"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC ถูกบล็อก"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "เสียบการ์ดใหม่แล้ว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "ดูพื้นที่ว่าง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "ดูความลับบนการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "บันทึกรหัสผ่านไปยังการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "ลบความลับจากการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "โหลด descriptor multisig"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "บันทึก descriptor multisig"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "โคลนความลับของการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "ออกไปหน้าหลัก"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "เริ่มต้นด้วย Seed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "โหลดเป็น descriptor"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "โหลด PSBT"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "ตั้ง PUK"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "ปลดล็อก PIN ด้วย PUK"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "ตั้งชื่อ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "ลบ Seed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "วัดประสิทธิภาพการเซ็น"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "วัดประสิทธิภาพการเซ็นข้อความ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "ตรวจสอบความเอนเอียงการเซ็น"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "ลบ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "รีเซ็ต"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "เปิด 2FA"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "มี Seed อยู่แล้ว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"xprv เริ่มต้น Satochip ไม่ได้\n"
+"ใช้ BIP39, SLIP39 หรือ Electrum"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "เปลี่ยน PIN การ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "โหลด Mnemonic"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "บันทึก Mnemonic"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "ล้าง Seed"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "กุญแจการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "สร้างแอปเพล็ต"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "ติดตั้งแอปเพล็ต"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "ถอนติดตั้งแอปเพล็ต"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "ป้อน PIN อื่น"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "โหลดกุญแจ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "บันทึกกุญแจ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "ปลดล็อกการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "ล็อกการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "ล้างกุญแจที่โหลด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "เขียนทับ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "ยกเลิกการบันทึก"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "ป้อนกุญแจเดี่ยว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "ป้อนชุดกุญแจ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "สร้างกุญแจเดี่ยว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "สร้างชุดกุญแจ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (ค่าเริ่มต้น)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "เอนโทรปี RNG ของระบบต่ำเกินไป ลองใหม่ภายหลัง"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "เอนโทรปีที่ได้จาก RNG ของระบบไม่ผ่านการตรวจสอบ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Seed ใหม่"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "Seed SLIP39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "QR ข้อความ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "ตัวสร้างรหัสผ่าน"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "เครื่องมือสมาร์ตการ์ด"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "เครื่องมือ MicroSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "ล้าง descriptor multisig"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "ไม่พบการ์ด microSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "เสียบการ์ด microSD เพื่อบันทึกบันทึกการคายประจุ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "โหลดข้อมูลเครือข่ายไม่ได้"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 คำ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 คำ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 คำ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 คำ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 คำ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+#, python-brace-format
+msgid "20 words ({} rolls)"
+msgstr "20 คำ ({} ครั้ง)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+#, python-brace-format
+msgid "33 words ({} rolls)"
+msgstr "33 คำ ({} ครั้ง)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "โหลด descriptor multisig แล้ว"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "โหลดจาก Satochip"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Seed Electrum"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "เข้ารหัสข้อความ"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "ถอดรหัส QR"
+

--- a/l10n/fork/tr/messages.po
+++ b/l10n/fork/tr/messages.po
@@ -1,0 +1,2870 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-11 13:41-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: tr\n"
+"Language-Team: tr <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "Hareketsizlik sonrası veriler silindi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Review Transaction"
+msgstr "İşlemi incele"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Review details"
+msgstr "Ayrıntıları incele"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Transaction Math"
+msgstr "İşlem hesabı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Review recipients"
+msgstr "Alıcıları incele"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/psbt_screens.py
+msgid "Sign Transaction"
+msgstr "İşlemi imzala"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "Kamera başlatılıyor..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "Şifre çözülsün mü?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "QR türünü seçin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "Şifreleme anahtarı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "Şifreleme anahtarını incele"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/screen.py
+msgid "I understand"
+msgstr "Anladım"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "Hesap numarası"
+
+#. FORK: translated by Claude 2026-07-11
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "Şifreli"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "Şifreli entropi bitleri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "Standart dışı yol!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Sign message"
+msgstr "Mesajı imzala"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "Mnemonik kimliği"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "Mnemonik kimliğini incele"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "İki modun ürettiği QR kodları farklı olabilir ama ikisi de geçerlidir."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "Şifreli QR'ı elle kopyala"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "Kullanılabilir seçenek yok"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "Pil bilgisi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "Sistem bilgisi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Platform: {platform_name}"
+msgstr "Platform: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Variant: {platform_variant}"
+msgstr "Varyant: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (CPU): {system_serial}"
+msgstr "Seri no (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "Seri no (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "Cihaz filtresi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "Ağ bilgisi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "Pil kalibrasyonu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "Pili tamamen şarj edin. Deşarj testini başlatmak için İleri'yi seçin."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "Başlat"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "Test pil bitene kadar sürer. Cihazı prize takmayın."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "Şarj algılandı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "Deşarj oluyor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "Geçen süre: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "Gerilim: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "Akım: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "Durum: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "DÜŞÜK ENTROPİ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "İYİ ENTROPİ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "Kodlanacak metin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "Zorlama PIN'i ayarla"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option; "default" = this is the format most wallets use
+#: src/seedsigner/models/settings_definition.py
+msgid "Animated (default)"
+msgstr "Hareketli (varsayılan)"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option (static = single frame, not animated)
+#: src/seedsigner/models/settings_definition.py
+msgid "Static"
+msgstr "Sabit"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option: old format that Specter Desktop used to use
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter legacy"
+msgstr "Specter legacy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "Kamera 0"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "Kamera 1"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "Kamera 2"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "Kamera 3"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 dakika"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 dakika"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 dakika"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 dakika"
+
+#. FORK: translated by Claude 2026-07-11
+#. MicroSD notification duration setting - Display notification for 5 seconds
+#: src/seedsigner/models/settings_definition.py
+msgid "5 seconds"
+msgstr "5 saniye"
+
+#. FORK: translated by Claude 2026-07-11
+#. MicroSD notification duration setting - Display notification until the SD
+#. card is removed
+#: src/seedsigner/models/settings_definition.py
+msgid "Until SD removed"
+msgstr "SD çıkarılana kadar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Aezeed parolası"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "CompactSeedQR'ı tercih et"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "EncryptedQR'ı tercih et"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "Her seferinde sor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "Kart PIN denemeleri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "Silme zamanlayıcısı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "Tohum uzunlukları"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Xpub QR format"
+msgstr "Xpub QR biçimi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "BIP32 hesabını sor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "Belirsiz QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "GPG anahtar türleri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "BIP85 GPG sürümü"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 en yenisidir; B9-B10 anahtarlarını yeniden üretmek için v2 kullanın"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "SLIP39 tohumları"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Aezeed tohumları"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "LND uyumlu, 24 kelime"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "Genişletilebilir SLIP39 payları"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "MicroSD notification duration"
+msgstr "MicroSD bildirim süresi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "BitBox02 yedekleri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Passport yedekleri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "TAPSIGNER yedekleri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "Akıllı kart desteği"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Satochip desteği"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Keycard desteği"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Specter-DIY desteği"
+
+#. FORK: translated by Claude 2026-07-11
+#. Hardware settings option to specify the screen driver (e.g. st7789 vs
+#. ili9341)
+#: src/seedsigner/models/settings_definition.py
+msgid "Display type"
+msgstr "Ekran türü"
+
+#. FORK: translated by Claude 2026-07-11
+#. Hardware settings option to invert how the screen driver displays colors.
+#: src/seedsigner/models/settings_definition.py
+msgid "Invert colors"
+msgstr "Renkleri ters çevir"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "Kamera kaynağı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "Masaüstü modu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "Güvenli değil!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Bu masaüstü sürümü yalnızca test içindir.\n"
+"Gerçek tohum veya özel anahtarlarla KULLANMAYIN."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "Anladım"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "Geliştirme derlemesi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Bu SeedSignerOS geliştirme derlemesi yalnızca test içindir.\n"
+"Gerçek tohum veya özel anahtarlarla KULLANMAYIN."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "Dosya işlemleri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "Anahtarları içe aktar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "Anahtarları dışa aktar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "Anahtarları görüntüle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "Güvenli mesajlaşma"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "GPG Araçları"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "Eksik paketler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "Gerekli ancak yüklü değil:\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "Alt anahtar işlemleri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "Kullanıcı kimliği işlemleri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "Anahtarları çapraz onayla"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "Açık anahtar paketini dışa aktar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "BIP85 meta verileri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "Alt anahtarlar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "Geri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "Paketi dışa aktar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "Hareketli QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "BIP85 verilerini kaydet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "BIP85 verilerini yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "BIP85 anahtarını yeniden oluştur"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "MicroSD'ye"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "QR'a"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "Seedkeeper'a"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "MicroSD'den"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "QR'dan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Seedkeeper'dan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "Alt anahtar ekle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "Alt anahtarları iptal et"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "Alt anahtarları sil"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "Geçerlilik süresini değiştir"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "Alt anahtar gizli verilerini dışa aktar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 yıl"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 yıl"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 yıl"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "Asla"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "Dosya"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "Akıllı kart"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "Kullanıcı kimliği ekle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "Kullanıcı kimliklerini düzenle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "Birincil kullanıcı kimliğini ayarla"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "Kullanıcı kimliğini iptal et"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "Kullanıcı kimliğini sil"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "Şifrele"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "Şifreyi çöz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "İmzala"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "İmzayı doğrula"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "Mesaj oluştur"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "Mesaj yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "Manifest"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "Mesaj yaz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Seedkeeper yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "QR tara"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "Dosya yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "Anahtar yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Seedkeeper'a kaydet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "QR olarak göster"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "Açık anahtar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "Özel anahtar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "Kart bilgisini görüntüle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "Kart üzerinde anahtar üret"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "Yönetici PIN'ini değiştir"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "Kullanıcı PIN'ini değiştir"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "Dosya şifreleniyor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(Biraz sürebilir)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "Dosyanın şifresi çözülüyor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "SHA256Sum'ı kontrol et"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "Güncelle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "Dosyadan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "Yeni üret"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "BIP85 türet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "OpenGPG kartı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "Metni düzenle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "Metni at"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "Metin atılsın mı?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "QR kodu üret"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "Elle kopyalama modu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "Tam ekran modu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "Elle kopyalama modu?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "Metin QR kodunu onayla"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "Metin QR onaylansın mı?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "Metin QR kodunu tara"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "Metin QR kodunu onayla"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "Elle kopyaladığınız metin QR kodu özgün metinle eşleşmiyor!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "Metin QR kodunu incele"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "Elle kopyaladığınız metin QR kodu başarıyla tarandı ve aynı metni verdi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "Metin QR'ı onayla"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "Elle kopyaladığınız metin QR kodu okunamadı!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "Düzenle ve QR kodu üret"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "Çözülen metin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "Testi çalıştır"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "İmajı yaz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "MicroSD'yi doğrula"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "Sil (sıfırlarla)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "Sil (rastgele)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "Doğrulamayı atla"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "Tümü"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "Özel"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF kısa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF uzun"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "Zar atışları"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "Şifre türü"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 bit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 bit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 bit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "Şifre gücü"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "Evet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "Hayır"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "Seçenekleri seç"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "En az bir karakter kümesi seçin."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "Sistem RNG denetimi başarısız oldu."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "Sistem RNG hatası"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "Kamera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "Zar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "Sistem RNG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "Entropi kaynağı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "Desteklenmiyor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85; Diceware, zar atışları, Hex, Base64 ve Base85 destekler."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "Yok"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "Baş harf büyük"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "Boşluk"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "Ayraç"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 yüzlü"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 yüzlü"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 yüzlü"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "Zar yüzleri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "Atış sayısı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "Geçersiz giriş"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "Atış sayısı en az 1 olmalıdır."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "Zayıf entropi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "Atışlar yeterince rastgele görünmedi. Lütfen tekrar deneyin."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "Kamera entropisi yeterince rastgele görünmedi. Lütfen tekrar deneyin."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "UYARI"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "BIP85 kullanmadan önce bir tohum yükleyin."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "Tohum seç"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "BIP85 için tohum seçin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "BIP85 dizini"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "Geçersiz uzunluk"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex 128 veya 256 bit destekler."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 120+ bit gerektirir."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 64-512 bit gerektirir."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "Şifre adı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "Yetersiz alan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"Gizli veri kaydediliyor\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "Başarılı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "Şifre Seedkeeper'a kaydedildi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "Seedkeeper'da şifre için yeterli alan yok"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "Başarısız"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "Şifre kaydedilemedi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "Düzenle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "Şifre"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "Şifreyi kaydet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Satochip kartı kullan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Keycard kullan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "15 kelimelik tohumu girin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "18 kelimelik tohumu girin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "21 kelimelik tohumu girin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "WIF girin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "WIF tara"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "BIP38 girin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "BIP38 tara"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "Parmak izi uyuşmuyor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "Kart PSBT'yi imzalayamıyor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "Kartın parmak izi ({}) PSBT imzacıları arasında yok."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "Özel anahtar (WIF)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "Geçersiz WIF!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "Geçerli bir WIF kodlu özel anahtar değil."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "BIP38 anahtarı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "BIP38 parolası"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "Geçersiz BIP38!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "BIP38 anahtarının şifresi çözülemedi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction has unsupported input script type, please verify your change addresses."
+msgstr "İşlemde desteklenmeyen giriş betik türü var; para üstü adreslerinizi doğrulayın."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "This transaction spends its entire input value. No change is coming back to your wallet."
+msgstr "Bu işlem tüm giriş tutarını harcıyor. Cüzdanınıza para üstü dönmeyecek."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Next recipient"
+msgstr "Sonraki alıcı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Skip verification"
+msgstr "Doğrulamayı atla"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Verify multisig change"
+msgstr "Çoklu imza para üstünü doğrula"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Verify multisig addr"
+msgstr "Çoklu imza adresini doğrula"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "Tanımlayıcı uyuşmuyor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "Tanımlayıcı temizlendi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "Yüklü çoklu imza cüzdan tanımlayıcısı bu PSBT ile eşleşmiyor. Doğru tanımlayıcıyı yükleyin ya da doğrulamayı atlayın."
+
+#. FORK: translated by Claude 2026-07-11
+#. Variable is either "change" or "self-transfer".
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction's {} address could not be verified from wallet descriptor."
+msgstr "İşlemin {} adresi cüzdan tanımlayıcısından doğrulanamadı."
+
+#. FORK: translated by Claude 2026-07-11
+#. Variable is either "change" or "self-transfer".
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction's {} address could not be generated from your seed."
+msgstr "İşlemin {} adresi tohumunuzdan üretilemedi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Suspicious Transaction"
+msgstr "Şüpheli işlem"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Discard transaction"
+msgstr "İşlemi at"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Approve transaction"
+msgstr "İşlemi onayla"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "PSBT imzalanıyor..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "İmza zaman aşımı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "Yeniden dene (daha uzun süre)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Saved as {}."
+msgstr "{} olarak kaydedildi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Failed to save PSBT: {}"
+msgstr "PSBT kaydedilemedi: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "PSBT kodlanıyor..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Select different seed"
+msgstr "Farklı tohum seç"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Transaction Error"
+msgstr "İşlem hatası"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "QR tarayıcı kullanılamıyor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "QR tarama altyapısı eksik. zbar (masaüstünde OpenCV) kurun ve yeniden başlatın."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "Tohum türünü seçin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "Saat şuna ayarlandı:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "Saat ayarlanamadı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "Geçersiz saat"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "QR'dan saat okunamadı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan Transaction"
+msgstr "İşlemi tara"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a transaction"
+msgstr "Bir işlem bekleniyordu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "SLIP-39 payı tara"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "SLIP-39 payı QR'ı bekleniyordu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "WIF özel anahtarı bekleniyordu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "BIP38 özel anahtarı bekleniyordu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "Az önce dışa aktardığınız cüzdandan {} numaralı alma adresini tarayın"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"Veriler birden çok\n"
+"QR türüyle eşleşiyor."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "Şifreleme anahtarını yaz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "Şifreleme anahtarını tara"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "Şifreleme anahtarını düzenle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "Şifreleme anahtarını at"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "Devam et"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "Tara ve bir tane daha ekle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/view.py
+msgid "Back to Main Menu"
+msgstr "Ana menüye dön"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "Çözülen metin"
+
+#. FORK: translated by Claude 2026-07-11
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "Resmî olmayan bir çatallamasıdır:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "BitBox02 yedeği"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Passport yedeği"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "TAPSIGNER yedeği"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Aezeed tohumu girin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "SLIP-39 payları"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " SeedQR tara"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "SeedKeeper'dan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Specter-DIY'dan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " Tohum oluştur"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load a Seed"
+msgstr "Bir tohum yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "microSD kart algılanmadı."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "Yedek bulunamadı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "microSD kartta BitBox02 yedeği (.bin, .bb02, .dat, .backup) bulunamadı."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "BitBox02 yedeğini seçin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup name: {}"
+msgstr "Yedek adı: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Created: {}"
+msgstr "Oluşturulma: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Firmware: {}"
+msgstr "Donanım yazılımı: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Birthdate: {}"
+msgstr "Oluşturulma tarihi: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed length: {} words"
+msgstr "Tohum uzunluğu: {} kelime"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "Tohum yüklendi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "microSD kartta Passport yedeği (.7z) bulunamadı."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Passport yedeğini seçin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Passport yedek kodu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "Yedek kodu boş olamaz."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Chain: {}"
+msgstr "Ağ: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "microSD kartta TAPSIGNER yedeği (.aes) bulunamadı."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "TAPSIGNER yedeğini seçin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "Yedek anahtarı (hex)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "TAPSIGNER yedeğinden xprv yüklendi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Path: {}"
+msgstr "Yol: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review & edit"
+msgstr "İncele ve düzenle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "Parolayı yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "Parolayı yaz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "Parolayı tara"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "SeedKeeper'dan yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Aezeed parolası"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"Bu mnemonik için\n"
+"parola gerekli."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "Geçersiz parola"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Aezeed parolası gerekli.\n"
+"Tekrar deneyin."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Yanlış Aezeed parolası.\n"
+"Tekrar deneyin."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Skip passphrase"
+msgstr "Parolayı atla"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current passphrase entry will be erased."
+msgstr "Girdiğiniz parola silinecek."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Skip passphrase?"
+msgstr "Parola atlansın mı?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "You have not entered a passphrase yet."
+msgstr "Henüz bir parola girmediniz."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "Geçersiz metin QR kodu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "UTF-8 olmayan veri algılandı."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Keep seed"
+msgstr "Tohumu koru"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Aezeed desteği"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"Aezeed girişi deneyseldir.\n"
+"Yalnızca doğrulanmış yedeklerle kullanın."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Electrum Warning"
+msgstr "Electrum uyarısı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "20 kelime girin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "33 kelime girin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "Pay yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Share Word #{}"
+msgstr "Payın {}. kelimesi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "Pay girin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "Pay tara"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "Payları birleştir"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "{} of {} needed"
+msgstr "{} / {} gerekli"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "Tekrar dene"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "Geçersiz SLIP-39 payı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "Sağlama hatası; geçerli bir SLIP-39 payı değil."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Genişletilemez tohum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Bu SLIP-39 tohumu yeni paylar üretemez."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan transaction"
+msgstr "İşlemi tara"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export xpub"
+msgstr "Xpub dışa aktar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Address explorer"
+msgstr "Adres gezgini"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup seed"
+msgstr "Tohumu yedekle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "BIP-85 child seed"
+msgstr "BIP-85 türetilmiş tohumu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard seed"
+msgstr "Tohumu at"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "View seed words"
+msgstr "Tohum kelimelerini görüntüle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "Şifresiz QR olarak dışa aktar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "SeedKeeper'a"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "Specter-DIY'a"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "Payları yeniden üret"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Xpub QR Format"
+msgstr "Xpub QR biçimi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "{} uygulamasını açın ve az önce dışa aktardığınız cüzdandan bir alma adresi görüntüleyin."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "cüzdan yazılımınız"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"Parola kullanıldı.\n"
+"Kelimeler + parola gerekecek."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 kelime"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Try again"
+msgstr "Tekrar dene"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "İncele"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "Türetilmiş tohumu tamamla"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review seed words"
+msgstr "Tohum kelimelerini incele"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "Şifreleme anahtarını girin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "Şifreleme anahtarı atılsın mı?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "Girdiğiniz anahtar silinecek"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "Geçersiz anahtar"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "Anahtar çok uzun."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "Kameradan giriş"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "Parmak izini kullan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "Özel kimlik ata"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "Mnemonik kimliğini girin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "Mnemonik kimliğini düzenle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "Mnemonik kimliğini at"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "Mnemonik kimliği atılsın mı?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "Girdiğiniz mnemonik kimliği silinecek"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "İşleniyor..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "Şifreleme hatası"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "Sonraki 100"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "Genişletilmiş arama"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "Bulunamadı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "Adres doğrulanamadı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses with no match."
+msgstr "{} adres kontrol edildi, eşleşme yok."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "Sonraki 10'u kontrol et"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses per path with no match."
+msgstr "Yol başına {} adres kontrol edildi, eşleşme yok."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "Cüzdan dışa aktarma"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "Cüzdan başarıyla dışa aktarıldı."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "Adres biçimi dışa aktarılan betik türüyle eşleşmiyor. Cüzdan dışa aktarılamadı."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "Cüzdan mevcut tohumla eşleştirilemedi. Cüzdan dışa aktarılamadı."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "Dışa aktarma başarısız"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "SeedKeeper yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Return to transaction"
+msgstr "İşleme geri dön"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Verify addr"
+msgstr "Adresi doğrula"
+
+#. FORK: translated by Claude 2026-07-11
+#. Multisig policy. For a "2 of 3" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/seed_views.py
+msgid "{threshold} of {n}"
+msgstr "{threshold} / {n}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "Xpub dışa aktarılıyor..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "Mesaj imzalanıyor..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "Doğrulama başarısız"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Hardware"
+msgstr "Donanım"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "Akıllı kartı test et"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "Kart okuyucuları listele"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "NFC taramayı test et"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "PCSC'yi yeniden başlat"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "Pil bilgisi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "Sistem bilgisi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "Yedek dosyalarını yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#. Title of a warning dialog when configuring a setting that requires at least
+#. one option to be selected.
+#: src/seedsigner/views/settings_views.py
+msgid "Selection Required"
+msgstr "Seçim gerekli"
+
+#. FORK: translated by Claude 2026-07-11
+#. The name of the setting being configured (e.g. "Script types") will be
+#. inserted.
+#: src/seedsigner/views/settings_views.py
+msgid "At least one option must be selected for \"{}\"."
+msgstr "\"{}\" için en az bir seçenek seçilmelidir."
+
+#. FORK: translated by Claude 2026-07-11
+#. Text for the button that returns the user to the setting configuration
+#. screen.
+#: src/seedsigner/views/settings_views.py
+msgid "Return to setting"
+msgstr "Ayara geri dön"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "Uyumlu pil monitörü algılanmadı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "Kullanılamıyor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "Ortak işlevler"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Satochip işlevleri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Keycard işlevleri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "SeedKeeper işlevleri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Specter-DIY işlevleri"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "DIY Araçları"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "Kart bilgisi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "Orijinallik denetimi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "PIN değiştir"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "Etiketi değiştir"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "NFC ilkesini değiştir"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "NDEF'i yapılandır"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "Kartı fabrika ayarlarına döndür"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "NDEF'i görüntüle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Seedkeeper uygulama bağlantısını kullan"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "NDEF'i temizle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "Özel NDEF ayarla"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "NDEF'i SeedKeeper'a kaydet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "NDEF'i SeedKeeper'dan yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "Metin kaydı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "URI kaydı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Android uygulaması başlatma"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "Özel (HEX)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "NDEF'i çöz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC açık"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC kapalı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC engellendi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "Kart yeniden takıldı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "Boş alanı görüntüle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "Karttaki gizli verileri görüntüle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "Şifreyi karta kaydet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "Karttan gizli veri sil"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "Çoklu imza tanımlayıcısını yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "Çoklu imza tanımlayıcısını kaydet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "Kartın gizli verilerini kopyala"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "Ana ekrana dön"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "Tohumla başlat"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "Tanımlayıcı olarak yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "PSBT yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "PUK ayarla"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "PIN'i PUK ile aç"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "Ad belirle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "Tohumu kaldır"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "İmza hız testi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "Mesaj imzalama hız testi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "İmza sapmasını kontrol et"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "Kaldır"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "Sıfırla"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "2FA'yı etkinleştir"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "Zaten tohum yüklü"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"xprv Satochip'i başlatamaz.\n"
+"BIP39, SLIP39 veya Electrum kullanın."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "Kart PIN'ini değiştir"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "Mnemonik yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "Mnemonik kaydet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "Tohumu sil"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "Kart anahtarları"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "Applet'leri derle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "Applet yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "Applet'i kaldır"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "Farklı bir PIN girin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "Anahtarları yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "Anahtarları kaydet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "Kartın kilidini aç"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "Kartı kilitle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "Yüklü anahtarları temizle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "Üzerine yaz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "Kaydetmeyi iptal et"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "Tek anahtar girin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "Anahtar seti girin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "Tek anahtar üret"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "Anahtar seti üret"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (varsayılan)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "Sistem RNG entropisi çok düşük. Daha sonra tekrar deneyin."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "Sistem RNG'den türetilen entropi denetimlerden geçemedi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Yeni tohum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "SLIP39 tohumu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Verify address"
+msgstr "Adresi doğrula"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "Metin QR kodu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "Şifre üretici"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "Akıllı Kart Araçları"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "MicroSD Araçları"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Çoklu imza tanımlayıcısını temizle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "microSD kart algılanmadı"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "Deşarj günlüğünü kaydetmek için microSD kart takın."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "Ağ bilgileri yüklenemedi."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 kelime"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 kelime"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 kelime"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 kelime"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 kelime"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words ({} rolls)"
+msgstr "20 kelime ({} atış)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words ({} rolls)"
+msgstr "33 kelime ({} atış)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Çoklu imza tanımlayıcısı yüklendi"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Satochip'ten yükle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Electrum tohumu"
+
+#. FORK: translated by Claude 2026-07-11
+#. label for addresses where others send us incoming payments
+#: src/seedsigner/views/tools_views.py
+msgid "Receive addresses"
+msgstr "Alma adresleri"
+
+#. FORK: translated by Claude 2026-07-11
+#. label for addresses that collect the change from our own outgoing payments
+#: src/seedsigner/views/tools_views.py
+msgid "Change addresses"
+msgstr "Para üstü adresleri"
+
+#. FORK: translated by Claude 2026-07-11
+#. Multisig policy. For a "2 / 3 multisig" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/tools_views.py
+msgid "{threshold} / {n} multisig"
+msgstr "{threshold} / {n} çoklu imza"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "Metni kodla"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "QR kodunu çöz"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Power off"
+msgstr "Kapat"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Back to main menu"
+msgstr "Ana menüye dön"
+
+#. FORK: translated by Claude 2026-07-11
+#. "network" will be mainnet/testnet/regtest.
+#: src/seedsigner/views/view.py
+msgid "Current network setting ({network}) doesn't match {derivation_path}."
+msgstr "Geçerli ağ ayarı ({network}) {derivation_path} ile eşleşmiyor."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Hardware Error"
+msgstr "Donanım hatası"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Cannot access camera"
+msgstr "Kameraya erişilemiyor"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Disconnect power and check for a loose camera connection."
+msgstr "Gücü kesin ve kamera bağlantısının gevşek olup olmadığını kontrol edin."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Update setting"
+msgstr "Ayarı güncelle"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid "Action Required"
+msgstr "İşlem gerekli"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/view.py
+msgid ""
+"You must remove the\n"
+"MicroSD card to continue."
+msgstr ""
+"Devam etmek için MicroSD\n"
+"kartı çıkarmalısınız."
+

--- a/l10n/fork/vi/messages.po
+++ b/l10n/fork/vi/messages.po
@@ -1,0 +1,2578 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-11 13:48-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: vi\n"
+"Language-Team: vi <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "Dữ liệu đã bị xóa do không hoạt động"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "Đang khởi động camera..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "Giải mã?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "Chọn loại QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "Khóa mã hóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "Xem lại khóa mã hóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "Số tài khoản"
+
+#. FORK: translated by Claude 2026-07-11
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "Đã mã hóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "Số bit entropy đã mã hóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "Đường dẫn không chuẩn!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "ID cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "Xem lại ID cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "Mã QR của hai chế độ có thể khác nhau nhưng đều hợp lệ."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "Chép lại QR đã mã hóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "Không có tùy chọn nào"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "Thông tin pin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "Thông tin hệ thống"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Platform: {platform_name}"
+msgstr "Nền tảng: {platform_name}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Variant: {platform_variant}"
+msgstr "Biến thể: {platform_variant}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (CPU): {system_serial}"
+msgstr "Số sê-ri (CPU): {system_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "Số sê-ri (MicroSD): {microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "Bộ lọc thiết bị"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "Thông tin mạng"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "Hiệu chỉnh pin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "Sạc đầy pin. Chọn Kế tiếp để bắt đầu kiểm tra xả pin."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "Bắt đầu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "Kiểm tra chạy đến khi hết pin. Không cắm sạc thiết bị."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "Phát hiện đang sạc"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "Đang xả pin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "Đã trôi qua: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "Điện áp: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "Dòng điện: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "Trạng thái: "
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "ENTROPY THẤP"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "ENTROPY TỐT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "Văn bản cần mã hóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "Đặt PIN khẩn cấp"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option; "default" = this is the format most wallets use
+#: src/seedsigner/models/settings_definition.py
+msgid "Animated (default)"
+msgstr "Động (mặc định)"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option (static = single frame, not animated)
+#: src/seedsigner/models/settings_definition.py
+msgid "Static"
+msgstr "Tĩnh"
+
+#. FORK: translated by Claude 2026-07-11
+#. QR code format option: old format that Specter Desktop used to use
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter legacy"
+msgstr "Specter legacy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "Camera 0"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "Camera 1"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "Camera 2"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "Camera 3"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 phút"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 phút"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 phút"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 phút"
+
+#. FORK: translated by Claude 2026-07-11
+#. MicroSD notification duration setting - Display notification for 5 seconds
+#: src/seedsigner/models/settings_definition.py
+msgid "5 seconds"
+msgstr "5 giây"
+
+#. FORK: translated by Claude 2026-07-11
+#. MicroSD notification duration setting - Display notification until the SD
+#. card is removed
+#: src/seedsigner/models/settings_definition.py
+msgid "Until SD removed"
+msgstr "Đến khi rút thẻ SD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Câu mật khẩu Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "Ưu tiên CompactSeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "Ưu tiên EncryptedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "Hỏi mỗi lần"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "Số lần thử PIN thẻ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "Hẹn giờ xóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "Độ dài cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Xpub QR format"
+msgstr "Định dạng QR của xpub"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "Hỏi tài khoản BIP32"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "QR không rõ ràng"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "Loại khóa GPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "Phiên bản GPG của BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 là mới nhất; dùng v2 để tạo lại khóa B9-B10"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "Cụm từ khóa SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Cụm từ khóa Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "Tương thích LND, 24 từ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "Phần SLIP39 mở rộng được"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "MicroSD notification duration"
+msgstr "Thời lượng thông báo MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "Bản sao lưu BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Bản sao lưu Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "Bản sao lưu TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "Hỗ trợ thẻ thông minh"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Hỗ trợ Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Hỗ trợ Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Hỗ trợ Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "Nguồn camera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "Chế độ máy tính"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "Không an toàn!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Bản máy tính này chỉ để thử nghiệm.\n"
+"KHÔNG dùng với cụm từ khóa hoặc khóa riêng thật."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "Tôi hiểu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "Bản dựng phát triển"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"Bản dựng phát triển SeedSignerOS này chỉ để thử nghiệm.\n"
+"KHÔNG dùng với cụm từ khóa hoặc khóa riêng thật."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "Thao tác với tệp"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "Nhập khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "Xuất khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "Xem khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "Nhắn tin bảo mật"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "Công cụ GPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "Thiếu gói phần mềm"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "Cần nhưng chưa được cài đặt:\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "Thao tác khóa phụ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "Thao tác ID người dùng"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "Chứng thực chéo các khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "Xuất gói khóa công khai"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "Siêu dữ liệu BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "Khóa phụ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "Quay lại"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "Xuất gói"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "QR động"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "Lưu dữ liệu BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "Tải dữ liệu BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "Tạo lại khóa BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "Sang MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "Sang QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "Sang Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "Từ MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "Từ QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "Từ Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "Thêm khóa phụ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "Thu hồi khóa phụ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "Xóa khóa phụ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "Đổi hạn dùng"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "Xuất bí mật khóa phụ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 năm"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 năm"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 năm"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "Không bao giờ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "Tệp"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "Thẻ thông minh"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "Thêm ID người dùng"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "Sửa ID người dùng"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "Đặt ID người dùng chính"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "Thu hồi ID người dùng"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "Xóa ID người dùng"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "Mã hóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "Giải mã"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "Ký"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "Xác nhận chữ ký"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "Tạo tin nhắn"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "Tải tin nhắn"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "Tệp kê khai"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "Gõ tin nhắn"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "Tải Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "Quét QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "Tải tệp"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "Tải khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "Lưu vào Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "Hiện dưới dạng QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "Khóa công khai"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "Khóa riêng"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "Xem thông tin thẻ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "Tạo khóa trên thẻ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "Đổi PIN quản trị"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "Đổi PIN người dùng"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "Đang mã hóa tệp"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "(Có thể mất một lúc)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "Đang giải mã tệp"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "Kiểm tra SHA256Sum"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "Cập nhật"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "Từ tệp"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "Tạo mới"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "Dẫn xuất BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "Thẻ OpenGPG"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "Sửa văn bản"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "Hủy văn bản"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "Hủy văn bản?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "Tạo mã QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "Chế độ chép lại"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "Chế độ toàn màn hình"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "Chế độ chép lại?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "Xác nhận mã QR văn bản"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "Xác nhận QR văn bản?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "Quét mã QR văn bản"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "Xác nhận mã QR văn bản"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "Mã QR văn bản bạn chép lại không khớp với văn bản gốc!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "Xem lại mã QR văn bản"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "Mã QR văn bản bạn chép lại đã quét thành công và cho cùng nội dung."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "Xác nhận QR văn bản"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "Không đọc được mã QR văn bản bạn chép lại!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "Sửa và tạo mã QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "Văn bản đã giải mã"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "Chạy kiểm tra"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "Ghi ảnh hệ thống"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "Xác nhận MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "Xóa (số 0)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "Xóa (ngẫu nhiên)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "Bỏ qua xác nhận"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "Tất cả"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "Tùy chỉnh"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF ngắn"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF dài"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "Gieo xúc xắc"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "Loại mật khẩu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 bit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 bit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 bit"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "Độ mạnh mật khẩu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "Có"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "Không"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "Chọn tùy chọn"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "Chọn ít nhất một bộ ký tự."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "Kiểm tra RNG hệ thống thất bại."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "Lỗi RNG hệ thống"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "Camera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "Xúc xắc"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "RNG hệ thống"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "Nguồn entropy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "Không hỗ trợ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 hỗ trợ Diceware, gieo xúc xắc, Hex, Base64 và Base85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "Không có"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "Viết hoa chữ đầu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "Dấu cách"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "Dấu phân cách"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 mặt"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 mặt"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 mặt"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "Số mặt xúc xắc"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "Số lần gieo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "Dữ liệu không hợp lệ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "Số lần gieo phải ít nhất là 1."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "Entropy kém"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "Các lần gieo có vẻ chưa đủ ngẫu nhiên. Vui lòng thử lại."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "Entropy từ camera có vẻ chưa đủ ngẫu nhiên. Vui lòng thử lại."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "CẢNH BÁO"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "Tải một cụm từ khóa trước khi dùng BIP85."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "Chọn cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "Chọn cụm từ khóa cho BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "Chỉ số BIP85"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "Độ dài không hợp lệ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex hỗ trợ 128 hoặc 256 bit."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 cần 120+ bit."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 cần 64-512 bit."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "Tên mật khẩu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "Không đủ dung lượng"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"Đang lưu bí mật\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "Thành công"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "Đã lưu mật khẩu vào Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "Seedkeeper không đủ chỗ để lưu mật khẩu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "Thất bại"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "Lưu mật khẩu thất bại"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "Sửa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "Mật khẩu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "Lưu mật khẩu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "Dùng thẻ Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "Dùng Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "Nhập 15 từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "Nhập 18 từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "Nhập 21 từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "Nhập WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "Quét WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "Nhập BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "Quét BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "Dấu vân tay không khớp"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "Thẻ không thể ký PSBT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "Dấu vân tay của thẻ ({}) không nằm trong danh sách ký PSBT."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "Khóa riêng (WIF)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "WIF không hợp lệ!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "Không phải khóa riêng mã hóa WIF hợp lệ."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "Khóa BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "Câu mật khẩu BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "BIP38 không hợp lệ!"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "Không thể giải mã khóa BIP38."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "Thông tin ví không khớp"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "Đã xóa thông tin ví"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "Thông tin ví đa chữ ký đã tải không khớp với PSBT này. Hãy tải đúng thông tin ví hoặc bỏ qua xác nhận."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "Đang ký PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "Hết thời gian ký"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "Thử lại (thời gian dài hơn)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Saved as {}."
+msgstr "Đã lưu thành {}."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Failed to save PSBT: {}"
+msgstr "Không lưu được PSBT: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "Đang mã hóa PSBT..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "Không có trình quét QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "Thiếu phần mềm quét QR. Cài zbar (hoặc OpenCV trên máy tính) rồi khởi động lại."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "Chọn loại cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "Đã đặt giờ thành:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "Đặt giờ thất bại"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "Giờ không hợp lệ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "Không đọc được giờ từ QR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "Quét phần SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "Cần QR của phần SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "Cần khóa riêng WIF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "Cần khóa riêng BIP38"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "Quét địa chỉ nhận {} từ ví bạn vừa xuất"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"Dữ liệu khớp với nhiều\n"
+"loại QR."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "Gõ khóa mã hóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "Quét khóa mã hóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "Sửa khóa mã hóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "Hủy khóa mã hóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "Tiếp tục"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "Quét và thêm cái khác"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "Văn bản đã giải mã"
+
+#. FORK: translated by Claude 2026-07-11
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "Bản fork không chính thức của:"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "Bản sao lưu BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Bản sao lưu Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "Bản sao lưu TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "Nhập cụm từ khóa Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "Các phần SLIP-39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " Quét SeedQR"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "Từ SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "Từ Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " Tạo cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "Không tìm thấy thẻ microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "Không tìm thấy bản sao lưu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "Không tìm thấy bản sao lưu BitBox02 (.bin, .bb02, .dat, .backup) trên thẻ microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "Chọn bản sao lưu BitBox02"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup name: {}"
+msgstr "Tên bản sao lưu: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Created: {}"
+msgstr "Tạo lúc: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Firmware: {}"
+msgstr "Firmware: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Birthdate: {}"
+msgstr "Ngày tạo: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed length: {} words"
+msgstr "Độ dài cụm từ khóa: {} từ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "Đã tải cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "Không tìm thấy bản sao lưu Passport (.7z) trên thẻ microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "Chọn bản sao lưu Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Mã bản sao lưu Passport"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "Mã bản sao lưu không được để trống."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Chain: {}"
+msgstr "Mạng: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "XFP: {}"
+msgstr "XFP: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "Không tìm thấy bản sao lưu TAPSIGNER (.aes) trên thẻ microSD."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "Chọn bản sao lưu TAPSIGNER"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "Khóa sao lưu (hex)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "Đã tải xprv từ bản sao lưu TAPSIGNER."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Path: {}"
+msgstr "Đường dẫn: {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "Tải câu mật khẩu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "Gõ câu mật khẩu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "Quét câu mật khẩu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "Tải từ SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Câu mật khẩu Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"Cụm từ khóa này cần\n"
+"câu mật khẩu."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "Câu mật khẩu không hợp lệ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"Cần câu mật khẩu Aezeed.\n"
+"Thử lại."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Câu mật khẩu Aezeed sai.\n"
+"Thử lại."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "Mã QR văn bản không hợp lệ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "Phát hiện dữ liệu không phải UTF-8."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Hỗ trợ Aezeed"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"Nhập Aezeed là tính năng thử nghiệm.\n"
+"Chỉ dùng với bản sao lưu đã kiểm chứng."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "Nhập 20 từ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "Nhập 33 từ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "Tải phần"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Share Word #{}"
+msgstr "Từ thứ {} của phần"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "Nhập phần"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "Quét phần"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "Ghép các phần"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "{} of {} needed"
+msgstr "Cần {} trong {}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "Thử lại"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "Phần SLIP-39 không hợp lệ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "Lỗi checksum; không phải phần SLIP-39 hợp lệ."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "Cụm từ khóa không mở rộng được"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "Cụm từ khóa SLIP-39 này không thể tạo phần mới."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "Xuất dưới dạng QR không mã hóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "Sang SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "Sang Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "Tạo lại các phần"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Xpub QR Format"
+msgstr "Định dạng QR của xpub"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "Mở {} và hiển thị một địa chỉ nhận từ ví bạn vừa xuất."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "phần mềm ví của bạn"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"Đã dùng câu mật khẩu.\n"
+"Bạn sẽ cần các từ + câu mật khẩu."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 từ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "Xem lại"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "Hoàn tất cụm từ khóa con"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "Nhập khóa mã hóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "Hủy khóa mã hóa?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "Khóa đã nhập sẽ bị xóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "Khóa không hợp lệ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "Khóa quá dài."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "Nhập từ camera"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "Dùng dấu vân tay"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "Gán ID tùy chỉnh"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "Nhập ID cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "Sửa ID cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "Hủy ID cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "Hủy ID cụm từ khóa?"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "ID cụm từ khóa đã nhập sẽ bị xóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "Đang xử lý..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "Mã hóa thất bại"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "100 tiếp theo"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "Tìm kiếm mở rộng"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "Không tìm thấy"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "Địa chỉ chưa được xác nhận"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses with no match."
+msgstr "Đã kiểm tra {} địa chỉ mà không khớp."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "Kiểm tra 10 địa chỉ tiếp"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Checked {} addresses per path with no match."
+msgstr "Đã kiểm tra {} địa chỉ mỗi đường dẫn mà không khớp."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "Xuất ví"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "Xuất ví thành công."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "Định dạng địa chỉ không khớp loại script đã xuất. Xuất ví thất bại."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "Không khớp được ví với cụm từ khóa hiện tại. Xuất ví thất bại."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "Xuất thất bại"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "Tải SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#. Multisig policy. For a "2 of 3" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/seed_views.py
+msgid "{threshold} of {n}"
+msgstr "{threshold} trong {n}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "Đang xuất xpub..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "Đang ký tin nhắn..."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "Xác nhận thất bại"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "Kiểm tra thẻ thông minh"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "Liệt kê đầu đọc thẻ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "Kiểm tra quét NFC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "Khởi động lại PCSC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "Thông tin pin"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "Thông tin hệ thống"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "Tải tệp sao lưu"
+
+#. FORK: translated by Claude 2026-07-11
+#. Title of a warning dialog when configuring a setting that requires at least
+#. one option to be selected.
+#: src/seedsigner/views/settings_views.py
+msgid "Selection Required"
+msgstr "Cần chọn ít nhất một mục"
+
+#. FORK: translated by Claude 2026-07-11
+#. The name of the setting being configured (e.g. "Script types") will be
+#. inserted.
+#: src/seedsigner/views/settings_views.py
+msgid "At least one option must be selected for \"{}\"."
+msgstr "Phải chọn ít nhất một tùy chọn cho \"{}\"."
+
+#. FORK: translated by Claude 2026-07-11
+#. Text for the button that returns the user to the setting configuration
+#. screen.
+#: src/seedsigner/views/settings_views.py
+msgid "Return to setting"
+msgstr "Quay lại cài đặt"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "Không tìm thấy bộ theo dõi pin tương thích"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "Không khả dụng"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "Chức năng chung"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Chức năng Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Chức năng Keycard"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "Chức năng SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Chức năng Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "Công cụ DIY"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "Thông tin thẻ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "Kiểm tra hàng thật"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "Đổi PIN"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "Đổi nhãn"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "Đổi chính sách NFC"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "Cấu hình NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "Khôi phục cài đặt gốc cho thẻ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "Xem NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "Dùng liên kết ứng dụng Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "Xóa NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "Đặt NDEF tùy chỉnh"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "Lưu NDEF vào SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "Tải NDEF từ SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "Bản ghi văn bản"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "Bản ghi URI"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Mở ứng dụng Android"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "Tùy chỉnh (HEX)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "Giải mã NDEF"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC bật"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC tắt"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC bị chặn"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "Thẻ đã cắm lại"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "Xem dung lượng trống"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "Xem bí mật trên thẻ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "Lưu mật khẩu vào thẻ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "Xóa bí mật khỏi thẻ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "Tải thông tin ví đa chữ ký"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "Lưu thông tin ví đa chữ ký"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "Sao chép bí mật của thẻ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "Về màn hình chính"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "Khởi tạo bằng cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "Tải làm thông tin ví"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "Tải PSBT"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "Đặt PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "Mở khóa PIN bằng PUK"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "Đặt tên"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "Gỡ cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "Đo tốc độ ký"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "Đo tốc độ ký tin nhắn"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "Kiểm tra độ lệch chữ ký"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "Gỡ bỏ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "Đặt lại"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "Bật 2FA"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "Đã có cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"xprv không thể khởi tạo Satochip.\n"
+"Dùng BIP39, SLIP39 hoặc Electrum."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "Đổi PIN thẻ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "Tải cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "Lưu cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "Xóa cụm từ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "Khóa của thẻ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "Dựng applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "Cài applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "Gỡ applet"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "Nhập PIN khác"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "Tải khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "Lưu khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "Mở khóa thẻ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "Khóa thẻ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "Xóa khóa đã tải"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "Ghi đè"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "Hủy lưu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "Nhập một khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "Nhập bộ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "Tạo một khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "Tạo bộ khóa"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB (mặc định)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "Entropy RNG hệ thống quá thấp. Thử lại sau."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "Entropy từ RNG hệ thống không qua được kiểm tra."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " Cụm từ khóa mới"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "Cụm từ khóa SLIP39"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "Mã QR văn bản"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "Trình tạo mật khẩu"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "Công cụ thẻ thông minh"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "Công cụ MicroSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "Xóa thông tin ví đa chữ ký"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "Không tìm thấy thẻ microSD"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "Cắm thẻ microSD để lưu nhật ký xả pin."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "Không tải được thông tin mạng."
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 từ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 từ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 từ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 từ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 từ"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "20 words ({} rolls)"
+msgstr "20 từ ({} lần gieo)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "33 words ({} rolls)"
+msgstr "33 từ ({} lần gieo)"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "Đã tải thông tin ví đa chữ ký"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "Tải từ Satochip"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Cụm từ khóa Electrum"
+
+#. FORK: translated by Claude 2026-07-11
+#. Multisig policy. For a "2 / 3 multisig" policy, "threshold" = 2; "n" = 3
+#: src/seedsigner/views/tools_views.py
+msgid "{threshold} / {n} multisig"
+msgstr "Đa chữ ký {threshold} / {n}"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "Mã hóa văn bản"
+
+#. FORK: translated by Claude 2026-07-11
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "Giải mã mã QR"
+
+#. FORK: translated by Claude 2026-07-11
+#. "network" will be mainnet/testnet/regtest.
+#: src/seedsigner/views/view.py
+msgid "Current network setting ({network}) doesn't match {derivation_path}."
+msgstr "Cài đặt mạng hiện tại ({network}) không khớp với {derivation_path}."
+

--- a/l10n/fork/zh_Hans_CN/messages.po
+++ b/l10n/fork/zh_Hans_CN/messages.po
@@ -1,0 +1,2516 @@
+# Fork translation overlay for SeedSigner (3rdIteration fork).
+# Contains ONLY strings that upstream's catalogs do not translate.
+# Merged with the upstream catalog at build time (upstream wins on overlap).
+# Managed by l10n/fork_translations.py — see l10n/README.md.
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-12 08:07-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_Hans_CN\n"
+"Language-Team: zh_Hans_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/controller.py src/seedsigner/views/view.py
+msgid "Data wiped after inactivity"
+msgstr "闲置后数据已擦除"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Starting camera..."
+msgstr "正在启动相机..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Decrypt?"
+msgstr "解密？"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Select QR Type"
+msgstr "选择二维码类型"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Encryption Key"
+msgstr "加密密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/scan_screens.py
+msgid "Review Encryption Key"
+msgstr "核对加密密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Account Number"
+msgstr "账户编号"
+
+#. FORK: translated by Claude 2026-07-12
+#. Refers to the SeedQR type: Standard or Compact or encrypted
+#: src/seedsigner/gui/screens/seed_screens.py
+#: src/seedsigner/views/seed_views.py
+msgid "Encrypted"
+msgstr "已加密"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Encrypted entropy bits"
+msgstr "加密的熵位"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Non-standard path!"
+msgstr "非标准路径！"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Mnemonic ID"
+msgstr "助记 ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Review Mnemonic ID"
+msgstr "核对助记 ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "The QR codes output in both modes may differ, but both are valid QR codes."
+msgstr "两种模式输出的二维码可能不同，但都是有效的二维码。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "Transcribe Encrypted QR"
+msgstr "誊写加密二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "No options available"
+msgstr "无可用选项"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#: src/seedsigner/views/settings_views.py
+msgid "Battery Info"
+msgstr "电池信息"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+msgid "System Info"
+msgstr "系统信息"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Platform: {platform_name}"
+msgstr "平台：{platform_name}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Variant: {platform_variant}"
+msgstr "变体：{platform_variant}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Serial (CPU): {system_serial}"
+msgstr "序列号(CPU)：{system_serial}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/settings_screens.py
+#, python-brace-format
+msgid "Serial (MicroSD): {microsd_serial}"
+msgstr "序列号(MicroSD)：{microsd_serial}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Device Filter"
+msgstr "设备过滤器"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Network Info"
+msgstr "网络信息"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/tools_views.py
+msgid "Battery Calibration"
+msgstr "电池校准"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charge the battery fully. Select Next to start the discharge test."
+msgstr "将电池充满。选择“下一步”开始放电测试。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Start"
+msgstr "开始"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Test runs until empty. Leave the device unplugged."
+msgstr "测试将持续到电量耗尽。请勿连接电源。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Charging detected"
+msgstr "检测到充电"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Discharging"
+msgstr "放电中"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Elapsed: "
+msgstr "已用时："
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Voltage: "
+msgstr "电压："
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Current: "
+msgstr "电流："
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Status: "
+msgstr "状态："
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "LOW ENTROPY"
+msgstr "熵不足"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "GOOD ENTROPY"
+msgstr "熵良好"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/gui/screens/tools_screens.py
+#: src/seedsigner/views/gpg_views.py
+msgid "Text to Encode"
+msgstr "要编码的文本"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/helpers/seedkeeper_utils.py
+msgid "Set Duress PIN"
+msgstr "设置胁迫 PIN"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 0"
+msgstr "相机 0"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 1"
+msgstr "相机 1"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 2"
+msgstr "相机 2"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera 3"
+msgstr "相机 3"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "5 minutes"
+msgstr "5 分钟"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "10 minutes"
+msgstr "10 分钟"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "15 minutes"
+msgstr "15 分钟"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "30 minutes"
+msgstr "30 分钟"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed Passphrase"
+msgstr "Aezeed 密码短语"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer CompactSeedQR"
+msgstr "优先 CompactSeedQR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Prefer EncryptedQR"
+msgstr "优先 EncryptedQR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Ask each time"
+msgstr "每次询问"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard PIN Attempts"
+msgstr "智能卡 PIN 尝试次数"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Wipe Timer"
+msgstr "擦除计时器"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Seed word lengths"
+msgstr "助记词单词数"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP32 account prompt"
+msgstr "BIP32 账户提示"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Ambiguous QR"
+msgstr "二维码含义不明"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "GPG key types"
+msgstr "GPG 密钥类型"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BIP85 GPG version"
+msgstr "BIP85 GPG 版本"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "v3 is the latest; use v2 to recreate B9-B10 keys"
+msgstr "v3 为最新版；重建 B9-B10 密钥请用 v2"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "SLIP39 seeds"
+msgstr "SLIP39 助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Aezeed seeds"
+msgstr "Aezeed 助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "LND-compatible, 24 words"
+msgstr "LND 兼容，24 词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Extendable SLIP39 shares"
+msgstr "可扩展的 SLIP39 分片"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "BitBox02 backups"
+msgstr "BitBox02 备份"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Passport backups"
+msgstr "Passport 备份"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "TAPSIGNER backups"
+msgstr "TAPSIGNER 备份"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Smartcard support"
+msgstr "智能卡支持"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Satochip support"
+msgstr "Satochip 支持"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "KeyCard support"
+msgstr "Keycard 支持"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Specter-DIY support"
+msgstr "Specter-DIY 支持"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/models/settings_definition.py
+msgid "Camera source"
+msgstr "相机来源"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+msgid "Desktop Mode"
+msgstr "桌面模式"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Not secure!"
+msgstr "不安全！"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+msgid ""
+"This desktop version is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"此桌面版本仅供测试。\n"
+"请勿用于真实助记词或私钥。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/desktop_warning.py
+#: src/seedsigner/views/developer_os_warning.py
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "I Understand"
+msgstr "我明白"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/developer_os_warning.py
+msgid "Development Build"
+msgstr "开发版本"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/developer_os_warning.py
+msgid ""
+"This SeedSignerOS development build is for testing only.\n"
+"Do NOT use with real seeds or private keys."
+msgstr ""
+"此 SeedSignerOS 开发版本仅供测试。\n"
+"请勿用于真实助记词或私钥。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "File Operations"
+msgstr "文件操作"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Import Keys"
+msgstr "导入密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Keys"
+msgstr "导出密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "View Keys"
+msgstr "查看密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Secure Messaging"
+msgstr "安全通信"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/tools_views.py
+msgid "GPG Tools"
+msgstr "GPG 工具"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Missing packages"
+msgstr "缺少软件包"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Required but not installed:\n"
+msgstr "必需但未安装：\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkey Operations"
+msgstr "子密钥操作"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "User ID Operations"
+msgstr "用户 ID 操作"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Cross Certify Keys"
+msgstr "交叉认证密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Public Key Bundle"
+msgstr "导出公钥包"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "BIP85 Metadata"
+msgstr "BIP85 元数据"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Subkeys"
+msgstr "子密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Back"
+msgstr "返回"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Bundle"
+msgstr "导出包"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Animated QR"
+msgstr "动态二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Save BIP85 Data"
+msgstr "保存 BIP85 数据"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load BIP85 Data"
+msgstr "载入 BIP85 数据"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Rebuild BIP85 Key"
+msgstr "重建 BIP85 密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To MicroSD"
+msgstr "到 MicroSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "To QR"
+msgstr "到二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "To Seedkeeper"
+msgstr "到 Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From MicroSD"
+msgstr "从 MicroSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "From QR"
+msgstr "从二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/smartcard_views.py
+msgid "From Seedkeeper"
+msgstr "从 Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Add Subkeys"
+msgstr "添加子密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke Subkeys"
+msgstr "吊销子密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete Subkeys"
+msgstr "删除子密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Expiry"
+msgstr "更改有效期"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Export Subkey Secrets"
+msgstr "导出子密钥私密"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "1 year"
+msgstr "1 年"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "2 years"
+msgstr "2 年"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "5 years"
+msgstr "5 年"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Never"
+msgstr "永不"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "File"
+msgstr "文件"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Smartcard"
+msgstr "智能卡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Add User ID"
+msgstr "添加用户 ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit User IDs"
+msgstr "编辑用户 ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Set Primary User ID"
+msgstr "设置主用户 ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Revoke User ID"
+msgstr "吊销用户 ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Delete User ID"
+msgstr "删除用户 ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypt"
+msgstr "加密"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/scan_views.py
+msgid "Decrypt"
+msgstr "解密"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Sign"
+msgstr "签名"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Verify Signature"
+msgstr "验证签名"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Create Message"
+msgstr "创建消息"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Message"
+msgstr "载入消息"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Manifest"
+msgstr "清单"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Type Message"
+msgstr "输入消息"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Seedkeeper"
+msgstr "载入 Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Scan QR"
+msgstr "扫描二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load File"
+msgstr "载入文件"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Load Key"
+msgstr "载入密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save to Seedkeeper"
+msgstr "保存到 Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Show as QR"
+msgstr "显示为二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Public Key"
+msgstr "公钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Private Key"
+msgstr "私钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "View Card Info"
+msgstr "查看卡信息"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate On-Card Key"
+msgstr "在卡上生成密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change Admin PIN"
+msgstr "更改管理员 PIN"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Change User PIN"
+msgstr "更改用户 PIN"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Encrypting File"
+msgstr "正在加密文件"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "(May take a while)"
+msgstr "（可能需要一些时间）"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Decrypting File"
+msgstr "正在解密文件"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Check SHA256Sum"
+msgstr "校验 SHA256Sum"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Update"
+msgstr "更新"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "From File"
+msgstr "从文件"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate New"
+msgstr "新建生成"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Derive BIP85"
+msgstr "派生 BIP85"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "OpenGPG Card"
+msgstr "OpenGPG 卡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit text"
+msgstr "编辑文本"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text"
+msgstr "放弃文本"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Discard text?"
+msgstr "放弃文本？"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Generate QR code"
+msgstr "生成二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe mode"
+msgstr "誊写模式"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "FullScreen mode"
+msgstr "全屏模式"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py src/seedsigner/views/seed_views.py
+msgid "Transcribe Mode ?"
+msgstr "誊写模式？"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm text QR code"
+msgstr "确认文本二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR ?"
+msgstr "确认文本二维码？"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Scan text QR code"
+msgstr "扫描文本二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR Code"
+msgstr "确认文本二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code does not match your original text!"
+msgstr "您誊写的文本二维码与原始文本不符！"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Review text QR code"
+msgstr "核对文本二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code successfully scanned and yielded the same text."
+msgstr "您誊写的文本二维码扫描成功，得到相同文本。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Confirm Text QR"
+msgstr "确认文本二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Your transcribed text QR code could not be read!"
+msgstr "无法读取您誊写的文本二维码！"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Edit & Generate QR code"
+msgstr "编辑并生成二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/gpg_views.py
+msgid "Decoded Text"
+msgstr "解码后的文本"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/keycard_bias.py src/seedsigner/views/satochip_bias.py
+msgid "Run Test"
+msgstr "运行测试"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Flash Image"
+msgstr "刷写镜像"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Verify MicroSD"
+msgstr "校验 MicroSD"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Zero)"
+msgstr "擦除(置零)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Wipe (Random)"
+msgstr "擦除(随机)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "Skip Verification"
+msgstr "跳过校验"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/microsd_views.py
+msgid "All"
+msgstr "全部"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Custom"
+msgstr "自定义"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Short"
+msgstr "Diceware-EFF 短"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-EFF Long"
+msgstr "Diceware-EFF 长"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Diceware-BIP39"
+msgstr "Diceware-BIP39"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Hex"
+msgstr "Hex"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Rolls"
+msgstr "掷骰"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Type"
+msgstr "密码类型"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "64 bits"
+msgstr "64 位"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "128 bits"
+msgstr "128 位"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "256 bits"
+msgstr "256 位"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Strength"
+msgstr "密码强度"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Yes"
+msgstr "是"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "No"
+msgstr "否"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Options"
+msgstr "选择选项"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose at least one character set."
+msgstr "请至少选择一种字符集。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG health check failed."
+msgstr "系统 RNG 健康检查失败。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG Error"
+msgstr "系统 RNG 错误"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Camera"
+msgstr "相机"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice"
+msgstr "骰子"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "System RNG"
+msgstr "系统 RNG"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Entropy Source"
+msgstr "熵来源"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Supported"
+msgstr "不支持"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 supports Diceware, Dice Rolls, Hex, Base64, and Base85."
+msgstr "BIP85 支持 Diceware、掷骰、Hex、Base64 和 Base85。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "None"
+msgstr "无"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Capitalise"
+msgstr "首字母大写"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Space"
+msgstr "空格"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Separator"
+msgstr "分隔符"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "6 sides"
+msgstr "6 面"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "10 sides"
+msgstr "10 面"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "20 sides"
+msgstr "20 面"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Dice Sides"
+msgstr "骰子面数"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of Rolls"
+msgstr "掷骰次数"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Input"
+msgstr "无效输入"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Number of rolls must be at least 1."
+msgstr "掷骰次数至少为 1。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Poor Entropy"
+msgstr "熵不足"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Dice rolls didn't appear random enough. Please try again."
+msgstr "掷骰结果随机性不足。请重试。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/tools_views.py
+msgid "Camera entropy didn't appear random enough. Please try again."
+msgstr "相机熵随机性不足。请重试。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "WARNING"
+msgstr "警告"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Load a seed before using BIP85."
+msgstr "使用 BIP85 前请先载入助记词。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Select Seed"
+msgstr "选择助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Choose seed for BIP85"
+msgstr "选择用于 BIP85 的助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Index"
+msgstr "BIP85 索引"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Invalid Length"
+msgstr "长度无效"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Hex supports 128 or 256 bits."
+msgstr "BIP85 Hex 支持 128 或 256 位。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base64 needs 120+ bits."
+msgstr "BIP85 Base64 需要 120 位以上。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "BIP85 Base85 needs 64-512 bits."
+msgstr "BIP85 Base85 需要 64-512 位。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password Name"
+msgstr "密码名称"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not Enough Space"
+msgstr "空间不足"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid ""
+"Saving Secret\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+msgstr ""
+"正在保存私密\n"
+"\n"
+"\n"
+"\n"
+"\n"
+"\n"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/psbt_views.py
+msgid "Success"
+msgstr "成功"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password saved to Seedkeeper"
+msgstr "密码已保存到 Seedkeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Not enough space on Seedkeeper for password"
+msgstr "Seedkeeper 上空间不足，无法保存密码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Failed"
+msgstr "失败"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password save failed"
+msgstr "密码保存失败"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+#: src/seedsigner/views/scan_views.py
+msgid "Edit"
+msgstr "编辑"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Password"
+msgstr "密码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/password_generator_views.py
+msgid "Save Password"
+msgstr "保存密码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+msgid "Use Satochip card"
+msgstr "使用 Satochip 卡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Use Keycard"
+msgstr "使用 Keycard"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 15-word seed"
+msgstr "输入 15 词助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 18-word seed"
+msgstr "输入 18 词助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
+#: src/seedsigner/views/smartcard_views.py src/seedsigner/views/tools_views.py
+msgid "Enter 21-word seed"
+msgstr "输入 21 词助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter WIF"
+msgstr "输入 WIF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan WIF"
+msgstr "扫描 WIF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Enter BIP38"
+msgstr "输入 BIP38"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/scan_views.py
+msgid "Scan BIP38"
+msgstr "扫描 BIP38"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Fingerprint mismatch"
+msgstr "指纹不匹配"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Card cannot sign PSBT"
+msgstr "卡无法签署此 PSBT"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Card fingerprint ({}) not in PSBT signers."
+msgstr "卡指纹({})不在 PSBT 签名者中。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Private Key (WIF)"
+msgstr "私钥(WIF)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid WIF!"
+msgstr "无效的 WIF！"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Not a valid WIF-encoded private key."
+msgstr "不是有效的 WIF 编码私钥。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Key"
+msgstr "BIP38 密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "BIP38 Passphrase"
+msgstr "BIP38 密码短语"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Invalid BIP38!"
+msgstr "无效的 BIP38！"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Could not decrypt BIP38 key."
+msgstr "无法解密 BIP38 密钥。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor mismatch"
+msgstr "descriptor 不匹配"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Descriptor cleared"
+msgstr "已清除 descriptor"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Loaded multisig wallet descriptor does not match this PSBT. Load the correct descriptor or skip verification to continue."
+msgstr "载入的多签钱包 descriptor 与此 PSBT 不符。请载入正确的 descriptor 或跳过校验以继续。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing PSBT..."
+msgstr "正在签署 PSBT..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Signing Timeout"
+msgstr "签名超时"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Retry (higher timeout)"
+msgstr "重试(延长超时)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Saved as {}."
+msgstr "已保存为 {}。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+#, python-brace-format
+msgid "Failed to save PSBT: {}"
+msgstr "保存 PSBT 失败：{}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/psbt_views.py
+msgid "Encoding PSBT..."
+msgstr "正在编码 PSBT..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "QR Scanner Unavailable"
+msgstr "二维码扫描器不可用"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "QR scanning backend missing. Install zbar (or OpenCV on desktop) and restart."
+msgstr "缺少二维码扫描后端。请安装 zbar（桌面版为 OpenCV）后重启。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Select Seed Type"
+msgstr "选择助记词类型"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Time set to:"
+msgstr "时间已设为："
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Set Time Failed"
+msgstr "设置时间失败"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Invalid Time"
+msgstr "无效时间"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Could not parse time from QR"
+msgstr "无法从二维码解析时间"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Scan SLIP-39 Share"
+msgstr "扫描 SLIP-39 分片"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a SLIP-39 share QR"
+msgstr "需要 SLIP-39 分片二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a WIF private key"
+msgstr "需要 WIF 私钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Expected a BIP38 private key"
+msgstr "需要 BIP38 私钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+#, python-brace-format
+msgid "Scan {} receive address from the wallet you just exported"
+msgstr "扫描您刚导出钱包的接收地址 {}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid ""
+"Data matches multiple\n"
+"QR types."
+msgstr ""
+"数据匹配多种\n"
+"二维码类型。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Type encryption key"
+msgstr "输入加密密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan encryption key"
+msgstr "扫描加密密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Edit encryption key"
+msgstr "编辑加密密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Discard encryption key"
+msgstr "放弃加密密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Proceed"
+msgstr "继续"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
+msgid "Scan & Append Another"
+msgstr "扫描并追加另一个"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/scan_views.py
+msgid "Decrypted Text"
+msgstr "解密后的文本"
+
+#. FORK: translated by Claude 2026-07-12
+#. This is on the opening splash screen, displayed above the Seedsigner logo
+#: src/seedsigner/views/screensaver.py
+msgid "An unofficial fork of:"
+msgstr "以下项目的非官方分支："
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "BitBox02 backup"
+msgstr "BitBox02 备份"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup"
+msgstr "Passport 备份"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "TAPSIGNER backup"
+msgstr "TAPSIGNER 备份"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter Aezeed seed"
+msgstr "输入 Aezeed 助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "SLIP-39 Shares"
+msgstr "SLIP-39 分片"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid " Scan a SeedQR"
+msgstr " 扫描 SeedQR"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "From SeedKeeper"
+msgstr "从 SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "From Specter-DIY"
+msgstr "从 Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid " Create a seed"
+msgstr " 创建助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "microSD card not detected."
+msgstr "未检测到 microSD 卡。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No Backups Found"
+msgstr "未找到备份"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No BitBox02 backups (.bin, .bb02, .dat, .backup) were found on the microSD card."
+msgstr "在 microSD 卡上未找到 BitBox02 备份(.bin、.bb02、.dat、.backup)。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select BitBox02 backup"
+msgstr "选择 BitBox02 备份"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Backup name: {}"
+msgstr "备份名称：{}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Created: {}"
+msgstr "创建时间：{}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Firmware: {}"
+msgstr "固件：{}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Birthdate: {}"
+msgstr "创建日期：{}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Seed length: {} words"
+msgstr "助记词长度：{} 词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Seed loaded"
+msgstr "助记词已载入"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No Passport backups (.7z) were found on the microSD card."
+msgstr "在 microSD 卡上未找到 Passport 备份(.7z)。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select Passport backup"
+msgstr "选择 Passport 备份"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Passport backup code"
+msgstr "Passport 备份码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Backup code cannot be empty."
+msgstr "备份码不能为空。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Chain: {}"
+msgstr "链：{}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "XFP: {}"
+msgstr "XFP：{}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "No TAPSIGNER backups (.aes) were found on the microSD card."
+msgstr "在 microSD 卡上未找到 TAPSIGNER 备份(.aes)。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Select TAPSIGNER backup"
+msgstr "选择 TAPSIGNER 备份"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Backup key (hex)"
+msgstr "备份密钥(hex)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "xprv loaded from TAPSIGNER backup."
+msgstr "已从 TAPSIGNER 备份载入 xprv。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Path: {}"
+msgstr "路径：{}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load Passphrase"
+msgstr "载入密码短语"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Type Passphrase"
+msgstr "输入密码短语"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Scan Passphrase"
+msgstr "扫描密码短语"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load from SeedKeeper"
+msgstr "从 SeedKeeper 载入"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed passphrase"
+msgstr "Aezeed 密码短语"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase required\n"
+"for this mnemonic."
+msgstr ""
+"此助记词\n"
+"需要密码短语。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid passphrase"
+msgstr "无效的密码短语"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed passphrase required.\n"
+"Try again."
+msgstr ""
+"需要 Aezeed 密码短语。\n"
+"请重试。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Wrong Aezeed passphrase.\n"
+"Try again."
+msgstr ""
+"Aezeed 密码短语错误。\n"
+"请重试。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Text QR Code"
+msgstr "无效的文本二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Non UTF-8 data detected."
+msgstr "检测到非 UTF-8 数据。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Aezeed support"
+msgstr "Aezeed 支持"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Aezeed entry is experimental.\n"
+"Use only with known-good backups."
+msgstr ""
+"Aezeed 输入为实验功能。\n"
+"仅用于已知良好的备份。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 20 words"
+msgstr "输入 20 词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter 33 words"
+msgstr "输入 33 词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load Share"
+msgstr "载入分片"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Share Word #{}"
+msgstr "分片单词 #{}"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Enter share"
+msgstr "输入分片"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Scan share"
+msgstr "扫描分片"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Combine shares"
+msgstr "合并分片"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "{} of {} needed"
+msgstr "需要 {} 个（共 {} 个）"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/settings_views.py
+#: src/seedsigner/views/smartcard_views.py
+msgid "Try Again"
+msgstr "重试"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid SLIP-39 Share"
+msgstr "无效的 SLIP-39 分片"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Checksum failure; not a valid SLIP-39 share."
+msgstr "校验和错误；不是有效的 SLIP-39 分片。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Non-extendable Seed"
+msgstr "不可扩展的助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "This SLIP-39 seed cannot regenerate new shares."
+msgstr "此 SLIP-39 助记词无法重新生成新分片。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Export as Plaintext QR"
+msgstr "导出为明文二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "To SeedKeeper"
+msgstr "到 SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "To Specter-DIY"
+msgstr "到 Specter-DIY"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Regenerate Shares"
+msgstr "重新生成分片"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Open {} and display a receive address from the wallet you just exported."
+msgstr "打开 {} 并显示您刚导出钱包的接收地址。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "your wallet software"
+msgstr "您的钱包软件"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid ""
+"Passphrase was used.\n"
+"You'll need words + passphrase."
+msgstr ""
+"已使用密码短语。\n"
+"您将需要单词 + 密码短语。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "18 Words"
+msgstr "18 词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Review"
+msgstr "核对"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Finalize child"
+msgstr "确定子助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input Encryption Key"
+msgstr "输入加密密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard encryption key?"
+msgstr "放弃加密密钥？"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Your current key entry will be erased"
+msgstr "当前输入的密钥将被清除"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Invalid Key"
+msgstr "无效密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Key length is too long."
+msgstr "密钥过长。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input from Camera"
+msgstr "从相机输入"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Use fingerprint"
+msgstr "使用指纹"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Assign custom ID"
+msgstr "指定自定义 ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Input Mnemonic ID"
+msgstr "输入助记 ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Edit mnemonic ID"
+msgstr "编辑助记 ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID"
+msgstr "放弃助记 ID"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Discard mnemonic ID?"
+msgstr "放弃助记 ID？"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Your current mnemonic ID entry will be erased"
+msgstr "当前输入的助记 ID 将被清除"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Processing..."
+msgstr "处理中..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Encryption failure"
+msgstr "加密失败"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Next 100"
+msgstr "下一组 100"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Expanded Search"
+msgstr "扩展搜索"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Not Found"
+msgstr "未找到"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Address Not Verified"
+msgstr "地址未验证"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Checked {} addresses with no match."
+msgstr "已检查 {} 个地址，无匹配。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Check Next 10"
+msgstr "检查下 10 个"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+#, python-brace-format
+msgid "Checked {} addresses per path with no match."
+msgstr "每条路径已检查 {} 个地址，无匹配。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet Export"
+msgstr "钱包导出"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Wallet export successful."
+msgstr "钱包导出成功。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Address format doesn't match exported script type. Wallet export unsuccessful."
+msgstr "地址格式与导出的脚本类型不符。钱包导出失败。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Unable to match wallet to current seed. Wallet export unsuccessful."
+msgstr "无法将钱包与当前助记词匹配。钱包导出失败。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Export Failed"
+msgstr "导出失败"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Load SeedKeeper"
+msgstr "载入 SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/smartcard_views.py
+msgid "Exporting xpub..."
+msgstr "正在导出 xpub..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Signing message..."
+msgstr "正在签署消息..."
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/seed_views.py
+msgid "Verification Failed"
+msgstr "验证失败"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Test Smartcard"
+msgstr "测试智能卡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "List card readers"
+msgstr "列出读卡器"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Test NFC Scan"
+msgstr "测试 NFC 扫描"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Restart PCSC"
+msgstr "重启 PCSC"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Battery info"
+msgstr "电池信息"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "System info"
+msgstr "系统信息"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "Load Backup Files"
+msgstr "载入备份文件"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py
+msgid "No compatible battery monitor detected"
+msgstr "未检测到兼容的电池监控器"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/settings_views.py src/seedsigner/views/tools_views.py
+msgid "Unavailable"
+msgstr "不可用"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Common Functions"
+msgstr "通用功能"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Satochip Functions"
+msgstr "Satochip 功能"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "KeyCard Functions"
+msgstr "Keycard 功能"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "SeedKeeper Functions"
+msgstr "SeedKeeper 功能"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Specter-DIY Functions"
+msgstr "Specter-DIY 功能"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "DIY Tools"
+msgstr "DIY 工具"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Info"
+msgstr "卡信息"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Genuine Check"
+msgstr "真伪检查"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change PIN"
+msgstr "更改 PIN"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Label"
+msgstr "更改标签"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change NFC Policy"
+msgstr "更改 NFC 策略"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Configure NDEF"
+msgstr "配置 NDEF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Factory Reset Card"
+msgstr "恢复卡出厂设置"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View NDEF"
+msgstr "查看 NDEF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Use Seedkeeper App Link"
+msgstr "使用 Seedkeeper 应用链接"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear NDEF"
+msgstr "清除 NDEF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Custom NDEF"
+msgstr "设置自定义 NDEF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save NDEF to SeedKeeper"
+msgstr "将 NDEF 保存到 SeedKeeper"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load NDEF from SeedKeeper"
+msgstr "从 SeedKeeper 载入 NDEF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Text Record"
+msgstr "文本记录"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "URI Record"
+msgstr "URI 记录"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Android App Launch"
+msgstr "Android 应用启动"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Custom (HEX)"
+msgstr "自定义(HEX)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Decode NDEF"
+msgstr "解码 NDEF"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Enabled"
+msgstr "NFC 已启用"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Disabled"
+msgstr "NFC 已禁用"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "NFC Blocked"
+msgstr "NFC 已阻止"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Re-Inserted"
+msgstr "卡已重新插入"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Free Space"
+msgstr "查看剩余空间"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "View Secrets on Card"
+msgstr "查看卡上的私密"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Password to Card"
+msgstr "将密码保存到卡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Delete Secret from Card"
+msgstr "从卡删除私密"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load MultiSig Descriptor"
+msgstr "载入多签 descriptor"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save MultiSig Descriptor"
+msgstr "保存多签 descriptor"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clone Card Secrets"
+msgstr "克隆卡上私密"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Exit to Home"
+msgstr "退出到主页"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Initialise with Seed"
+msgstr "用助记词初始化"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load as Descriptor"
+msgstr "作为 descriptor 载入"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load PSBT"
+msgstr "载入 PSBT"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set PUK"
+msgstr "设置 PUK"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unblock PIN with PUK"
+msgstr "用 PUK 解锁 PIN"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Set Name"
+msgstr "设置名称"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove Seed"
+msgstr "移除助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Signing"
+msgstr "签名基准测试"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Benchmark Message Signing"
+msgstr "消息签名基准测试"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Check signing bias"
+msgstr "检查签名偏差"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Remove"
+msgstr "移除"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Reset"
+msgstr "重置"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enable 2FA"
+msgstr "启用 2FA"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Already Seeded"
+msgstr "已设置助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid ""
+"xprv cannot init Satochip.\n"
+"Use BIP39, SLIP39, or Electrum."
+msgstr ""
+"xprv 无法初始化 Satochip。\n"
+"请使用 BIP39、SLIP39 或 Electrum。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Change Card PIN"
+msgstr "更改卡 PIN"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Mnemonic"
+msgstr "载入助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Mnemonic"
+msgstr "保存助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Wipe Seed"
+msgstr "擦除助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Card Keys"
+msgstr "卡密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Build Applets"
+msgstr "构建小程序"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Install Applet"
+msgstr "安装小程序"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Uninstall Applet"
+msgstr "卸载小程序"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Different PIN"
+msgstr "输入其他 PIN"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Load Keys"
+msgstr "载入密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Save Keys"
+msgstr "保存密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Unlock Card"
+msgstr "解锁卡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Lock Card"
+msgstr "锁定卡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Clear Loaded Keys"
+msgstr "清除已载入的密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Overwrite"
+msgstr "覆盖"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Abort Save"
+msgstr "中止保存"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Single Key"
+msgstr "输入单个密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Enter Key Set"
+msgstr "输入密钥组"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Single Key"
+msgstr "生成单个密钥"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "Generate Key Set"
+msgstr "生成密钥组"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/smartcard_views.py
+msgid "8 KB (default)"
+msgstr "8 KB(默认)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG entropy too low. Try again later."
+msgstr "系统 RNG 熵过低。请稍后重试。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "System RNG derived entropy failed health checks."
+msgstr "系统 RNG 派生的熵未通过健康检查。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid " New seed"
+msgstr " 新建助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "SLIP39 seed"
+msgstr "SLIP39 助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Text QR Code"
+msgstr "文本二维码"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Password Generator"
+msgstr "密码生成器"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Smartcard Tools"
+msgstr "智能卡工具"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "MicroSD Tools"
+msgstr "MicroSD 工具"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Clear Multisig Descriptor"
+msgstr "清除多签 descriptor"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "microSD card not detected"
+msgstr "未检测到 microSD 卡"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Insert a microSD card to save the discharge log."
+msgstr "插入 microSD 卡以保存放电日志。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Unable to load network information."
+msgstr "无法载入网络信息。"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "15 words"
+msgstr "15 词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "18 words"
+msgstr "18 词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "21 words"
+msgstr "21 词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "20 words"
+msgstr "20 词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "33 words"
+msgstr "33 词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+#, python-brace-format
+msgid "20 words ({} rolls)"
+msgstr "20 词({} 次)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+#, python-brace-format
+msgid "33 words ({} rolls)"
+msgstr "33 词({} 次)"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Loaded Multisig Descriptor"
+msgstr "已载入多签 descriptor"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Load from Satochip"
+msgstr "从 Satochip 载入"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Electrum Seed"
+msgstr "Electrum 助记词"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Encode text"
+msgstr "编码文本"
+
+#. FORK: translated by Claude 2026-07-12
+#: src/seedsigner/views/tools_views.py
+msgid "Decode QR code"
+msgstr "解码二维码"
+

--- a/l10n/fork_translations.py
+++ b/l10n/fork_translations.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Manage the fork's translation overlay catalogs.
+
+The fork adds UI strings that upstream's translators (Transifex) will never see.
+Those translations live in overlay catalogs at ``l10n/fork/<locale>/messages.po``
+containing ONLY the fork-gap entries. At build time the custom ``compile_catalog``
+command in setup.py merges each upstream catalog (in the seedsigner-translations
+submodule) with its overlay — upstream always wins for any msgid it has translated —
+and writes the combined ``.mo``.
+
+Subcommands:
+    status  Per-locale coverage table (pot vs upstream vs overlay).
+    stub    Add missing msgids to a locale's overlay catalog with empty msgstr.
+    prune   Drop overlay entries now translated upstream or gone from the pot.
+    check   Validate overlay catalogs (parse, placeholders, stray empties).
+
+Run from the repo root, e.g.:
+    python l10n/fork_translations.py status
+    python l10n/fork_translations.py stub --locale es
+    python l10n/fork_translations.py stub --all
+    python l10n/fork_translations.py prune
+    python l10n/fork_translations.py check
+"""
+import argparse
+import os
+import re
+import sys
+
+from babel.messages.catalog import Catalog
+from babel.messages.pofile import read_po, write_po
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+POT_PATH = os.path.join(REPO_ROOT, "l10n", "messages.pot")
+UPSTREAM_L10N_DIR = os.path.join(
+    REPO_ROOT, "src", "seedsigner", "resources", "seedsigner-translations", "l10n"
+)
+OVERLAY_DIR = os.path.join(REPO_ROOT, "l10n", "fork")
+
+# Matches str.format() placeholders, both positional and named: {}, {0}, {name}
+FORMAT_PLACEHOLDER_REGEX = re.compile(r"\{[a-zA-Z0-9_]*\}")
+
+
+def load_pot() -> Catalog:
+    with open(POT_PATH, "rb") as f:
+        return read_po(f)
+
+
+def upstream_locales() -> list[str]:
+    if not os.path.isdir(UPSTREAM_L10N_DIR):
+        raise SystemExit(
+            f"Upstream l10n dir not found: {UPSTREAM_L10N_DIR}\n"
+            "Did you run `git submodule update --init`?"
+        )
+    return sorted(
+        d for d in os.listdir(UPSTREAM_L10N_DIR)
+        if os.path.isfile(os.path.join(UPSTREAM_L10N_DIR, d, "LC_MESSAGES", "messages.po"))
+    )
+
+
+def upstream_po_path(locale: str) -> str:
+    return os.path.join(UPSTREAM_L10N_DIR, locale, "LC_MESSAGES", "messages.po")
+
+
+def overlay_po_path(locale: str) -> str:
+    return os.path.join(OVERLAY_DIR, locale, "messages.po")
+
+
+def load_catalog(path: str, locale: str = None) -> Catalog:
+    with open(path, "rb") as f:
+        return read_po(f, locale=locale)
+
+
+def load_overlay(locale: str) -> Catalog:
+    path = overlay_po_path(locale)
+    if os.path.isfile(path):
+        return load_catalog(path, locale=locale)
+    catalog = Catalog(locale=locale, domain="messages", fuzzy=False)
+    catalog.header_comment = (
+        "# Fork translation overlay for SeedSigner (3rdIteration fork).\n"
+        "# Contains ONLY strings that upstream's catalogs do not translate.\n"
+        "# Merged with the upstream catalog at build time (upstream wins on overlap).\n"
+        "# Managed by l10n/fork_translations.py — see l10n/README.md."
+    )
+    return catalog
+
+
+def save_overlay(locale: str, catalog: Catalog):
+    path = overlay_po_path(locale)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        write_po(f, catalog, width=0, sort_by_file=False, omit_header=False)
+
+
+def translated_ids(catalog: Catalog) -> set:
+    """msgids with a non-empty msgstr (excludes the header entry)."""
+    return {m.id for m in catalog if m.id and m.string}
+
+
+def all_ids(catalog: Catalog) -> set:
+    return {m.id for m in catalog if m.id}
+
+
+def cmd_status(args) -> int:
+    pot_ids = all_ids(load_pot())
+    print(f"messages.pot: {len(pot_ids)} translatable strings\n")
+    print(f"{'locale':12} {'upstream':>9} {'overlay':>8} {'stubs':>6} {'gap':>6} {'coverage':>9}")
+    print("-" * 56)
+    for locale in upstream_locales():
+        upstream_done = translated_ids(load_catalog(upstream_po_path(locale), locale)) & pot_ids
+        overlay = load_overlay(locale)
+        overlay_done = (translated_ids(overlay) & pot_ids) - upstream_done
+        overlay_stubs = (all_ids(overlay) & pot_ids) - translated_ids(overlay) - upstream_done
+        gap = len(pot_ids) - len(upstream_done) - len(overlay_done)
+        coverage = (len(upstream_done) + len(overlay_done)) / len(pot_ids)
+        print(f"{locale:12} {len(upstream_done):>9} {len(overlay_done):>8} {len(overlay_stubs):>6} {gap:>6} {coverage:>8.1%}")
+    return 0
+
+
+def cmd_stub(args) -> int:
+    pot = load_pot()
+    pot_ids = all_ids(pot)
+    locales = upstream_locales() if args.all else [args.locale]
+    for locale in locales:
+        if not os.path.isfile(upstream_po_path(locale)):
+            print(f"{locale}: no upstream catalog; skipping")
+            continue
+        upstream_done = translated_ids(load_catalog(upstream_po_path(locale), locale))
+        overlay = load_overlay(locale)
+        existing = all_ids(overlay)
+        added = 0
+        for message in pot:
+            if not message.id or message.id in upstream_done or message.id in existing:
+                continue
+            overlay.add(
+                message.id,
+                string="",
+                locations=message.locations,
+                auto_comments=message.auto_comments,
+                context=message.context,
+            )
+            added += 1
+        if added:
+            save_overlay(locale, overlay)
+        print(f"{locale}: added {added} stub(s) -> {os.path.relpath(overlay_po_path(locale), REPO_ROOT)}")
+    return 0
+
+
+def cmd_prune(args) -> int:
+    pot_ids = all_ids(load_pot())
+    for locale in upstream_locales():
+        path = overlay_po_path(locale)
+        if not os.path.isfile(path):
+            continue
+        upstream_done = translated_ids(load_catalog(upstream_po_path(locale), locale))
+        overlay = load_overlay(locale)
+        kept = Catalog(locale=locale, domain="messages", fuzzy=False)
+        kept.header_comment = overlay.header_comment
+        dropped_upstream = dropped_obsolete = 0
+        for message in overlay:
+            if not message.id:
+                continue
+            if message.id in upstream_done:
+                dropped_upstream += 1
+                continue
+            if message.id not in pot_ids:
+                dropped_obsolete += 1
+                continue
+            kept.add(
+                message.id,
+                string=message.string,
+                locations=message.locations,
+                auto_comments=message.auto_comments,
+                user_comments=message.user_comments,
+                context=message.context,
+                flags=message.flags,
+            )
+        if dropped_upstream or dropped_obsolete:
+            save_overlay(locale, kept)
+        print(
+            f"{locale}: dropped {dropped_upstream} now-translated-upstream, "
+            f"{dropped_obsolete} obsolete; {len(all_ids(kept))} entries remain"
+        )
+    return 0
+
+
+def cmd_check(args) -> int:
+    pot_ids = all_ids(load_pot())
+    errors = 0
+    checked = 0
+    for locale in upstream_locales():
+        path = overlay_po_path(locale)
+        if not os.path.isfile(path):
+            continue
+        checked += 1
+        try:
+            overlay = load_catalog(path, locale)
+        except Exception as e:
+            print(f"ERROR {locale}: catalog does not parse: {e}")
+            errors += 1
+            continue
+
+        upstream_done = translated_ids(load_catalog(upstream_po_path(locale), locale))
+        for message in overlay:
+            if not message.id:
+                continue
+            prefix = f"{locale}: {message.id[:60]!r}"
+            if message.id not in pot_ids:
+                print(f"WARN  {prefix} not in messages.pot (run prune)")
+            if message.id in upstream_done:
+                print(f"WARN  {prefix} already translated upstream (run prune)")
+            if message.string:
+                src_ph = sorted(FORMAT_PLACEHOLDER_REGEX.findall(message.id))
+                dst_ph = sorted(FORMAT_PLACEHOLDER_REGEX.findall(message.string))
+                if src_ph != dst_ph:
+                    print(f"ERROR {prefix} placeholder mismatch: {src_ph} vs {dst_ph}")
+                    errors += 1
+                if message.id.count("\n") != message.string.count("\n"):
+                    print(f"WARN  {prefix} line-break count differs from source")
+    print(f"\nChecked {checked} overlay catalog(s); {errors} error(s).")
+    return 1 if errors else 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("status", help="Per-locale coverage report")
+
+    p_stub = sub.add_parser("stub", help="Add missing msgids to an overlay catalog")
+    group = p_stub.add_mutually_exclusive_group(required=True)
+    group.add_argument("--locale", help="Locale code, e.g. es, de, zh_Hans_CN")
+    group.add_argument("--all", action="store_true", help="Stub every upstream locale")
+
+    sub.add_parser("prune", help="Drop entries now translated upstream or gone from the pot")
+    sub.add_parser("check", help="Validate overlay catalogs")
+
+    args = parser.parse_args()
+    return {"status": cmd_status, "stub": cmd_stub, "prune": cmd_prune, "check": cmd_check}[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/l10n/fork_translations.py
+++ b/l10n/fork_translations.py
@@ -184,8 +184,27 @@ def cmd_prune(args) -> int:
     return 0
 
 
+def _mnemonic_wordlist() -> set:
+    """BIP39 + SLIP39 words: translating a msgid that equals one of these could
+    corrupt seed backup/entry screens if such a string ever flowed through
+    gettext. (Verified word-rendering paths bypass gettext, but guard anyway.)"""
+    words = set()
+    try:
+        from embit import bip39
+        words.update(bip39.WORDLIST)
+    except ImportError:
+        pass
+    try:
+        from shamir_mnemonic.wordlist import WORDLIST as SLIP39_WORDLIST
+        words.update(SLIP39_WORDLIST)
+    except ImportError:
+        pass
+    return words
+
+
 def cmd_check(args) -> int:
     pot_ids = all_ids(load_pot())
+    mnemonic_words = _mnemonic_wordlist()
     errors = 0
     checked = 0
     for locale in upstream_locales():
@@ -209,6 +228,9 @@ def cmd_check(args) -> int:
                 print(f"WARN  {prefix} not in messages.pot (run prune)")
             if message.id in upstream_done:
                 print(f"WARN  {prefix} already translated upstream (run prune)")
+            if message.id in mnemonic_words:
+                print(f"ERROR {prefix} msgid equals a BIP39/SLIP39 mnemonic word — never translate these (see GLOSSARY.md)")
+                errors += 1
             if message.string:
                 src_ph = sorted(FORMAT_PLACEHOLDER_REGEX.findall(message.id))
                 dst_ph = sorted(FORMAT_PLACEHOLDER_REGEX.findall(message.string))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools", "wheel"]
+# Babel is required so the isolated PEP 517 build can import setup.py's
+# compile_catalog override (see setup.py). Kept in sync with
+# l10n/requirements-l10n.txt. setup.py also guards the import so a build without
+# babel still installs; this ensures the translation command is actually present.
+requires = ["setuptools", "wheel", "Babel==2.16.0"]
 
 [project]
 authors = [{name = "SeedSigner", email = "author@example.com"}]

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,80 @@
 """
-Empty setup.py necessary for the python-babel integration (e.g. python setup.py extract_messages).
-
+setup.py for the python-babel integration (e.g. python setup.py extract_messages).
 See the configuration in setup.cfg.
+
+`compile_catalog` is overridden to merge the fork's translation overlay catalogs
+(l10n/fork/<locale>/messages.po) into the upstream catalogs from the
+seedsigner-translations submodule before writing each .mo. Upstream translations
+always win for any msgid they cover; the overlay only fills the gaps for
+fork-added strings. See l10n/README.md and l10n/fork_translations.py.
+
+This keeps every build path (CI, seedsigner-os image builds, local dev) on the
+same single command it already runs: `python setup.py compile_catalog`.
 """
+import os
+
 import setuptools
 
-setuptools.setup()
+from babel.messages.frontend import compile_catalog
+from babel.messages.mofile import write_mo
+from babel.messages.pofile import read_po
+
+OVERLAY_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "l10n", "fork")
+
+
+class compile_catalog_with_overlay(compile_catalog):
+    """Compile upstream + fork-overlay catalogs into a single .mo per locale."""
+
+    def run(self):
+        # babel's finalize_options() turns `domain` into a list
+        domains = self.domain if isinstance(self.domain, list) else [self.domain]
+        # Honor `-l <locale>` filtering (babel accepts a comma-separated list)
+        only_locales = None
+        if self.locale:
+            only_locales = self.locale if isinstance(self.locale, list) else [loc.strip() for loc in self.locale.split(",")]
+        for domain in domains:
+            for locale in sorted(os.listdir(self.directory)):
+                if only_locales and locale not in only_locales:
+                    continue
+                upstream_po = os.path.join(self.directory, locale, "LC_MESSAGES", f"{domain}.po")
+                if not os.path.isfile(upstream_po):
+                    continue
+
+                with open(upstream_po, "rb") as f:
+                    catalog = read_po(f, locale=locale, domain=domain)
+
+                overlay_po = os.path.join(OVERLAY_DIR, locale, f"{domain}.po")
+                merged = 0
+                if os.path.isfile(overlay_po):
+                    with open(overlay_po, "rb") as f:
+                        overlay = read_po(f, locale=locale, domain=domain)
+                    for message in overlay:
+                        if not message.id or not message.string:
+                            continue
+                        existing = catalog.get(message.id, context=message.context)
+                        if existing is None:
+                            catalog.add(
+                                message.id,
+                                string=message.string,
+                                context=message.context,
+                                flags=message.flags,
+                            )
+                            merged += 1
+                        elif not existing.string:
+                            existing.string = message.string
+                            merged += 1
+
+                mo_path = os.path.join(self.directory, locale, "LC_MESSAGES", f"{domain}.mo")
+                self.log.info(
+                    "compiling catalog %s to %s (+%d fork overlay entries)",
+                    upstream_po, mo_path, merged,
+                )
+                with open(mo_path, "wb") as f:
+                    write_mo(f, catalog, use_fuzzy=self.use_fuzzy)
+
+        return 0
+
+
+setuptools.setup(
+    cmdclass={"compile_catalog": compile_catalog_with_overlay},
+)

--- a/setup.py
+++ b/setup.py
@@ -15,66 +15,83 @@ import os
 
 import setuptools
 
-from babel.messages.frontend import compile_catalog
-from babel.messages.mofile import write_mo
-from babel.messages.pofile import read_po
+# Babel is only needed for the translation commands (e.g. `python setup.py
+# compile_catalog`). Those run in an environment that has
+# l10n/requirements-l10n.txt installed. Babel is NOT available during the
+# isolated build that `pip install -e .` performs, so import it lazily and fall
+# back to a plain setup() when it is absent — otherwise the editable install
+# fails with ModuleNotFoundError before compile_catalog is ever invoked. Any
+# environment that actually runs `compile_catalog` must have babel installed
+# (see l10n/requirements-l10n.txt); without it the command is simply unavailable.
+try:
+    from babel.messages.frontend import compile_catalog
+    from babel.messages.mofile import write_mo
+    from babel.messages.pofile import read_po
+    HAVE_BABEL = True
+except ImportError:
+    HAVE_BABEL = False
 
 OVERLAY_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "l10n", "fork")
 
+cmdclass = {}
 
-class compile_catalog_with_overlay(compile_catalog):
-    """Compile upstream + fork-overlay catalogs into a single .mo per locale."""
+if HAVE_BABEL:
 
-    def run(self):
-        # babel's finalize_options() turns `domain` into a list
-        domains = self.domain if isinstance(self.domain, list) else [self.domain]
-        # Honor `-l <locale>` filtering (babel accepts a comma-separated list)
-        only_locales = None
-        if self.locale:
-            only_locales = self.locale if isinstance(self.locale, list) else [loc.strip() for loc in self.locale.split(",")]
-        for domain in domains:
-            for locale in sorted(os.listdir(self.directory)):
-                if only_locales and locale not in only_locales:
-                    continue
-                upstream_po = os.path.join(self.directory, locale, "LC_MESSAGES", f"{domain}.po")
-                if not os.path.isfile(upstream_po):
-                    continue
+    class compile_catalog_with_overlay(compile_catalog):
+        """Compile upstream + fork-overlay catalogs into a single .mo per locale."""
 
-                with open(upstream_po, "rb") as f:
-                    catalog = read_po(f, locale=locale, domain=domain)
+        def run(self):
+            # babel's finalize_options() turns `domain` into a list
+            domains = self.domain if isinstance(self.domain, list) else [self.domain]
+            # Honor `-l <locale>` filtering (babel accepts a comma-separated list)
+            only_locales = None
+            if self.locale:
+                only_locales = self.locale if isinstance(self.locale, list) else [loc.strip() for loc in self.locale.split(",")]
+            for domain in domains:
+                for locale in sorted(os.listdir(self.directory)):
+                    if only_locales and locale not in only_locales:
+                        continue
+                    upstream_po = os.path.join(self.directory, locale, "LC_MESSAGES", f"{domain}.po")
+                    if not os.path.isfile(upstream_po):
+                        continue
 
-                overlay_po = os.path.join(OVERLAY_DIR, locale, f"{domain}.po")
-                merged = 0
-                if os.path.isfile(overlay_po):
-                    with open(overlay_po, "rb") as f:
-                        overlay = read_po(f, locale=locale, domain=domain)
-                    for message in overlay:
-                        if not message.id or not message.string:
-                            continue
-                        existing = catalog.get(message.id, context=message.context)
-                        if existing is None:
-                            catalog.add(
-                                message.id,
-                                string=message.string,
-                                context=message.context,
-                                flags=message.flags,
-                            )
-                            merged += 1
-                        elif not existing.string:
-                            existing.string = message.string
-                            merged += 1
+                    with open(upstream_po, "rb") as f:
+                        catalog = read_po(f, locale=locale, domain=domain)
 
-                mo_path = os.path.join(self.directory, locale, "LC_MESSAGES", f"{domain}.mo")
-                self.log.info(
-                    "compiling catalog %s to %s (+%d fork overlay entries)",
-                    upstream_po, mo_path, merged,
-                )
-                with open(mo_path, "wb") as f:
-                    write_mo(f, catalog, use_fuzzy=self.use_fuzzy)
+                    overlay_po = os.path.join(OVERLAY_DIR, locale, f"{domain}.po")
+                    merged = 0
+                    if os.path.isfile(overlay_po):
+                        with open(overlay_po, "rb") as f:
+                            overlay = read_po(f, locale=locale, domain=domain)
+                        for message in overlay:
+                            if not message.id or not message.string:
+                                continue
+                            existing = catalog.get(message.id, context=message.context)
+                            if existing is None:
+                                catalog.add(
+                                    message.id,
+                                    string=message.string,
+                                    context=message.context,
+                                    flags=message.flags,
+                                )
+                                merged += 1
+                            elif not existing.string:
+                                existing.string = message.string
+                                merged += 1
 
-        return 0
+                    mo_path = os.path.join(self.directory, locale, "LC_MESSAGES", f"{domain}.mo")
+                    self.log.info(
+                        "compiling catalog %s to %s (+%d fork overlay entries)",
+                        upstream_po, mo_path, merged,
+                    )
+                    with open(mo_path, "wb") as f:
+                        write_mo(f, catalog, use_fuzzy=self.use_fuzzy)
+
+            return 0
+
+    cmdclass["compile_catalog"] = compile_catalog_with_overlay
 
 
 setuptools.setup(
-    cmdclass={"compile_catalog": compile_catalog_with_overlay},
+    cmdclass=cmdclass,
 )

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -577,14 +577,25 @@ def generate_screenshots(locale):
     # Report the translation progress
     if locale != SettingsConstants.LOCALE__ENGLISH:
         try:
-            translated_messages_path = os.path.join(pathlib.Path(__file__).parent.resolve().parent.resolve().parent.resolve(), "src", "seedsigner", "resources", "seedsigner-translations", "l10n", locale, "LC_MESSAGES", "messages.po") 
-            with open(translated_messages_path, 'r', encoding='utf-8') as translation_file:
-                locale_translations = translation_file.read()
-                num_locale_translations = locale_translations.count("msgid \"") - locale_translations.count("""msgstr ""\n\n""") - 1
+            repo_root = pathlib.Path(__file__).parent.resolve().parent.resolve().parent.resolve()
 
-                if locale != "en":
-                    locale_readme += f"## Translation progress: {num_locale_translations / num_source_messages:.1%}\n\n"
-                locale_readme += "---\n\n"
+            def count_translated(po_path) -> int:
+                with open(po_path, 'r', encoding='utf-8') as translation_file:
+                    contents = translation_file.read()
+                return contents.count("msgid \"") - contents.count("""msgstr ""\n\n""") - 1
+
+            translated_messages_path = os.path.join(repo_root, "src", "seedsigner", "resources", "seedsigner-translations", "l10n", locale, "LC_MESSAGES", "messages.po")
+            num_locale_translations = count_translated(translated_messages_path)
+
+            # Fork overlay translations (see l10n/fork_translations.py) count
+            # toward coverage too; they're merged into the .mo at compile time.
+            fork_overlay_path = os.path.join(repo_root, "l10n", "fork", locale, "messages.po")
+            if os.path.isfile(fork_overlay_path):
+                num_locale_translations += count_translated(fork_overlay_path)
+
+            if locale != "en":
+                locale_readme += f"## Translation progress: {num_locale_translations / num_source_messages:.1%}\n\n"
+            locale_readme += "---\n\n"
         except Exception as e:
             from traceback import print_exc
             print_exc()


### PR DESCRIPTION
Summary
The fork adds ~500 UI strings per locale (smartcard, GPG, password generator, SLIP39, …) that upstream's Transifex translators never see — today they silently fall back to English on non-English devices (upstream coverage of the fork's messages.pot is only 31–40% per locale). This PR adds a fork translation overlay pipeline so those gaps can be translated in-repo while upstream translations keep flowing in via plain submodule bumps.

How it works
Overlay catalogs at l10n/fork/<locale>/messages.po contain only fork-gap entries. The seedsigner-translations submodule stays pointed at upstream, untouched.
Merge rule: the overridden compile_catalog in setup.py merges each upstream catalog with its overlay into a single .mo — upstream always wins for any msgid it has translated; the overlay only fills gaps. When a future upstream release translates a string we overlaid, prune drops our copy.
Zero build-system changes: CI, the seedsigner-os image build (opt/build.sh), and local dev all already run python setup.py compile_catalog; they pick up the merge automatically.
Management script l10n/fork_translations.py:
status — per-locale coverage table (pot vs upstream vs overlay)
stub --locale <loc> | --all — add missing msgids with empty msgstr
prune — drop entries now translated upstream / gone from the pot (run after submodule bumps)
check — validate catalogs (parse, {} placeholder consistency)
Agent workflow .claude/commands/translate-gaps.md (/translate-gaps <locale>): fills a locale's gaps using the upstream catalog as the terminology glossary, tags every entry with a #. FORK: provenance comment, and batches ambiguous strings back to the maintainer instead of guessing. Each locale ships as its own small PR.
Screenshot README "Translation progress" now counts overlay entries too.
l10n/README.md documents the overlay concept and the upstream-pull procedure.
Pipeline verification (Spanish seed entries)
The es overlay is seeded with 3 translated entries as an end-to-end test:

$ python setup.py compile_catalog -l es
compiling catalog .../es/LC_MESSAGES/messages.po to .../messages.mo (+3 fork overlay entries)
gettext("Smartcard Tools")     -> "Herramientas de tarjeta inteligente"   (overlay)
gettext("Scan")                -> "Escanear"                              (upstream wins)
gettext("Battery Calibration") -> "Battery Calibration"                   (unfilled gap → English fallback)
fork_translations.py check passes; test_flows_l10n.py and related suites pass locally.

Follow-ups (separate PRs)
Per-locale translation passes via /translate-gaps — infrastructure only in this PR by design.