### PR TITLE
Fix latent NameErrors from tools_views.py split; add pyflakes guard

### DIFF
--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -163,14 +163,6 @@ def normalize_descriptor_str(descriptor_str: str) -> str:
     return descriptor_str
 
 
-
-    root = bip32.HDKey.from_seed(seed_bytes, version=NETWORKS[embit_network]["xprv"])
-    xprv = root.derive(derivation_path)
-    xpub = xprv.to_public()
-    return xpub
-
-
-
 def get_single_sig_address(xpub: HDKey, script_type: str = SettingsConstants.NATIVE_SEGWIT, index: int = 0, is_change: bool = False, embit_network: str = "main") -> str:
     if is_change:
         pubkey = xpub.derive([1,index]).key

--- a/src/seedsigner/views/gpg_views.py
+++ b/src/seedsigner/views/gpg_views.py
@@ -37,8 +37,28 @@ from .view import View, Destination, BackStackView, MainMenuView
 # Imported from tools_views for use by _text_qr_done_destination (defined near end of file)
 from .tools_views import ToolsMenuView, ToolsTextQRView
 
+# Shared helpers/screens used across GPG views (previously resolved via the
+# monolithic tools_views.py; made explicit after the module split).
+from seedsigner.gui.screens.tools_screens import (
+    ToolsTextQRTextEntryScreen,
+    ToolsTextQRReviewTextScreen,
+    ToolsTextQRTranscribeModePromptScreen,
+    ToolsTranscribeTextQRWholeQRScreen,
+    ToolsTranscribeTextQRZoomedInScreen,
+    ToolsTranscribeTextQRConfirmQRPromptScreen,
+)
+from seedsigner.helpers import seedkeeper_utils
+from seedsigner.helpers.iso7816 import format_sw_error
+from seedsigner.hardware.microsd import MicroSD
+from seedsigner.models.encode_qr import GenericStaticQrEncoder
+
 try:
     from pysatochip.JCconstants import SEEDKEEPER_DIC_TYPE, SEEDKEEPER_DIC_EXPORT_RIGHTS
+except ImportError:
+    pass
+
+try:
+    from pysatochip.CardConnector import UnexpectedSW12Error
 except ImportError:
     pass
 

--- a/src/seedsigner/views/password_generator_views.py
+++ b/src/seedsigner/views/password_generator_views.py
@@ -38,14 +38,25 @@ from seedsigner.helpers import password_generation, diceware, mnemonic_generatio
 # Re-exported from tools_views.py (shared helpers used by password generation views)
 from .tools_views import (
     BIP85_APP_DICE,
+    BIP85_APP_HEX,
+    BIP85_APP_BASE64,
+    BIP85_APP_BASE85,
     ToolsImageEntropyLivePreviewView,
+    _bip85_supported_password_type,
     _cache_password_entropy,
     _clear_password_entropy_cache,
+    _derive_camera_entropy_bytes,
+    _derive_hardware_rng_entropy_bytes,
+    _dice_rolls_for_strength,
     _diceware_word_count,
+    _format_word_password,
     _get_password_entropy_cache,
     _is_diceware_password_type,
+    _random_charset,
     _strength_to_length,
 )
+
+from seedsigner.helpers import seedkeeper_utils
 
 # Re-exported from gpg_views.py (TextQR display views shared across modules)
 from .gpg_views import (
@@ -1208,6 +1219,7 @@ class ToolsPasswordBIP85GenerateView(View):
 
 def _save_password_to_seedkeeper(view: View, password: str) -> bool:
     from seedsigner.gui.screens.screen import LoadingScreenThread
+    from pysatochip.CardConnector import UnexpectedSW12Error
 
     label = seed_screens.SeedAddPassphraseScreen(title=_("Password Name")).display()
     if "is_back_button" in label:

--- a/src/seedsigner/views/smartcard_views.py
+++ b/src/seedsigner/views/smartcard_views.py
@@ -10,14 +10,17 @@ import json
 import logging
 import os
 import platform
+import re
 import struct
 import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
 
 from embit.bip32 import HDKey
 from embit.descriptor import Descriptor
+from embit.psbt import PSBT
 from gettext import gettext as _
 
 from seedsigner.gui.components import (
@@ -34,10 +37,14 @@ from seedsigner.gui.screens import (
     ErrorScreen,
     seed_screens,
 )
-from seedsigner.gui.screens.tools_screens import ToolsCommonFilterScreen
+from seedsigner.gui.screens.tools_screens import (
+    ToolsCommonFilterScreen,
+    ToolsTextQRTextEntryScreen,
+    ToolsTextQRReviewTextScreen,
+)
 from seedsigner.gui.screens.screen import ButtonOption
 from seedsigner.hardware.microsd import MicroSD
-from seedsigner.helpers import embit_utils, seedkeeper_utils
+from seedsigner.helpers import embit_utils, ndef_helper, seedkeeper_utils
 from seedsigner.helpers.satochip_signer import (
     _call_with_timeout,
     _get_extended_key,
@@ -49,6 +56,7 @@ from seedsigner.models.settings_definition import SettingsConstants
 
 try:
     from pysatochip import satochip
+    from pysatochip.CardConnector import CardConnector
     from pysatochip.exception import UnexpectedSW12Error
     from pysatochip.JCconstants import (
         SEEDKEEPER_DIC_TYPE,
@@ -2747,6 +2755,7 @@ class ToolsKeycardAdvancedView(View):
             return Destination(ToolsKeycardBenchmarkMessageSignView)
 
         elif button_data[selected_menu_num] == self.BIAS_TEST:
+            from seedsigner.views.keycard_bias import ToolsKeycardBiasCheckView
             return Destination(ToolsKeycardBiasCheckView)
 
 
@@ -3407,6 +3416,7 @@ class ToolsSatochipAdvancedView(View):
             return Destination(ToolsSatochipBenchmarkMessageSignView)
 
         elif button_data[selected_menu_num] == self.BIAS_TEST:
+            from seedsigner.views.satochip_bias import ToolsSatochipBiasCheckView
             return Destination(ToolsSatochipBiasCheckView)
 
 class ToolsSatochipBenchmarkSignView(View):
@@ -3696,6 +3706,7 @@ class ToolsSatochipImportSeedView(View):
         elif button_data[selected_menu_num] == self.TYPE_SLIP39:
             return Destination(SeedSlip39MnemonicStartView)
         elif button_data[selected_menu_num] == self.CREATE:
+            from seedsigner.views.tools_views import ToolsMenuView
             return Destination(ToolsMenuView, view_args={"include_password_generator": False})
         elif button_data[selected_menu_num] == self.TYPE_ELECTRUM:
             return Destination(SeedElectrumMnemonicStartView)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -11,3 +11,4 @@ typing-extensions==4.14.1
 zipp==3.23.0
 colorama==0.4.6
 pytest-order==1.3.0
+pyflakes==3.4.0

--- a/tests/test_no_undefined_names.py
+++ b/tests/test_no_undefined_names.py
@@ -1,0 +1,105 @@
+"""Static guard: no shipping code references an undefined name.
+
+A symbol used in a function body but never imported/defined in scope does **not**
+fail at import time — Python only raises ``NameError`` when that exact line runs.
+That is precisely how the ``tools_views.py`` module split leaked runtime crashes
+(e.g. the password generator's ``_derive_camera_entropy_bytes``) past both the
+import smoke tests and the menu-navigation walk, which stops before the terminal
+view actually executes.
+
+``pyflakes`` performs full lexical-scope analysis and flags every such reference
+statically. This test runs it over the whole ``seedsigner`` package and fails on
+any *undefined name* finding — one self-maintaining guard for this entire class
+of bug. It deliberately ignores every other pyflakes category (unused imports,
+``import *`` warnings, redefinitions, …): those are style, not latent crashes.
+"""
+import os
+
+import pyflakes.api
+import pyflakes.messages
+
+import seedsigner
+
+
+# Reviewed, genuine false positives may be parked here as ``"<rel/path>:<name>"``
+# strings. This is expected to stay EMPTY; the test also fails if an entry here
+# no longer occurs, forcing the allowlist to ratchet down as code is fixed.
+ALLOWLIST: set[str] = set()
+
+# pyflakes message classes that mean "this name is not defined in scope" — i.e. a
+# latent ``NameError`` — as opposed to the style findings we don't gate on.
+_UNDEFINED_MESSAGE_TYPES = (
+    pyflakes.messages.UndefinedName,
+    pyflakes.messages.UndefinedLocal,
+    pyflakes.messages.UndefinedExport,
+)
+
+
+class _Collector:
+    """Minimal pyflakes reporter that keeps only undefined-name findings."""
+
+    def __init__(self):
+        self.undefined = []      # (rel_path, lineno, name)
+        self.syntax_errors = []  # (rel_path, lineno, msg)
+        self.unexpected = []     # (rel_path, msg)
+        self._root = os.path.dirname(seedsigner.__file__)
+
+    def _rel(self, filename):
+        return os.path.relpath(filename, self._root).replace(os.sep, "/")
+
+    def unexpectedError(self, filename, msg):
+        self.unexpected.append((self._rel(filename), msg))
+
+    def syntaxError(self, filename, msg, lineno, offset, text):
+        self.syntax_errors.append((self._rel(filename), lineno, msg))
+
+    def flake(self, message):
+        if isinstance(message, _UNDEFINED_MESSAGE_TYPES):
+            name = message.message_args[0] if message.message_args else "?"
+            self.undefined.append((self._rel(message.filename), message.lineno, name))
+
+
+def _iter_source_files():
+    root = os.path.dirname(seedsigner.__file__)
+    for dirpath, _dirnames, filenames in os.walk(root):
+        if "__pycache__" in dirpath.split(os.sep):
+            continue
+        for filename in filenames:
+            if filename.endswith(".py"):
+                yield os.path.join(dirpath, filename)
+
+
+def test_no_undefined_names_in_package():
+    collector = _Collector()
+    files_checked = 0
+    for path in _iter_source_files():
+        pyflakes.api.checkPath(path, collector)
+        files_checked += 1
+
+    # Sanity: make sure we actually scanned the package (guards against a walk
+    # that silently finds nothing and passes vacuously).
+    assert files_checked > 50, f"only scanned {files_checked} files — walk is broken"
+
+    assert not collector.syntax_errors, (
+        "pyflakes could not parse:\n  "
+        + "\n  ".join(f"{f}:{ln}: {m}" for f, ln, m in collector.syntax_errors)
+    )
+
+    findings_by_key = {}  # "rel:name" -> "rel:lineno: name" (first occurrence)
+    for rel, lineno, name in sorted(collector.undefined):
+        findings_by_key.setdefault(f"{rel}:{name}", f"{rel}:{lineno}: undefined name '{name}'")
+
+    unexpected = sorted(v for k, v in findings_by_key.items() if k not in ALLOWLIST)
+    stale = sorted(a for a in ALLOWLIST if a not in findings_by_key)
+
+    assert not unexpected, (
+        "Undefined name(s) found - a symbol is used but never imported/defined in "
+        "scope, which raises NameError only when that line runs at runtime.\n"
+        "Add the missing import (module-level, or local to avoid a circular "
+        "import), or fix the reference:\n  " + "\n  ".join(unexpected)
+    )
+
+    assert not stale, (
+        "ALLOWLIST entries no longer occur and must be removed (ratchet down):\n  "
+        + "\n  ".join(stale)
+    )

--- a/tests/test_password_generator_views.py
+++ b/tests/test_password_generator_views.py
@@ -1,6 +1,7 @@
 import embit.bip32 as embit_bip32
 import embit.bip85 as embit_bip85
 from seedsigner.views import tools_views
+import seedsigner.views.password_generator_views as pgv
 
 
 def _make_roll_count_view(password_type: str, entropy_source: str):
@@ -619,3 +620,211 @@ def test_network_info_back_returns_back_stack(monkeypatch):
     dest = tools_views.ToolsNetworkInfoView.run(view)
 
     assert dest.View_cls is tools_views.BackStackView
+
+
+# ---------------------------------------------------------------------------
+# Deep-execution coverage for the terminal generation views.
+#
+# These drive the camera / hardware-RNG / random-charset / BIP85-hex code paths
+# that reference helpers pulled into password_generator_views.py during the
+# tools_views.py module split (_derive_camera_entropy_bytes,
+# _derive_hardware_rng_entropy_bytes, _random_charset, BIP85_APP_HEX, ...).
+# Before the missing imports were restored these raised NameError only when the
+# line actually ran — which the menu-navigation walk never reaches because it
+# stops at intermediate screens. tests/test_no_undefined_names.py is the static
+# catch-all; these give runtime coverage of the exact reported crash paths.
+# ---------------------------------------------------------------------------
+_HEXDIGITS = "0123456789abcdefABCDEF"
+
+
+def _make_generate_view(password_type, entropy_source, **overrides):
+    view = object.__new__(tools_views.ToolsPasswordGenerateView)
+    view.password_type = password_type
+    view.entropy_source = entropy_source
+    view.strength_bits = overrides.get("strength_bits", 128)
+    view.random_options = overrides.get("random_options", {})
+    view.roll_data = overrides.get("roll_data", None)
+    view.roll_count = overrides.get("roll_count", None)
+    view.word_count = overrides.get("word_count", None)
+    view.word_separator = tools_views.PASSWORD_WORD_SEPARATOR_NONE
+    view.entropy_bytes_override = None
+    view.dice_sides = overrides.get("dice_sides", 6)
+
+    class _Controller:
+        pass
+
+    view.controller = _Controller()
+    return view
+
+
+def test_generate_view_camera_source_derives_entropy_and_clears_frames(monkeypatch):
+    """CAMERA source path (the exact line from the reported crash)."""
+    view = _make_generate_view(
+        tools_views.PASSWORD_TYPE_HEX, tools_views.PASSWORD_ENTROPY_CAMERA
+    )
+    view.controller.image_entropy_preview_frames = object()
+    view.controller.image_entropy_final_image = object()
+
+    monkeypatch.setattr(
+        pgv, "_derive_camera_entropy_bytes", lambda _frames, _final: b"\x02" * 32
+    )
+
+    dest = tools_views.ToolsPasswordGenerateView.run(view)
+
+    assert dest.View_cls is tools_views.ToolsPasswordReviewView
+    password = dest.view_args["password"]
+    assert len(password) == 32 and all(c in _HEXDIGITS for c in password)
+    # Collected frames must be cleared so the same entropy can never be reused.
+    assert view.controller.image_entropy_preview_frames is None
+    assert view.controller.image_entropy_final_image is None
+
+
+def test_generate_view_camera_poor_entropy_returns_back(monkeypatch):
+    """CAMERA source that fails the randomness check routes back with an error."""
+    view = _make_generate_view(
+        tools_views.PASSWORD_TYPE_HEX, tools_views.PASSWORD_ENTROPY_CAMERA
+    )
+    view.controller.image_entropy_preview_frames = object()
+    view.controller.image_entropy_final_image = object()
+
+    monkeypatch.setattr(
+        pgv, "_derive_camera_entropy_bytes", lambda _frames, _final: None
+    )
+    monkeypatch.setattr(
+        tools_views.ToolsPasswordGenerateView, "run_screen",
+        lambda self, *_a, **_k: 0,
+    )
+
+    dest = tools_views.ToolsPasswordGenerateView.run(view)
+
+    assert dest.View_cls is tools_views.BackStackView
+
+
+def test_generate_view_hardware_rng_source_builds_random_password(monkeypatch):
+    """HARDWARE_RNG source + RANDOM type exercises _derive_hardware_rng_entropy_bytes
+    and _random_charset."""
+    view = _make_generate_view(
+        tools_views.PASSWORD_TYPE_RANDOM,
+        tools_views.PASSWORD_ENTROPY_HARDWARE_RNG,
+        random_options={"lower": True, "digits": True},
+    )
+    view.controller.hardware_rng_is_healthy = True
+    view.controller.hardware_rng_failure_reason = None
+
+    monkeypatch.setattr(
+        pgv, "_derive_hardware_rng_entropy_bytes", lambda: b"\x03" * 64
+    )
+
+    dest = tools_views.ToolsPasswordGenerateView.run(view)
+
+    assert dest.View_cls is tools_views.ToolsPasswordReviewView
+    password = dest.view_args["password"]
+    charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+    assert password and all(c in charset for c in password)
+
+
+def test_generate_view_hardware_rng_unhealthy_returns_back(monkeypatch):
+    """Unhealthy System RNG warns and routes back without deriving entropy."""
+    view = _make_generate_view(
+        tools_views.PASSWORD_TYPE_HEX, tools_views.PASSWORD_ENTROPY_HARDWARE_RNG
+    )
+    view.controller.hardware_rng_is_healthy = False
+    view.controller.hardware_rng_failure_reason = "health check failed"
+
+    monkeypatch.setattr(
+        tools_views.ToolsPasswordGenerateView, "run_screen",
+        lambda self, *_a, **_k: 0,
+    )
+
+    dest = tools_views.ToolsPasswordGenerateView.run(view)
+
+    assert dest.View_cls is tools_views.BackStackView
+
+
+def test_hardware_rng_entropy_view_caches_and_routes(monkeypatch):
+    """ToolsPasswordHardwareRngEntropyView.run() caches derived entropy and routes
+    to the word-separator step."""
+    view = object.__new__(tools_views.ToolsPasswordHardwareRngEntropyView)
+    view.password_type = tools_views.PASSWORD_TYPE_DICEWARE_EFF_SHORT
+    view.strength_bits = 64
+    view.random_options = {}
+
+    class _Controller:
+        hardware_rng_is_healthy = True
+        hardware_rng_failure_reason = None
+
+    view.controller = _Controller()
+
+    monkeypatch.setattr(
+        pgv, "_derive_hardware_rng_entropy_bytes", lambda: b"\x04" * 64
+    )
+
+    dest = tools_views.ToolsPasswordHardwareRngEntropyView.run(view)
+
+    assert dest.View_cls is tools_views.ToolsPasswordWordSeparatorView
+    assert dest.view_args["entropy_source"] == tools_views.PASSWORD_ENTROPY_HARDWARE_RNG
+    assert view.controller.password_generator_entropy_cache["entropy_bytes"] == b"\x04" * 64
+
+
+def test_bip85_generate_hex_uses_bip85_app_hex(monkeypatch):
+    """BIP85 Hex path derives with the BIP85_APP_HEX application number."""
+    master_xprv = "xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb"
+
+    view = object.__new__(tools_views.ToolsPasswordBIP85GenerateView)
+    view.password_type = tools_views.PASSWORD_TYPE_HEX
+    view.strength_bits = 256
+    view.random_options = {}
+    view.dice_sides = None
+    view.roll_count = None
+
+    class SeedObj:
+        @staticmethod
+        def get_root(_network=None):
+            return embit_bip32.HDKey.from_string(master_xprv)
+
+    class Storage:
+        seeds = [SeedObj()]
+
+    class Controller:
+        storage = Storage()
+
+        @staticmethod
+        def get_seed(_idx):
+            return SeedObj()
+
+    view.controller = Controller()
+
+    class S:
+        @staticmethod
+        def get_value(_key):
+            return "M"
+
+    view.settings = S()
+
+    class FakeIndexScreen:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def display(self):
+            return "0"
+
+    monkeypatch.setattr(
+        tools_views.seed_screens, "SeedBIP85SelectChildIndexScreen", FakeIndexScreen
+    )
+
+    captured = {}
+
+    def fake_derive_entropy(_root, app_no, params):
+        captured["app_no"] = app_no
+        captured["params"] = params
+        return bytes(range(32))
+
+    monkeypatch.setattr(embit_bip85, "derive_entropy", fake_derive_entropy)
+
+    dest = tools_views.ToolsPasswordBIP85GenerateView.run(view)
+
+    assert captured["app_no"] == tools_views.BIP85_APP_HEX
+    assert captured["params"] == [32, 0]
+    assert dest.View_cls is tools_views.ToolsPasswordGenerateView
+    assert dest.view_args["entropy_source"] == tools_views.PASSWORD_ENTROPY_BIP85
+    assert dest.view_args["roll_data"] == bytes(range(32))


### PR DESCRIPTION
## Problem

A user hit `System Error → NameError password_generator_views.py, 842, in run name '_derive_camera_entropy_bytes' is not defined` while generating a password.

This was one instance of a **class** of bug the `tools_views.py` module split left behind: a symbol used in a function body but never imported into the new module. The module still imports fine, so it only raises `NameError` when that exact line runs at runtime — invisible to import smoke tests and to the menu-navigation walk (which stops at intermediate screens before the terminal view executes).

A `pyflakes` scan found **75** such references across the split:

| File | count |
|---|---|
| `views/gpg_views.py` | 36 |
| `views/smartcard_views.py` | 22 |
| `views/password_generator_views.py` | 14 |
| `helpers/embit_utils.py` | 3 (unrelated orphaned dead code) |

## Fixes

- Add the missing imports in each view module — module-level for leaf deps; **local** imports where a module-level import would create the `tools_views` ↔ split-module circular import (`ToolsMenuView`, the bias views); guarded `try/except ImportError` for optional `pysatochip` symbols.
- Delete an unreachable duplicate of `get_xpub()` in `embit_utils.py` (dead code sitting after a `return`).

## Guard against regressions

- **`tests/test_no_undefined_names.py`** (new) runs `pyflakes` over all of `src/seedsigner/` and fails on any *undefined-name* finding (ignores unused-import / star-import warnings). It runs in CI through the existing `pytest` step — no workflow change — so the whole project is checked on every push, matching the existing static-contract tests (`test_view_kwargs_contract.py`, `test_split_module_imports.py`). `pyflakes==3.4.0` added to `tests/requirements.txt`.
- **`tests/test_password_generator_views.py`**: 6 deep-flow tests that actually execute the camera / hardware-RNG / random-charset / BIP85-hex terminal paths (the exact reported crash lines), catching logic regressions the static check cannot.

## Verification

- `pyflakes src/` → **zero** undefined names.
- Guard test passes, and a bite check (removing one import) makes it fail with a precise message pointing at the reintroduced line.
- Password-generator tests: 26 pass (incl. 6 new); menu-navigation walk: 55 pass; tools flows: 22 pass; `test_split_module_imports` + `test_view_kwargs_contract`: 21 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)