### PR TITLE
ci: fail the docker build step on in-container build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,7 +190,11 @@ jobs:
         run: |
           cd seedsigner-os
           mkdir -p .buildroot-ccache .ccache images
-          docker compose up --force-recreate --build
+          # --abort-on-container-exit + --exit-code-from make `up` return the
+          # build container's exit code, so an in-container build failure fails
+          # this step instead of silently passing and only tripping the later
+          # upload step's if-no-files-found guard.
+          docker compose up --force-recreate --build --abort-on-container-exit --exit-code-from build-images
           docker compose down
 
       - name: Fix permissions


### PR DESCRIPTION
## Problem

`docker compose up` returns exit code 0 even when the `build-images` service exits non-zero. As a result, a failed buildroot build shows the **Build image with docker compose** step as green, and the job only fails later at **upload images** via `if-no-files-found: error`. The failure is mis-attributed to the upload step, hiding the real cause.

This was observed while testing a `lafrite` build ([run 29978564280](https://github.com/3rdIteration/seedsigner/actions/runs/29978564280)): buildroot aborted with `Makefile:194: *** '.././lafrite-smartcard//external.desc': does not define the name.  Stop.` (`build-images-1 exited with code 2`), yet the build step reported success.

## Fix

Add `--abort-on-container-exit --exit-code-from build-images` to the `docker compose up` invocation so the step returns the build container's exit code and fails at the correct step.

## Notes

- `build-images` is the sole service in `seedsigner-os/docker-compose.yml`, so aborting on its exit is exactly the desired behavior.
- No change to successful builds — they continue to exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)