### PR TITLE
Fix Satochip seed import reporting failure on a card that was seeded

### DIFF
--- a/src/seedsigner/views/smartcard_views.py
+++ b/src/seedsigner/views/smartcard_views.py
@@ -3650,17 +3650,23 @@ class ToolsSatochipImportSeedView(View):
                 self.loading_screen = LoadingScreenThread(text="Importing Secret\n\n\n\n\n\n")
                 self.loading_screen.start()
 
-                _resp, sw1, sw2 = Satochip_Connector.card_bip32_import_seed(seeds[selected_menu_num].seed_bytes)
-                if (sw1, sw2) != (0x90, 0x00):
-                    if (
-                        getattr(Satochip_Connector, "is_keycard_backend", False)
-                        and (sw1, sw2) == (0x69, 0x85)
-                    ):
-                        raise ValueError(
-                            "Keycard blocked seed import (SW=6985).\n"
-                            "Try Factory Reset Card, then retry import."
-                        )
-                    raise ValueError(f"Import failed with SW={sw1:02X}{sw2:02X}")
+                result = Satochip_Connector.card_bip32_import_seed(seeds[selected_menu_num].seed_bytes)
+                if getattr(Satochip_Connector, "is_keycard_backend", False):
+                    # KeycardSatochipConnector.card_bip32_import_seed returns
+                    # ([], sw1, sw2).
+                    _resp, sw1, sw2 = result
+                    if (sw1, sw2) != (0x90, 0x00):
+                        if (sw1, sw2) == (0x69, 0x85):
+                            raise ValueError(
+                                "Keycard blocked seed import (SW=6985).\n"
+                                "Try Factory Reset Card, then retry import."
+                            )
+                        raise ValueError(f"Import failed with SW={sw1:02X}{sw2:02X}")
+                elif result is None:
+                    # pysatochip's CardConnector returns the authentikey on
+                    # success and None otherwise; it raises CardError itself for
+                    # 9C17 (already seeded) and 9C0F (invalid parameter).
+                    raise ValueError("Import failed")
 
                 _status_resp, status_sw1, status_sw2, post_status = Satochip_Connector.card_get_status()
                 if (status_sw1, status_sw2) != (0x90, 0x00):

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -1334,6 +1334,10 @@ class TestSatochipImportSeedView(BaseTest):
                 return "deadbeef"
 
         class MockConnector:
+            # Only the Keycard adapter returns (resp, sw1, sw2); the SW-formatted
+            # message under test is the Keycard branch.
+            is_keycard_backend = True
+
             def card_get_status(self):
                 return (None, 0x90, 0x00, {"is_seeded": False})
 
@@ -1373,6 +1377,8 @@ class TestSatochipImportSeedView(BaseTest):
                 return "deadbeef"
 
         class MockConnector:
+            is_keycard_backend = True
+
             def __init__(self):
                 self.status_calls = 0
 
@@ -1404,4 +1410,96 @@ class TestSatochipImportSeedView(BaseTest):
 
         warning_text = captured["warning_text"].lower()
         assert "seeded key" in warning_text
+        assert destination.View_cls == tools_views.MainMenuView
+
+    def test_import_seed_pysatochip_backend_shows_success(self, monkeypatch):
+        """pysatochip's card_bip32_import_seed returns a single authentikey, not
+        the (resp, sw1, sw2) tuple the Keycard adapter returns. Unpacking three
+        values raised TypeError on a card the APDU had just successfully seeded,
+        the view's except-block swallowed it, and the user was shown Failed for a
+        card that now held the seed."""
+        from seedsigner.views import tools_views
+        from seedsigner.helpers import seedkeeper_utils
+
+        class MockSeed:
+            seed_bytes = b"\x01" * 64
+
+            def get_fingerprint(self, _network):
+                return "deadbeef"
+
+        class MockAuthentikey:
+            """Stands in for the ECPubkey pysatochip returns on success."""
+
+        class MockConnector:
+            # No is_keycard_backend attribute -- this is the pysatochip backend.
+            def __init__(self):
+                self.is_seeded = False
+
+            def card_get_status(self):
+                return (None, 0x90, 0x00, {"is_seeded": self.is_seeded})
+
+            def card_bip32_import_seed(self, _seed_bytes):
+                self.is_seeded = True
+                return MockAuthentikey()
+
+        monkeypatch.setattr(
+            seedkeeper_utils, "init_satochip", lambda *a, **k: MockConnector()
+        )
+
+        self.controller.storage.seeds = [MockSeed()]
+
+        view = tools_views.ToolsSatochipImportSeedView()
+        responses = iter([0, 0])
+        captured = {"screens": []}
+
+        def fake_run_screen(screen_cls, **kwargs):
+            captured["screens"].append(screen_cls)
+            captured["title"] = kwargs.get("title")
+            return next(responses)
+
+        monkeypatch.setattr(view, "run_screen", fake_run_screen)
+        view.run()
+
+        assert tools_views.LargeIconStatusScreen in captured["screens"]
+        assert tools_views.WarningScreen not in captured["screens"]
+        assert captured["title"] == "Success"
+
+    def test_import_seed_pysatochip_backend_none_shows_failed_warning(self, monkeypatch):
+        """pysatochip returns None (not a status-word tuple) when the card
+        rejects the import, so the failure path has to test for None."""
+        from seedsigner.views import tools_views
+        from seedsigner.helpers import seedkeeper_utils
+
+        class MockSeed:
+            seed_bytes = b"\x01" * 64
+
+            def get_fingerprint(self, _network):
+                return "deadbeef"
+
+        class MockConnector:
+            def card_get_status(self):
+                return (None, 0x90, 0x00, {"is_seeded": False})
+
+            def card_bip32_import_seed(self, _seed_bytes):
+                return None
+
+        monkeypatch.setattr(
+            seedkeeper_utils, "init_satochip", lambda *a, **k: MockConnector()
+        )
+
+        self.controller.storage.seeds = [MockSeed()]
+
+        view = tools_views.ToolsSatochipImportSeedView()
+        responses = iter([0, 0])
+        captured = {}
+
+        def fake_run_screen(screen_cls, **kwargs):
+            if screen_cls is tools_views.WarningScreen:
+                captured["warning_text"] = kwargs.get("text")
+            return next(responses)
+
+        monkeypatch.setattr(view, "run_screen", fake_run_screen)
+        destination = view.run()
+
+        assert "import failed" in captured["warning_text"].lower()
         assert destination.View_cls == tools_views.MainMenuView


### PR DESCRIPTION
### The problem

`smartcard_views.py:3653` on `dev` (`f6e79ba09855`), and `:3654` on the `generalized-platform-detection` branch (#383):

```python
_resp, sw1, sw2 = Satochip_Connector.card_bip32_import_seed(seeds[n].seed_bytes)
```

`KeycardSatochipConnector.card_bip32_import_seed` (`keycard_connector.py:732`) returns `([], sw1, sw2)`. `pysatochip.CardConnector.card_bip32_import_seed` has a single `return authentikey`, an `ECPubkey`, in `3rdIteration/pysatochip@0.6a` and in every PyPI release.

`ToolsSatochipView` sets `smartcard_backend_preference = "pysatochip"` (`smartcard_views.py:132`), so this view binds `CardConnector` on the Satochip path.

**Effect:** the APDU succeeds and the card is seeded, then the unpack raises `TypeError: cannot unpack non-iterable ECPubkey object`, the view's `except Exception` catches it, and the user is shown **Failed** for a card that now holds the seed. `if (sw1, sw2) != (0x90, 0x00)` below is unreachable on that path.

### Where it came from

No unpacking through `SeSi-0.8.6+ShSi-B10`. It appeared with the Keycard backend (#361), call site adapted in `be5e52c` (#369). The Satochip path was left on the old contract.

### Why tests are green

- `tests/test_flows_seed.py:1384` mocks `(None, 0x90, 0x00)`, the Keycard shape.
- `tests/test_smartcard_hardware.py:1337` uses the real library and treats the return as one object: `authentikey = connector.card_bip32_import_seed(...)`.

The suite matches the mock rather than pysatochip, and the hardware test that encodes the real contract needs a card.

### Reproduce without hardware

```sh
pip install pysatochip==0.17.0
python - <<'PY'
import ast, inspect
from pysatochip.CardConnector import CardConnector
src = inspect.getsource(CardConnector.card_bip32_import_seed)
rets = [n for n in ast.walk(ast.parse(src.lstrip())) if isinstance(n, ast.Return)]
print(len(rets), "return statement;", "tuple:", any(isinstance(r.value, ast.Tuple) for r in rets))
PY
```

Every status word the function branches on was checked: success returns `ECPubkey`, `6985` / `6D00` / `9C06` return `None`, `9C17` and `9C0F` raise inside pysatochip. No card response produces a three-tuple.

### The change

Branch on `is_keycard_backend`, the same test already used a few lines below, and treat pysatochip's `None` as failure. The existing `card_get_status()` check still verifies a seeded key for both backends, so no status words are invented for the pysatochip path.

### Notes

- Found while building a browser-based SeedSigner simulator, so **this is not verified on physical hardware**. The reasoning and the reproduction above are library-level.
- The other `Satochip_Connector.<method>` unpacks in this module may have the same Keycard versus pysatochip mismatch and are worth an audit; this PR deliberately changes only the one call site.
