### PR TITLE
ci: clone the fork when building a pull request from one

### DIFF
--- a/.github/workflows/build-buildroot.yml
+++ b/.github/workflows/build-buildroot.yml
@@ -125,7 +125,15 @@ jobs:
         run: |
           echo "builder_hash=$(git -C seedsigner-os rev-parse --short HEAD)" | tee -a "$GITHUB_ENV"
 
-          APP_REPO_INPUT="${{ github.event_name == 'workflow_dispatch' && github.event.inputs['app-repo'] || github.repository }}"
+          # For a PR from a fork, head.sha only exists in the fork: a plain clone
+          # of the base repo cannot resolve it (refs/pull/* is not fetched by
+          # default). Take the repo from the same event that supplies APP_REF
+          # below. Falls back to github.repository if the fork is gone.
+          APP_REPO_INPUT="${{
+            github.event_name == 'workflow_dispatch' && github.event.inputs['app-repo']
+            || github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name
+            || github.repository
+          }}"
           if [[ "${APP_REPO_INPUT}" =~ ^https?:// ]]; then
             APP_REPO_URL="${APP_REPO_INPUT}"
           else


### PR DESCRIPTION
## The problem

The image build fails for any PR opened from a fork, before it compiles anything:

```
build-images-1  | cloning repo https://github.com/3rdIteration/seedsigner with commit id 658d257f...
build-images-1  | fatal: Could not parse object '658d257f373d5829cf5109efebed605e31f58f3e'.
build-images-1 exited with code 128
```

`Prepare build metadata` picks the repo and the ref from different places:

| Variable | Source | Value for a fork PR |
|---|---|---|
| `APP_REPO_URL` | `github.repository` | `3rdIteration/seedsigner` (base) |
| `APP_REF` | `github.event.pull_request.head.sha` | commit in the contributor's fork |

The build container clones `APP_REPO_URL` and checks out `APP_REF`. A plain clone does not fetch `refs/pull/*`, so a fork's head SHA is unresolvable even though GitHub exposes it as `refs/pull/N/head` on the base repo.

## The change

Give `APP_REPO_INPUT` the same `pull_request` case `APP_REF` already has, so both come from the same event:

```yaml
APP_REPO_INPUT="${{
  github.event_name == 'workflow_dispatch' && github.event.inputs['app-repo']
  || github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name
  || github.repository
}}"
```

It falls through to `github.repository` when `head.repo` is null (deleted fork), so same-repo PRs, pushes to `main`/`dev`, and `workflow_dispatch` are all unchanged.

## Why it surfaced now

`build-buildroot.yml` was added in c4996630 (#383). [#386](https://github.com/3rdIteration/seedsigner/pull/386) is the first PR from a fork to actually run it — #383 and #392 were both same-repo branches, and #386's earlier runs sat at `action_required` until a maintainer approved them.

## Verification

This PR is from a same-repo branch, so its own build exercises the unchanged fallback path. Confirming the fork path needs a re-run of #386's build once this lands, since `pull_request` workflows run from the merge ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
