### PR TITLE
Fix SeedKeeperSelectView back-button crash on missing self.seed (#389)

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -467,7 +467,7 @@ class SeedKeeperSelectView(View):
                     text="No BIP39 Secrets to Load from Seedkeeper",
                     show_back_button=False,
                 )
-                if isinstance(self.seed, AezeedSeed):
+                if isinstance(getattr(self, "seed", None), AezeedSeed):
                     return Destination(SeedAezeedPassphraseModeView)
                 return Destination(BackStackView)
 
@@ -480,7 +480,7 @@ class SeedKeeperSelectView(View):
             )
 
             if selected_menu_num == RET_CODE__BACK_BUTTON:
-                if isinstance(self.seed, AezeedSeed):
+                if isinstance(getattr(self, "seed", None), AezeedSeed):
                     return Destination(SeedAezeedPassphraseModeView)
                 return Destination(BackStackView)
 

--- a/tests/test_status_headlines.py
+++ b/tests/test_status_headlines.py
@@ -2,9 +2,10 @@ import base  # noqa: F401 -- ensure hardware mocks
 from unittest.mock import Mock
 
 from base import BaseTest
-from seedsigner.gui.screens.screen import DireWarningScreen, ErrorScreen, WarningScreen
+from seedsigner.gui.screens.screen import DireWarningScreen, ErrorScreen, RET_CODE__BACK_BUTTON, WarningScreen
 from seedsigner.hardware.battery_hat import BatteryHat
 from seedsigner.views import seed_views, tools_views
+from seedsigner.views.view import BackStackView, Destination
 
 
 class TestStatusHeadlines(BaseTest):
@@ -27,10 +28,40 @@ class TestStatusHeadlines(BaseTest):
         view = seed_views.SeedKeeperSelectView()
         view.run_screen = Mock(return_value=0)
 
-        view.run()
+        result = view.run()
 
+        assert view.run_screen.call_count == 1
         assert view.run_screen.call_args.args[0] is WarningScreen
         assert view.run_screen.call_args.kwargs["status_headline"] is None
+        assert result == Destination(BackStackView)
+
+    def test_seedkeeper_back_button_returns_backstack(self, monkeypatch):
+        """Regression test for issue #389: pressing back on "Select Secret"
+        must return BackStackView without crashing on the missing `self.seed`
+        attribute."""
+        class MockConnector:
+            def seedkeeper_list_secret_headers(self):
+                return [{
+                    "id": 1,
+                    "label": "Test Secret",
+                    "type": 48,
+                    "subtype": 0,
+                    "export_rights": 1,
+                }]
+
+        monkeypatch.setattr(
+            seed_views.seedkeeper_utils,
+            "init_satochip",
+            lambda *args, **kwargs: MockConnector(),
+        )
+
+        view = seed_views.SeedKeeperSelectView()
+        view.run_screen = Mock(return_value=RET_CODE__BACK_BUTTON)
+
+        result = view.run()
+
+        assert view.run_screen.call_count == 1
+        assert result == Destination(BackStackView)
 
     def test_seedkeeper_error_warning_omits_privacy_headline(self, monkeypatch):
         class MockConnector:


### PR DESCRIPTION
## Summary

Fixes #389

Pressing the back button on the "Select Secret" screen (Seeds -> Load a seed -> From SeedKeeper) crashed with:

```
AttributeError: 'SeedKeeperSelectView' object has no attribute 'seed'
```

## Root cause

`SeedKeeperSelectView` (in `seed_views.py`) does not define `__init__`, so `self.seed` does not exist until line 595, where it is assigned **after** a secret has been selected and decoded:

```python
self.seed = self.controller.storage.get_pending_seed()
```

However, PR #320 (Aezeed import support) added `isinstance(self.seed, AezeedSeed)` checks at two earlier sites - the back-button path (line 483) and the "No Secrets to Load" path (line 470) - both of which run **before** `self.seed` is assigned.

The `AttributeError` was silently caught by the surrounding `try/except Exception` block, causing an error screen to be shown instead of a clean back navigation. The existing test `test_seedkeeper_no_secrets_warning_omits_privacy_headline` happened to pass through the bug because both the "No Secrets" `WarningScreen` and the error-handler `WarningScreen` use `status_headline=None`.

## Fix

Replace both early `isinstance(self.seed, AezeedSeed)` checks with:

```python
if isinstance(getattr(self, "seed", None), AezeedSeed):
```

This makes the attribute read safe. The Aezeed-specific handling at line 597 (after `self.seed` is properly assigned at line 595) is unaffected.

## Regression tests

- **Strengthened** `test_seedkeeper_no_secrets_warning_omits_privacy_headline` to assert `call_count == 1` and `result == Destination(BackStackView)` - catching the bug where the exception handler would call `run_screen` a second time.
- **Added** `test_seedkeeper_back_button_returns_backstack` - simulates pressing back on the "Select Secret" screen and verifies it returns `Destination(BackStackView)` without triggering the error handler.

Both tests were verified to **fail** against the unpatched code and **pass** after the fix.

## Testing

- `pytest tests/test_status_headlines.py -v` - 7 passed
- `pytest tests/test_seedkeeper_xprv_storage.py tests/test_flows_menu_navigation.py tests/test_split_module_imports.py tests/test_seed.py -v` - 169 passed, 0 failures
