### PR TITLE
fix: prevent UnboundLocalError in ToolsSeedkeeperViewSecretsView except handler (#385)

### DIFF
--- a/src/seedsigner/views/smartcard_views.py
+++ b/src/seedsigner/views/smartcard_views.py
@@ -1915,6 +1915,10 @@ class ToolsSeedkeeperViewSecretsView(View):
 
     def run(self):
         from seedsigner.gui.screens.screen import LoadingScreenThread
+        # Safe defaults so the except handler never references unbound names
+        # when an exception fires before these variables are assigned.
+        selected_menu_num = RET_CODE__BACK_BUTTON
+        secret_dict = {}
         try:
             Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["seedkeeper"])
             
@@ -2113,7 +2117,10 @@ class ToolsSeedkeeperViewSecretsView(View):
             
         except Exception as e:
             logger.info(e)
-            self.loading_screen.stop()
+            try:
+                self.loading_screen.stop()
+            except Exception:
+                pass
             self.run_screen(
                 WarningScreen,
                 title="Error",
@@ -2129,7 +2136,7 @@ class ToolsSeedkeeperViewSecretsView(View):
                 from seedsigner.gui.screens.screen import QRDisplayScreen
                 from seedsigner.models.encode_qr import GenericStaticQrEncoder
 
-                qr_encoder = GenericStaticQrEncoder(data=secret_dict['secret'])
+                qr_encoder = GenericStaticQrEncoder(data=secret_dict.get('secret', str(e)))
                 self.run_screen(
                     QRDisplayScreen,
                     qr_encoder=qr_encoder,

--- a/tests/test_pysatochip_contract.py
+++ b/tests/test_pysatochip_contract.py
@@ -25,6 +25,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from unittest.mock import Mock
+
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -163,6 +165,37 @@ def test_real_connector_has_satodime_ndef_v2():
         "assert callable(getattr(CardConnector, 'card_get_ndef_v2', None))\n"
     )
     assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+
+def test_view_secrets_except_handler_no_unboundlocal_on_early_failure(monkeypatch):
+    """B11 / #385 regression: ToolsSeedkeeperViewSecretsView.run() wraps its body
+    in try/except, but the except handler referenced selected_menu_num and
+    secret_dict — names that were never assigned when an exception fired before
+    the selection-screen step. That produced an UnboundLocalError, masking the
+    original error. After the fix, the view returns Destination(BackStackView)
+    cleanly."""
+    from seedsigner.views.smartcard_views import ToolsSeedkeeperViewSecretsView
+    from seedsigner.views.view import Destination, BackStackView
+    from seedsigner.helpers import seedkeeper_utils
+
+    from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
+
+    view = object.__new__(ToolsSeedkeeperViewSecretsView)
+    view.settings = Mock()
+    view.controller = Mock()
+    view.run_screen = Mock(return_value=RET_CODE__BACK_BUTTON)
+
+    # Simulate a card that connects but blows up during secret listing
+    # — the except handler MUST NOT explode with UnboundLocalError.
+    monkeypatch.setattr(
+        seedkeeper_utils,
+        "init_satochip",
+        Mock(side_effect=Exception("Connection refused during listing")),
+    )
+
+    result = view.run()
+    assert isinstance(result, Destination)
+    assert result.View_cls == BackStackView
 
 
 @requires_real_pysatochip


### PR DESCRIPTION
Fixes the secondary crash from #385 where the except handler in ToolsSeedkeeperViewSecretsView.run() would hit an UnboundLocalError because selected_menu_num and secret_dict were never assigned before the exception.