### PR TITLE
fix: multisig address verification always reports non-standard path

### DIFF
--- a/src/seedsigner/helpers/embit_utils.py
+++ b/src/seedsigner/helpers/embit_utils.py
@@ -63,20 +63,22 @@ def is_standard_derivation(derivation_path: str, script_type: str, network: str)
     """
     Returns True if the derivation_path matches the standard BIP path for the
     given script_type, network, and any account 0-9.  For example, native segwit
-    on mainnet must be m/84'/0'/<account>'.
+    on mainnet must be m/84'/0'/<account>' for singlesig or
+    m/48'/0'/<account>'/2' for multisig.
     """
-    for account in range(10):
-        try:
-            standard = get_standard_derivation_path(
-                network=network,
-                wallet_type=SettingsConstants.SINGLE_SIG,
-                script_type=script_type,
-                account=account,
-            )
-            if derivation_path == standard:
-                return True
-        except Exception:
-            pass
+    for wallet_type in (SettingsConstants.SINGLE_SIG, SettingsConstants.MULTISIG):
+        for account in range(10):
+            try:
+                standard = get_standard_derivation_path(
+                    network=network,
+                    wallet_type=wallet_type,
+                    script_type=script_type,
+                    account=account,
+                )
+                if derivation_path == standard:
+                    return True
+            except Exception:
+                pass
     return False
 
 

--- a/tests/test_embit_utils.py
+++ b/tests/test_embit_utils.py
@@ -720,6 +720,30 @@ def test_is_standard_derivation():
     # Non-standard: account beyond 9 still returns False
     assert embit_utils.is_standard_derivation("m/84'/0'/10'", SC.NATIVE_SEGWIT, SC.MAINNET) is False
 
+    # Standard multisig BIP48 native segwit paths
+    assert embit_utils.is_standard_derivation("m/48'/0'/0'/2'", SC.NATIVE_SEGWIT, SC.MAINNET) is True
+    assert embit_utils.is_standard_derivation("m/48'/1'/0'/2'", SC.NATIVE_SEGWIT, SC.TESTNET) is True
+    assert embit_utils.is_standard_derivation("m/48'/1'/0'/2'", SC.NATIVE_SEGWIT, SC.REGTEST) is True
+
+    # Standard multisig BIP48 native segwit with non-zero account
+    assert embit_utils.is_standard_derivation("m/48'/0'/5'/2'", SC.NATIVE_SEGWIT, SC.MAINNET) is True
+    assert embit_utils.is_standard_derivation("m/48'/1'/3'/2'", SC.NATIVE_SEGWIT, SC.TESTNET) is True
+
+    # Standard multisig BIP48 nested segwit paths
+    assert embit_utils.is_standard_derivation("m/48'/0'/0'/1'", SC.NESTED_SEGWIT, SC.MAINNET) is True
+    assert embit_utils.is_standard_derivation("m/48'/1'/0'/1'", SC.NESTED_SEGWIT, SC.TESTNET) is True
+
+    # Standard multisig BIP45 legacy path
+    assert embit_utils.is_standard_derivation("m/45'", SC.LEGACY_P2PKH, SC.MAINNET) is True
+    assert embit_utils.is_standard_derivation("m/45'", SC.LEGACY_P2PKH, SC.TESTNET) is True
+
+    # Non-standard: BIP48 path with wrong script type
+    assert embit_utils.is_standard_derivation("m/48'/0'/0'/2'", SC.NESTED_SEGWIT, SC.MAINNET) is False
+    assert embit_utils.is_standard_derivation("m/48'/0'/0'/1'", SC.NATIVE_SEGWIT, SC.MAINNET) is False
+
+    # Non-standard: BIP48 account beyond 9
+    assert embit_utils.is_standard_derivation("m/48'/0'/10'/2'", SC.NATIVE_SEGWIT, SC.MAINNET) is False
+
 
 def test_normalize_descriptor_str():
     """


### PR DESCRIPTION
## What

`is_standard_derivation()` only recognized single-sig paths as standard. Every multisig address verification displayed a false "Non-standard path!" warning in red, even for correct BIP48 derivations like `m/48'/0'/0'/2'`.

## Why

The function looped over accounts 0–9 but pinned `wallet_type` to `SINGLE_SIG`. `get_standard_derivation_path()` already had complete BIP48 (native/nested segwit) and BIP45 (legacy) multisig support — it was just unreachable due to the hardcoded wallet type.

## What changed

- **`embit_utils.py`** — `is_standard_derivation()` now iterates over both `SINGLE_SIG` and `MULTISIG`, so BIP48/45 paths are checked. The existing `try/except` already swallows the "Taproot multisig not yet supported" exception for BIP48/taproot combinations, so no additional guarding is needed.
- **`test_embit_utils.py`** — added 12 assertions covering standard multisig paths (native segwit, nested segwit, legacy), testnet/mainnet, non-zero accounts, and non-standard cases (wrong change suffix, account >9).

## Before / after

**Before:** `m/48'/0'/0'/2'` (correct BIP48 native segwit path) → `is_standard_derivation()` returns `False` → red "Non-standard path!" shown

**After:** same path → returns `True` → path displayed normally, no false warning

## Scope

Display only. `is_non_standard` feeds only the success screen's path color and warning label. Address verification logic is unaffected.
