### PR TITLE
Add SeedQR support for BIP39 passphrase input

### DIFF
--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -123,11 +123,49 @@ class DecodeQR:
         return self.add_data(data)
 
 
+    def _try_seedqr_as_passphrase(self, data):
+        """Decode explicit SeedQR formats into a canonical mnemonic passphrase.
+
+        SeedQR does not preserve formatting. Its canonical passphrase
+        representation is therefore lowercase BIP39 words separated by one
+        ordinary ASCII space.
+        """
+        detected_type = DecodeQR.detect_segment_type(
+            data,
+            wordlist_language_code=self.wordlist_language_code,
+        )
+        if detected_type not in {
+            QRType.SEED__SEEDQR,
+            QRType.SEED__COMPACTSEEDQR,
+        }:
+            return None
+
+        seed_decoder = SeedQrDecoder(
+            wordlist_language_code=self.wordlist_language_code
+        )
+        status = seed_decoder.add(data, detected_type)
+        if status != DecodeQRStatus.COMPLETE:
+            return status
+
+        passphrase = " ".join(seed_decoder.get_seed_phrase())
+        self.qr_type = QRType.PASSPHRASE
+        self.decoder = PassphraseQrDecoder()
+
+        status = self.decoder.add(passphrase, QRType.PASSPHRASE)
+        if status == DecodeQRStatus.COMPLETE:
+            self.complete = True
+        return status
+
+
     def add_data(self, data):
         if data == None:
             return DecodeQRStatus.FALSE
 
         if self.is_passphrase:
+            seedqr_status = self._try_seedqr_as_passphrase(data)
+            if seedqr_status is not None:
+                return seedqr_status
+
             qr_type = QRType.PASSPHRASE
         elif self.is_encryptionkey:
             qr_type = QRType.ENCRYPTION_KEY

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -147,7 +147,13 @@ class DecodeQR:
         )
         status = seed_decoder.add(data, detected_type)
         if status != DecodeQRStatus.COMPLETE:
-            return status
+            # The payload was identified as SeedQR, so a decoding failure must
+            # remain invalid rather than falling through as plaintext or an
+            # empty passphrase.
+            self.qr_type = QRType.INVALID
+            self.decoder = None
+            self.complete = False
+            return DecodeQRStatus.INVALID
 
         passphrase = " ".join(seed_decoder.get_seed_phrase())
         self.qr_type = QRType.PASSPHRASE
@@ -369,8 +375,9 @@ class DecodeQR:
 
 
     def get_passphrase(self):
-        if self.is_passphrase:
+        if self.is_passphrase and self.decoder is not None and self.complete:
             return self.decoder.get_passphrase()
+        return None
 
 
     def get_encryption_key(self):

--- a/src/seedsigner/models/decode_qr.py
+++ b/src/seedsigner/models/decode_qr.py
@@ -124,11 +124,13 @@ class DecodeQR:
 
 
     def _try_seedqr_as_passphrase(self, data):
-        """Decode explicit SeedQR formats into a canonical mnemonic passphrase.
+        """Decode SeedQR as a canonical mnemonic-style BIP39 passphrase.
 
-        SeedQR does not preserve formatting. Its canonical passphrase
-        representation is therefore lowercase BIP39 words separated by one
-        ordinary ASCII space.
+        SeedQR intentionally does not preserve formatting such as capitalization
+        or custom separators. When used as a passphrase, reconstruct it as
+        lowercase BIP39 words separated by single ASCII spaces.
+
+        Plain UTF-8 passphrase QRs continue to preserve their exact text.
         """
         detected_type = DecodeQR.detect_segment_type(
             data,

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1416,6 +1416,18 @@ class SeedScanPassphraseView(View):
             if isinstance(self.seed, AezeedSeed):
                 return Destination(SeedFinalizeView)
             return Destination(SeedReviewPassphraseView)
+        elif decoder.is_invalid:
+            self.run_screen(
+                WarningScreen,
+                title=_("Invalid QR"),
+                status_headline=None,
+                text=_("The scanned QR code is not a valid passphrase QR."),
+                show_back_button=False,
+                button_data=[ButtonOption("OK")],
+            )
+            if isinstance(self.seed, AezeedSeed):
+                return Destination(SeedAezeedPassphraseModeView)
+            return Destination(BackStackView)
         elif decoder.is_nonUTF8:
             DireWarningScreen(
                 title=_("Error!"),

--- a/tests/test_passphrase_seedqr.py
+++ b/tests/test_passphrase_seedqr.py
@@ -30,7 +30,9 @@ def test_standard_seedqr_decodes_as_canonical_passphrase():
     status = decoder.add_data(payload)
 
     assert status == DecodeQRStatus.COMPLETE
-    assert decoder.get_passphrase() == CANONICAL_PASSPHRASE
+    passphrase = decoder.get_passphrase()
+    assert passphrase == CANONICAL_PASSPHRASE
+    assert passphrase.split() == MNEMONIC_WORDS
 
 
 def test_compact_seedqr_decodes_as_canonical_passphrase():
@@ -46,7 +48,9 @@ def test_compact_seedqr_decodes_as_canonical_passphrase():
     status = decoder.add_data(payload)
 
     assert status == DecodeQRStatus.COMPLETE
-    assert decoder.get_passphrase() == CANONICAL_PASSPHRASE
+    passphrase = decoder.get_passphrase()
+    assert passphrase == CANONICAL_PASSPHRASE
+    assert passphrase.split() == MNEMONIC_WORDS
 
 
 def test_standard_and_compact_seedqr_produce_identical_passphrases():
@@ -66,9 +70,14 @@ def test_standard_and_compact_seedqr_produce_identical_passphrases():
     assert standard_decoder.add_data(standard_payload) == DecodeQRStatus.COMPLETE
     assert compact_decoder.add_data(compact_payload) == DecodeQRStatus.COMPLETE
 
-    assert standard_decoder.get_passphrase() == CANONICAL_PASSPHRASE
-    assert compact_decoder.get_passphrase() == CANONICAL_PASSPHRASE
-    assert standard_decoder.get_passphrase() == compact_decoder.get_passphrase()
+    standard_passphrase = standard_decoder.get_passphrase()
+    compact_passphrase = compact_decoder.get_passphrase()
+
+    assert standard_passphrase == CANONICAL_PASSPHRASE
+    assert compact_passphrase == CANONICAL_PASSPHRASE
+    assert standard_passphrase.split() == MNEMONIC_WORDS
+    assert compact_passphrase.split() == MNEMONIC_WORDS
+    assert standard_passphrase == compact_passphrase
 
 
 def test_invalid_binary_payload_is_not_accepted_as_passphrase():

--- a/tests/test_passphrase_seedqr.py
+++ b/tests/test_passphrase_seedqr.py
@@ -87,3 +87,16 @@ def test_invalid_binary_payload_is_not_accepted_as_passphrase():
 
     assert status == DecodeQRStatus.INVALID
     assert decoder.is_complete is False
+
+
+def test_malformed_standard_seedqr_is_rejected_as_invalid():
+    """SeedQR-shaped data with an invalid word index must not become a passphrase."""
+    payload = b"000000000000000000000000000000000000000000009999"
+
+    decoder = DecodeQR(is_passphrase=True)
+    status = decoder.add_data(payload)
+
+    assert status == DecodeQRStatus.INVALID
+    assert decoder.is_invalid is True
+    assert decoder.is_complete is False
+    assert decoder.get_passphrase() is None

--- a/tests/test_passphrase_seedqr.py
+++ b/tests/test_passphrase_seedqr.py
@@ -1,0 +1,80 @@
+from embit import bip39
+
+from seedsigner.models.decode_qr import DecodeQR, DecodeQRStatus
+from seedsigner.models.encode_qr import CompactSeedQrEncoder, SeedQrEncoder
+from seedsigner.models.settings import Settings
+from seedsigner.models.settings_definition import SettingsConstants
+
+
+ENTROPY = b"\x00" * 16
+MNEMONIC_WORDS = bip39.mnemonic_from_bytes(ENTROPY).split()
+CANONICAL_PASSPHRASE = " ".join(MNEMONIC_WORDS)
+
+
+def test_plaintext_passphrase_qr_remains_unchanged():
+    """Ordinary UTF-8 TextQR passphrases must retain their exact contents."""
+    passphrase = "Correct horse  battery staple!"
+
+    decoder = DecodeQR(is_passphrase=True)
+    status = decoder.add_data(passphrase.encode("utf-8"))
+
+    assert status == DecodeQRStatus.COMPLETE
+    assert decoder.get_passphrase() == passphrase
+
+
+def test_standard_seedqr_decodes_as_canonical_passphrase():
+    """Standard SeedQR should become lowercase words separated by one space."""
+    payload = SeedQrEncoder(mnemonic=MNEMONIC_WORDS).next_part()
+
+    decoder = DecodeQR(is_passphrase=True)
+    status = decoder.add_data(payload)
+
+    assert status == DecodeQRStatus.COMPLETE
+    assert decoder.get_passphrase() == CANONICAL_PASSPHRASE
+
+
+def test_compact_seedqr_decodes_as_canonical_passphrase():
+    """CompactSeedQR should become lowercase words separated by one space."""
+    Settings.get_instance().set_value(
+        SettingsConstants.SETTING__AMBIGUOUS_QR,
+        SettingsConstants.AMBIGUOUS_QR_COMPACT,
+        save=False,
+    )
+    payload = CompactSeedQrEncoder(mnemonic=MNEMONIC_WORDS).next_part()
+
+    decoder = DecodeQR(is_passphrase=True)
+    status = decoder.add_data(payload)
+
+    assert status == DecodeQRStatus.COMPLETE
+    assert decoder.get_passphrase() == CANONICAL_PASSPHRASE
+
+
+def test_standard_and_compact_seedqr_produce_identical_passphrases():
+    """Both SeedQR encodings must reconstruct the exact same passphrase."""
+    Settings.get_instance().set_value(
+        SettingsConstants.SETTING__AMBIGUOUS_QR,
+        SettingsConstants.AMBIGUOUS_QR_COMPACT,
+        save=False,
+    )
+
+    standard_payload = SeedQrEncoder(mnemonic=MNEMONIC_WORDS).next_part()
+    compact_payload = CompactSeedQrEncoder(mnemonic=MNEMONIC_WORDS).next_part()
+
+    standard_decoder = DecodeQR(is_passphrase=True)
+    compact_decoder = DecodeQR(is_passphrase=True)
+
+    assert standard_decoder.add_data(standard_payload) == DecodeQRStatus.COMPLETE
+    assert compact_decoder.add_data(compact_payload) == DecodeQRStatus.COMPLETE
+
+    assert standard_decoder.get_passphrase() == CANONICAL_PASSPHRASE
+    assert compact_decoder.get_passphrase() == CANONICAL_PASSPHRASE
+    assert standard_decoder.get_passphrase() == compact_decoder.get_passphrase()
+
+
+def test_invalid_binary_payload_is_not_accepted_as_passphrase():
+    """Unrecognized binary data must remain invalid."""
+    decoder = DecodeQR(is_passphrase=True)
+    status = decoder.add_data(b"\xff\xfe\xfd\xfc")
+
+    assert status == DecodeQRStatus.INVALID
+    assert decoder.is_complete is False

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -493,6 +493,41 @@ class TestAezeedPassphraseMode(BaseTest):
         assert destination.View_cls == seed_views.MainMenuView
         assert destination.clear_history is True
 
+    def test_invalid_passphrase_qr_shows_warning_and_returns_to_mode(self, monkeypatch):
+        mnemonic = (
+            "absent beef crazy include regret city blanket plug thought spatial boy receive "
+            "bag jazz fade emerge quit beach crucial giant mutual reward captain excite"
+        ).split()
+        self.controller.storage.set_pending_seed(AezeedSeed(mnemonic=mnemonic))
+
+        class DummyDecodeQR:
+            def __init__(self, is_passphrase=False):
+                self.is_complete = False
+                self.is_invalid = True
+                self.is_nonUTF8 = False
+
+        monkeypatch.setattr("seedsigner.models.decode_qr.DecodeQR", DummyDecodeQR)
+
+        view = seed_views.SeedScanPassphraseView()
+        screen_calls = []
+
+        def capture_screen(screen_cls, *args, **kwargs):
+            screen_calls.append((screen_cls, kwargs))
+            return None
+
+        monkeypatch.setattr(view, "run_screen", capture_screen)
+
+        destination = view.run()
+
+        assert len(screen_calls) == 2
+        assert screen_calls[1][0] == seed_views.WarningScreen
+        assert screen_calls[1][1]["title"] == "Invalid QR"
+        assert (
+            screen_calls[1][1]["text"]
+            == "The scanned QR code is not a valid passphrase QR."
+        )
+        assert destination.View_cls == seed_views.SeedAezeedPassphraseModeView
+
     def test_scan_wrong_aezeed_passphrase_returns_mode(self, monkeypatch):
         mnemonic = (
             "absent beef crazy include regret city blanket plug thought spatial boy receive "


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

SeedSigner's passphrase QR workflow accepts plaintext UTF-8 QR codes, but does not accept Standard SeedQR or Compact SeedQR as passphrase input.

This PR adds the option to use either SeedQR format as a BIP39 passphrase while preserving the existing plaintext QR behavior.

### Solution

When scanning a passphrase QR, Standard SeedQR and Compact SeedQR payloads are detected and decoded using the existing SeedQR decoding logic.

Because SeedQR represents BIP39 word indexes rather than the original text formatting, decoded SeedQR passphrases are reconstructed canonically as lowercase BIP39 words separated by single ASCII spaces.

Plain UTF-8 passphrase QR input continues to preserve the exact text provided.

Malformed SeedQR input is rejected rather than being accepted as an empty or otherwise unintended passphrase. The passphrase scan workflow displays an "Invalid QR" warning when this occurs.

Tests cover:
- Standard SeedQR passphrase decoding
- Compact SeedQR passphrase decoding
- Equivalent Standard/Compact representations
- Preservation of existing plaintext passphrase behavior
- Malformed SeedQR rejection
- Invalid passphrase QR handling

### Additional Information

Tested on a Raspberry Pi Zero W with physical SeedSigner hardware.

Using the same seed, I tested equivalent passphrases supplied as:
- plaintext QR
- Standard SeedQR
- Compact SeedQR

All three produced the same wallet fingerprint.

Malformed SeedQR input was also tested on the physical device and correctly displayed the invalid QR warning.

The branch was rebased onto the current `3rdIteration/dev` before final testing.

### Screenshots

No screenshots included. The only new screen behavior is the invalid QR warning using the existing warning UI.

---

This pull request is categorized as:

- [x] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [x] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [ ] N/A

Full suite result: `1026 passed, 58 skipped, 1 xfailed`

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [x] No
- [ ] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [x] Yes
- [ ] No, I'm a fool
- [ ] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [x] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [x] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0w board
- [ ] Emulator

---

#### I have reviewed these notes:
* Keep your changes limited in scope.
* If you uncover other issues or improvements along the way, ideally submit those as a separate PR.
* The more complicated the PR, the harder it is to review, test, and merge.
* We appreciate your efforts, but we're a small team of volunteers so PR review can be a very slow process.
* Please only "@" mention a contributor if their input is truly needed to enable further progress.

- [x] I understand

---

Thank you! Please join our [Devs' Telegram group](https://t.me/seedsigner_new_devs) to get more involved.