### PR TITLE
fix: La Frite boot hang, GPG Tools pgpy failure, opt-in error diagnostics

### DIFF
--- a/.github/workflows/build-buildroot.yml
+++ b/.github/workflows/build-buildroot.yml
@@ -58,6 +58,11 @@ on:
         required: false
         default: 'false'
         type: boolean
+      enable-error-diagnostics:
+        description: 'Enable the opt-in "Save to MicroSD" button on OS/package error screens (off by default; also flagged by the hardening self-check when on)'
+        required: false
+        default: 'false'
+        type: boolean
       upload-release:
         description: Upload built .img files to the matching GitHub release (if it exists)
         required: false
@@ -70,9 +75,20 @@ on:
 permissions:
   contents: read
 
-# Cancel in-progress builds when a PR is updated; unique per-PR or per-SHA
+# Cancel in-progress builds when a PR is updated; unique per-PR or per-SHA.
+# workflow_dispatch gets its own branch of the key: two manual dispatches of
+# the SAME commit are common (e.g. dev vs non-dev, or different os-ref/
+# source-ref) and must NOT collide just because the sha matches -- only the
+# combination of sha + the inputs that actually distinguish one build from
+# another should share a group.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event_name == 'workflow_dispatch'
+        && format('dispatch-{0}-{1}-{2}-{3}-{4}', github.sha, github.event.inputs.target, github.event.inputs.dev, github.event.inputs['os-ref'], github.event.inputs['source-ref'])
+        || github.event.pull_request.number
+        || github.sha
+    }}
   cancel-in-progress: true
 
 jobs:
@@ -167,6 +183,13 @@ jobs:
           fi
 
           echo "SS_ARGS=${SS_ARGS}" | tee -a "$GITHUB_ENV"
+
+          # Consumed directly by seedsigner-os's post-build.sh (docker-compose.yml
+          # forwards it through) -- not an opt/build.sh flag, so it's exported
+          # separately from SS_ARGS rather than appended to it.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.enable-error-diagnostics }}" = "true" ]; then
+            echo "SEEDSIGNER_ENABLE_ERROR_DIAGNOSTICS=1" | tee -a "$GITHUB_ENV"
+          fi
 
       - name: free disk space
         run: |

--- a/src/seedsigner/helpers/hardening.py
+++ b/src/seedsigner/helpers/hardening.py
@@ -338,6 +338,25 @@ def check_remote_shells() -> HardeningCheck:
     )
 
 
+def check_error_diagnostics_export() -> HardeningCheck:
+    """The GPG Tools "Save to MicroSD" diagnostic button (see
+    helpers.seedsigner_os.is_error_microsd_export_enabled) writes OS/package
+    error text -- never seeds, secrets, or PINs -- to a physically inserted
+    card when enabled. Low-risk compared to the other CRITICAL checks here,
+    but it is still a deliberately-added capability a production image
+    should not silently ship with, so it is flagged the same way."""
+    from seedsigner.helpers.seedsigner_os import ERROR_MICROSD_EXPORT_MARKER_PATH
+
+    if os.path.exists(ERROR_MICROSD_EXPORT_MARKER_PATH):
+        state, detail = STATE_FAIL, _("Error-to-MicroSD export enabled")
+    else:
+        state, detail = STATE_PASS, _("Disabled")
+    return HardeningCheck(
+        key="error_diagnostics_export", label=_("Error diagnostics export disabled"), severity=SEVERITY_CRITICAL,
+        state=state, detail=detail, open_name=_("diagnostics"),
+    )
+
+
 # --------------------------------------------------------------------------
 # INFO checks — reported, never warned on.
 # --------------------------------------------------------------------------
@@ -448,6 +467,7 @@ ALL_CHECKS: tuple[Callable[[], HardeningCheck], ...] = (
     check_usb_gadget,
     check_serial_console,
     check_remote_shells,
+    check_error_diagnostics_export,
     check_rootfs_non_persistent,
     check_panic_reboot,
     check_logging_daemons,

--- a/src/seedsigner/helpers/seedsigner_os.py
+++ b/src/seedsigner/helpers/seedsigner_os.py
@@ -84,6 +84,23 @@ def get_os_release(path: str = OS_RELEASE_PATH) -> dict:
     return data
 
 
+ERROR_MICROSD_EXPORT_MARKER_PATH = "/etc/seedsigner-error-microsd-export"
+
+
+def is_error_microsd_export_enabled() -> bool:
+    """Diagnostic aid, off by default: whether an OS/package-error screen (e.g.
+    GPG Tools' "Missing packages") should offer a "Save to MicroSD" button for
+    the exact error text already shown on screen.
+
+    Gated by a build-time marker file rather than an app-source constant so a
+    given image can opt in without a code change, and so the hardening
+    self-check (helpers.hardening) can see it and flag it as an open exposure
+    when present -- a build that ships this should not report itself as fully
+    hardened, since it is a deliberately-added capability, however low-risk.
+    """
+    return os.path.exists(ERROR_MICROSD_EXPORT_MARKER_PATH)
+
+
 def is_running_from_microsd() -> bool:
     """True when the running SeedSigner source is loaded from the microSD card
     (a dev workflow) rather than the embedded system partition.

--- a/src/seedsigner/views/gpg_views.py
+++ b/src/seedsigner/views/gpg_views.py
@@ -322,11 +322,11 @@ class ToolsGPGMenuView(View):
         except ImportError as e:
             # A bare "pgpy" in the UI could mean pgpy itself is absent, or that
             # something in its own import chain (e.g. cryptography's compiled
-            # extension) failed to load -- log the real exception so a
-            # platform-specific failure isn't indistinguishable from a
-            # genuinely missing package.
+            # extension) failed to load. Put the real exception in the on-screen
+            # text too, not just the log: on a hardened non-dev image there's no
+            # SSH/UART/log file to check it any other way.
             logger.warning(f"pgpy import failed: {e!r}", exc_info=True)
-            missing.append("pgpy")
+            missing.append(f"pgpy ({e})")
         if not shutil.which("gpg"):
             missing.append("gnupg2")
         if missing:

--- a/src/seedsigner/views/gpg_views.py
+++ b/src/seedsigner/views/gpg_views.py
@@ -319,7 +319,13 @@ class ToolsGPGMenuView(View):
         missing = []
         try:
             import pgpy  # noqa: F401
-        except ImportError:
+        except ImportError as e:
+            # A bare "pgpy" in the UI could mean pgpy itself is absent, or that
+            # something in its own import chain (e.g. cryptography's compiled
+            # extension) failed to load -- log the real exception so a
+            # platform-specific failure isn't indistinguishable from a
+            # genuinely missing package.
+            logger.warning(f"pgpy import failed: {e!r}", exc_info=True)
             missing.append("pgpy")
         if not shutil.which("gpg"):
             missing.append("gnupg2")

--- a/src/seedsigner/views/gpg_views.py
+++ b/src/seedsigner/views/gpg_views.py
@@ -314,6 +314,7 @@ class ToolsGPGMenuView(View):
     def run(self):
         import shutil
         from seedsigner.controller import Controller
+        from seedsigner.helpers.seedsigner_os import is_error_microsd_export_enabled
 
         # Check that required dependencies are available
         missing = []
@@ -330,13 +331,19 @@ class ToolsGPGMenuView(View):
         if not shutil.which("gpg"):
             missing.append("gnupg2")
         if missing:
-            self.run_screen(
+            error_text = _("Required but not installed:\n") + ", ".join(missing)
+            export_enabled = is_error_microsd_export_enabled()
+            SAVE_TO_MICROSD = ButtonOption("Save to MicroSD")
+            button_data = [ButtonOption("OK"), SAVE_TO_MICROSD] if export_enabled else [ButtonOption("OK")]
+            selected = self.run_screen(
                 ErrorScreen,
                 title=_("GPG Tools"),
                 status_headline=_("Missing packages"),
-                text=_("Required but not installed:\n") + ", ".join(missing),
-                button_data=[ButtonOption("OK")],
+                text=error_text,
+                button_data=button_data,
             )
+            if export_enabled and button_data[selected] == SAVE_TO_MICROSD:
+                self._save_error_to_microsd(error_text)
             return Destination(BackStackView)
 
         if self.controller.resume_main_flow == self.controller.FLOW__GPG_MESSAGE:
@@ -378,6 +385,49 @@ class ToolsGPGMenuView(View):
             return Destination(ToolsGPGSmartMenuView)
         elif button_data[selected_menu_num] == self.ADVANCED:
             return Destination(ToolsGPGAdvancedMenuView)
+
+
+    def _save_error_to_microsd(self, error_text: str):
+        """Diagnostic aid (see helpers.seedsigner_os.is_error_microsd_export_enabled):
+        write the exact on-screen error text -- and nothing else -- to the
+        microSD card. Requires a physically inserted card; deliberately does
+        not fall back to a non-removable location like resolve_microsd_images_dir()
+        would, since the entire point is getting the text off a device that has
+        no SSH, no UART shell, and no readable log file."""
+        from seedsigner.hardware.microsd import MicroSD
+        import os
+        import time
+
+        if not MicroSD.get_instance().is_inserted:
+            self.run_screen(
+                WarningScreen,
+                title=_("MicroSD"),
+                status_headline=_("No card detected"),
+                text=_("Insert a microSD card and try again."),
+                button_data=[ButtonOption("OK")],
+            )
+            return
+
+        filename = f"seedsigner_error_{time.strftime('%Y%m%d_%H%M%S')}.txt"
+        filepath = os.path.join(MicroSD.get_microsd_dir(), filename)
+        try:
+            with open(filepath, "w", encoding="utf-8") as f:
+                f.write(error_text)
+            self.run_screen(
+                LargeIconStatusScreen,
+                title=_("Saved"),
+                status_headline=None,
+                text=_("Saved to {filename}").format(filename=filename),
+                button_data=[ButtonOption("OK")],
+            )
+        except OSError as e:
+            self.run_screen(
+                WarningScreen,
+                title=_("MicroSD"),
+                status_headline=_("Save failed"),
+                text=str(e),
+                button_data=[ButtonOption("OK")],
+            )
 
 
 class ToolsGPGAdvancedMenuView(View):

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -234,11 +234,6 @@ class MainMenuView(View):
 
         controller = Controller.get_instance()
 
-        # Reaching Home is the "healthy enough" signal for the U-Boot boot-counter
-        # failover, which runs once per boot. The counter is memory-backed
-        # (CONFIG_SYS_BOOTCOUNT_ADDR = GRF OS_REG scratch register 0xFF020218), so
-        # clearing it via devmem writes no flash.
-        #
         # The OS watchdog's liveness marker is signalled much earlier, in
         # Controller.start() — a blocking startup interstitial (the
         # unhardened-build warning) would otherwise stop a perfectly working
@@ -248,7 +243,19 @@ class MainMenuView(View):
             from seedsigner.helpers.seedsigner_os import signal_app_alive
 
             signal_app_alive()
-            if not getattr(controller, "boot_failover_cleared", False):
+
+            # Reaching Home is the "healthy enough" signal for the Luckfox U-Boot
+            # boot-counter failover, which runs once per boot. That counter is
+            # memory-backed (CONFIG_SYS_BOOTCOUNT_ADDR = Rockchip GRF OS_REG
+            # scratch register 0xFF020218), so clearing it via devmem writes no
+            # flash. This address is meaningless outside Rockchip's memory map —
+            # on the La Frite (Amlogic S805X) it lands on live MMIO register
+            # space and hangs the whole board, not just the app, the first time
+            # Home is reached each boot. Must stay gated to Luckfox boards.
+            if (
+                Settings.RUNTIME_PROFILE in PowerOptionsView.LUCKFOX_PROFILES
+                and not getattr(controller, "boot_failover_cleared", False)
+            ):
                 controller.boot_failover_cleared = True
                 try:
                     from subprocess import run as _run, DEVNULL as _DEVNULL


### PR DESCRIPTION
## Summary

Fixes for the Libre Computer La Frite build, found while debugging a series of issues live on hardware this session (paired with 3rdIteration/seedsigner-os#111 for the OS-side hardening/bz2 fix):

- **Boot hang on first Home screen visit**: `MainMenuView.run()` cleared a Rockchip-specific U-Boot boot-failover counter via `devmem 0xFF020218 32 0`, gated only by `Settings.is_seedsigner_os()` rather than by board. On non-Rockchip hardware this wrote a Rockchip GRF register address into an unrelated SoC's physical memory map — reliably hanging the whole La Frite board (not just the app) the first time Home was reached each boot, requiring a full power cycle. Now gated to `PowerOptionsView.LUCKFOX_PROFILES`, matching the guard already used for the Luckfox-only "reboot to Loader" option.
- **GPG Tools "Missing packages: pgpy"**: `ToolsGPGMenuView` caught a bare `ImportError` and always showed a generic "pgpy" label, discarding the real exception. Diagnosed this end-to-end using a new opt-in "Save to MicroSD" button (see below) since a hardened non-dev image has no SSH/UART/log access — the real cause turned out to be a missing Buildroot Python package (`BR2_PACKAGE_PYTHON3_BZIP2`) on the OS side, fixed in the paired seedsigner-os PR. The real exception is now surfaced both in the app log and directly on screen.
- **New opt-in diagnostic**: OS/package-level error screens (currently just GPG Tools' missing-packages screen) can now offer a "Save to MicroSD" button that writes the exact on-screen error text — nothing else, never automatic — to the microSD card. Off by default, gated behind a build-time marker file (`helpers/seedsigner_os.py: is_error_microsd_export_enabled()`); its presence is also flagged as an open exposure by the hardening self-check (`helpers/hardening.py: check_error_diagnostics_export()`), so a build that ships this on correctly reports itself as unhardened.
- **CI**: added an `enable-error-diagnostics` input to `build-buildroot.yml` so the flag above is reachable via `workflow_dispatch` instead of requiring a hand-committed file. Also fixed the workflow's concurrency group, which fell back to `github.sha` alone for non-PR events — meaning two `workflow_dispatch` runs of the same commit (e.g. dispatching a dev build right after a non-dev one) always collided and silently cancelled each other regardless of differing inputs. It now incorporates `target`/`dev`/`os-ref`/`source-ref` so genuinely different dispatched builds of the same commit run concurrently.

## Test plan

- [x] Confirmed on actual La Frite hardware: non-dev build no longer hangs reaching Home after the devmem fix.
- [x] Confirmed on hardware: GPG Tools "Missing packages" screen showed the real `No module named '_bz2'` error via the Save-to-MicroSD button, which led directly to the OS-side root-cause fix.
- [x] Confirmed on hardware (paired with the OS-side bz2 fix): GPG Tools now opens cleanly, and the hardening screen does not list "diagnostics" when `enable-error-diagnostics` is left at its default (off).
- [x] `tests/test_hardening.py`, `tests/test_seedsigner_os.py`, `tests/test_flows_menu_navigation.py`, `tests/test_destination_repr.py` pass locally.
- [x] Verified the CI concurrency fix live: dispatching non-dev then dev back-to-back on the same commit left both runs `in_progress` simultaneously instead of the second cancelling the first.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

