### PR TITLE
Add off-by-default testing build Home menu

### DIFF
--- a/.github/workflows/build-buildroot.yml
+++ b/.github/workflows/build-buildroot.yml
@@ -63,6 +63,11 @@ on:
         required: false
         default: 'false'
         type: boolean
+      testing-build:
+        description: 'Ship the testing build Home menu (I/O Test, Test Smartcard, Flash Applet, Settings) - off by default'
+        required: false
+        default: 'false'
+        type: boolean
       upload-release:
         description: Upload built .img files to the matching GitHub release (if it exists)
         required: false
@@ -189,6 +194,11 @@ jobs:
           # separately from SS_ARGS rather than appended to it.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.enable-error-diagnostics }}" = "true" ]; then
             echo "SEEDSIGNER_ENABLE_ERROR_DIAGNOSTICS=1" | tee -a "$GITHUB_ENV"
+          fi
+
+          # Same as above: consumed directly by post-build.sh via docker-compose.yml.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.testing-build }}" = "true" ]; then
+            echo "SEEDSIGNER_TESTING_BUILD=1" | tee -a "$GITHUB_ENV"
           fi
 
       - name: free disk space

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import os
 import sys
 
 from seedsigner.controller import Controller
@@ -34,6 +35,11 @@ def main(sys_argv=None):
         action="store_true",
         help="Launch directly into the I/O test screen",
     )
+    parser.add_argument(
+        "--testing-build",
+        action="store_true",
+        help="Launch with the testing build's Home menu (I/O Test, Test Smartcard, Flash Applet, Settings)",
+    )
 
     args = parser.parse_args(sys_argv)
 
@@ -50,6 +56,9 @@ def main(sys_argv=None):
         logging.getLogger(module).setLevel(level)
 
     logger.info(f"Starting SeedSigner with: {args.__dict__}")
+
+    if args.testing_build:
+        os.environ["SEEDSIGNER_TESTING_BUILD"] = "1"
 
     # Get the one and only Controller instance and start our main loop
     initial_destination = None

--- a/src/seedsigner/helpers/seedsigner_os.py
+++ b/src/seedsigner/helpers/seedsigner_os.py
@@ -101,6 +101,24 @@ def is_error_microsd_export_enabled() -> bool:
     return os.path.exists(ERROR_MICROSD_EXPORT_MARKER_PATH)
 
 
+TESTING_BUILD_MARKER_PATH = "/etc/seedsigner-testing-build"
+
+
+def is_testing_build_enabled() -> bool:
+    """Off by default. Swaps Home's normal 4 options for a hardware-bring-up set
+    (I/O Test, Test Smartcard, Flash Applet, Settings) -- see views.view.MainMenuView.
+
+    Gated by a build-time marker file (same pattern as
+    is_error_microsd_export_enabled()) so an image can opt in without a code change,
+    and by the SEEDSIGNER_TESTING_BUILD env var so a desktop/dev-board run can flip
+    it on without rebuilding an image (see the --testing-build flag in main.py).
+    """
+    return (
+        os.path.exists(TESTING_BUILD_MARKER_PATH)
+        or os.environ.get("SEEDSIGNER_TESTING_BUILD") == "1"
+    )
+
+
 def is_running_from_microsd() -> bool:
     """True when the running SeedSigner source is loaded from the microSD card
     (a dev workflow) rather than the embedded system partition.

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -227,6 +227,11 @@ class MainMenuView(View):
     TOOLS = ButtonOption("Tools", SeedSignerIconConstants.TOOLS)
     SETTINGS = ButtonOption("Settings", SeedSignerIconConstants.SETTINGS)
 
+    # Testing build only (off by default; see helpers.seedsigner_os.is_testing_build_enabled)
+    IO_TEST = ButtonOption("I/O Test")
+    TEST_SMARTCARD = ButtonOption("Test Smartcard")
+    FLASH_APPLET = ButtonOption("Flash Applet")
+
     def run(self):
         from seedsigner.gui.screens.screen import MainMenuScreen
         from seedsigner.controller import Controller
@@ -271,10 +276,18 @@ class MainMenuView(View):
         if controller.auto_wiped:
             controller.auto_wiped = False
             controller.activate_toast(InfoToast(label_text=_("Data wiped after inactivity")))
-        button_data = [self.SCAN, self.SEEDS, self.TOOLS, self.SETTINGS]
+        from seedsigner.helpers.seedsigner_os import is_testing_build_enabled
+
+        if is_testing_build_enabled():
+            button_data = [self.IO_TEST, self.TEST_SMARTCARD, self.FLASH_APPLET, self.SETTINGS]
+            title = _("Testing")
+        else:
+            button_data = [self.SCAN, self.SEEDS, self.TOOLS, self.SETTINGS]
+            title = _("Home")
+
         selected_menu_num = self.run_screen(
             MainMenuScreen,
-            title=_("Home"),
+            title=title,
             button_data=button_data,
         )
 
@@ -294,7 +307,7 @@ class MainMenuView(View):
         if button_data[selected_menu_num] == self.SCAN:
             from seedsigner.views.scan_views import ScanView
             return Destination(ScanView)
-        
+
         elif button_data[selected_menu_num] == self.SEEDS:
             from seedsigner.views.seed_views import SeedsMenuView
             return Destination(SeedsMenuView)
@@ -306,6 +319,18 @@ class MainMenuView(View):
         elif button_data[selected_menu_num] == self.SETTINGS:
             from seedsigner.views.settings_views import SettingsMenuView
             return Destination(SettingsMenuView)
+
+        elif button_data[selected_menu_num] == self.IO_TEST:
+            from seedsigner.views.settings_views import IOTestView
+            return Destination(IOTestView)
+
+        elif button_data[selected_menu_num] == self.TEST_SMARTCARD:
+            from seedsigner.views.settings_views import SCARDTestView
+            return Destination(SCARDTestView)
+
+        elif button_data[selected_menu_num] == self.FLASH_APPLET:
+            from seedsigner.views.smartcard_views import ToolsDIYInstallAppletView
+            return Destination(ToolsDIYInstallAppletView)
 
 
 


### PR DESCRIPTION
## Summary
- Adds an off-by-default "testing build" mode: Home's normal 4 options (Scan, Seeds, Tools, Settings) are swapped for a hardware bring-up set (I/O Test, Test Smartcard, Flash Applet, Settings) when enabled.
- Gated by `is_testing_build_enabled()` in `helpers/seedsigner_os.py`, checking a build-time marker file (`/etc/seedsigner-testing-build`) or the `SEEDSIGNER_TESTING_BUILD` env var — mirrors the existing `is_error_microsd_export_enabled()` pattern.
- Adds a `--testing-build` CLI flag to `main.py` for local/desktop runs.
- Adds a `testing-build` `workflow_dispatch` input to `build-buildroot.yml` (off by default), which forwards `SEEDSIGNER_TESTING_BUILD=1` to the seedsigner-os build the same way `enable-error-diagnostics` does.
- Routes directly to the existing `IOTestView`, `SCARDTestView`, and `ToolsDIYInstallAppletView` — no changes to those views.
- Companion PR in seedsigner-os wires the marker file into each board's `post-build.sh`.

## Test plan
- [x] `PYTHONPATH=src python -m pytest` — full suite passes (2 pre-existing hardware-dependent smartcard failures, unrelated to this change — no live card connected).
- [x] CI: triggered `build-buildroot.yml` against this branch + the seedsigner-os `testing-build` branch, both `dev: true` and `dev: false`, `smartcard: true`, `testing-build: true` — both builds succeeded:
  - https://github.com/3rdIteration/seedsigner/actions/runs/31753692038 (dev)
  - https://github.com/3rdIteration/seedsigner/actions/runs/31760931818 (non-dev)
- [ ] Flash a built image and confirm Home shows the 4 testing buttons and each launches correctly on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)