### PR TITLE
Fix LCD booting with inverted colors on ST7789 displays

### DIFF
--- a/src/seedsigner/gui/renderer.py
+++ b/src/seedsigner/gui/renderer.py
@@ -61,8 +61,8 @@ class Renderer(ConfigurableSingleton):
 
             self.disp = DisplayDriverFactory.instantiate_display_driver(self.display_type, width=int(width), height=int(height))
 
-            if Settings.get_instance().get_value(SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED, default_if_none=True) == SettingsConstants.OPTION__ENABLED:
-                self.disp.invert()
+            invert_enabled = Settings.get_instance().get_value(SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED, default_if_none=True) == SettingsConstants.OPTION__ENABLED
+            self.disp.invert(enabled=invert_enabled)
 
             if self.display_type in [DISPLAY_TYPE__ST7789, DISPLAY_TYPE__DESKTOP]:
                 self.canvas_width = self.disp.width


### PR DESCRIPTION
## Summary
- ST7789 init sequences (`ST7789.py`, `st7789_mpy.py`) hardcode INVON (`0x21`) as a boot-time register step, independent of the "Invert colors" setting.
- `Renderer.initialize_display()` only forced the hardware register ON when the setting was Enabled; it never forced it OFF when Disabled (the default), so the display booted inverted and stayed that way until the setting was toggled off/on in the Settings menu.
- This also reproduces whenever the "Display type" setting is changed (e.g. `st7789_320x240` ↔ `st7789_240x240`), since driver swaps go through the same `initialize_display()` path.
- Fix: always sync the hardware inversion register to match the setting (both true and false) after instantiating a display driver, mirroring the logic already used by the Settings-view toggle handler.

## Test plan
- [x] `pytest tests/ -k "renderer or display"` — 10 passed
- [x] Full `pytest tests/` suite — 898 passed, 135 skipped, 1 xfailed, 0 failed (excluding `test_smartcard_hardware.py`, which requires a physical smartcard reader and is unaffected by this change)
- [ ] Manual verification on ST7789 hardware: confirm display boots with correct colors when "Invert colors" is Disabled, boots inverted when Enabled, and stays correct after switching "Display type" between `st7789_240x240`/`st7789_320x240`

🤖 Generated with [Claude Code](https://claude.com/claude-code)