### PR TITLE
Add a testing-build input to the Luckfox Pico workflow

### DIFF
--- a/.github/workflows/build-luckfox.yml
+++ b/.github/workflows/build-luckfox.yml
@@ -2,14 +2,15 @@ name: Build Luckfox Pico
 run-name: >-
   Build Luckfox Pico${{ github.event_name == 'workflow_dispatch'
     && format(
-      ' {0}/{1} {2} from {3}@{4} (os {5}@{6})',
+      ' {0}/{1} {2}{7} from {3}@{4} (os {5}@{6})',
       github.event.inputs.hardware_type,
       github.event.inputs.boot_medium,
       github.event.inputs.build_variant,
       github.event.inputs['app-repo'] || github.repository,
       github.event.inputs['source-ref'],
       github.event.inputs['os-repo'],
-      github.event.inputs['os-ref']
+      github.event.inputs['os-ref'],
+      github.event.inputs['testing-build'] == 'on' && ' TESTING' || ''
     )
     || github.event_name == 'pull_request' && format(' Pico Pi hardened, PR #{0}', github.event.pull_request.number)
     || github.event_name == 'push' && format(' Pico Pi hardened, push {0}', github.ref_name)
@@ -110,6 +111,14 @@ on:
           - 'on'
           - 'off'
         default: 'off'
+      testing-build:
+        description: 'Ship the testing build Home menu (I/O Test, Test Smartcard, Flash Applet, Settings) - off by default'
+        required: false
+        type: choice
+        options:
+          - 'off'
+          - 'on'
+        default: 'off'
       source-ref:
         description: The seedsigner ref (tag/branch/sha1) to use
         required: true
@@ -161,6 +170,7 @@ jobs:
       harden_adb: 'on'
       readonly_rootfs: 'on'
       boot_log: 'off'
+      testing_build: 'off'
       # Unlike build-buildroot.yml, the app cannot be pinned to a commit sha
       # here: the reusable workflow clones it with `git clone -b <ref>`, which
       # takes a branch or tag only. On a pull_request, github.ref_name is
@@ -194,6 +204,7 @@ jobs:
       harden_adb: ${{ github.event.inputs.harden_adb }}
       readonly_rootfs: ${{ github.event.inputs.readonly_rootfs }}
       boot_log: ${{ github.event.inputs.boot_log }}
+      testing_build: ${{ github.event.inputs['testing-build'] }}
       seedsigner_repo_url: https://github.com/${{ github.event.inputs['app-repo'] }}
       seedsigner_branch: ${{ github.event.inputs['source-ref'] }}
       seedsigner_os_repo: ${{ github.event.inputs['os-repo'] }}


### PR DESCRIPTION
Mirrors `build-buildroot.yml`'s `testing-build` input (Pi/La Frite) for the Luckfox Pico path.

## What it does

Adds a `testing-build` `workflow_dispatch` input and passes it to seedsigner-os's reusable workflow, which ships `/etc/seedsigner-testing-build`. The app already swaps Home for the hardware test menu (I/O Test, Test Smartcard, Flash Applet, Settings) when it sees that marker — see `helpers/seedsigner_os.py` `is_testing_build_enabled()`, added in #400. **No app code changes here**, only the workflow.

Three small pieces:

- the input itself, worded like `build-buildroot.yml:66-70`
- `testing_build` passed through in the `dispatch` job
- `testing_build: 'off'` pinned explicitly in the automatic `ci-pico-pi` job, rather than left to the reusable workflow's default. That job already pins every other hardening lever for the same reason, and a production CI image must never carry the test menu.

The run name gains a `TESTING` marker so a bring-up image is not indistinguishable from a release build in the Actions list.

## Depends on

3rdIteration/seedsigner-os#116 — **merge that first.** This workflow calls the reusable one at `@main`, so until that lands the `testing_build` input does not exist there and the call fails.

## Verification

The seedsigner-os side was built in CI (Pico Mini / SPI_NAND, non-dev, `testing_build=on`) and the resulting image was flashed to a real Pico Mini, where the Testing menu came up as expected. This PR is the caller plumbing for that same input; it cannot be exercised end to end until #116 is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)