### PR TITLE
Add live "Memory info" screen under Settings > Hardware

### DIFF
--- a/src/seedsigner/gui/screens/settings_screens.py
+++ b/src/seedsigner/gui/screens/settings_screens.py
@@ -9,6 +9,7 @@ from typing import List
 
 
 from seedsigner.helpers.l10n import mark_for_translation as _mft
+from seedsigner.helpers.system_memory import format_kb, get_memory_stats
 from seedsigner.gui.components import Button, CheckboxButton, CheckedSelectionButton, FontAwesomeIconConstants, Fonts, GUIConstants, Icon, IconButton, IconTextLine, SeedSignerIconConstants, TextArea, resize_image_to_fit
 from seedsigner.gui.screens.scan_screens import ScanScreen
 from seedsigner.gui.screens.screen import BaseScreen, BaseTopNavScreen, ButtonListScreen, ButtonOption, KeyboardScreen
@@ -569,6 +570,134 @@ class SystemInfoScreen(BaseTopNavScreen):
             )
             self.components.append(text_area)
             start_y += text_area.height + line_spacing
+
+
+@dataclass
+class MemoryInfoScreen(BaseTopNavScreen):
+    """Live system RAM usage, refreshed on a timer.
+
+    Polls like BatteryInfoScreen, but lays its rows out left-aligned like
+    SystemInfoScreen: these values are columnar and centering makes them hard to
+    compare at a glance.
+    """
+    # Seconds between reads. /proc/meminfo is cheap, but re-rendering six
+    # TextAreas is not free on a Luckfox, so don't poll faster than the numbers
+    # are worth watching.
+    REFRESH_INTERVAL = 2.0
+
+    # (attribute name, display label) -- also fixes the row order.
+    ROWS = [
+        ("total_text", "Total"),
+        ("available_text", "Available"),
+        ("free_text", "Free"),
+        ("cached_text", "Buf/Cache"),
+        ("swap_text", "Swap"),
+        ("rss_text", "App (RSS)"),
+    ]
+
+    def __post_init__(self):
+        self.title = _("Memory Info")
+        super().__post_init__()
+
+        # Labels are translated once here rather than on every refresh tick.
+        self.row_labels = [
+            (attr, _(label)) for attr, label in MemoryInfoScreen.ROWS
+        ]
+
+        start_y = self.top_nav.height + 2 * GUIConstants.COMPONENT_PADDING
+        line_spacing = GUIConstants.COMPONENT_PADDING
+
+        # Populate with a real reading immediately; waiting for the first thread
+        # tick would show a screen full of placeholders for two seconds.
+        for (attr, _label), line in zip(self.row_labels, self._build_lines()):
+            text_area = self._build_text_area(line, start_y)
+            setattr(self, attr, text_area)
+            self.components.append(text_area)
+            start_y += text_area.height + line_spacing
+
+        self.threads.append(MemoryInfoScreen.UpdateThread(self))
+
+    def _build_text_area(self, text: str, screen_y: int) -> TextArea:
+        return TextArea(
+            text=text,
+            screen_x=GUIConstants.EDGE_PADDING,
+            width=self.canvas_width - 2 * GUIConstants.EDGE_PADDING,
+            is_text_centered=False,
+            auto_line_break=True,
+            screen_y=screen_y,
+        )
+
+    def _build_lines(self) -> List[str]:
+        """Read memory now and format one "Label: value" line per row."""
+        stats = get_memory_stats()
+
+        available = format_kb(stats.available_kb)
+        percent = stats.available_percent
+        if percent is not None:
+            available = f"{available} ({percent:.0f}%)"
+
+        if stats.swap_total_kb:
+            swap = f"{format_kb(stats.swap_used_kb)} / {format_kb(stats.swap_total_kb)}"
+        elif stats.swap_total_kb == 0:
+            # A real answer, and the expected one on these boards; "0.0 MB / 0.0 MB"
+            # reads like a failed lookup.
+            swap = _("None")
+        else:
+            swap = "--"
+
+        values = [
+            format_kb(stats.total_kb),
+            available,
+            format_kb(stats.free_kb),
+            format_kb(stats.buffers_cached_kb),
+            swap,
+            format_kb(stats.app_rss_kb),
+        ]
+
+        return [
+            f"{label}: {value}"
+            for (_attr, label), value in zip(self.row_labels, values)
+        ]
+
+    def _replace_info_text(self, attribute: str, text: str) -> None:
+        text_area = getattr(self, attribute)
+        if text_area.text == text:
+            # Most rows are unchanged between ticks; skip the re-render.
+            return
+
+        updated_area = self._build_text_area(text, text_area.screen_y)
+        try:
+            index = self.components.index(text_area)
+        except ValueError:
+            index = None
+        if index is None:
+            self.components.append(updated_area)
+        else:
+            self.components[index] = updated_area
+        setattr(self, attribute, updated_area)
+        updated_area.render()
+
+    class UpdateThread(BaseThread):
+        def __init__(self, screen):
+            super().__init__()
+            self.screen = screen
+
+        def run(self):
+            while self.keep_running:
+                # Read outside the lock; only the render needs it.
+                lines = self.screen._build_lines()
+                with self.screen.renderer.lock:
+                    for (attr, _label), line in zip(self.screen.row_labels, lines):
+                        self.screen._replace_info_text(attr, line)
+                    self.screen.renderer.show_image()
+
+                # Sleep in short steps rather than one flat interval:
+                # BaseScreen.display() spins until every thread is dead, so a
+                # flat sleep would make the back button feel laggy on exit.
+                elapsed = 0.0
+                while self.keep_running and elapsed < MemoryInfoScreen.REFRESH_INTERVAL:
+                    time.sleep(0.25)
+                    elapsed += 0.25
 
 
 @dataclass

--- a/src/seedsigner/gui/screens/settings_screens.py
+++ b/src/seedsigner/gui/screens/settings_screens.py
@@ -593,6 +593,7 @@ class MemoryInfoScreen(BaseTopNavScreen):
         ("cached_text", "Buf/Cache"),
         ("swap_text", "Swap"),
         ("rss_text", "App (RSS)"),
+        ("peak_text", "App (peak)"),
     ]
 
     def __post_init__(self):
@@ -652,6 +653,9 @@ class MemoryInfoScreen(BaseTopNavScreen):
             format_kb(stats.buffers_cached_kb),
             swap,
             format_kb(stats.app_rss_kb),
+            # VmHWM: the kernel's own high-water mark, so this is the exact peak
+            # rather than whatever a sampling thread happened to catch.
+            format_kb(stats.app_peak_rss_kb),
         ]
 
         return [

--- a/src/seedsigner/helpers/system_memory.py
+++ b/src/seedsigner/helpers/system_memory.py
@@ -1,0 +1,123 @@
+"""Read system RAM usage from the kernel's own virtual files.
+
+Deliberately app-side only: ``/proc/meminfo`` and ``/proc/self/status`` are
+provided by the kernel and readable by an unprivileged ``open()``, so no
+seedsigner-os helper script is needed. Shelling out to busybox ``free`` would
+mean spawning a process on a RAM-starved board just to re-read these same
+files, and busybox's column layout differs from coreutils'.
+
+Follows the ``helpers.hardening`` / ``helpers.seedsigner_os`` precedent: probe
+the live system, return plain data, never raise. Every field degrades on its own
+so a partial read still reports whatever it could get, and a desktop/CI host
+without ``/proc`` simply gets ``None`` everywhere.
+"""
+import logging
+import re
+from dataclasses import dataclass
+
+
+logger = logging.getLogger(__name__)
+
+
+MEMINFO_PATH = "/proc/meminfo"
+SELF_STATUS_PATH = "/proc/self/status"
+
+# "MemTotal:       110284 kB" -- the unit is always kB on Linux, but a handful
+# of fields (e.g. HugePages_Total) carry no unit at all, hence the optional group.
+_MEMINFO_LINE = re.compile(r"^(?P<key>\w+):\s+(?P<value>\d+)(?:\s+kB)?\s*$")
+
+
+@dataclass
+class MemoryStats:
+    """A snapshot of system memory, all values in kB. ``None`` means "couldn't read"."""
+    total_kb: int | None = None
+    available_kb: int | None = None
+    free_kb: int | None = None
+    buffers_cached_kb: int | None = None
+    swap_total_kb: int | None = None
+    swap_used_kb: int | None = None
+    app_rss_kb: int | None = None
+
+    @property
+    def available_percent(self) -> float | None:
+        if not self.total_kb or self.available_kb is None:
+            return None
+        return 100.0 * self.available_kb / self.total_kb
+
+
+def parse_meminfo(text: str) -> dict[str, int]:
+    """Parse ``/proc/meminfo`` text into ``{key: kB}``. Unparseable lines are skipped."""
+    values: dict[str, int] = {}
+    for line in text.splitlines():
+        match = _MEMINFO_LINE.match(line.strip())
+        if match:
+            values[match.group("key")] = int(match.group("value"))
+    return values
+
+
+def _read_file(path: str) -> str | None:
+    try:
+        with open(path, "r", encoding="utf-8") as file:
+            return file.read()
+    except Exception:
+        return None
+
+
+def _get_app_rss_kb() -> int | None:
+    """This process's resident set size, from ``/proc/self/status``.
+
+    On a 64MB Luckfox this is the number that actually says how close to OOM the
+    app is, so it's worth showing alongside the system-wide figures.
+    """
+    text = _read_file(SELF_STATUS_PATH)
+    if not text:
+        return None
+    for line in text.splitlines():
+        if line.startswith("VmRSS:"):
+            match = _MEMINFO_LINE.match(line.strip())
+            if match:
+                return int(match.group("value"))
+            break
+    return None
+
+
+def get_memory_stats() -> MemoryStats:
+    """Snapshot current memory usage. Always returns a MemoryStats; never raises."""
+    stats = MemoryStats()
+
+    # Read RSS first so it still reports if /proc/meminfo is the thing that fails.
+    stats.app_rss_kb = _get_app_rss_kb()
+
+    text = _read_file(MEMINFO_PATH)
+    if not text:
+        return stats
+
+    values = parse_meminfo(text)
+    stats.total_kb = values.get("MemTotal")
+    stats.free_kb = values.get("MemFree")
+
+    buffers = values.get("Buffers")
+    cached = values.get("Cached")
+    if buffers is not None or cached is not None:
+        stats.buffers_cached_kb = (buffers or 0) + (cached or 0)
+
+    stats.available_kb = values.get("MemAvailable")
+    if stats.available_kb is None and stats.free_kb is not None:
+        # MemAvailable has existed since Linux 3.14 so both the Luckfox (5.10)
+        # and the Pi have it; approximate rather than show nothing if some other
+        # kernel doesn't.
+        stats.available_kb = stats.free_kb + (stats.buffers_cached_kb or 0)
+
+    stats.swap_total_kb = values.get("SwapTotal")
+    swap_free = values.get("SwapFree")
+    if stats.swap_total_kb is not None and swap_free is not None:
+        stats.swap_used_kb = stats.swap_total_kb - swap_free
+
+    return stats
+
+
+def format_kb(value: int | None) -> str:
+    """Render a kB value as MB for display; ``None`` becomes a placeholder."""
+    if value is None:
+        return "--"
+    return f"{value / 1024:.1f} MB"

--- a/src/seedsigner/helpers/system_memory.py
+++ b/src/seedsigner/helpers/system_memory.py
@@ -37,6 +37,7 @@ class MemoryStats:
     swap_total_kb: int | None = None
     swap_used_kb: int | None = None
     app_rss_kb: int | None = None
+    app_peak_rss_kb: int | None = None
 
     @property
     def available_percent(self) -> float | None:
@@ -63,22 +64,35 @@ def _read_file(path: str) -> str | None:
         return None
 
 
-def _get_app_rss_kb() -> int | None:
-    """This process's resident set size, from ``/proc/self/status``.
+def _get_app_rss() -> tuple[int | None, int | None]:
+    """This process's current and peak resident set size, from ``/proc/self/status``.
 
-    On a 64MB Luckfox this is the number that actually says how close to OOM the
-    app is, so it's worth showing alongside the system-wide figures.
+    On a 64MB Luckfox the current figure is what says how close to OOM the app
+    is right now. ``VmHWM`` is the kernel's own high-water mark, updated on
+    every allocation, so the peak is both exact and free: a sampling thread
+    could only ever catch peaks that happened to land on a tick, and would miss
+    a spike during e.g. PSBT signing entirely.
     """
     text = _read_file(SELF_STATUS_PATH)
     if not text:
-        return None
+        return None, None
+
+    current = None
+    peak = None
     for line in text.splitlines():
-        if line.startswith("VmRSS:"):
-            match = _MEMINFO_LINE.match(line.strip())
-            if match:
-                return int(match.group("value"))
+        if not line.startswith(("VmRSS:", "VmHWM:")):
+            continue
+        match = _MEMINFO_LINE.match(line.strip())
+        if not match:
+            continue
+        if match.group("key") == "VmRSS":
+            current = int(match.group("value"))
+        else:
+            peak = int(match.group("value"))
+        if current is not None and peak is not None:
             break
-    return None
+
+    return current, peak
 
 
 def get_memory_stats() -> MemoryStats:
@@ -86,7 +100,7 @@ def get_memory_stats() -> MemoryStats:
     stats = MemoryStats()
 
     # Read RSS first so it still reports if /proc/meminfo is the thing that fails.
-    stats.app_rss_kb = _get_app_rss_kb()
+    stats.app_rss_kb, stats.app_peak_rss_kb = _get_app_rss()
 
     text = _read_file(MEMINFO_PATH)
     if not text:

--- a/src/seedsigner/views/settings_views.py
+++ b/src/seedsigner/views/settings_views.py
@@ -29,6 +29,7 @@ class SettingsMenuView(View):
     RESTART_PCSC = ButtonOption("Restart PCSC")
     BATTERY_INFO = ButtonOption("Battery info")
     SYSTEM_INFO = ButtonOption("System info")
+    MEMORY_INFO = ButtonOption("Memory info")
     TEST_HARDENING = ButtonOption("Test hardening")
     LOAD_BACKUP_FILES = ButtonOption("Load Backup Files", right_icon_name=SeedSignerIconConstants.CHEVRON_RIGHT)
 
@@ -91,6 +92,7 @@ class SettingsMenuView(View):
         elif self.visibility == SettingsConstants.VISIBILITY__HARDWARE:
             title = "Hardware"
             button_data.append(self.SYSTEM_INFO)
+            button_data.append(self.MEMORY_INFO)
             button_data.append(self.BATTERY_INFO)
             button_data.append(self.IO_TEST)
             if self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_SUPPORT) == SettingsConstants.OPTION__ENABLED:
@@ -158,6 +160,9 @@ class SettingsMenuView(View):
 
         elif button_data[selected_menu_num] == self.SYSTEM_INFO:
             return Destination(SystemInfoView)
+
+        elif button_data[selected_menu_num] == self.MEMORY_INFO:
+            return Destination(MemoryInfoView)
 
         elif settings_entries[selected_menu_num].attr_name == SettingsConstants.SETTING__ENCRYPTION_ITER:
             return Destination(SettingPBKDF2IterationsView, view_args=dict(attr_name=settings_entries[selected_menu_num].attr_name, parent_initial_scroll=initial_scroll))
@@ -932,6 +937,18 @@ class SystemInfoView(View):
             os_build=self._format_build(os_release, "SEEDSIGNER_OS_"),
             app_build=self._format_build(os_release, "SEEDSIGNER_APP_"),
         )
+
+        return Destination(SettingsMenuView, view_args={"visibility": SettingsConstants.VISIBILITY__HARDWARE})
+
+
+class MemoryInfoView(View):
+    """Live RAM headroom, mainly for the memory-constrained Luckfox Pico boards.
+
+    All probing lives in helpers.system_memory and all polling in the screen's
+    update thread, so this View stays a thin route.
+    """
+    def run(self):
+        self.run_screen(settings_screens.MemoryInfoScreen)
 
         return Destination(SettingsMenuView, view_args={"visibility": SettingsConstants.VISIBILITY__HARDWARE})
 

--- a/tests/test_flows_settings.py
+++ b/tests/test_flows_settings.py
@@ -108,6 +108,17 @@ class TestSettingsFlows(FlowTest):
         ])
 
 
+    def test_memory_info(self):
+        """Basic flow from MainMenuView to Memory Info View."""
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SETTINGS),
+            FlowStep(settings_views.SettingsMenuView, button_data_selection=settings_views.SettingsMenuView.HARDWARE),
+            FlowStep(settings_views.SettingsMenuView, button_data_selection=settings_views.SettingsMenuView.MEMORY_INFO),
+            FlowStep(settings_views.MemoryInfoView),
+            FlowStep(settings_views.SettingsMenuView),
+        ])
+
+
     def test_hardware_menu_back_returns_to_main(self):
         """Ensure BACK from Hardware settings returns to main Settings menu."""
         def assert_general(view: settings_views.SettingsMenuView):

--- a/tests/test_system_memory.py
+++ b/tests/test_system_memory.py
@@ -37,7 +37,9 @@ class TestParseMeminfo:
 
 
 class TestGetMemoryStats:
-    def _patch_reads(self, monkeypatch, meminfo, status="VmRSS:\t   39112 kB\n"):
+    STATUS_SAMPLE = "VmPeak:\t  102400 kB\nVmRSS:\t   39112 kB\nVmHWM:\t   46080 kB\n"
+
+    def _patch_reads(self, monkeypatch, meminfo, status=STATUS_SAMPLE):
         def fake_read(path):
             if path == system_memory.MEMINFO_PATH:
                 return meminfo
@@ -58,6 +60,7 @@ class TestGetMemoryStats:
         assert stats.swap_total_kb == 0
         assert stats.swap_used_kb == 0
         assert stats.app_rss_kb == 39112
+        assert stats.app_peak_rss_kb == 46080
 
     def test_swap_used(self, monkeypatch):
         self._patch_reads(monkeypatch, "SwapTotal: 65536 kB\nSwapFree: 20480 kB\n")
@@ -80,6 +83,21 @@ class TestGetMemoryStats:
 
         assert stats.app_rss_kb == 39112
         assert stats.total_kb is None
+        assert stats.app_peak_rss_kb == 46080
+
+    def test_peak_absent_without_vmhwm(self, monkeypatch):
+        """VmHWM is universal on Linux, but don't blank VmRSS if it is missing."""
+        self._patch_reads(monkeypatch, MEMINFO_SAMPLE, status="VmRSS:\t   39112 kB\n")
+        stats = get_memory_stats()
+
+        assert stats.app_rss_kb == 39112
+        assert stats.app_peak_rss_kb is None
+
+    def test_vmpeak_is_not_mistaken_for_vmhwm(self, monkeypatch):
+        """VmPeak is peak *virtual* size and precedes VmHWM; only VmHWM is RSS."""
+        self._patch_reads(monkeypatch, MEMINFO_SAMPLE)
+
+        assert get_memory_stats().app_peak_rss_kb == 46080
 
     def test_no_proc_at_all(self, monkeypatch):
         """Desktop/Windows/CI: returns an all-None snapshot rather than raising."""

--- a/tests/test_system_memory.py
+++ b/tests/test_system_memory.py
@@ -1,0 +1,116 @@
+import pytest
+
+from seedsigner.helpers import system_memory
+from seedsigner.helpers.system_memory import MemoryStats, format_kb, get_memory_stats, parse_meminfo
+
+
+# Captured from a Luckfox Pico Pro Max (trimmed to the keys we consume, plus a
+# couple of unit-less lines to prove they don't break the parser).
+MEMINFO_SAMPLE = """MemTotal:         241084 kB
+MemFree:           12408 kB
+MemAvailable:      41728 kB
+Buffers:            2064 kB
+Cached:            32872 kB
+SwapCached:            0 kB
+SwapTotal:             0 kB
+SwapFree:              0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+"""
+
+
+class TestParseMeminfo:
+    def test_parses_expected_keys(self):
+        values = parse_meminfo(MEMINFO_SAMPLE)
+        assert values["MemTotal"] == 241084
+        assert values["MemAvailable"] == 41728
+        assert values["SwapTotal"] == 0
+
+    def test_parses_unitless_lines(self):
+        assert parse_meminfo(MEMINFO_SAMPLE)["HugePages_Total"] == 0
+
+    def test_ignores_garbage(self):
+        assert parse_meminfo("not a meminfo line\n\nMemTotal: bogus kB\n") == {}
+
+    def test_empty_input(self):
+        assert parse_meminfo("") == {}
+
+
+class TestGetMemoryStats:
+    def _patch_reads(self, monkeypatch, meminfo, status="VmRSS:\t   39112 kB\n"):
+        def fake_read(path):
+            if path == system_memory.MEMINFO_PATH:
+                return meminfo
+            if path == system_memory.SELF_STATUS_PATH:
+                return status
+            return None
+
+        monkeypatch.setattr(system_memory, "_read_file", fake_read)
+
+    def test_derived_values(self, monkeypatch):
+        self._patch_reads(monkeypatch, MEMINFO_SAMPLE)
+        stats = get_memory_stats()
+
+        assert stats.total_kb == 241084
+        assert stats.free_kb == 12408
+        assert stats.available_kb == 41728
+        assert stats.buffers_cached_kb == 2064 + 32872
+        assert stats.swap_total_kb == 0
+        assert stats.swap_used_kb == 0
+        assert stats.app_rss_kb == 39112
+
+    def test_swap_used(self, monkeypatch):
+        self._patch_reads(monkeypatch, "SwapTotal: 65536 kB\nSwapFree: 20480 kB\n")
+        assert get_memory_stats().swap_used_kb == 65536 - 20480
+
+    def test_falls_back_when_memavailable_absent(self, monkeypatch):
+        """Pre-3.14 kernels have no MemAvailable; approximate rather than show nothing."""
+        without = "\n".join(
+            line for line in MEMINFO_SAMPLE.splitlines() if not line.startswith("MemAvailable")
+        )
+        self._patch_reads(monkeypatch, without)
+        stats = get_memory_stats()
+
+        assert stats.available_kb == 12408 + 2064 + 32872
+
+    def test_rss_survives_missing_meminfo(self, monkeypatch):
+        """Fields must degrade independently."""
+        self._patch_reads(monkeypatch, None)
+        stats = get_memory_stats()
+
+        assert stats.app_rss_kb == 39112
+        assert stats.total_kb is None
+
+    def test_no_proc_at_all(self, monkeypatch):
+        """Desktop/Windows/CI: returns an all-None snapshot rather than raising."""
+        monkeypatch.setattr(system_memory, "_read_file", lambda path: None)
+        stats = get_memory_stats()
+
+        assert isinstance(stats, MemoryStats)
+        assert stats.total_kb is None
+        assert stats.available_percent is None
+
+    def test_does_not_raise_on_real_system(self):
+        """Runs unpatched against whatever host this is, including Windows."""
+        assert isinstance(get_memory_stats(), MemoryStats)
+
+
+class TestAvailablePercent:
+    def test_computes_percent(self):
+        assert MemoryStats(total_kb=1000, available_kb=250).available_percent == pytest.approx(25.0)
+
+    def test_none_when_unknown(self):
+        assert MemoryStats(total_kb=1000).available_percent is None
+        assert MemoryStats(available_kb=250).available_percent is None
+
+    def test_no_zero_division(self):
+        assert MemoryStats(total_kb=0, available_kb=0).available_percent is None
+
+
+class TestFormatKb:
+    def test_placeholder_for_none(self):
+        assert format_kb(None) == "--"
+
+    def test_renders_mb(self):
+        assert format_kb(41728) == "40.8 MB"
+        assert format_kb(0) == "0.0 MB"


### PR DESCRIPTION
## Why

The Luckfox Pico boards are memory-constrained — Pico Mini ships 64MB, Mini B/Plus 128MB, Pro/Max 256MB — and there was no way to see RAM headroom on-device. Until now the only way to answer "how close to OOM is this board?" was a serial console, which a hardened image doesn't have.

This adds a read-only diagnostic screen under **Settings > Hardware**, beside the existing "System info", refreshing every 2s:

```
   Memory Info
   ─────────────────────────
   Total: 235.4 MB
   Available: 40.8 MB (17%)
   Free: 12.1 MB
   Buf/Cache: 34.1 MB
   Swap: 44.0 MB / 128.0 MB
   App (RSS): 38.2 MB
   App (peak): 45.0 MB
```

## No OS-side helper needed

This is pure Python, app-side only. `/proc/meminfo` and `/proc/self/status` are kernel-provided virtual files readable by an unprivileged `open()` — the same mechanism `SystemInfoView` already uses for `/proc/cpuinfo` and `/proc/device-tree/model`. Shelling out to busybox `free` would only spawn a process on a RAM-starved board to re-read these same files, and busybox's column layout differs from coreutils'.

## Peak RSS comes free from the kernel

The "App (peak)" row is `VmHWM` from `/proc/self/status` — the kernel's own high-water mark of resident set size, updated on every allocation. That makes it both exact and free. A background sampler could only ever catch peaks that happened to land on a tick, and would miss a spike during e.g. PSBT signing entirely; `VmHWM` catches all of them with no thread, no polling interval, and no missed peaks.

(For reference, the sampler this replaces would have cost ~1–2 ms per sample on an RV1103 — about 0.01% of one core at a 15s interval — so the argument for `VmHWM` is exactness, not CPU.)

System-wide *min*-free is the one thing the kernel does not watermark, so that would still need polling. Not included here.

## What's in it

**`helpers/system_memory.py`** (new) — `parse_meminfo()` / `get_memory_stats()` / `format_kb()`. Follows the `helpers/hardening.py` and `helpers/seedsigner_os.py` precedent: probe the live system, return plain data, never raise. Every field degrades independently, so a partial read still reports what it could get, and a desktop/Windows/CI host without `/proc` gets an all-`None` snapshot rather than a traceback. Falls back to `MemFree + Buffers + Cached` if `MemAvailable` is absent (it exists on both the Luckfox 5.10 and Pi kernels, but approximating beats showing nothing).

**`MemoryInfoScreen`** — polls like `BatteryInfoScreen`, but lays its rows out left-aligned like `SystemInfoScreen`, since these values are columnar and centering makes them hard to compare. Two details worth calling out:

- It sleeps in short steps rather than one flat interval. `BaseScreen.display()`'s `finally` block spins until every thread is dead, so a flat sleep makes the back button feel laggy on exit — that's why `BatteryInfoScreen`'s `time.sleep(5)` delays its own back-button today.
- It skips the re-render for rows whose text didn't change, which is most of them on most ticks.

**`MemoryInfoView`** — a thin route; all probing lives in the helper, all polling in the screen thread. Returns to the Hardware menu on back, matching `SystemInfoView`.

## Testing

- `tests/test_system_memory.py` (new, 17 cases) — parser against a captured `/proc/meminfo`, the derived values (`buffers_cached_kb`, `swap_used_kb`, `available_percent`), the `MemAvailable`-absent fallback, `VmHWM` parsing including that `VmPeak` (peak *virtual* size, which precedes it in the file) isn't mistaken for it, independent field degradation, and the no-`/proc` path that keeps Windows/CI green.
- `tests/test_flows_settings.py` — `test_memory_info` mirroring the existing `test_system_info` flow.
- Full suite: **914 passed, 135 skipped**.
- Layout verified by rendering the screen to a 240x240 canvas in the widest realistic case (swap present, `Swap: 44.0 MB / 128.0 MB`) — all seven rows fit, no wrapping. Pairing peak onto the RSS line instead wrapped, so it gets its own row.
- A non-dev `RV1103_Luckfox_Pico_Mini` / `SPI_NAND` image built green off this branch: [run 32666792845](https://github.com/3rdIteration/seedsigner/actions/runs/32666792845).

Still to verify on real hardware: that Total matches each board's advertised RAM minus the kernel carve-out, and that Available visibly moves when the camera opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
