### PR TITLE
fix: DIY smartcard applet uninstall crashes the app to a black screen

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pycryptodomex==3.23.0
 pgpy @ https://github.com/3rdIteration/PGPy/archive/7cdad000a76ced53c873211241d5ba20019a8488.zip  # v0.6.0 fork: cryptography primary backend, pycryptodomex/ecdsa/embit fallbacks
 pyasn1==0.6.2
 specter-card @ git+https://github.com/3rdIteration/specter-javacard.git@06dcde629cdc1057934b434afc46d822c2d2425d#subdirectory=py
-pygp @ https://github.com/3rdIteration/pygp/archive/15682ec8fd042b5d0ae3422e9434e9734db6e55b.zip
+pygp @ https://github.com/3rdIteration/pygp/archive/e316f6b427b7d1020cf24d082f28bd7be7d3874c.zip
 pysatochip==0.17.0
 ndeflib==0.3.3
 pyscard==2.3.1

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 import time
 import traceback
 from gettext import gettext as _
@@ -524,7 +525,18 @@ class Controller(Singleton):
                     # Re-raise so the test suite can handle it.
                     raise e
 
-                except Exception as e:
+                except (KeyboardInterrupt, SystemExit):
+                    # Deliberate exit paths (PowerOffView calls sys.exit(0); the
+                    # screensaver and button loop re-raise KeyboardInterrupt on
+                    # purpose). These must keep unwinding.
+                    raise
+
+                except BaseException as e:
+                    # Deliberately BaseException, not Exception. A library that
+                    # raises bare BaseException -- as PyGP <=0.2a did on every
+                    # card error -- would otherwise escape this loop entirely
+                    # and kill the process, leaving the user a blank screen with
+                    # no message and no log.
                     # Display user-friendly error screen w/debugging info
                     import traceback
                     traceback.print_exc()
@@ -579,9 +591,14 @@ class Controller(Singleton):
             if self.rng_monitor_thread and self.rng_monitor_thread.is_alive():
                 self.rng_monitor_thread.stop()
 
-            # Clear the screen when exiting
-            logger.info("Clearing screen, exiting")
-            Renderer.get_instance().display_blank_screen()
+            # Clear the screen when exiting. If we are unwinding because of an
+            # unhandled error, leave whatever is on the panel alone: blanking it
+            # here is what turned a crash into a silent black screen.
+            if sys.exc_info()[0] is None:
+                logger.info("Clearing screen, exiting")
+                Renderer.get_instance().display_blank_screen()
+            else:
+                logger.info("Exiting due to an unhandled error; leaving screen as-is")
 
 
     @property
@@ -706,8 +723,11 @@ class Controller(Singleton):
         else:
             exception_msg = ""
 
-        # Scan for the last debugging line that includes a line number reference
-        line_info = None
+        # Scan for the last debugging line that includes a line number reference.
+        # Defaults to "" rather than None: UnhandledExceptionView concatenates
+        # this with a str, so a None here raised TypeError and replaced the real
+        # error on screen with a bogus one.
+        line_info = ""
         for i in range(len(traceback.format_exc().splitlines()) - 1, 0, -1):
             traceback_line = traceback.format_exc().splitlines()[i]
             if ", line " in traceback_line:

--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -144,6 +144,27 @@ class LoadingScreenThread(BaseThread):
         self.text =text
 
 
+    def __enter__(self):
+        """
+        Start the spinner and guarantee it is stopped again, even if the body
+        raises. A leaked spinner thread keeps holding the renderer lock, which
+        freezes the display far more visibly than the original error.
+
+        Note that the spinner must be stopped *before* the next screen is
+        drawn, so keep the `with` body limited to the slow work itself and
+        render results after the block exits.
+        """
+        self.start()
+        return self
+
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # BaseThread.stop() only clears a flag, so calling it again on a
+        # path that already stopped the spinner is harmless.
+        self.stop()
+        return False
+
+
     def run(self):
         from seedsigner.gui.renderer import Renderer
         renderer: Renderer = Renderer.get_instance()

--- a/src/seedsigner/views/smartcard_views.py
+++ b/src/seedsigner/views/smartcard_views.py
@@ -5683,49 +5683,56 @@ class ToolsJavacardUnlockCardView(View):
         if confirm == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        self.loading_screen = LoadingScreenThread(text="Unlocking Card")
-        self.loading_screen.start()
+        unlocking_error = None
         try:
             import pygp
-            pygp.terminal()
-            pygp.card()
-            
-            # Get the actual keys based on key type (single vs set)
-            if keys.get("type") == "single":
-                enc_key = keys.get('key')
-                mac_key = keys.get('key')
-                dek_key = keys.get('key')
-            else:  # type == "set"
-                enc_key = keys.get('enc')
-                mac_key = keys.get('mac')
-                dek_key = keys.get('dek')
-            
-            # Validate keys
-            for key_name, key_value in [('enc', enc_key), ('mac', mac_key), ('dek', dek_key)]:
-                if not key_value:
-                    raise ValueError(f"Missing key: {key_name}")
-                if not isinstance(key_value, str):
-                    raise TypeError(f"Key {key_name} is not a string: {type(key_value)}")
-                # Validate hex format
-                try:
-                    int(key_value, 16)
-                except ValueError:
-                    raise ValueError(f"Key {key_name} contains invalid hex characters")
-            
-            # Unlock: authenticate with the LOADED keys and set back to DEFAULT
-            pygp.auth(enc_key=enc_key, mac_key=mac_key, dek_key=dek_key, keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_DEC_C_MAC)
-            DEFAULT_GP_KEY = "404142434445464748494A4B4C4D4E4F"
-            pygp.set_key(f"01/1/DES/{DEFAULT_GP_KEY}")
-            pygp.set_key(f"01/2/DES/{DEFAULT_GP_KEY}")
-            pygp.set_key(f"01/3/DES/{DEFAULT_GP_KEY}")
-            pygp.put_scp_key("01", replace=True)
-            self.loading_screen.stop()
+            # The spinner must stop before any result screen is drawn, so
+            # the `with` block covers only the card operations.
+            with LoadingScreenThread(text="Unlocking Card") as self.loading_screen:
+                pygp.terminal()
+                pygp.card()
+        
+                # Get the actual keys based on key type (single vs set)
+                if keys.get("type") == "single":
+                    enc_key = keys.get('key')
+                    mac_key = keys.get('key')
+                    dek_key = keys.get('key')
+                else:  # type == "set"
+                    enc_key = keys.get('enc')
+                    mac_key = keys.get('mac')
+                    dek_key = keys.get('dek')
+        
+                # Validate keys
+                for key_name, key_value in [('enc', enc_key), ('mac', mac_key), ('dek', dek_key)]:
+                    if not key_value:
+                        raise ValueError(f"Missing key: {key_name}")
+                    if not isinstance(key_value, str):
+                        raise TypeError(f"Key {key_name} is not a string: {type(key_value)}")
+                    # Validate hex format
+                    try:
+                        int(key_value, 16)
+                    except ValueError:
+                        raise ValueError(f"Key {key_name} contains invalid hex characters")
+        
+                # Unlock: authenticate with the LOADED keys and set back to DEFAULT
+                pygp.auth(enc_key=enc_key, mac_key=mac_key, dek_key=dek_key, keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_DEC_C_MAC)
+                DEFAULT_GP_KEY = "404142434445464748494A4B4C4D4E4F"
+                pygp.set_key(f"01/1/DES/{DEFAULT_GP_KEY}")
+                pygp.set_key(f"01/2/DES/{DEFAULT_GP_KEY}")
+                pygp.set_key(f"01/3/DES/{DEFAULT_GP_KEY}")
+                pygp.put_scp_key("01", replace=True)
+        except BaseException as e:
+            # PyGP <=0.2a raised bare BaseException, so `except Exception`
+            # let ordinary card errors escape and kill the app.
+            unlocking_error = seedkeeper_utils.pygp_format_error(e)[:100]
+            logger.error(f"Unlocking Card failed: {str(e)}")
+
+        if unlocking_error:
+            self.run_screen(WarningScreen, title="Failed", status_headline=None, text=unlocking_error, show_back_button=False)
+        else:
             self.run_screen(LargeIconStatusScreen, title="Success", status_headline=None, text="Card Unlocked", show_back_button=False)
-        except Exception as e:
-            self.loading_screen.stop()
-            self.run_screen(WarningScreen, title="Failed", status_headline=None, text=seedkeeper_utils.pygp_format_error(e)[:100], show_back_button=False)
-        finally:
-            seedkeeper_utils.restart_pn532(self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_INTERFACES))
+
+        seedkeeper_utils.restart_pn532(self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_INTERFACES))
 
         return Destination(BackStackView)
 
@@ -5756,49 +5763,56 @@ class ToolsJavacardLockCardView(View):
         if confirm == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        self.loading_screen = LoadingScreenThread(text="Locking Card")
-        self.loading_screen.start()
+        locking_error = None
         try:
             import pygp
-            pygp.terminal()
-            pygp.card()
-            
-            # Get the actual keys based on key type (single vs set)
-            if keys.get("type") == "single":
-                enc_key = keys.get('key')
-                mac_key = keys.get('key')
-                dek_key = keys.get('key')
-            else:  # type == "set"
-                enc_key = keys.get('enc')
-                mac_key = keys.get('mac')
-                dek_key = keys.get('dek')
-            
-            # Validate keys
-            for key_name, key_value in [('enc', enc_key), ('mac', mac_key), ('dek', dek_key)]:
-                if not key_value:
-                    raise ValueError(f"Missing key: {key_name}")
-                if not isinstance(key_value, str):
-                    raise TypeError(f"Key {key_name} is not a string: {type(key_value)}")
-                # Validate hex format
-                try:
-                    int(key_value, 16)
-                except ValueError:
-                    raise ValueError(f"Key {key_name} contains invalid hex characters")
-            
-            # Lock: authenticate with DEFAULT keys and set to the LOADED keys
-            DEFAULT_GP_KEY = "404142434445464748494A4B4C4D4E4F"
-            pygp.auth(enc_key=DEFAULT_GP_KEY, mac_key=DEFAULT_GP_KEY, dek_key=DEFAULT_GP_KEY, keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_DEC_C_MAC)
-            pygp.set_key(f"01/1/DES/{enc_key.upper()}")
-            pygp.set_key(f"01/2/DES/{mac_key.upper()}")
-            pygp.set_key(f"01/3/DES/{dek_key.upper()}")
-            pygp.put_scp_key("01", replace=True)
-            self.loading_screen.stop()
+            # The spinner must stop before any result screen is drawn, so
+            # the `with` block covers only the card operations.
+            with LoadingScreenThread(text="Locking Card") as self.loading_screen:
+                pygp.terminal()
+                pygp.card()
+        
+                # Get the actual keys based on key type (single vs set)
+                if keys.get("type") == "single":
+                    enc_key = keys.get('key')
+                    mac_key = keys.get('key')
+                    dek_key = keys.get('key')
+                else:  # type == "set"
+                    enc_key = keys.get('enc')
+                    mac_key = keys.get('mac')
+                    dek_key = keys.get('dek')
+        
+                # Validate keys
+                for key_name, key_value in [('enc', enc_key), ('mac', mac_key), ('dek', dek_key)]:
+                    if not key_value:
+                        raise ValueError(f"Missing key: {key_name}")
+                    if not isinstance(key_value, str):
+                        raise TypeError(f"Key {key_name} is not a string: {type(key_value)}")
+                    # Validate hex format
+                    try:
+                        int(key_value, 16)
+                    except ValueError:
+                        raise ValueError(f"Key {key_name} contains invalid hex characters")
+        
+                # Lock: authenticate with DEFAULT keys and set to the LOADED keys
+                DEFAULT_GP_KEY = "404142434445464748494A4B4C4D4E4F"
+                pygp.auth(enc_key=DEFAULT_GP_KEY, mac_key=DEFAULT_GP_KEY, dek_key=DEFAULT_GP_KEY, keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_DEC_C_MAC)
+                pygp.set_key(f"01/1/DES/{enc_key.upper()}")
+                pygp.set_key(f"01/2/DES/{mac_key.upper()}")
+                pygp.set_key(f"01/3/DES/{dek_key.upper()}")
+                pygp.put_scp_key("01", replace=True)
+        except BaseException as e:
+            # PyGP <=0.2a raised bare BaseException, so `except Exception`
+            # let ordinary card errors escape and kill the app.
+            locking_error = seedkeeper_utils.pygp_format_error(e)[:100]
+            logger.error(f"Locking Card failed: {str(e)}")
+
+        if locking_error:
+            self.run_screen(WarningScreen, title="Failed", status_headline=None, text=locking_error, show_back_button=False)
+        else:
             self.run_screen(LargeIconStatusScreen, title="Success", status_headline=None, text="Card Locked", show_back_button=False)
-        except Exception as e:
-            self.loading_screen.stop()
-            self.run_screen(WarningScreen, title="Failed", status_headline=None, text=seedkeeper_utils.pygp_format_error(e)[:100], show_back_button=False)
-        finally:
-            seedkeeper_utils.restart_pn532(self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_INTERFACES))
+
+        seedkeeper_utils.restart_pn532(self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_INTERFACES))
 
         return Destination(BackStackView)
 
@@ -6013,6 +6027,7 @@ class ToolsDIYInstallAppletView(View):
             selected_option = storage_options[selected_storage_num]
             storage_param = selected_option.return_data or "1FFF"
 
+        cap_path = None
         self.loading_screen = LoadingScreenThread(text="Installing Applet")
         self.loading_screen.start()
         try:
@@ -6034,37 +6049,33 @@ class ToolsDIYInstallAppletView(View):
                     # No custom keys provided, try default test key
                     pygp.auth(enc_key=DEFAULT_GP_KEY, mac_key=DEFAULT_GP_KEY, dek_key=DEFAULT_GP_KEY, keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_MAC)
                     logger.info("Card authentication successful with default key")
-            except Exception as e:
+            except BaseException as e:
                 logger.warning(f"Card authentication failed: {str(e)}, attempting install anyway")
             
             cap_path = f"{cap_dir}/{applet_file}"
             
             ndef_conflict_detected = False
             
-            try:
-                if "smartpgp" in applet_file.lower():
-                    serial_hex = secrets.token_bytes(4).hex().upper()
-                    aid = f"D276000124010304C0FE{serial_hex}0000"
-                    logger.info("SmartPGP AID: %s", aid)
-                    result = pygp.install_capfile(cap_path, instance_aids=[aid])
-                    success_text = f"Applet Installed\nSerial: {serial_hex}"
-                elif "seedkeeper" in applet_file.lower():
-                    result = pygp.install_capfile(cap_path, application_specific_parameters=storage_param)
-                    success_text = "Applet Installed"
-                else:
-                    result = pygp.install_capfile(cap_path)
-                    success_text = "Applet Installed"
-                
-                # Handle both old return format (list) and new format (dict)
-                if isinstance(result, dict):
-                    ndef_conflict_detected = result.get('ndef_skipped', False)
-                else:
-                    # Fallback for older PyGP versions that return list
-                    ndef_conflict_detected = False
-            except Exception as e:
-                # Re-raise to be caught by outer exception handler
-                raise
-                
+            if "smartpgp" in applet_file.lower():
+                serial_hex = secrets.token_bytes(4).hex().upper()
+                aid = f"D276000124010304C0FE{serial_hex}0000"
+                logger.info("SmartPGP AID: %s", aid)
+                result = pygp.install_capfile(cap_path, instance_aids=[aid])
+                success_text = f"Applet Installed\nSerial: {serial_hex}"
+            elif "seedkeeper" in applet_file.lower():
+                result = pygp.install_capfile(cap_path, application_specific_parameters=storage_param)
+                success_text = "Applet Installed"
+            else:
+                result = pygp.install_capfile(cap_path)
+                success_text = "Applet Installed"
+            
+            # Handle both old return format (list) and new format (dict)
+            if isinstance(result, dict):
+                ndef_conflict_detected = result.get('ndef_skipped', False)
+            else:
+                # Fallback for older PyGP versions that return list
+                ndef_conflict_detected = False
+
             self.loading_screen.stop()
             
             # Inform user if PyGP reported NDEF conflict handling
@@ -6079,22 +6090,29 @@ class ToolsDIYInstallAppletView(View):
             
             self.run_screen(LargeIconStatusScreen, title="Success", status_headline=None, text=success_text, show_back_button=False)
             
-        except Exception as e:
+        except BaseException as e:
+            # PyGP <=0.2a raised bare BaseException, so `except Exception` let
+            # ordinary card errors escape and kill the app.
             self.loading_screen.stop()
             error_msg = seedkeeper_utils.pygp_format_error(e)[:100]
             logger.error(f"Install failed: {str(e)}")
             self.run_screen(WarningScreen, title="Failed", status_headline=None, text=error_msg, show_back_button=False)
-            # Try to uninstall if it failed partially
-            if "0x6444" in str(e) or "0x6F00" in str(e) or "SCARD_E_NOT_TRANSACTED" in str(e):
-                self.loading_screen = LoadingScreenThread(text="Uninstalling Applet")
-                self.loading_screen.start()
+            # Try to uninstall if it failed partially. cap_path is only bound
+            # once the applet file has been chosen; a failure before that (e.g.
+            # pygp.card() surfacing SCARD_E_NOT_TRANSACTED) would otherwise
+            # raise UnboundLocalError here instead of reporting the real error.
+            if cap_path is not None and ("0x6444" in str(e) or "0x6F00" in str(e) or "SCARD_E_NOT_TRANSACTED" in str(e)):
+                rollback_ok = False
                 try:
-                    pkg_aid = pygp.get_cap_info(cap_path).get_aid()
-                    pygp.delete_package(pkg_aid)
-                    self.loading_screen.stop()
+                    with LoadingScreenThread(text="Uninstalling Applet") as self.loading_screen:
+                        pkg_aid = pygp.get_cap_info(cap_path).get_aid()
+                        pygp.delete_package(pkg_aid)
+                    rollback_ok = True
+                except BaseException as rollback_error:
+                    logger.error(f"Rollback failed: {str(rollback_error)}")
+
+                if rollback_ok:
                     self.run_screen(WarningScreen, title="Failed", status_headline=None, text="Mis-Installed Applet Uninstalled", show_back_button=False)
-                except Exception:
-                    self.loading_screen.stop()
 
         finally:
             seedkeeper_utils.restart_pn532(self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_INTERFACES))
@@ -6119,50 +6137,54 @@ class ToolsDIYUninstallAppletView(View):
         if ret == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
-        self.loading_screen = LoadingScreenThread(text="Checking Installed Applets")
-        self.loading_screen.start()
-        
         package_aids = None
         error_message = None
-        
+
         try:
             import pygp
-            pygp.terminal()
-            pygp.card()
+            # The spinner must stop before any result screen is drawn, so the
+            # `with` block covers only the card operations.
+            with LoadingScreenThread(text="Checking Installed Applets") as self.loading_screen:
+                pygp.terminal()
+                pygp.card()
             
-            # Always try to establish secure channel first, like the CLI does
-            # This is required for get_status() to return the full package list
-            # Use provided keys or fall back to default test key
-            DEFAULT_GP_KEY = "404142434445464748494A4B4C4D4E4F"
-            try:
-                if self.controller.javacard_keys:
-                    keys = self.controller.javacard_keys
-                    if keys.get("type") == "single":
-                        pygp.auth(enc_key=keys.get('key'), mac_key=keys.get('key'), dek_key=keys.get('key'), keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_MAC)
-                    else:  # type == "set"
-                        pygp.auth(enc_key=keys.get('enc'), mac_key=keys.get('mac'), dek_key=keys.get('dek'), keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_MAC)
-                    logger.info("Card authentication successful with custom keys")
-                else:
-                    # No custom keys provided, try default test key
-                    pygp.auth(enc_key=DEFAULT_GP_KEY, mac_key=DEFAULT_GP_KEY, dek_key=DEFAULT_GP_KEY, keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_MAC)
-                    logger.info("Card authentication successful with default key")
-            except Exception as e:
-                # Authentication failed - log warning but continue
-                # Some operations might still work without secure channel
-                logger.warning(f"Card authentication failed: {str(e)}, attempting to list packages anyway")
-            
-            try:
-                # Get the list of loaded package AIDs from pygp (public API)
-                # Note: This requires secure channel to be established (via auth above)
-                package_aids = pygp.get_loaded_package_aids()
-                logger.info(f"Loaded package AIDs: {package_aids}")
-            except Exception as e:
-                logger.warning(f"Could not list packages: {str(e)}")
-        except Exception as e:
-            error_message = str(e)
+                # Always try to establish secure channel first, like the CLI does
+                # This is required for get_status() to return the full package list
+                # Use provided keys or fall back to default test key
+                DEFAULT_GP_KEY = "404142434445464748494A4B4C4D4E4F"
+                try:
+                    if self.controller.javacard_keys:
+                        keys = self.controller.javacard_keys
+                        if keys.get("type") == "single":
+                            pygp.auth(enc_key=keys.get('key'), mac_key=keys.get('key'), dek_key=keys.get('key'), keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_MAC)
+                        else:  # type == "set"
+                            pygp.auth(enc_key=keys.get('enc'), mac_key=keys.get('mac'), dek_key=keys.get('dek'), keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_MAC)
+                        logger.info("Card authentication successful with custom keys")
+                    else:
+                        # No custom keys provided, try default test key
+                        pygp.auth(enc_key=DEFAULT_GP_KEY, mac_key=DEFAULT_GP_KEY, dek_key=DEFAULT_GP_KEY, keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_MAC)
+                        logger.info("Card authentication successful with default key")
+                except BaseException as e:
+                    # Authentication failed - log warning but continue
+                    # Some operations might still work without secure channel
+                    logger.warning(f"Card authentication failed: {str(e)}, attempting to list packages anyway")
+
+                try:
+                    # Get the list of loaded package AIDs from pygp (public API)
+                    # Note: This requires secure channel to be established (via auth above)
+                    package_aids = pygp.get_loaded_package_aids()
+                    logger.info(f"Loaded package AIDs: {package_aids}")
+                except BaseException as e:
+                    logger.warning(f"Could not list packages: {str(e)}")
+                    # Leaving package_aids as None here used to fall all the way
+                    # through to the menu with no feedback at all, so the button
+                    # looked like it simply did nothing.
+                    error_message = seedkeeper_utils.pygp_format_error(e)
+        except BaseException as e:
+            # PyGP <=0.2a raised bare BaseException, so `except Exception` let
+            # ordinary card errors escape and kill the app.
+            error_message = seedkeeper_utils.pygp_format_error(e)
             logger.error(f"Smartcard error: {error_message}")
-        finally:
-            self.loading_screen.stop()
 
         if error_message:
             self.run_screen(WarningScreen, title="Smartcard Error", status_headline=None, text=error_message[:100], show_back_button=False)
@@ -6175,14 +6197,14 @@ class ToolsDIYUninstallAppletView(View):
             # Get module-to-package mapping
             try:
                 module_map = pygp.get_package_module_map()
-            except Exception as e:
+            except BaseException as e:
                 module_map = {}
                 logger.warning(f"Could not get module map: {str(e)}")
             
             # Also get installed applications to verify NDEF is actually instantiated
             try:
                 installed_apps = pygp.get_installed_application_aids()
-            except Exception as e:
+            except BaseException as e:
                 installed_apps = []
                 logger.warning(f"Could not get installed apps: {str(e)}")
             
@@ -6253,45 +6275,52 @@ class ToolsDIYUninstallAppletView(View):
 
                 applet_aid = installed_applets_aids[selected_applet_num]
 
-                self.loading_screen = LoadingScreenThread(text="Uninstalling Applet")
-                self.loading_screen.start()
+                uninstall_error = None
                 try:
-                    pygp.terminal()
-                    pygp.card()
-                    
-                    # Always establish secure channel for delete operations
-                    DEFAULT_GP_KEY = "404142434445464748494A4B4C4D4E4F"
-                    try:
-                        if self.controller.javacard_keys:
-                            keys = self.controller.javacard_keys
-                            if keys.get("type") == "single":
-                                pygp.auth(enc_key=keys.get('key'), mac_key=keys.get('key'), dek_key=keys.get('key'), keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_MAC)
-                            else:  # type == "set"
-                                pygp.auth(enc_key=keys.get('enc'), mac_key=keys.get('mac'), dek_key=keys.get('dek'), keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_MAC)
-                            logger.info("Card authentication successful with custom keys")
-                        else:
-                            # No custom keys provided, try default test key
-                            pygp.auth(enc_key=DEFAULT_GP_KEY, mac_key=DEFAULT_GP_KEY, dek_key=DEFAULT_GP_KEY, keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_MAC)
-                            logger.info("Card authentication successful with default key")
-                    except Exception as e:
-                        logger.warning(f"Card authentication failed: {str(e)}, attempting delete anyway")
-                    
-                    pygp.delete_package(applet_aid)
-                    self.loading_screen.stop()
+                    # The spinner must stop before any result screen is drawn,
+                    # so the `with` block covers only the card operations.
+                    with LoadingScreenThread(text="Uninstalling Applet") as self.loading_screen:
+                        pygp.terminal()
+                        pygp.card()
+
+                        # Always establish secure channel for delete operations
+                        DEFAULT_GP_KEY = "404142434445464748494A4B4C4D4E4F"
+                        try:
+                            if self.controller.javacard_keys:
+                                keys = self.controller.javacard_keys
+                                if keys.get("type") == "single":
+                                    pygp.auth(enc_key=keys.get('key'), mac_key=keys.get('key'), dek_key=keys.get('key'), keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_MAC)
+                                else:  # type == "set"
+                                    pygp.auth(enc_key=keys.get('enc'), mac_key=keys.get('mac'), dek_key=keys.get('dek'), keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_MAC)
+                                logger.info("Card authentication successful with custom keys")
+                            else:
+                                # No custom keys provided, try default test key
+                                pygp.auth(enc_key=DEFAULT_GP_KEY, mac_key=DEFAULT_GP_KEY, dek_key=DEFAULT_GP_KEY, keysetversion="00", securitylevel=pygp.SECURITY_LEVEL_C_MAC)
+                                logger.info("Card authentication successful with default key")
+                        except BaseException as e:
+                            logger.warning(f"Card authentication failed: {str(e)}, attempting delete anyway")
+
+                        pygp.delete_package(applet_aid)
+                except BaseException as e:
+                    # PyGP <=0.2a raised bare BaseException, so `except Exception`
+                    # let ordinary card errors escape and kill the app.
+                    logger.error(f"Uninstall failed: {str(e)}")
+                    uninstall_error = seedkeeper_utils.pygp_format_error(e)[:100]
+
+                if uninstall_error:
+                    self.run_screen(
+                        WarningScreen,
+                        title="Failed",
+                        status_headline=None,
+                        text=uninstall_error,
+                        show_back_button=False,
+                    )
+                else:
                     self.run_screen(
                         LargeIconStatusScreen,
                         title="Success",
                         status_headline=None,
                         text="Applet Uninstalled",
-                        show_back_button=False,
-                    )
-                except Exception as e:
-                    self.loading_screen.stop()
-                    self.run_screen(
-                        WarningScreen,
-                        title="Failed",
-                        status_headline=None,
-                        text=seedkeeper_utils.pygp_format_error(e)[:100],
                         show_back_button=False,
                     )
 

--- a/tests/test_smartcard_pygp_errors.py
+++ b/tests/test_smartcard_pygp_errors.py
@@ -1,0 +1,241 @@
+"""
+Regression tests for the PyGP BaseException crash.
+
+PyGP <=0.2a raised bare ``BaseException`` from every card operation. Since
+``except Exception`` does not catch ``BaseException``, a routine card error
+(no card seated, wrong key, flaky reader) escaped the view's handler, escaped
+the Controller loop, and killed the process -- the user saw a black screen with
+no message and no log.
+
+These tests deliberately raise ``BaseException``, the original broken type, so
+they keep proving the views are defensive no matter what PyGP raises next.
+"""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from seedsigner.views import smartcard_views
+from seedsigner.helpers import seedkeeper_utils
+
+
+CARD_ERROR = "Failed to connect, please check the card."
+
+
+class SpyLoadingScreen:
+    """Stand-in for LoadingScreenThread that records start/stop calls."""
+
+    instances = []
+
+    def __init__(self, text=None):
+        self.text = text
+        self.started = False
+        self.stopped = False
+        SpyLoadingScreen.instances.append(self)
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop()
+        return False
+
+
+class FakePyGP:
+    """Fake pygp module whose named methods raise bare BaseException."""
+
+    SECURITY_LEVEL_C_MAC = 1
+    SECURITY_LEVEL_C_DEC_C_MAC = 3
+
+    def __init__(self, failing, packages=None):
+        self.failing = set(failing)
+        self._packages = packages if packages is not None else ["536565644B6565706572"]
+
+    def _maybe_fail(self, name):
+        if name in self.failing:
+            raise BaseException(CARD_ERROR)
+
+    def terminal(self):
+        self._maybe_fail("terminal")
+
+    def card(self):
+        self._maybe_fail("card")
+
+    def auth(self, **kwargs):
+        self._maybe_fail("auth")
+
+    def get_loaded_package_aids(self):
+        self._maybe_fail("get_loaded_package_aids")
+        return list(self._packages)
+
+    def get_package_module_map(self):
+        self._maybe_fail("get_package_module_map")
+        return {}
+
+    def get_installed_application_aids(self):
+        self._maybe_fail("get_installed_application_aids")
+        return []
+
+    def delete_package(self, aid):
+        self._maybe_fail("delete_package")
+
+    def install_capfile(self, *args, **kwargs):
+        self._maybe_fail("install_capfile")
+        return {}
+
+    def get_cap_info(self, path):
+        self._maybe_fail("get_cap_info")
+        return SimpleNamespace(get_aid=lambda: "AABBCC")
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    SpyLoadingScreen.instances = []
+    monkeypatch.setattr(
+        "seedsigner.gui.screens.screen.LoadingScreenThread", SpyLoadingScreen
+    )
+    monkeypatch.setattr(
+        smartcard_views,
+        "logger",
+        SimpleNamespace(
+            info=lambda *a, **k: None,
+            warning=lambda *a, **k: None,
+            error=lambda *a, **k: None,
+        ),
+    )
+    monkeypatch.setattr(seedkeeper_utils, "restart_pn532", lambda *a, **k: None)
+
+
+def _make_uninstall_view(monkeypatch, fake, screens):
+    view = object.__new__(smartcard_views.ToolsDIYUninstallAppletView)
+    view.settings = SimpleNamespace(get_value=lambda *a, **k: [])
+    view.controller = SimpleNamespace(javacard_keys=None)
+    monkeypatch.setitem(sys.modules, "pygp", fake)
+
+    def fake_run_screen(screen_cls, **kwargs):
+        screens.append((screen_cls.__name__, kwargs))
+        return 0
+
+    view.run_screen = fake_run_screen
+    return view
+
+
+@pytest.mark.parametrize("failing_call", ["terminal", "card", "get_loaded_package_aids"])
+def test_uninstall_survives_baseexception_while_listing(monkeypatch, failing_call):
+    """A card error while listing applets must show a screen, not propagate."""
+    screens = []
+    view = _make_uninstall_view(monkeypatch, FakePyGP(failing=[failing_call]), screens)
+
+    # Must not raise -- this is the crash being regression-tested.
+    destination = view.run()
+
+    assert destination is not None
+    titles = [kwargs.get("title") for _, kwargs in screens]
+    assert "Smartcard Error" in titles, f"no error screen shown; got {titles}"
+
+    # And the spinner must not be left running.
+    assert all(s.stopped for s in SpyLoadingScreen.instances if s.started)
+
+
+def test_uninstall_survives_baseexception_on_delete(monkeypatch):
+    """A card error during the actual delete must show 'Failed', not propagate."""
+    screens = []
+    view = _make_uninstall_view(monkeypatch, FakePyGP(failing=["delete_package"]), screens)
+
+    destination = view.run()
+
+    assert destination is not None
+    titles = [kwargs.get("title") for _, kwargs in screens]
+    assert "Failed" in titles, f"no failure screen shown; got {titles}"
+    assert "Success" not in titles
+
+    # The delete block previously had no `finally`, so the spinner leaked while
+    # still holding the renderer lock.
+    assert all(s.stopped for s in SpyLoadingScreen.instances if s.started)
+
+
+def test_uninstall_never_returns_silently(monkeypatch):
+    """
+    Listing failing non-fatally used to leave package_aids AND error_message
+    both None, so the view returned to the menu having shown nothing at all.
+    """
+    screens = []
+    view = _make_uninstall_view(
+        monkeypatch, FakePyGP(failing=["get_loaded_package_aids"]), screens
+    )
+
+    view.run()
+
+    assert screens, "view returned to the menu without showing anything"
+
+
+def _make_install_view(monkeypatch, tmp_path, fake, screens):
+    from seedsigner.hardware import microsd
+
+    cap_dir = tmp_path / "javacard-cap"
+    cap_dir.mkdir()
+    (cap_dir / "SeedKeeper-v0.2.cap").touch()
+    monkeypatch.setattr(
+        smartcard_views, "_get_internal_cap_dir", lambda: tmp_path / "nonexistent"
+    )
+    monkeypatch.setattr(microsd.MicroSD, "get_microsd_dir", lambda: tmp_path)
+
+    view = object.__new__(smartcard_views.ToolsDIYInstallAppletView)
+    view.settings = SimpleNamespace(get_value=lambda *a, **k: [])
+    view.controller = SimpleNamespace(javacard_keys=None)
+    monkeypatch.setitem(sys.modules, "pygp", fake)
+
+    responses = iter([0, 1])
+
+    def fake_run_screen(screen_cls, **kwargs):
+        screens.append((screen_cls.__name__, kwargs))
+        try:
+            return next(responses)
+        except StopIteration:
+            return 0
+
+    view.run_screen = fake_run_screen
+    return view
+
+
+def test_install_survives_baseexception(monkeypatch, tmp_path):
+    """The install view must report a card error rather than propagating."""
+    screens = []
+    view = _make_install_view(
+        monkeypatch, tmp_path, FakePyGP(failing=["install_capfile"]), screens
+    )
+
+    destination = view.run()
+
+    assert destination is not None
+    titles = [kwargs.get("title") for _, kwargs in screens]
+    assert "Failed" in titles, f"no failure screen shown; got {titles}"
+
+
+def test_install_rollback_does_not_raise_unbound_local(monkeypatch, tmp_path):
+    """
+    The rollback path references cap_path, which is only bound once an applet
+    file has been chosen. A failure before that point must still report the real
+    error instead of raising UnboundLocalError.
+    """
+
+    class EarlyFail(FakePyGP):
+        def card(self):
+            raise BaseException("SCARD_E_NOT_TRANSACTED")
+
+    screens = []
+    view = _make_install_view(monkeypatch, tmp_path, EarlyFail(failing=[]), screens)
+
+    destination = view.run()
+
+    assert destination is not None
+    texts = [str(kwargs.get("text", "")) for _, kwargs in screens]
+    assert not any("UnboundLocalError" in t for t in texts)


### PR DESCRIPTION
## The bug

Walking through **Tools → DIY Tools → Uninstall Applet** kills the whole app on any card error, leaving a black screen with no message, no log, and no restart (production systemd sets `Restart=no`, `StandardError=null`).

PyGP `<=0.2a` raised bare `BaseException`, which `except Exception` does **not** catch. So an ordinary card error — no card seated, wrong key, flaky reader — escaped every handler:

| # | Location | What happens |
|---|---|---|
| 1 | `pygp.terminal()` raises bare `BaseException` | no card seated / wrong key / flaky reader |
| 2 | `smartcard_views.py` `except Exception` | **misses it** |
| 3 | `controller.py:527` `except Exception` | **misses it** |
| 4 | `controller.py:459` `try:` has only a `finally:`, no `except` | re-raises |
| 5 | `controller.py:584` `finally: display_blank_screen()` | **actively paints the panel black** |
| 6 | `main.py:70`, unguarded | process exits |

The panel is an SPI TFT that holds its last framebuffer, so the blackness is step 5 *deliberately* blanking it — not the crash itself. That's why it reads as a dead screen rather than a frozen one.

Because those handlers could never fire, every friendly message in `pygp_format_error()` ("Applet is not on the card, nothing to uninstall.") was unreachable.

Verified against the real library, same call, same condition (no reader attached):

| | `pygp.terminal()` with no reader |
|---|---|
| old `0.2a` | `BaseException` — **escapes** `except Exception` |
| new `0.3a` | `PyGPCardError` — **caught** by `except Exception` |

## Changes

**Root cause is fixed upstream** in `3rdIteration/PyGP` (now tag `0.3a`): 19 bare `raise BaseException` replaced with a `PyGPError(Exception)` hierarchy, every message string byte-identical since `pygp_format_error()` matches on text. This PR bumps the pin and hardens the app side.

`smartcard_views.py`
- Widen every handler guarding a pygp call to `except BaseException` (uninstall, install, lock, unlock, rollback, module-map, installed-apps). Verified by AST walk, not grep: no `try`/`except` containing a pygp call is narrow.
- Uninstall no longer returns silently. If listing packages failed non-fatally, `package_aids` and `error_message` were both left `None` and the view returned to the menu having shown nothing — the button looked like it simply did nothing.
- Guard the install rollback on `cap_path`, which is only bound once an applet file is chosen. A failure before that raised `UnboundLocalError` instead of reporting the real error (same class as the already-fixed #385).
- Drop a `try`/`except` that only re-raised.

`gui/screens/screen.py`
- `LoadingScreenThread` gains `__enter__`/`__exit__`. The uninstall delete block had no `finally` at all, so an escaping error orphaned the spinner thread while it still held the renderer lock — freezing the display on its own. The `with` body covers only the card work, since the spinner must stop before the next screen is drawn.

`controller.py`
- Catch `BaseException` in the main loop, re-raising `KeyboardInterrupt` and `SystemExit` **first** so `PowerOffView`'s `sys.exit(0)` and the screensaver's deliberate `KeyboardInterrupt` still work. Defence in depth: users on a stale pygp pin still hit the old behaviour, and pyscard could do the same.
- Don't blank the panel when unwinding from an unhandled error — leave it readable.
- `handle_exception`: default `line_info` to `""` instead of `None`, which made `UnhandledExceptionView` raise `TypeError` and show a bogus error in place of the real one.

`requirements.txt`
- Bump pygp to `e316f6b`.

> [!IMPORTANT]
> pygp is pinned **twice** and both pins must move together: `requirements.txt` (by sha) and `seedsigner-os/opt/external-packages/python-pygp` (by tag). Pairs with 3rdIteration/seedsigner-os#117. A half-update is invisible until someone hits a card error on one install type but not the other.

## Tests

New `tests/test_smartcard_pygp_errors.py` injects a fake pygp raising bare `BaseException` — deliberately the *old* broken type, so the tests stay meaningful whatever PyGP raises next. **All 7 fail on the pre-fix source and pass after.**

The existing `FakePyGP` in `test_seedkeeper_install.py` never raised, which is exactly why CI never caught this.

Full suite: **900 passed**. The 5 l10n failures are pre-existing locally (compiled `.mo` catalogs are gitignored and built at image-build time) — confirmed identical on unmodified source.

## Verification

- [x] Regression tests fail before / pass after
- [x] Real `pygp.terminal()` with no reader now caught by `except Exception`
- [x] Poweroff and screensaver paths preserved (`KeyboardInterrupt`/`SystemExit` re-raised first)
- [ ] Luckfox Pico Mini / SPI NAND image build
- [ ] On hardware: Uninstall Applet with no card seated (the original repro), wrong key, card yanked mid-operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

