### PR TITLE
Harden JavaCard DIY build: stop executing user-supplied ANT XML

### DIFF
--- a/docs/smartcard_support_installation.md
+++ b/docs/smartcard_support_installation.md
@@ -204,6 +204,36 @@ _The applet management (install/uninstall) in the SeedSigner menu assume that th
 
 Follow the guide here: https://github.com/3rdIteration/Satochip-DIY
 
+### Building Applets from the SeedSigner Menu (Javacard DIY → Build Applets)
+
+The **Build Applets** menu generates the JavaCard applet `.cap` files and writes
+them to `javacard-cap/` on the microSD, where **Install Applet** can then flash
+them to a card.
+
+The build XML is generated inside SeedSigner from trusted, hard-coded toolchain
+paths. A `javacard-build.xml` placed on the microSD is **never executed** — ANT
+build files are effectively arbitrary code, so allowing one from the card would be
+a security risk (and the old flow even ran it with `sudo`).
+
+To customize the build, place a strictly-validated `javacard-build.json` file at
+the root of the microSD. Only the following keys are honored; everything else is
+ignored and a missing/malformed file builds every applet with its defaults:
+
+```json
+{
+  "applets": ["satochip", "seedkeeper", "satodime",
+              "satochip-thd89", "seedkeeper-thd89", "satodime-thd89"],
+  "overrides": {
+    "seedkeeper": { "aid": "536565644B6565706572", "version": "0.2" }
+  }
+}
+```
+
+- `applets`: a list of known applet names to build (unknown names are dropped).
+- `overrides`: per-applet `aid` (32 hex chars) and `version` (`N.N`) only.
+  Paths such as `sources`/`jckit` cannot be overridden and are always the trusted
+  values from the SeedSigner image.
+
 ### OpenCT and Generic/Old Blue "Sim Readers" (Optional: Get a more modern Smart Card reader if possible... )
 **Included only for Reference/Education/Backup, as these can be built from Scratch...**
 

--- a/src/seedsigner/views/smartcard_views.py
+++ b/src/seedsigner/views/smartcard_views.py
@@ -5852,51 +5852,249 @@ class ToolsJavacardClearKeysView(View):
         return Destination(BackStackView)
 
 
+# --- JavaCard applet build (generated from trusted constants) -----------------
+# A user-supplied `javacard-build.xml` on the microSD is NEVER executed: ANT
+# build files are effectively arbitrary code (they can run <exec>, <script>,
+# <delete>, etc.), and the old flow even ran them with `sudo`. Customization is
+# now limited to a strictly-validated `javacard-build.json` parameter file; the
+# actual build XML is always generated here from hard-coded toolchain paths.
+_JAVACARD_BUILD_CONF_FILENAME = "javacard-build.json"
+
+_JAVACARD_TASKDEF_CLASSPATH = {
+    "seedsigner_os": "/mnt/diy/Satochip-DIY/lib/ant-javacard.jar",
+    "dev_board": "/home/pi/Satochip-DIY/lib/ant-javacard.jar",
+    "other": str(Path.home() / "Satochip-DIY" / "lib" / "ant-javacard.jar"),
+}
+
+_JAVACARD_JCKIT = {
+    "seedsigner_os": "/mnt/diy/Satochip-DIY/sdks/jc304_kit",
+    "dev_board": "/home/pi/Satochip-DIY/sdks/jc304_kit",
+    "other": str(Path.home() / "Satochip-DIY" / "sdks" / "jc304_kit"),
+}
+
+# Per-platform root of the Satochip-DIY toolchain (sources/jckit are relative).
+_JAVACARD_TOOLCHAIN_ROOT = {
+    "seedsigner_os": "/mnt/diy/Satochip-DIY",
+    "dev_board": "/home/pi/Satochip-DIY",
+    "other": str(Path.home() / "Satochip-DIY"),
+}
+
+# Allowed applets and their trusted defaults. `sources_rel` and `applet_class`
+# are fixed; only `aid`/`version` can be overridden via the validated config.
+_JAVACARD_APPLETS = {
+    "satochip": {
+        "sources_rel": "applets/satochip/src/org/satochip/applet",
+        "applet_class": "org.satochip.applet.CardEdge",
+        "aid": "5361746F43686970",
+        "version": "0.1",
+        "out": "SatoChip-built-0.12.cap",
+    },
+    "seedkeeper": {
+        "sources_rel": "applets/seedkeeper/src/main/java/org/seedkeeper/applet",
+        "applet_class": "org.seedkeeper.applet.SeedKeeper",
+        "aid": "536565644b6565706572",
+        "version": "0.2",
+        "out": "SeedKeeper-built-0.2.cap",
+    },
+    "satodime": {
+        "sources_rel": "applets/satodime/src/org/satodime/applet",
+        "applet_class": "org.satodime.applet.Satodime",
+        "aid": "5361746f44696d65",
+        "version": "0.1",
+        "out": "SatoDime-built-0.1.2.cap",
+    },
+    "satochip-thd89": {
+        "sources_rel": "applets/satochip-thd89/src/org/satochip/applet",
+        "applet_class": "org.satochip.applet.CardEdge",
+        "aid": "5361746F43686970",
+        "version": "0.1",
+        "out": "SatoChip-THD89-built-0.12.cap",
+    },
+    "seedkeeper-thd89": {
+        "sources_rel": "applets/seedkeeper-thd89/src/main/java/org/seedkeeper/applet",
+        "applet_class": "org.seedkeeper.applet.SeedKeeper",
+        "aid": "536565644b6565706572",
+        "version": "0.2",
+        "out": "SeedKeeper-THD89-built-0.2.cap",
+    },
+    "satodime-thd89": {
+        "sources_rel": "applets/satodime-thd89/src/org/satodime/applet",
+        "applet_class": "org.satodime.applet.Satodime",
+        "aid": "5361746f44696d65",
+        "version": "0.1",
+        "out": "SatoDime-THD89-built-0.1.2.cap",
+    },
+}
+
+
+def _javacard_platform_key() -> str:
+    from seedsigner.models.settings import Settings
+
+    if Settings.is_seedsigner_os():
+        return "seedsigner_os"
+    if Settings.is_dev_board():
+        return "dev_board"
+    return "other"
+
+
+def _validate_javacard_aid(value) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if cleaned.lower().startswith("0x"):
+        cleaned = cleaned[2:]
+    if len(cleaned) != 32:
+        return None
+    if not re.fullmatch(r"[0-9a-fA-F]+", cleaned):
+        return None
+    return cleaned.upper()
+
+
+def _validate_javacard_version(value) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if re.fullmatch(r"\d+\.\d+", value):
+        return value
+    return None
+
+
+def _load_javacard_build_config(microsd_dir: Path) -> dict:
+    """Return a safe build config from an allowlisted microSD parameter file.
+
+    Only the keys ``applets`` (a list of known applet names) and ``overrides``
+    (per-applet ``aid``/``version``) are honored. Everything else is ignored,
+    and a missing or malformed file falls back to building every applet with its
+    trusted defaults. The returned dict maps applet name -> spec dict and never
+    contains user-controlled paths or tasks.
+    """
+    config = {name: dict(spec) for name, spec in _JAVACARD_APPLETS.items()}
+
+    conf_path = microsd_dir / _JAVACARD_BUILD_CONF_FILENAME
+    if not conf_path.is_file():
+        return config
+
+    try:
+        with open(conf_path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception as e:
+        logger.warning("Ignoring invalid %s: %s", conf_path.name, e)
+        return config
+
+    if isinstance(data, dict) and isinstance(data.get("applets"), list):
+        wanted = {str(a).strip() for a in data["applets"]}
+        selected = {name for name in _JAVACARD_APPLETS if name in wanted}
+    else:
+        selected = set(_JAVACARD_APPLETS.keys())
+
+    overrides = data.get("overrides") if isinstance(data, dict) else None
+    if isinstance(overrides, dict):
+        for name, ov in overrides.items():
+            if name not in _JAVACARD_APPLETS or not isinstance(ov, dict):
+                continue
+            spec = config[name]
+            aid = _validate_javacard_aid(ov.get("aid"))
+            if aid is not None:
+                spec["aid"] = aid
+            version = _validate_javacard_version(ov.get("version"))
+            if version is not None:
+                spec["version"] = version
+
+    return {name: spec for name, spec in config.items() if name in selected}
+
+
+def _generate_javacard_build_xml(config: dict, platform_key: str, output_dir: Path) -> str:
+    """Generate a trusted ANT build file.
+
+    The output is built only from the validated ``config`` and hard-coded
+    toolchain paths. It can never contain arbitrary tasks such as ``<exec>`` or
+    ``<script>``; the only ``taskdef`` points at the trusted ``ant-javacard.jar``.
+    """
+    classpath = _JAVACARD_TASKDEF_CLASSPATH[platform_key]
+    root = _JAVACARD_TOOLCHAIN_ROOT[platform_key]
+    jckit = _JAVACARD_JCKIT[platform_key]
+
+    caps = []
+    for spec in config.values():
+        sources = f"{root}/{spec['sources_rel']}"
+        output = f"{output_dir}/{spec['out']}"
+        # Applet instance AID = package AID + "00" (matches the original templates).
+        applet_aid = spec["aid"] + "00"
+        caps.append(
+            "    <javacard>\n"
+            f'      <cap jckit="{jckit}" aid="{spec["aid"]}" version="{spec["version"]}" '
+            f'output="{output}" sources="{sources}">\n'
+            f'        <applet class="{spec["applet_class"]}" aid="{applet_aid}"/>\n'
+            "      </cap>\n"
+            "    </javacard>"
+        )
+    caps_xml = "\n".join(caps)
+
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<project name="Satochip-DIY" default="build" basedir=".">\n'
+        "  <description>SeedSigner-generated JavaCard build (trusted template).</description>\n"
+        f'  <taskdef name="javacard" classname="pro.javacard.ant.JavaCard" classpath="{classpath}"/>\n'
+        '  <target name="build">\n'
+        f"{caps_xml}\n"
+        "  </target>\n"
+        "</project>\n"
+    )
+
+
 class ToolsDIYBuildAppletsView(View):
     def run(self):
         from subprocess import run
         import os
-        import shutil
-        from pathlib import Path
         from seedsigner.gui.screens.screen import LoadingScreenThread
         from seedsigner.hardware.microsd import MicroSD
-        from seedsigner.models.settings import Settings
 
         self.loading_screen = LoadingScreenThread(text="Building Applets\n\n\n\n\n\n(This takes a while)")
         self.loading_screen.start()
 
         microsd_dir = MicroSD.get_microsd_dir()
-        repo_root = Path(__file__).resolve().parents[3]
 
-        if Settings.is_seedsigner_os():
-            if not os.path.exists(microsd_dir / "javacard-build.xml"):
-                os.system(f"cp /opt/tools/javacard-build.xml.seedsigneros {microsd_dir}/javacard-build.xml")
+        # Output goes to the microSD javacard-cap dir (user-writable, no sudo).
+        cap_dir = microsd_dir / "javacard-cap"
+        try:
+            os.makedirs(cap_dir, exist_ok=True)
+        except OSError:
+            pass
 
-            if not os.path.exists(microsd_dir / "javacard-cap/"):
-                os.makedirs(microsd_dir / "javacard-cap/", exist_ok=True)
+        platform_key = _javacard_platform_key()
+        config = _load_javacard_build_config(microsd_dir)
+        build_xml = _generate_javacard_build_xml(config, platform_key, cap_dir)
 
-            os.environ["JAVA_HOME"] = "/mnt/diy/jdk"
-            commandString = ["/mnt/diy/ant/bin/ant", "-f", str(microsd_dir / "javacard-build.xml")]
-        elif Settings.is_dev_board():
-            if not os.path.exists(microsd_dir / "javacard-build.xml"):
-                run(["sudo", "cp", str(repo_root / "tools" / "javacard-build.xml.manual"), str(microsd_dir / "javacard-build.xml")], check=False)
+        # Write the generated (trusted) build file to a TEMP location. We never
+        # read or execute a user-supplied javacard-build.xml from the microSD.
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".xml", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp.write(build_xml)
+            tmp_path = tmp.name
 
-            if not os.path.exists(microsd_dir / "javacard-cap/"):
-                run(["sudo", "mkdir", "-p", str(microsd_dir / "javacard-cap/")], check=False)
+        try:
+            if platform_key == "seedsigner_os":
+                # Preserve the prior JAVA_HOME used by the SeedSigner OS image.
+                os.environ["JAVA_HOME"] = "/mnt/diy/jdk"
 
-            commandString = ["sudo", "ant", "-f", str(microsd_dir / "javacard-build.xml")]
-        else:
-            build_xml = microsd_dir / "javacard-build.xml"
-            if not build_xml.exists():
-                shutil.copy(repo_root / "tools" / "javacard-build.xml.manual", build_xml)
+            if platform_key == "seedsigner_os":
+                ant_path = "/mnt/diy/ant/bin/ant"
+            elif platform_key == "dev_board":
+                ant_path = "/home/pi/Satochip-DIY/ant/bin/ant"
+            else:
+                ant_path = str(Path.home() / "Satochip-DIY" / "ant" / "bin" / "ant")
 
-            cap_dir = microsd_dir / "javacard-cap"
-            if not cap_dir.exists():
-                os.makedirs(cap_dir)
+            # No `sudo`: building applets requires no root privileges, and
+            # running as root would let a build file (or a bug) touch the OS.
+            commandString = [ant_path, "-f", tmp_path]
 
-            commandString = ["ant", "-f", str(build_xml)]
-
-        data = run(commandString, capture_output=True, text=True)
+            data = run(commandString, capture_output=True, text=True)
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
         logger.info(data)
 
@@ -5918,7 +6116,6 @@ class ToolsDIYBuildAppletsView(View):
                 text=data.stderr.replace("\n", " "),
                 show_back_button=False,
             )
-
 
         return Destination(MainMenuView)
 

--- a/tests/test_diy_build_applets.py
+++ b/tests/test_diy_build_applets.py
@@ -1,0 +1,155 @@
+import json
+
+from seedsigner.views import smartcard_views
+
+
+def test_generate_build_xml_contains_only_safe_elements():
+    config = {name: dict(spec) for name, spec in smartcard_views._JAVACARD_APPLETS.items()}
+    xml = smartcard_views._generate_javacard_build_xml(
+        config, "other", "/tmp/out"
+    )
+
+    # Only the trusted build structure is present.
+    assert "<project" in xml
+    assert "<target" in xml
+    assert "<javacard>" in xml
+    assert "<cap " in xml
+    assert "<applet " in xml
+
+    # No arbitrary/executable tasks may ever be emitted.
+    for forbidden in ("<exec", "<script", "<delete", "<copy", "<move", "<import", "<macrodef"):
+        assert forbidden not in xml
+
+    # The only taskdef is the trusted ant-javacard.jar.
+    assert "ant-javacard.jar" in xml
+    # Sources/jckit are the trusted constants, never user-influenced.
+    # Normalize path separators so the assertion holds on Windows test runners
+    # as well as the Linux devices this actually runs on.
+    normalized = xml.replace("\\", "/")
+    assert "Satochip-DIY/sdks/jc304_kit" in normalized
+    assert "Satochip-DIY/applets/satochip/src/org/satochip/applet" in normalized
+
+
+def test_generate_build_xml_honors_validated_overrides():
+    config = {
+        "satochip": {
+            "sources_rel": smartcard_views._JAVACARD_APPLETS["satochip"]["sources_rel"],
+            "applet_class": "org.satochip.applet.CardEdge",
+            "aid": "00112233445566778899AABBCCDDEEFF",
+            "version": "9.9",
+            "out": "SatoChip-built-0.12.cap",
+        }
+    }
+    xml = smartcard_views._generate_javacard_build_xml(config, "other", "/tmp/out")
+    assert 'aid="00112233445566778899AABBCCDDEEFF"' in xml
+    assert 'version="9.9"' in xml
+    # Applet instance AID is package AID + "00".
+    assert 'aid="00112233445566778899AABBCCDDEEFF00"' in xml
+
+
+def test_load_config_defaults_when_no_file(tmp_path):
+    config = smartcard_views._load_javacard_build_config(tmp_path)
+    assert set(config.keys()) == set(smartcard_views._JAVACARD_APPLETS.keys())
+
+
+def test_load_config_ignores_malicious_entries(tmp_path):
+    malicious = {
+        "applets": ["satochip", "totally-unknown-applet"],
+        "overrides": {
+            "satochip": {
+                # Invalid AID (too short) and invalid version must be ignored.
+                "aid": "../../../../etc/passwd",
+                "version": "not-a-version",
+                # Unknown keys must be ignored.
+                "sources": "/etc",
+                "jckit": "/evil",
+            }
+        },
+        # Unknown top-level keys must be ignored.
+        "exec": "rm -rf /",
+    }
+    (tmp_path / smartcard_views._JAVACARD_BUILD_CONF_FILENAME).write_text(
+        json.dumps(malicious), encoding="utf-8"
+    )
+
+    config = smartcard_views._load_javacard_build_config(tmp_path)
+
+    # Only known applets are kept; unknown entry is dropped.
+    assert "totally-unknown-applet" not in config
+    assert "satochip" in config
+    # Invalid overrides are NOT applied; trusted defaults remain.
+    spec = config["satochip"]
+    assert spec["aid"] == smartcard_views._JAVACARD_APPLETS["satochip"]["aid"]
+    assert spec["version"] == smartcard_views._JAVACARD_APPLETS["satochip"]["version"]
+    assert "sources" not in spec
+
+
+def test_load_config_applies_valid_overrides(tmp_path):
+    conf = {
+        "applets": ["seedkeeper"],
+        "overrides": {
+            "seedkeeper": {
+                "aid": "AABBCCDDEEFF00112233445566778899",
+                "version": "3.1",
+            }
+        },
+    }
+    (tmp_path / smartcard_views._JAVACARD_BUILD_CONF_FILENAME).write_text(
+        json.dumps(conf), encoding="utf-8"
+    )
+
+    config = smartcard_views._load_javacard_build_config(tmp_path)
+    assert set(config.keys()) == {"seedkeeper"}
+    assert config["seedkeeper"]["aid"] == "AABBCCDDEEFF00112233445566778899"
+    assert config["seedkeeper"]["version"] == "3.1"
+
+
+def test_build_view_never_runs_sudo_or_user_xml(monkeypatch, tmp_path):
+    import subprocess
+
+    from seedsigner.hardware import microsd as microsd_mod
+
+    captured = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout="BUILD SUCCESSFUL", stderr=""
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(microsd_mod.MicroSD, "get_microsd_dir", lambda: tmp_path)
+
+    # A malicious javacard-build.xml sitting on the card must be inert.
+    (tmp_path / "javacard-build.xml").write_text(
+        '<project><target name="build"><exec executable="/bin/rm"/></target></project>',
+        encoding="utf-8",
+    )
+
+    class FakeLoadingScreen:
+        def __init__(self, *a, **k):
+            pass
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    import seedsigner.gui.screens.screen as screen_mod
+
+    monkeypatch.setattr(screen_mod, "LoadingScreenThread", FakeLoadingScreen)
+
+    view = object.__new__(smartcard_views.ToolsDIYBuildAppletsView)
+    view.run_screen = lambda *a, **k: None
+    view.run()
+
+    cmd = captured["cmd"]
+    # No sudo, and we never point ANT at a user-supplied microSD build file.
+    assert "sudo" not in cmd
+    assert str(tmp_path / "javacard-build.xml") not in cmd
+    # The -f argument must be a generated temp file, not the microSD path.
+    f_index = cmd.index("-f")
+    build_arg = cmd[f_index + 1]
+    assert build_arg != str(tmp_path / "javacard-build.xml")
+    assert "javacard-build.xml" not in build_arg or build_arg.startswith(str(tmp_path))


### PR DESCRIPTION
## Summary

The JavaCard DIY **Build Applets** flow previously executed a `javacard-build.xml` read directly from the microSD card via ANT — including with `sudo` on some platforms. ANT build files are effectively arbitrary code (`<exec>`, `<script>`, `<delete>`, etc.), so a malicious or tampered file on the card could run commands on the device, with root on the dev/OS paths. This contradicts the project's own rule that SD-card content is untrusted input.

## Changes

- **No longer reads or executes a user-supplied `javacard-build.xml` from the microSD.** Any such file on the card is now inert.
- The build XML is **generated in code** from trusted, hard-coded toolchain paths (`_JAVACARD_APPLETS`, `_JAVACARD_JCKIT`, `_JAVACARD_TOOLCHAIN_ROOT`) and written to a **temp file**, then run via `ant -f <temp>` as the unprivileged user.
- Customization is exposed only through a strictly-validated `javacard-build.json` on the microSD:
  - `_load_javacard_build_config()` honors only `applets` (known names) and `overrides` (per-applet `aid`/`version`); everything else is ignored.
  - `_validate_javacard_aid` (32 hex) and `_validate_javacard_version` (`N.N`) reject invalid/path-traversal values; malformed files fall back to safe defaults.
  - `_generate_javacard_build_xml()` emits only `<project>/<target>/<javacard>/<cap>/<applet>` — it physically cannot contain `exec`/`script`/`delete`/etc.
- The `sudo` invocation is removed; the ANT path is absolute (no PATH hijack).

## Notes

- `.cap` install from microSD is unchanged: it uses pygp to flash the card (a card operation, not host code execution), and the user-supplied caps are trusted/marked separately.
- The old `javacard-build.xml` on a card is now ignored; users who edited it should migrate to `javacard-build.json` (documented in `docs/smartcard_support_installation.md`).

## Test plan

- Added `tests/test_diy_build_applets.py`: safe XML generation, malicious-config rejection, valid overrides applied, and that the build view never uses `sudo` nor a user-supplied microSD XML.
- `pytest tests/test_diy_build_applets.py -v` → 6 passed.
