### PR TITLE
fix: SeedKeeper V2 descriptor read-back decode + tolerate 0x6D00 status (#413, #416)

### DIFF
--- a/src/seedsigner/helpers/seedkeeper_utils.py
+++ b/src/seedsigner/helpers/seedkeeper_utils.py
@@ -4,6 +4,7 @@ from pysatochip.JCconstants import (
     SEEDKEEPER_DIC_ORIGIN,
     SEEDKEEPER_DIC_EXPORT_RIGHTS,
 )
+from pysatochip.CardConnector import UnexpectedSW12Error
 from seedsigner.gui.screens import (
     RET_CODE__BACK_BUTTON,
     ButtonListScreen,
@@ -191,12 +192,30 @@ def ensure_seedkeeper_capacity(connector, secret_dic: dict, free_memory: int | N
     ``free_memory`` is ``None`` the helper will query the Seedkeeper for the
     latest free space value, otherwise the supplied ``free_memory`` will be used
     for the comparison.
+
+    Some (older DIY) Seedkeeper applets do not implement the seedkeeper status
+    command (INS 0xA7) and answer 0x6D00 ("instruction not supported") instead of
+    reporting free space.  In that case capacity cannot be pre-checked, so treat
+    the import as fitting and let the card surface its own out-of-memory error
+    (0x9C01) during the actual import, rather than blocking every write.
     """
 
     required_bytes = calculate_seedkeeper_secret_size(secret_dic)
     available_bytes = free_memory
     if available_bytes is None:
-        available_bytes = get_seedkeeper_free_memory(connector)
+        try:
+            available_bytes = get_seedkeeper_free_memory(connector)
+        except UnexpectedSW12Error:
+            logger.warning(
+                "Seedkeeper does not support status (0x6D00); "
+                "skipping capacity pre-check"
+            )
+            available_bytes = None
+
+    if available_bytes is None:
+        # Capacity cannot be determined (0x6D00); assume it fits so the write
+        # proceeds and the card can reject it with its own memory error.
+        return True, required_bytes, None
 
     return required_bytes <= available_bytes, required_bytes, available_bytes
 

--- a/src/seedsigner/views/smartcard_views.py
+++ b/src/seedsigner/views/smartcard_views.py
@@ -2556,9 +2556,14 @@ class ToolsSeedkeeperSaveDescriptorView(View):
             for secret_id, secret_label in multisig_descriptor_secrets:
                 secret_dict = Satochip_Connector.seedkeeper_export_secret(secret_id, None)
 
-                secret_dict['secret'] = unhexlify(secret_dict['secret'])[1:].decode()
+                # V2 "Descriptor" secrets are stored with a 2-byte length prefix,
+                # while V1 "Password"-style secrets use a 1-byte prefix. The shared
+                # decode helper tries the 2-byte form first, then 1-byte, then raw,
+                # so re-reading an existing V2 Descriptor no longer trips a utf-8
+                # decode error (we were stripping only one byte with [1:]).
+                multisig_descriptor_templates.append(_decode_seedkeeper_text(secret_dict))
 
-                multisig_descriptor_templates.append(secret_dict['secret'])
+                logger.debug("Decoded existing descriptor template")
 
             logger.debug("Loaded %d multisig descriptor templates from Seedkeeper", len(multisig_descriptor_templates))
 

--- a/tests/test_seedkeeper_descriptor.py
+++ b/tests/test_seedkeeper_descriptor.py
@@ -1,0 +1,182 @@
+"""SeedKeeper descriptor save/load regression tests.
+
+Two regressions that the hardware (card-present) suite never exercised:
+
+* #416 — ToolsSeedkeeperSaveDescriptorView read back an existing V2 "Descriptor"
+  secret with a hard-coded 1-byte length strip; V2 Descriptor secrets are stored
+  with a 2-byte prefix, so the low length byte was left as the first content
+  byte and produced ``'utf-8' codec can't decode byte 0xc0``.
+* #413 — ensure_seedkeeper_capacity() unconditionally queried the Seedkeeper
+  status (INS 0xA7); applets that answer 0x6D00 ("instruction not supported")
+  would block every write instead of allowing the card to reject an
+  out-of-memory import itself.
+
+These use a mocked connector so they run in CI without hardware.
+"""
+
+import base
+from embit.descriptor import Descriptor
+from unittest.mock import MagicMock
+
+from seedsigner.controller import Controller
+from seedsigner.gui.screens import seed_screens
+from seedsigner.views import smartcard_views
+from seedsigner.helpers import seedkeeper_utils
+from seedsigner.views.smartcard_views import ToolsSeedkeeperSaveDescriptorView
+
+
+# A valid two-key multisig descriptor so embit can parse it; the stored text is
+# derived from the Descriptor object so the duplicate-skip comparison is
+# deterministic. It must be long enough (> ~128 bytes) that the 2-byte length
+# prefix's low byte is non-ASCII (>= 0x80) — otherwise the OLD buggy [1:] strip
+# would coincidentally decode as printable ASCII and not reproduce #416.
+DESCRIPTOR_STRING = (
+    "wsh(sortedmulti(1,"
+    "[22bde1a9/48h/1h/0h/2h]"
+    "tpubDFfsBrmpj226ZYiRszYi2qK6iGvh2vkkghfGB2YiRUVY4rqqedHCFEgw12FwDkm7rUoVtq9wLTKc6BN2sxswvQeQgp7m8st4FP8WtP8go76/{0,1}/*,"
+    "[73c5da0a/48h/1h/0h/2h]"
+    "tpubDFH9dgzveyD8zTbPUFuLrGmCydNvxehyNdUXKJAQN8x4aZ4j6UZqGfnqFrD4NqyaTVGKbvEW54tsvPTK2UoSbCC1PJY8iCNiwTL3RWZEheQ/{0,1}/*))"
+    "#3jhtf6yx"
+)
+
+
+def _fresh_controller_with_descriptor():
+    base.BaseTest.reset_controller()
+    base.BaseTest.reset_settings()
+    controller = Controller.get_instance()
+    controller.multisig_wallet_descriptor = Descriptor.from_string(DESCRIPTOR_STRING)
+    return controller
+
+
+def test_seedkeeper_save_descriptor_reads_back_v2_without_crashing(monkeypatch):
+    """Regression for #416.
+
+    The view must be able to read back an already-stored V2 "Descriptor" secret
+    (2-byte length prefix) without crashing on the utf-8 decode, and therefore
+    detect it as a duplicate and skip re-importing it.
+    """
+    desc = _fresh_controller_with_descriptor().multisig_wallet_descriptor
+    stored_text = desc.to_string()
+    stored_len = len(stored_text.encode("utf-8"))
+    stored_payload = list(stored_len.to_bytes(2, "big")) + list(stored_text.encode("utf-8"))
+
+    class FakeLabelScreen:
+        def __init__(self, **kwargs):
+            pass
+
+        def display(self):
+            return {"passphrase": "mydesc"}
+
+    class FakeConnector:
+        def __init__(self):
+            self.imported = []
+            self.exported = []
+
+        def card_get_status(self):
+            return (None, None, None, {"protocol_minor_version": 2})
+
+        def seedkeeper_list_secret_headers(self):
+            return [
+                {
+                    "id": 0x0001,
+                    "type": 0xC1,  # Descriptor (V2)
+                    "subtype": 0x00,
+                    "label": "mydesc",
+                    "origin": 0x01,
+                    "export_rights": 0x01,
+                    "export_nbplain": 0,
+                    "export_nbsecure": 0,
+                    "export_counter": 0,
+                    "fingerprint": b"\x00\x00\x00\x00",
+                }
+            ]
+
+        def seedkeeper_export_secret(self, sid, _pubkey):
+            # Round-trip exactly what the save view writes (2-byte prefix).
+            self.exported.append(sid)
+            return {"secret": bytes(stored_payload).hex(), "secret_list": stored_payload}
+
+        def make_header(self, secret_type, export_rights, label):
+            return "00" * 20
+
+        def seedkeeper_import_secret(self, secret_dic):
+            self.imported.append(secret_dic)
+            return (0x0002, "00" * 4)
+
+        def seedkeeper_get_status(self):
+            return (None, None, None, {"free_memory": 4096})
+
+    fake = FakeConnector()
+
+    # pysatochip is mocked in the unit-test env, so the constants imported by the
+    # view are MagicMocks and the 0xC1 -> "Descriptor" classification would fail.
+    # Provide the real (minimal) mappings so the header is treated as a V2
+    # Descriptor, mirroring the runtime behaviour.
+    monkeypatch.setattr(smartcard_views, "SEEDKEEPER_DIC_TYPE", {0xC0: "Data", 0xC1: "Descriptor"})
+    monkeypatch.setattr(
+        smartcard_views,
+        "SEEDKEEPER_DIC_EXPORT_RIGHTS",
+        {0x01: "Plaintext export allowed"},
+    )
+    monkeypatch.setattr(
+        smartcard_views,
+        "SEEDKEEPER_DIC_ORIGIN",
+        {0x01: "Plaintext import"},
+    )
+    monkeypatch.setattr(seedkeeper_utils, "init_satochip", lambda *a, **k: fake)
+    monkeypatch.setattr(seed_screens, "SeedAddPassphraseScreen", FakeLabelScreen)
+    monkeypatch.setattr("seedsigner.gui.screens.screen.LoadingScreenThread", MagicMock)
+    shown_screens = []
+    monkeypatch.setattr(
+        ToolsSeedkeeperSaveDescriptorView,
+        "run_screen",
+        lambda self, screen, *a, **k: shown_screens.append(screen),
+    )
+
+    view = ToolsSeedkeeperSaveDescriptorView()
+    view.run()
+
+    # The pre-existing V2 Descriptor was read back (exported) without a utf-8
+    # crash, and since it matches the descriptor being saved it was skipped. The
+    # view must reach its success screen, NOT an error screen (the outer
+    # try/except swallows a decode failure into an "Error" WarningScreen).
+    assert fake.exported == [0x0001]
+    assert fake.imported == []
+    assert smartcard_views.LargeIconStatusScreen in shown_screens
+    assert smartcard_views.WarningScreen not in shown_screens
+
+
+def test_seedkeeper_ensure_capacity_tolerates_unsupported_status(monkeypatch):
+    """Regression for #413.
+
+    A Seedkeeper applet that does not implement the status command (INS 0xA7,
+    answered 0x6D00) must not block writes. The capacity pre-check should treat
+    the import as fitting and let the card reject an out-of-memory import with
+    its own error instead.
+    """
+
+    class UnsupportedStatusError(Exception):
+        pass
+
+    # The function catches `UnexpectedSW12Error` by module-global name; in the
+    # mocked-pysatochip test env that symbol is a MagicMock (not a real exception
+    # class), so substitute a real exception class for the test.
+    monkeypatch.setattr(seedkeeper_utils, "UnexpectedSW12Error", UnsupportedStatusError)
+
+    class StatusUnsupportedConnector:
+        def seedkeeper_get_status(self):
+            raise UnsupportedStatusError(
+                "Error while fetching SeedKeeper status: (error code 0x6d00)"
+            )
+
+    header_hex = ("00" * 2 + "900101" + "000000" + "00000000" + "0000" + "04") + "74657374"
+    # id(2) + type/origin/export(3) + export_counters(3) + fingerprint(4) + rfu(2) + label_size(1) + label(4)
+    secret_dic = {"header": header_hex, "secret_list": [len(b"secret")] + list(b"secret")}
+
+    fits, required_bytes, free_bytes = seedkeeper_utils.ensure_seedkeeper_capacity(
+        StatusUnsupportedConnector(), secret_dic
+    )
+
+    assert fits is True
+    assert required_bytes > 0
+    assert free_bytes is None

--- a/tests/test_smartcard_hardware.py
+++ b/tests/test_smartcard_hardware.py
@@ -872,6 +872,38 @@ class TestSeedKeeper:
         assert "DEK" in parsed
         connector.seedkeeper_reset_secret(sid)
 
+    def test_import_export_descriptor(self):
+        """Round-trip a V2 "Descriptor" secret (type 0xC1, 2-byte length prefix).
+
+        Mirrors ToolsSeedkeeperSaveDescriptorView / ToolsSeedkeeperLoadDescriptorView:
+        the Save view stores descriptors with a 2-byte big-endian length prefix and
+        the Load view decodes it with the shared ``_decode_seedkeeper_text`` helper.
+        This guards the #416 regression where re-reading the stored descriptor
+        crashed with ``'utf-8' codec can't decode byte 0xc0`` (the read-back used a
+        1-byte strip for a 2-byte-prefixed secret).
+
+        Skipped when the installed pysatochip/applet does not expose the Descriptor
+        secret type (0xC1), e.g. the vanilla PyPI ``pysatochip==0.17.0``.
+        """
+        payload = b"wsh(sortedmulti(2,aabbccddeeff00112233445566778899))"
+        connector = self._connect()
+        header = connector.make_header("Descriptor", "Plaintext export allowed", "test_descriptor")
+        secret_list = list(len(payload).to_bytes(2, "big")) + list(payload)
+        try:
+            (sid, _) = connector.seedkeeper_import_secret({
+                "header": header,
+                "secret_list": secret_list,
+            })
+        except Exception as exc:
+            pytest.skip(f"installed pysatochip/applet does not support Descriptor (0xC1): {exc}")
+
+        try:
+            exported = connector.seedkeeper_export_secret(sid, None)
+            decoded = _decode_seedkeeper_text(exported["secret"])
+            assert decoded == payload.decode("utf-8")
+        finally:
+            connector.seedkeeper_reset_secret(sid)
+
     def test_change_pin(self):
         connector = self._connect()
         old_pin = list("1234".encode("utf-8"))


### PR DESCRIPTION
fix: SeedKeeper V2 descriptor read-back decode + tolerate 0x6D00 status (#413, #416)

The V2 (JavaCard) SeedKeeper path had two bugs that the physical Satochip
(V1) path never hit:

#416: ToolsSeedkeeperSaveDescriptorView read back an existing V2 'Descriptor'
secret with a hard-coded 1-byte length strip, but V2 Descriptor secrets are
stored with a 2-byte length prefix. Re-saving a descriptor left the low
length byte (e.g. 0xC0) as the first content byte and crashed with
"'utf-8' codec can't decode byte 0xc0". Use the shared _decode_seedkeeper_text
helper (2-byte first, then 1-byte, then raw) for the duplicate-skip read-back.

#413: ensure_seedkeeper_capacity() unconditionally queried seedkeeper_get_status
(INS 0xA7) for free space before every write. DIY JavaCards whose applet answers
0x6D00 ('instruction not supported') were blocked from writing even though
reading still worked. Treat an unsupported status as 'cannot determine capacity'
and assume the write fits, letting the card reject an out-of-memory import with
its own error.

Also add regression tests: a mocked-connector test that reproduces the #416
read-back decode crash and the #413 0x6D00 fallback (both run in CI without
hardware), plus a hardware-only round-trip for the Descriptor/0xC1 secret type
in test_smartcard_hardware.py.
