### PR TITLE
fix: don't bury completed workflows in the back stack (#423)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,37 @@ When moving or renaming an underscore-prefixed function:
 - Use the same patterns as existing tests: `object.__new__(ViewClass)` to create view instances without triggering `__init__`, then monkeypatch dependencies.
 - For views that reference symbols from split modules, ensure those symbols are accessible through `tools_views` (see star import caveat above).
 
+### Back stack and workflow completion
+
+`Controller.start()` keeps a `back_stack` of `Destination`s; the top entry is the View
+currently running, and the back arrow (`Destination(BackStackView)`) pops the current View plus
+the one beneath it. When a View returns a `Destination` that is **already in the stack**, the
+Controller truncates the stack at that point rather than pushing a duplicate — so a completed
+workflow returning to its entry menu removes its own screens instead of burying them under it.
+
+Follow these rules when a View ends a workflow (see issue #423 for what happens otherwise: back
+from the Javacard DIY menu re-ran the uninstall flow, which dead-ended and looped forever):
+
+- **The whole workflow lives in one View** (however many Screens it runs), reached directly from a
+  menu → return **`Destination(BackStackView)`**. The Controller pops the finished View and lands
+  on whichever menu launched it. No hard-coded coupling, and it stays correct for Views reachable
+  from more than one menu.
+- **The workflow spans several View classes** → the last one cannot use `BackStackView` (that
+  lands on the previous *flow screen*). Return the entry menu explicitly:
+  **`Destination(EntryMenuView)`**. The truncation above keeps this from stacking up.
+  If the chain has several entry points and no single menu to name, `MainMenuView` is an
+  acceptable fallback — add a comment saying why (see `SatochipLoadDescriptorDetailsView`).
+- **`Destination(MainMenuView)`** is reserved for workflows whose entry point genuinely *is* Home
+  (Scan, PSBT signing, top-level Seeds flows) and for error handlers that deliberately reset
+  navigation. **It is not a way to clear the back stack** — it only looks like one because the
+  Controller wipes the stack whenever it routes to Home.
+- **`clear_history=True`** is for flows that must not be re-enterable at all (error views, the
+  post-wipe / settings-changed paths). Prefer the rules above for ordinary completions; it
+  discards the parent menus too.
+
+Whenever you add or change a workflow-terminating return, add the matching back-navigation
+FlowStep to `tests/test_flows_menu_navigation.py` (see below).
+
 ### Navigation test maintenance
 
 `tests/test_flows_menu_navigation.py` (**60 tests**) walks every UI menu path to catch lazy-import errors and platform-crashes. **Whenever a menu tree (a View's button_data list) is changed, a new View is added, or a View's imports are modified, update this test file** to cover the new/changed path.

--- a/src/seedsigner/controller.py
+++ b/src/seedsigner/controller.py
@@ -629,13 +629,29 @@ class Controller(Singleton):
 
                 # The next_destination up always goes on the back_stack, even if it's the
                 #   one we just popped.
-                # Do not push a "new" destination if it is the same as the current one on
-                # the top of the stack.
-                if len(self.back_stack) == 0 or self.back_stack[-1] != next_destination:
-                    logger.info(f"Appending next destination: {next_destination}")
-                    self.back_stack.append(next_destination)
-                else:
-                    logger.info(f"NOT appending {next_destination}")
+                #
+                # If it is already somewhere in the stack then we have arrived back at a
+                # View we have been through before -- most often a completed workflow
+                # returning to the menu that launched it. Truncate the stack at that
+                # point instead of pushing a duplicate; otherwise "back" from that menu
+                # pops straight into the workflow we just finished, and flows that
+                # dead-end on re-entry (e.g. "Uninstall Applet" with no applets left)
+                # loop with no way out but a power cycle. See issue #423.
+                #
+                # Truncating at the last index and re-appending is a no-op, which also
+                # covers the older "don't re-push the current top of the stack" case.
+                try:
+                    unwind_index = self.back_stack.index(next_destination)
+                except ValueError:
+                    unwind_index = None
+
+                if unwind_index is not None:
+                    if unwind_index < len(self.back_stack) - 1:
+                        logger.info(f"Unwinding back_stack to {next_destination}")
+                    del self.back_stack[unwind_index:]
+
+                logger.info(f"Appending next destination: {next_destination}")
+                self.back_stack.append(next_destination)
 
         finally:
             from seedsigner.gui.renderer import Renderer

--- a/src/seedsigner/views/gpg_views.py
+++ b/src/seedsigner/views/gpg_views.py
@@ -523,7 +523,7 @@ class ToolsGPGAdvancedMenuView(View):
             return Destination(ToolsGPGExportBundleView)
         if choice == self.BIP85_META:
             return Destination(ToolsGPGBip85MetadataMenuView)
-        return Destination(ToolsGPGMenuView)
+        return Destination(BackStackView)
 
 
 # ---- GPG algorithm code → human-readable name map ---------------------------
@@ -1052,7 +1052,7 @@ class ToolsGPGExportBundleView(View):
                 show_back_button=False,
                 button_data=[ButtonOption("Continue")],
             )
-            return Destination(MainMenuView)
+            return Destination(BackStackView)
 
         loading = LoadingScreenThread(text="Encoding...")
         loading.start()
@@ -1077,7 +1077,7 @@ class ToolsGPGExportBundleView(View):
             return Destination(BackStackView)
 
         self.run_screen(QRDisplayScreen, qr_encoder=qr_encoder)
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsGPGBip85MetadataMenuView(View):
@@ -3208,7 +3208,7 @@ class ToolsGPGEncryptMessageView(View):
                 show_back_button=False,
                 button_data=[ButtonOption("Continue")],
             )
-            return Destination(MainMenuView)
+            return Destination(BackStackView)
 
         loading = LoadingScreenThread(text="Encoding...")
         loading.start()
@@ -3233,7 +3233,7 @@ class ToolsGPGEncryptMessageView(View):
             return Destination(BackStackView)
 
         self.run_screen(QRDisplayScreen, qr_encoder=qr_encoder)
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsGPGDecryptMessageView(View):
@@ -3649,14 +3649,14 @@ class ToolsGPGDecryptMessageView(View):
                     show_back_button=False,
                     button_data=[ButtonOption("I Understand")],
                 )
-            return Destination(MainMenuView)
+            return Destination(BackStackView)
 
         if button_data[selected_option] == SHOW:
             encoder = GenericStaticQrEncoder(data=plaintext)
             self.run_screen(QRDisplayScreen, qr_encoder=encoder)
-            return Destination(MainMenuView)
+            return Destination(BackStackView)
 
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsGPGImportMenuView(View):
@@ -3776,7 +3776,7 @@ class ToolsGPGGenerateKeyOnCardView(View):
             show_back_button=False,
             button_data=[ButtonOption("Continue")],
         )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsGPGChangeAdminPinView(View):
@@ -3831,7 +3831,7 @@ class ToolsGPGChangeAdminPinView(View):
                 show_back_button=False,
                 button_data=[ButtonOption("Continue")],
             )
-            return Destination(MainMenuView)
+            return Destination(BackStackView)
         self.run_screen(
             LargeIconStatusScreen,
             title="Success",
@@ -3840,7 +3840,7 @@ class ToolsGPGChangeAdminPinView(View):
             show_back_button=False,
             button_data=[ButtonOption("Continue")],
         )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsGPGChangeUserPinView(View):
@@ -3906,7 +3906,7 @@ class ToolsGPGChangeUserPinView(View):
                 show_back_button=False,
                 button_data=[ButtonOption("Continue")],
             )
-            return Destination(MainMenuView)
+            return Destination(BackStackView)
         self.run_screen(
             LargeIconStatusScreen,
             title="Success",
@@ -3915,7 +3915,7 @@ class ToolsGPGChangeUserPinView(View):
             show_back_button=False,
             button_data=[ButtonOption("Continue")],
         )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsGPGEncryptFileView(View):
@@ -4115,7 +4115,7 @@ class ToolsGPGEncryptFileView(View):
             show_back_button=False,
             button_data=[ButtonOption("Done")],
         )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsGPGDecryptFileView(View):
@@ -4341,7 +4341,7 @@ class ToolsGPGDecryptFileView(View):
             show_back_button=False,
             button_data=[ButtonOption("Done")],
         )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsGPGVerifyFileView(View):
@@ -4435,7 +4435,7 @@ class ToolsGPGVerifyFileView(View):
                     text="Can't find\ncorresponding file for\nthis signature...",
                     show_back_button=True,
                 )
-                return Destination(MainMenuView)
+                return Destination(BackStackView)
             cmd = ["gpg", "--status-fd=1", "--verify", verify_file_name, filechecked]
         else:
             filechecked = verify_file_name
@@ -4679,7 +4679,7 @@ class ToolsGPGVerifyFileView(View):
             )
 
 
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsGPGSignFileView(View):
@@ -4813,7 +4813,7 @@ class ToolsGPGSignFileView(View):
             button_data=[ButtonOption("Done")],
         )
 
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsGPGSignManifestView(View):
@@ -4973,7 +4973,7 @@ class ToolsGPGSignManifestView(View):
             button_data=[ButtonOption("Done")],
         )
 
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 def _check_future_key_creation(view, key_blob: str) -> None:
@@ -7338,7 +7338,7 @@ class ToolsGPGGenerateKeyView(View):
                 button_data=[ButtonOption("I Understand")],
             )
 
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsGPGExportPubkeyView(View):
@@ -7458,7 +7458,7 @@ class ToolsGPGExportPubkeyView(View):
                 show_back_button=False,
                 button_data=[ButtonOption("Continue")],
             )
-            return Destination(MainMenuView)
+            return Destination(BackStackView)
         elif dest_selected == 1:
             exported = run(
                 ["gpg", "--armor", "--export", key["fpr"]],
@@ -7498,7 +7498,7 @@ class ToolsGPGExportPubkeyView(View):
                 return Destination(BackStackView)
 
             self.run_screen(QRDisplayScreen, qr_encoder=qr_encoder)
-            return Destination(MainMenuView)
+            return Destination(BackStackView)
         else:
             exported = run(
                 ["gpg", "--armor", "--export", key["fpr"]],
@@ -7586,7 +7586,7 @@ class ToolsGPGExportPubkeyView(View):
                     show_back_button=False,
                     button_data=[ButtonOption("Continue")],
                 )
-                return Destination(MainMenuView)
+                return Destination(BackStackView)
             except UnexpectedSW12Error as e:
                 self.loading_screen.stop()
                 if e.sw1 == 0x6A and e.sw2 == 0x84:
@@ -7776,7 +7776,7 @@ class ToolsGPGExportPrivkeyView(View):
                 show_back_button=False,
                 button_data=[ButtonOption("Continue")],
             )
-            return Destination(MainMenuView)
+            return Destination(BackStackView)
         elif dest_selected == 1:
             exported = run(
                 ["gpg", "--armor", "--export-secret-keys", key["fpr"]],
@@ -7864,7 +7864,7 @@ class ToolsGPGExportPrivkeyView(View):
                     show_back_button=False,
                     button_data=[ButtonOption("Continue")],
                 )
-                return Destination(MainMenuView)
+                return Destination(BackStackView)
             except UnexpectedSW12Error as e:
                 self.loading_screen.stop()
                 if e.sw1 == 0x6A and e.sw2 == 0x84:

--- a/src/seedsigner/views/smartcard_views.py
+++ b/src/seedsigner/views/smartcard_views.py
@@ -584,7 +584,7 @@ class ToolsCommonNdefView(View):
                 text=success_text,
                 show_back_button=False,
             )
-            return Destination(MainMenuView)
+            return Destination(BackStackView)
         except Exception as e:
             self.run_screen(
                 WarningScreen,
@@ -988,7 +988,7 @@ class ToolsSatochipChangePinView(View):
                 show_back_button=True,
             )
         
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
     
 class ToolsSatochipChangeNFCView(View):
     def run(self):
@@ -1040,7 +1040,7 @@ class ToolsSatochipChangeNFCView(View):
                 text=f"NFC policy applied successfully!",
                 show_back_button=False,
             )
-            return Destination(MainMenuView)
+            return Destination(BackStackView)
     
         else:
             error_messages = {
@@ -1062,7 +1062,7 @@ class ToolsSatochipChangeNFCView(View):
                 text=failed_string,
                 show_back_button=True,
             )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 class ToolsSatochipFactoryResetView(View):
     def run(self):
@@ -1516,7 +1516,7 @@ class ToolsSatochipChangeLabelView(View):
                 show_back_button=True,
             )
 
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 class ToolsSeedkeeperView(View):
     VIEW_FREE_SPACE = ButtonOption("View Free Space")
@@ -2934,7 +2934,7 @@ class ToolsKeycardBenchmarkSignView(View):
             text=text,
             show_back_button=False,
         )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsKeycardBenchmarkMessageSignView(View):
@@ -3037,7 +3037,7 @@ class ToolsKeycardBenchmarkMessageSignView(View):
             text=text,
             show_back_button=False,
         )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsKeycardChangePinView(View):
@@ -3081,7 +3081,7 @@ class ToolsKeycardChangePinView(View):
                     text="PIN update failed",
                     show_back_button=True,
                 )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsKeycardChangePukView(View):
@@ -3117,7 +3117,7 @@ class ToolsKeycardChangePukView(View):
                 text="PUK update failed",
                 show_back_button=True,
             )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsKeycardUnblockPinView(View):
@@ -3182,7 +3182,7 @@ class ToolsKeycardUnblockPinView(View):
                     text="PIN unblock failed",
                     show_back_button=True,
                 )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsKeycardSetNameView(View):
@@ -3225,7 +3225,7 @@ class ToolsKeycardSetNameView(View):
                     text="Name update failed",
                     show_back_button=True,
                 )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsKeycardRemoveSeedView(View):
@@ -3266,7 +3266,7 @@ class ToolsKeycardRemoveSeedView(View):
                 text="Remove seed failed",
                 show_back_button=True,
             )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsKeycardFactoryResetView(View):
@@ -3309,7 +3309,7 @@ class ToolsKeycardFactoryResetView(View):
                 text="Factory reset failed",
                 show_back_button=True,
             )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsSatochipLoadPsbtView(View):
@@ -3502,7 +3502,7 @@ class ToolsSatochipBenchmarkSignView(View):
             text=text,
             show_back_button=False,
         )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsSatochipBenchmarkMessageSignView(View):
@@ -3578,7 +3578,7 @@ class ToolsSatochipBenchmarkMessageSignView(View):
             text=text,
             show_back_button=False,
         )
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsSatochipImportSeedView(View):
@@ -3620,7 +3620,7 @@ class ToolsSatochipImportSeedView(View):
                 text=_(f"{card_name} card already contains a seed."),
                 show_back_button=False,
             )
-            return Destination(MainMenuView)
+            return Destination(BackStackView)
 
         seeds = self.controller.storage.seeds
         button_data = []
@@ -3744,7 +3744,7 @@ class ToolsSatochipImportSeedView(View):
         elif button_data[selected_menu_num] == self.TYPE_ELECTRUM:
             return Destination(SeedElectrumMnemonicStartView)
         
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 class ToolsSatochipEnable2FAView(View):
     def run(self):
@@ -3804,7 +3804,7 @@ class ToolsSatochipEnable2FAView(View):
                 show_back_button=False,
             )
 
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class SatochipExportXpubSigTypeView(View):
@@ -4375,6 +4375,12 @@ class SatochipLoadDescriptorDetailsView(View):
             show_back_button=False,
         )
 
+        # Deliberately Home, not BackStackView: this View is the tail of a
+        # multi-View chain (script type -> account number -> here), so "back"
+        # would land on the previous *chain* screen rather than on a menu. The
+        # chain also has several entry points -- ToolsSatochipView and
+        # ToolsKeycardView reach it with no resume_main_flow set -- so there is
+        # no single entry menu to name here either.
         return Destination(MainMenuView)
 
 
@@ -6233,7 +6239,7 @@ class ToolsDIYBuildAppletsView(View):
                 show_back_button=False,
             )
 
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 def _get_internal_cap_dir() -> Path:
     """Return the internal javacard-cap directory. Extracted as a module-level
@@ -6430,7 +6436,7 @@ class ToolsDIYInstallAppletView(View):
         finally:
             seedkeeper_utils.restart_pn532(self.settings.get_value(SettingsConstants.SETTING__SMARTCARD_INTERFACES))
 
-        return Destination(MainMenuView)
+        return Destination(BackStackView)
 
 
 class ToolsDIYUninstallAppletView(View):

--- a/src/seedsigner/views/view.py
+++ b/src/seedsigner/views/view.py
@@ -204,11 +204,17 @@ class Destination:
 
     def __eq__(self, obj):
         """
-            Equality test IGNORES the skip_current_view and clear_history options
+            Equality test IGNORES the skip_current_view and clear_history options.
+
+            `view_args` of None and {} mean the same thing -- "no args" -- and must
+            compare equal: `_instantiate_view()` rewrites None to {} in place, so a
+            Destination that has already been run would otherwise stop matching the
+            equivalent Destination a View returns later. The Controller relies on
+            this comparison to spot a Destination it has been to before.
         """
         return (isinstance(obj, Destination) and 
             obj.View_cls == self.View_cls and
-            obj.view_args == self.view_args)
+            (obj.view_args or {}) == (self.view_args or {}))
     
 
     def __ne__(self, obj):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,9 +1,11 @@
 import pytest
 
 # Must import this before the Controller
-from base import BaseTest
+from base import BaseTest, FlowTest, FlowStep
 
 from seedsigner.controller import Controller
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, ButtonListScreen, ButtonOption
+from seedsigner.views.view import BackStackView, Destination, View
 
 
 class TestController(BaseTest):
@@ -79,3 +81,141 @@ class TestController(BaseTest):
         # ...get a new copy of the instance and confirm change
         controller = Controller.get_instance()
         assert controller.unverified_address == "123abc"
+
+
+
+"""
+    Minimal Views used to exercise the Controller's back_stack handling in
+    isolation: a two-level menu tree (parent menu -> entry menu) plus the
+    workflows that an entry menu can launch.
+
+    Note that the Controller never pushes the *initial* Destination onto the
+    back_stack, so `BackStackRootView` is only a bootstrap and never appears in
+    the assertions below.
+"""
+class BackStackRootView(View):
+    def run(self):
+        self.run_screen(ButtonListScreen, button_data=[ButtonOption("Next")])
+        return Destination(BackStackParentMenuView)
+
+
+class BackStackParentMenuView(View):
+    def run(self):
+        self.run_screen(ButtonListScreen, button_data=[ButtonOption("Next")])
+        return Destination(BackStackEntryMenuView)
+
+
+class BackStackEntryMenuView(View):
+    """The menu a workflow is launched from, and that it returns to when done."""
+    def run(self):
+        ret = self.run_screen(ButtonListScreen, button_data=[ButtonOption("Next")])
+        if ret == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+        return Destination([
+            BackStackWorkflowView,
+            BackStackClearHistoryView,
+            BackStackSkippedView,
+        ][ret])
+
+
+class BackStackWorkflowView(View):
+    """A complete workflow that ends by returning to the menu that launched it."""
+    def run(self):
+        self.run_screen(ButtonListScreen, button_data=[ButtonOption("Done")])
+        return Destination(BackStackEntryMenuView)
+
+
+class BackStackClearHistoryView(View):
+    def run(self):
+        self.run_screen(ButtonListScreen, button_data=[ButtonOption("Done")])
+        return Destination(BackStackEntryMenuView, clear_history=True)
+
+
+class BackStackSkippedView(View):
+    """Forwards straight through; should not be left in the back_stack."""
+    def run(self):
+        self.run_screen(ButtonListScreen, button_data=[ButtonOption("Next")])
+        return Destination(BackStackWorkflowView, skip_current_view=True)
+
+
+
+class TestBackStack(FlowTest):
+    """
+        A workflow that finishes by returning to the menu it was launched from must
+        not leave its own screens above that menu in the back_stack; "back" from the
+        menu would then re-enter the workflow that just completed. Flows that
+        dead-end on re-entry (e.g. "Uninstall Applet" with no applets left) loop with
+        no way out but a power cycle. See issue #423.
+    """
+
+    def view_classes(self) -> list:
+        return [d.View_cls for d in self.controller.back_stack]
+
+
+    def test_completed_workflow_unwinds_the_back_stack(self):
+        self.run_sequence([
+            FlowStep(BackStackRootView, screen_return_value=0),
+            FlowStep(BackStackParentMenuView, screen_return_value=0),
+            FlowStep(BackStackEntryMenuView, screen_return_value=0),
+            FlowStep(BackStackWorkflowView, screen_return_value=0),
+            FlowStep(BackStackEntryMenuView),
+        ])
+
+        # The workflow's View is gone; only the entry menu and its parent remain.
+        assert self.view_classes() == [BackStackParentMenuView, BackStackEntryMenuView]
+
+
+    def test_back_from_entry_menu_skips_the_completed_workflow(self):
+        """ "Back" from the entry menu must reach its parent, not re-run the workflow """
+        self.run_sequence([
+            FlowStep(BackStackRootView, screen_return_value=0),
+            FlowStep(BackStackParentMenuView, screen_return_value=0),
+            FlowStep(BackStackEntryMenuView, screen_return_value=0),
+            FlowStep(BackStackWorkflowView, screen_return_value=0),
+            FlowStep(BackStackEntryMenuView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(BackStackParentMenuView),
+        ])
+
+
+    def test_distinct_destinations_are_still_appended(self):
+        """ Unwinding must only trigger on a Destination we have actually been to """
+        self.run_sequence([
+            FlowStep(BackStackRootView, screen_return_value=0),
+            FlowStep(BackStackParentMenuView, screen_return_value=0),
+            FlowStep(BackStackEntryMenuView, screen_return_value=0),
+            FlowStep(BackStackWorkflowView),
+        ])
+
+        assert self.view_classes() == [
+            BackStackParentMenuView,
+            BackStackEntryMenuView,
+            BackStackWorkflowView,
+        ]
+
+
+    def test_clear_history_still_wipes_the_back_stack(self):
+        self.run_sequence([
+            FlowStep(BackStackRootView, screen_return_value=0),
+            FlowStep(BackStackParentMenuView, screen_return_value=0),
+            FlowStep(BackStackEntryMenuView, screen_return_value=1),
+            FlowStep(BackStackClearHistoryView, screen_return_value=0),
+            FlowStep(BackStackEntryMenuView),
+        ])
+
+        assert self.view_classes() == [BackStackEntryMenuView]
+
+
+    def test_skip_current_view_still_drops_the_forwarding_view(self):
+        self.run_sequence([
+            FlowStep(BackStackRootView, screen_return_value=0),
+            FlowStep(BackStackParentMenuView, screen_return_value=0),
+            FlowStep(BackStackEntryMenuView, screen_return_value=2),
+            FlowStep(BackStackSkippedView, screen_return_value=0),
+            FlowStep(BackStackWorkflowView),
+        ])
+
+        assert self.view_classes() == [
+            BackStackParentMenuView,
+            BackStackEntryMenuView,
+            BackStackWorkflowView,
+        ]

--- a/tests/test_flows_menu_navigation.py
+++ b/tests/test_flows_menu_navigation.py
@@ -1,6 +1,8 @@
 import importlib.util
 import os
 import shutil
+import sys
+from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import MagicMock, patch, PropertyMock
 
@@ -74,6 +76,39 @@ def _patch_gpg_verify_file(view):
         p.start()
 
     view.controller.gpg_keys_imported = True
+
+
+class _FakePyGP:
+    """Stand-in for the ``pygp`` native module used by the Javacard DIY views.
+
+    Reports one installed applet (Satochip) so the uninstall flow reaches its
+    applet picker, and accepts every card operation without touching hardware.
+    """
+    SECURITY_LEVEL_C_MAC = 1
+
+    def terminal(self): pass
+    def card(self): pass
+    def auth(self, **kwargs): pass
+    def get_loaded_package_aids(self): return ["5361746F43686970"]
+    def get_package_module_map(self): return {}
+    def get_installed_application_aids(self): return []
+    def delete_package(self, aid): pass
+    def install_capfile(self, *args, **kwargs): return {}
+    def get_cap_info(self, path): raise AssertionError("not expected in this flow")
+
+
+def _patch_javacard_diy(cap_dir=None):
+    """Context managers that let the Javacard DIY views run without a card."""
+    patchers = [
+        patch.dict(sys.modules, {"pygp": _FakePyGP()}),
+        patch("seedsigner.helpers.seedkeeper_utils.restart_pn532"),
+    ]
+    if cap_dir is not None:
+        patchers += [
+            patch("seedsigner.views.smartcard_views._get_internal_cap_dir", return_value=cap_dir),
+            patch("seedsigner.hardware.microsd.MicroSD.get_microsd_dir", return_value=cap_dir.parent),
+        ]
+    return patchers
 
 
 class TestMenuNavigationFlows(FlowTest):
@@ -722,6 +757,104 @@ class TestMenuNavigationFlows(FlowTest):
                 FlowStep(ToolsSatochipDIYView, button_data_selection=ToolsSatochipDIYView.MOUNT_STATUS),
                 FlowStep(ToolsDIYMountStatusView, screen_return_value=RET_CODE__BACK_BUTTON),
                 FlowStep(ToolsSatochipDIYView),
+            ])
+
+
+    # ======================================================================
+    #  WORKFLOW COMPLETION / BACK STACK
+    # ======================================================================
+    #
+    #  A workflow that finishes by returning to the menu it was launched from
+    #  must not leave its own screens above that menu in the back stack. See
+    #  issue #423: "back" from the Javacard DIY menu re-ran the uninstall flow,
+    #  which then dead-ended on "No Applets to Uninstall" and looped forever.
+
+    def test_diy_uninstall_applet_back_leaves_the_menu(self):
+        """Tools → Smartcard → DIY Tools → Uninstall Applet → done → BACK.
+
+        BACK from the DIY menu must reach the Smartcard menu, not re-enter the
+        uninstall flow that just completed (issue #423).
+        """
+        from seedsigner.views.smartcard_views import (
+            ToolsSmartcardMenuView, ToolsSatochipDIYView, ToolsDIYUninstallAppletView,
+        )
+        with ExitStack() as stack:
+            for patcher in _patch_javacard_diy():
+                stack.enter_context(patcher)
+
+            self.run_sequence([
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+                FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.SMARTCARD),
+                FlowStep(ToolsSmartcardMenuView, button_data_selection=ToolsSmartcardMenuView.Satochip_DIY),
+                FlowStep(ToolsSatochipDIYView, button_data_selection=ToolsSatochipDIYView.UNINSTALL_APPLET),
+                # Confirms the "this wipes ALL data" warning, then picks the first applet.
+                FlowStep(ToolsDIYUninstallAppletView, screen_return_value=0),
+                FlowStep(ToolsSatochipDIYView, screen_return_value=RET_CODE__BACK_BUTTON),
+                FlowStep(ToolsSmartcardMenuView),
+            ])
+
+    def test_diy_install_applet_returns_to_diy_menu(self):
+        """Tools → Smartcard → DIY Tools → Install Applet → done → DIY menu.
+
+        The flow used to end at Home; it now returns to the menu it was
+        launched from, and BACK from there still reaches the Smartcard menu.
+        """
+        import tempfile
+        from seedsigner.views.smartcard_views import (
+            ToolsSmartcardMenuView, ToolsSatochipDIYView, ToolsDIYInstallAppletView,
+        )
+
+        cap_dir = Path(tempfile.mkdtemp(prefix="javacard_cap_test_")) / "javacard-cap"
+        cap_dir.mkdir()
+        (cap_dir / "Satochip.cap").write_bytes(b"test")
+
+        with ExitStack() as stack:
+            for patcher in _patch_javacard_diy(cap_dir=cap_dir):
+                stack.enter_context(patcher)
+
+            self.run_sequence([
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+                FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.SMARTCARD),
+                FlowStep(ToolsSmartcardMenuView, button_data_selection=ToolsSmartcardMenuView.Satochip_DIY),
+                FlowStep(ToolsSatochipDIYView, button_data_selection=ToolsSatochipDIYView.INSTALL_APPLET),
+                FlowStep(ToolsDIYInstallAppletView, screen_return_value=0),
+                FlowStep(ToolsSatochipDIYView, screen_return_value=RET_CODE__BACK_BUTTON),
+                FlowStep(ToolsSmartcardMenuView),
+            ])
+
+    def test_gpg_import_key_back_leaves_the_gpg_menu(self):
+        """Tools → GPG Tools → Import Keys → Public Key → From File → done → BACK.
+
+        The import views end on ``ToolsGPGMenuView``; BACK from there must reach
+        the Tools menu rather than walking back through the import screens the
+        user just completed.
+        """
+        import tempfile
+
+        if shutil.which("gpg") is None or importlib.util.find_spec("pgpy") is None:
+            pytest.skip("gpg binary and/or pgpy not available")
+
+        images_dir = Path(tempfile.mkdtemp(prefix="gpg_import_test_"))
+        (images_dir / "pubkey.asc").write_text("not a real key")
+        gnupg_home = Path(tempfile.mkdtemp(prefix="gpg_import_home_"))
+
+        with ExitStack() as stack:
+            # Keep the real `gpg --import` away from the host's keyring.
+            stack.enter_context(patch.dict(os.environ, {"GNUPGHOME": str(gnupg_home)}))
+            stack.enter_context(patch(
+                "seedsigner.views.gpg_views.resolve_microsd_images_dir",
+                return_value=images_dir,
+            ))
+
+            self.run_sequence([
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+                FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.GPG),
+                FlowStep(tools_views.ToolsGPGMenuView, button_data_selection=tools_views.ToolsGPGMenuView.IMPORT),
+                FlowStep(tools_views.ToolsGPGImportMenuView, button_data_selection=tools_views.ToolsGPGImportMenuView.PUBKEY),
+                FlowStep(tools_views.ToolsGPGImportPubkeyMenuView, button_data_selection=tools_views.ToolsGPGImportPubkeyMenuView.LOAD_FILE),
+                FlowStep(tools_views.ToolsGPGImportPubkeyFileView, screen_return_value=0),
+                FlowStep(tools_views.ToolsGPGMenuView, screen_return_value=RET_CODE__BACK_BUTTON),
+                FlowStep(tools_views.ToolsMenuView),
             ])
 
 

--- a/tests/test_flows_seed.py
+++ b/tests/test_flows_seed.py
@@ -1278,11 +1278,11 @@ class TestSatochipImportSeedView(BaseTest):
         view.run_screen = Mock(return_value=0)
         destination = view.run()
 
-        # Should warn user and return to main menu without attempting import
+        # Should warn user and return to the menu that launched it, without attempting import
         assert view.run_screen.call_count == 1
         assert view.run_screen.call_args.args[0] is tools_views.WarningScreen
         assert "already" in view.run_screen.call_args.kwargs["text"].lower()
-        assert destination.View_cls == tools_views.MainMenuView
+        assert destination.View_cls == tools_views.BackStackView
 
     def test_xprv_seed_shows_unsupported_message(self, monkeypatch):
         from seedsigner.views import tools_views
@@ -1364,7 +1364,7 @@ class TestSatochipImportSeedView(BaseTest):
 
         warning_text = captured["warning_text"].lower()
         assert "import failed with sw=6a80" in warning_text
-        assert destination.View_cls == tools_views.MainMenuView
+        assert destination.View_cls == tools_views.BackStackView
 
     def test_import_seed_unseeded_post_status_shows_failed_warning(self, monkeypatch):
         from seedsigner.views import tools_views
@@ -1410,7 +1410,7 @@ class TestSatochipImportSeedView(BaseTest):
 
         warning_text = captured["warning_text"].lower()
         assert "seeded key" in warning_text
-        assert destination.View_cls == tools_views.MainMenuView
+        assert destination.View_cls == tools_views.BackStackView
 
     def test_import_seed_pysatochip_backend_shows_success(self, monkeypatch):
         """pysatochip's card_bip32_import_seed returns a single authentikey, not
@@ -1502,4 +1502,4 @@ class TestSatochipImportSeedView(BaseTest):
         destination = view.run()
 
         assert "import failed" in captured["warning_text"].lower()
-        assert destination.View_cls == tools_views.MainMenuView
+        assert destination.View_cls == tools_views.BackStackView


### PR DESCRIPTION
Fixes #423.

## The bug

Uninstalling a Javacard applet left the user in an inescapable loop: "back" from **Tools → Smartcard → Javacard DIY** re-entered the uninstall flow, which immediately dead-ended on "No Applets to Uninstall" and returned to the same menu. Only a power cycle got out.

The GPG **Import Keys → Private Key** flows had the same defect in a milder form — after a successful import, "back" walked the user back through the import screens they had just completed.

## Root cause — one bug, ~30 exposed call sites

`Controller.start()` unconditionally *appended* each new `Destination`, skipping only an exact duplicate of the current top. A workflow that finishes by returning to the menu it was launched from therefore pushed that menu **on top of its own screens**:

```
back_stack: [ToolsMenuView, ToolsSmartcardMenuView, ToolsSatochipDIYView,
             ToolsDIYUninstallAppletView, ToolsSatochipDIYView]   ← "back" pops 2 → Uninstall
```

`pop_prev_from_back_stack()` pops the current View and then the one below it — the last screen of the workflow that just completed. Every menu in the GPG and smartcard trees returns `Destination(BackStackView)` for its back button, so all of them were exposed. (Settings menus hard-route their back button to a specific parent, so they were never affected.)

## The fix

**`Controller.start()` now truncates the back stack** when the next `Destination` is already in it, rather than pushing a duplicate — standard "clear-top" navigation. It drops the finished workflow's screens while preserving the parent menus above it, and it subsumes the older "don't re-push the current top" special case. One change fixes every instance of this bug class, including future ones.

**`Destination.__eq__` now treats `view_args` of `None` and `{}` as equal.** `_instantiate_view()` rewrites `None` to `{}` in place, so a `Destination` that had already run never compared equal to the equivalent one a View returned later. That silently defeated the old top-of-stack de-duplication too.

## Second half: Home was being used to clear the back stack

~45 other workflows ended with `Destination(MainMenuView)`, which was safe only because the Controller wipes the stack whenever it routes to Home. The cost was that finishing "Change Card PIN" or "Encrypt File" dumped the user at Home instead of the menu they started from.

Those that run entirely inside one View launched from a menu now return `Destination(BackStackView)`, which lands on whichever menu launched them — no hard-coded coupling, and still correct for Views reachable from more than one menu:

| Entry menu | Retargeted |
|---|---|
| `ToolsCommonView` | NDEF config, change PIN / NFC policy / label |
| `ToolsKeycardView` / `ToolsKeycardAdvancedView` | change PIN / PUK, unblock PIN, set name, remove seed, factory reset, benchmarks |
| `ToolsSatochipView` / `ToolsSatochipAdvancedView` | import seed, enable 2FA, benchmarks |
| `ToolsSeedkeeperView` | clone secrets |
| `ToolsSatochipDIYView` | build applets, install applet |
| `ToolsGPGSmartMenuView` | generate key on card, change admin / user PIN |
| `ToolsGPGFileOpsMenuView` / `ToolsGPGSignMenuView` | encrypt / decrypt / verify / sign file, sign manifest |
| `ToolsGPGMessageMenuView` / `ToolsGPGExportMenuView` / `ToolsGPGAdvancedMenuView` | encrypt / decrypt message, export pubkey / privkey / bundle |

Left at `MainMenuView` on purpose: top-level flows whose entry point genuinely *is* Home (Scan, PSBT signing, Seeds, xpub export), error handlers, the explicit "Exit to Home" button in the SeedKeeper clone flow, and `SatochipLoadDescriptorDetailsView` — a multi-View chain with several entry points and no single menu to name (now commented to say so).

## Docs

`AGENTS.md` gains a **Back stack and workflow completion** section stating the contract: one-View workflow → `BackStackView`; multi-View chain → explicit entry menu; `MainMenuView` only when Home really is the entry point, never as a way to clear the stack.

## Tests

- `tests/test_controller.py::TestBackStack` — 5 tests over the mechanism itself (unwind, back-from-entry-menu, no false truncation, `clear_history`, `skip_current_view`) using throwaway Views.
- `tests/test_flows_menu_navigation.py` — 3 end-to-end regressions: the #423 uninstall path, the GPG import path, and the Javacard install-applet retarget.
- `tests/test_flows_seed.py` — 4 assertions updated to the new `ToolsSatochipImportSeedView` destination.

Verified the new tests fail on `dev` and pass with the fix. Full suite: **1495 passed, 205 skipped, 0 failed** (baseline before these changes was 1487 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
