### PR TITLE
Fix false "Open: serial" warning; page the Test hardening report

### DIFF
--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -622,6 +622,76 @@ class ButtonListScreen(BaseTopNavScreen):
 
 
 @dataclass
+class PagedTextScreen(ButtonListScreen):
+    """Read-only text that is longer than one screenful, shown a page at a time.
+
+    Back button at the top, one advance button at the bottom -- "More" until the
+    last page, "Done" on it. Anything that has more to say than fits in 240x240
+    can use this instead of silently running off the bottom edge.
+
+    The caller splits the text: call get_paging_dimensions() and hand the result
+    to components.reflow_text_into_pages(), then pass the pages in as
+    `paged_info`. Splitting in the View rather than here means the page count is
+    known before the first render, so the button label and the title's page
+    counter are right on page 1, and the pages are computed once for the whole
+    walk rather than on every page turn.
+    """
+    paged_info: List[str] = None
+    page_num: int = 0
+
+    # Defaults filled in at init: class attrs cannot call the get_*_font_*()
+    # methods, which are only correct after the display size is known.
+    text_font_name: str = None
+    text_font_size: int = None
+    next_button_text: str = None
+    done_button_text: str = None
+
+
+    @staticmethod
+    def get_paging_dimensions() -> Tuple[int, int]:
+        """(width, height) in px of the body area one page has to fit into."""
+        from seedsigner.gui.renderer import Renderer
+        renderer = Renderer.get_instance()
+        start_y = GUIConstants.TOP_NAV_HEIGHT + GUIConstants.COMPONENT_PADDING
+        end_y = renderer.canvas_height - GUIConstants.EDGE_PADDING - GUIConstants.BUTTON_HEIGHT - GUIConstants.COMPONENT_PADDING
+        return (renderer.canvas_width - 2 * GUIConstants.EDGE_PADDING, end_y - start_y)
+
+
+    def __post_init__(self):
+        if not self.paged_info:
+            raise Exception("paged_info is required")
+        if self.page_num >= len(self.paged_info):
+            raise Exception("Bug in paged_info calculation")
+
+        if len(self.paged_info) > 1:
+            # Page counter in the title: on a screen this small the user needs to
+            # know how much is left before deciding to click through it.
+            self.title = _("{title} {page}/{total}").format(
+                title=self.title, page=self.page_num + 1, total=len(self.paged_info)
+            )
+
+        self.is_bottom_list = True
+        is_last_page = self.page_num == len(self.paged_info) - 1
+        if is_last_page:
+            button_text = self.done_button_text or _("Done")
+        else:
+            button_text = self.next_button_text or _("More")
+        self.button_data = [ButtonOption(button_text)]
+
+        super().__post_init__()
+
+        self.components.append(TextArea(
+            text=self.paged_info[self.page_num],
+            is_text_centered=False,
+            font_name=self.text_font_name,
+            font_size=self.text_font_size,
+            screen_y=GUIConstants.TOP_NAV_HEIGHT + GUIConstants.COMPONENT_PADDING,
+            height=self.get_paging_dimensions()[1],
+        ))
+
+
+
+@dataclass
 class LargeButtonScreen(BaseTopNavScreen):
     button_data: list = None
 

--- a/src/seedsigner/gui/screens/settings_screens.py
+++ b/src/seedsigner/gui/screens/settings_screens.py
@@ -14,7 +14,7 @@ from seedsigner.helpers.system_memory import format_kb, get_memory_stats
 from seedsigner.gui.components import Button, CheckboxButton, CheckedSelectionButton, FontAwesomeIconConstants, Fonts, GUIConstants, Icon, IconButton, IconTextLine, SeedSignerIconConstants, TextArea, resize_image_to_fit
 from seedsigner.gui.screens.scan_screens import ScanScreen
 from seedsigner.gui.keyboard import Keyboard
-from seedsigner.gui.screens.screen import BaseScreen, BaseTopNavScreen, ButtonListScreen, ButtonOption, KeyboardScreen
+from seedsigner.gui.screens.screen import BaseScreen, BaseTopNavScreen, ButtonListScreen, ButtonOption, KeyboardScreen, PagedTextScreen
 from seedsigner.models.threads import BaseThread
 from seedsigner.hardware.buttons import HardwareButtonsConstants
 from seedsigner.hardware.camera import Camera
@@ -712,37 +712,20 @@ class MemoryInfoScreen(BaseTopNavScreen):
 
 
 @dataclass
-class HardeningTestScreen(BaseTopNavScreen):
+class HardeningTestScreen(PagedTextScreen):
     """Per-check results from the runtime hardening self-test.
 
-    Follows SystemInfoScreen's TextArea list. Each line is prefixed with a
-    plain-text glyph rather than a coloured icon so the state survives a photo
-    of the screen and a monochrome display.
-    """
-    verdict: str = ""
-    result_lines: List[str] = None
+    A dozen checks with their detail text do not fit on one 240x240 screen -- the
+    original single-page layout simply ran off the bottom edge and the failing
+    check's detail, the whole point of the screen, was the part you could not
+    read. PagedTextScreen pages through it instead.
 
+    Each line is prefixed with a plain-text glyph rather than a coloured icon so
+    the state survives a photo of the screen and a monochrome display.
+    """
     def __post_init__(self):
         self.title = _("Test Hardening")
         super().__post_init__()
-
-        start_y = self.top_nav.height + 2 * GUIConstants.COMPONENT_PADDING
-        line_spacing = GUIConstants.COMPONENT_PADDING
-
-        lines = [self.verdict] if self.verdict else []
-        lines += self.result_lines or []
-
-        for line in lines:
-            text_area = TextArea(
-                text=line,
-                screen_x=GUIConstants.EDGE_PADDING,
-                width=self.canvas_width - 2 * GUIConstants.EDGE_PADDING,
-                is_text_centered=False,
-                auto_line_break=True,
-                screen_y=start_y,
-            )
-            self.components.append(text_area)
-            start_y += text_area.height + line_spacing
 
 
 @dataclass

--- a/src/seedsigner/gui/screens/tools_screens.py
+++ b/src/seedsigner/gui/screens/tools_screens.py
@@ -13,7 +13,7 @@ from seedsigner.hardware.camera import Camera
 from seedsigner.helpers.qr import QR
 from seedsigner.gui.components import FontAwesomeIconConstants, Fonts, GUIConstants, IconTextLine, SeedSignerIconConstants, TextArea, Button, IconButton, CheckboxButton, load_image, resize_image_to_fit
 from seedsigner.gui.keyboard import Keyboard, TextEntryDisplay
-from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, BaseScreen, BaseTopNavScreen, ButtonListScreen, KeyboardScreen, WarningEdgesMixin, ButtonOption, LoadingScreenThread
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON, BaseScreen, BaseTopNavScreen, ButtonListScreen, KeyboardScreen, PagedTextScreen, WarningEdgesMixin, ButtonOption, LoadingScreenThread
 from seedsigner.hardware.buttons import HardwareButtonsConstants
 from seedsigner.models.settings_definition import SettingsConstants, SettingsDefinition
 
@@ -32,40 +32,13 @@ class ToolsCommonFilterScreen(ButtonListScreen):
 
 
 @dataclass
-class ToolsNetworkInfoScreen(ButtonListScreen):
-    page_num: int = 0
-    paged_info: List[str] = None
-
+class ToolsNetworkInfoScreen(PagedTextScreen):
     def __post_init__(self):
-        renderer = Renderer.get_instance()
-        start_y = GUIConstants.TOP_NAV_HEIGHT + GUIConstants.COMPONENT_PADDING
-        end_y = renderer.canvas_height - GUIConstants.EDGE_PADDING - GUIConstants.BUTTON_HEIGHT - GUIConstants.COMPONENT_PADDING
-        info_height = end_y - start_y
-
-        if self.paged_info is None:
-            raise Exception("paged_info is required")
-
-        if self.page_num >= len(self.paged_info):
-            raise Exception("Bug in paged_info calculation")
-
-        if len(self.paged_info) == 1:
-            self.title = _("Network Info")
-        else:
-            self.title = f"""Network Info (pt {self.page_num + 1}/{len(self.paged_info)})"""
-
-        self.is_bottom_list = True
-        button_label = _("Next") if self.page_num < len(self.paged_info) - 1 else _("Done")
-        self.button_data = [ButtonOption(button_label)]
+        self.title = _("Network Info")
+        # Fixed width so the ifconfig-style columns line up.
+        self.text_font_name = GUIConstants.FIXED_WIDTH_FONT_NAME
+        self.next_button_text = _("Next")
         super().__post_init__()
-
-        message_display = TextArea(
-            text=self.paged_info[self.page_num],
-            is_text_centered=False,
-            font_name=GUIConstants.FIXED_WIDTH_FONT_NAME,
-            screen_y=start_y,
-            height=info_height,
-        )
-        self.components.append(message_display)
 
 
 @dataclass

--- a/src/seedsigner/helpers/hardening.py
+++ b/src/seedsigner/helpers/hardening.py
@@ -53,6 +53,10 @@ WIFI_MODULE_PATTERNS = (
 REMOTE_SHELL_DAEMONS = ("telnetd", "sshd", "dropbear")
 LOGGING_DAEMONS = ("syslogd", "klogd")
 DEV_TOOLS = ("pip", "pip3", "curl", "wget")
+# console= devices that are not a physical port: the null sink, and the numeric
+# virtual terminals (tty0..tty63) the framebuffer console lives on.
+SILENT_CONSOLE = "ttynull"
+VIRTUAL_CONSOLE_PREFIX = "tty"
 # Filesystems whose contents do not survive a reboot.
 VOLATILE_FSTYPES = ("tmpfs", "ramfs")
 
@@ -302,19 +306,47 @@ def check_usb_gadget() -> HardeningCheck:
 
 
 def check_serial_console() -> HardeningCheck:
+    """Fails only for a console on a *physical port*.
+
+    Not every ``console=`` token is an exposure, and treating them alike caused a
+    false alarm: a Raspberry Pi whose cmdline.txt names no console still boots
+    with whatever the firmware and DTB supply, which can be a plain virtual
+    terminal. A numeric VT (``tty0``, ``tty1``) is the framebuffer -- there is no
+    port to clip onto and no getty on it in any SeedSigner image -- so it is
+    reported but not failed. ``ttynull`` is the null sink, i.e. silence itself.
+    Anything else (``ttyAMA0``, ``ttyS0``, ``ttyFIQ0``, ``ttyUSB0``, ``ttyGS0``,
+    ...) is a real UART and still fails.
+    """
     cmdline = _read_text(PROC_CMDLINE)
     if cmdline is None:
-        state, detail = STATE_NA, _("No /proc/cmdline")
-    else:
-        consoles = [
-            token for token in cmdline.split()
-            if token.startswith("console=") and not token.startswith("console=ttynull")
-        ]
-        if consoles:
-            state = STATE_FAIL
-            detail = _("Console: {tokens}").format(tokens=" ".join(consoles))
+        return HardeningCheck(
+            key="serial_console", label=_("Serial console silenced"), severity=SEVERITY_CRITICAL,
+            state=STATE_NA, detail=_("No /proc/cmdline"), open_name=_("serial"),
+        )
+
+    ports: list[str] = []
+    virtual: list[str] = []
+    for token in cmdline.split():
+        if not token.startswith("console="):
+            continue
+        # console=<device>[,<options>] -- e.g. console=ttyAMA0,115200n8
+        device = token[len("console="):].split(",", 1)[0]
+        if device == SILENT_CONSOLE:
+            continue
+        suffix = device[len(VIRTUAL_CONSOLE_PREFIX):]
+        if device.startswith(VIRTUAL_CONSOLE_PREFIX) and suffix.isdigit():
+            virtual.append(device)
         else:
-            state, detail = STATE_PASS, _("No serial console")
+            ports.append(device)
+
+    if ports:
+        state = STATE_FAIL
+        detail = _("Console: {devices}").format(devices=" ".join(ports))
+    elif virtual:
+        state = STATE_PASS
+        detail = _("Virtual terminal only: {devices}").format(devices=" ".join(virtual))
+    else:
+        state, detail = STATE_PASS, _("No serial console")
     return HardeningCheck(
         key="serial_console", label=_("Serial console silenced"), severity=SEVERITY_CRITICAL,
         state=state, detail=detail, open_name=_("serial"),

--- a/src/seedsigner/views/settings_views.py
+++ b/src/seedsigner/views/settings_views.py
@@ -6,7 +6,7 @@ from gettext import gettext as _
 
 #from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen, WarningScreen, settings_screens)
 
-from seedsigner.gui.components import GUIConstants, SeedSignerIconConstants
+from seedsigner.gui.components import GUIConstants, SeedSignerIconConstants, reflow_text_into_pages
 from seedsigner.gui.screens import (RET_CODE__BACK_BUTTON, ButtonListScreen, WarningScreen, settings_screens)
 from seedsigner.gui.screens.screen import ButtonOption
 from seedsigner.models.settings import Settings, SettingsConstants, SettingsDefinition
@@ -983,7 +983,16 @@ class HardeningTestView(View):
         "n/a": "[--]",
     }
 
-    def run(self):
+    def __init__(self, page_num: int = 0, paged_info: list[str] | None = None):
+        super().__init__()
+        self.page_num = page_num
+        # Carried across page turns so the probes run once per visit rather than
+        # once per page: re-running them would be wasted work, and could report a
+        # different answer halfway through the same walk.
+        self.paged_info = paged_info
+
+
+    def _build_report(self) -> str:
         from seedsigner.helpers import hardening
 
         results = hardening.run_checks()
@@ -1014,13 +1023,36 @@ class HardeningTestView(View):
             for result in results
         ]
 
-        self.run_screen(
+        # Blank line after the verdict so it reads as a heading rather than as
+        # the first check in the list.
+        return chr(10).join([verdict, ""] + result_lines)
+
+
+    def run(self):
+        if self.paged_info is None:
+            width, height = settings_screens.HardeningTestScreen.get_paging_dimensions()
+            self.paged_info = reflow_text_into_pages(
+                text=self._build_report(),
+                width=width,
+                height=height,
+            )
+
+        selected_menu_num = self.run_screen(
             settings_screens.HardeningTestScreen,
-            verdict=verdict,
-            result_lines=result_lines,
+            page_num=self.page_num,
+            paged_info=self.paged_info,
         )
 
-        return Destination(SettingsMenuView, view_args={"visibility": SettingsConstants.VISIBILITY__ADVANCED})
+        if selected_menu_num == RET_CODE__BACK_BUTTON:
+            return Destination(BackStackView)
+
+        if self.page_num >= len(self.paged_info) - 1:
+            return Destination(SettingsMenuView, view_args={"visibility": SettingsConstants.VISIBILITY__ADVANCED})
+
+        return Destination(
+            HardeningTestView,
+            view_args=dict(page_num=self.page_num + 1, paged_info=self.paged_info),
+        )
 
 class VersionView(View):
     def run(self):

--- a/src/seedsigner/views/tools_views.py
+++ b/src/seedsigner/views/tools_views.py
@@ -542,14 +542,11 @@ class ToolsNetworkInfoView(View):
         if not network_info:
             return None
 
-        start_y = GUIConstants.TOP_NAV_HEIGHT + GUIConstants.COMPONENT_PADDING
-        end_y = self.renderer.canvas_height - GUIConstants.EDGE_PADDING - GUIConstants.BUTTON_HEIGHT - GUIConstants.COMPONENT_PADDING
-        info_height = end_y - start_y
-
+        width, height = ToolsNetworkInfoScreen.get_paging_dimensions()
         return reflow_text_into_pages(
             text=network_info,
-            width=self.renderer.canvas_width - 2 * GUIConstants.EDGE_PADDING,
-            height=info_height,
+            width=width,
+            height=height,
             font_name=GUIConstants.FIXED_WIDTH_FONT_NAME,
             font_size=GUIConstants.get_body_font_size(),
         )

--- a/tests/base.py
+++ b/tests/base.py
@@ -12,7 +12,13 @@ try:
     import numpy
 except ImportError:
     sys.modules['numpy'] = MagicMock()  # numpy is only in the Raspi requirements; not needed for tests. But is imported in BackgroundImportThread.
-sys.modules['seedsigner.gui.renderer'] = MagicMock()
+_renderer_module = MagicMock()
+# Real integer canvas dimensions: view code that lays text out (e.g. splitting a
+# report into pages) does arithmetic on these before any Screen is constructed,
+# and MagicMocks do not compare or subtract. 240x240 is the baseline display.
+_renderer_module.Renderer.get_instance.return_value.canvas_width = 240
+_renderer_module.Renderer.get_instance.return_value.canvas_height = 240
+sys.modules['seedsigner.gui.renderer'] = _renderer_module
 sys.modules['seedsigner.gui.screens.screensaver'] = MagicMock()
 sys.modules['seedsigner.gui.toast'] = MagicMock()
 sys.modules['seedsigner.hardware.buttons'] = MagicMock()

--- a/tests/test_flows_settings.py
+++ b/tests/test_flows_settings.py
@@ -152,9 +152,32 @@ class TestSettingsFlows(FlowTest):
             FlowStep(MainMenuView, button_data_selection=MainMenuView.SETTINGS),
             FlowStep(settings_views.SettingsMenuView, button_data_selection=settings_views.SettingsMenuView.ADVANCED),
             FlowStep(settings_views.SettingsMenuView, button_data_selection=settings_views.SettingsMenuView.TEST_HARDENING),
-            FlowStep(settings_views.HardeningTestView),
+            FlowStep(settings_views.HardeningTestView, screen_return_value=RET_CODE__BACK_BUTTON),
             FlowStep(settings_views.SettingsMenuView),
         ])
+
+
+    def test_test_hardening_advances_a_page_at_a_time(self):
+        """The report is paged; "More" moves to the next page, the last page exits.
+
+        Page count depends on what the probes can read, so drive the paging
+        directly rather than asserting a fixed number of screens.
+        """
+        pages = ["page one", "page two", "page three"]
+
+        view = settings_views.HardeningTestView(page_num=0, paged_info=pages)
+        with patch.object(settings_views.HardeningTestView, "run_screen", return_value=0):
+            dest = view.run()
+        assert dest.View_cls is settings_views.HardeningTestView
+        assert dest.view_args["page_num"] == 1
+        # Probes must not re-run mid-walk; the same pages are carried forward.
+        assert dest.view_args["paged_info"] is pages
+
+        last = settings_views.HardeningTestView(page_num=len(pages) - 1, paged_info=pages)
+        with patch.object(settings_views.HardeningTestView, "run_screen", return_value=0):
+            dest = last.run()
+        assert dest.View_cls is settings_views.SettingsMenuView
+        assert dest.view_args["visibility"] == SettingsConstants.VISIBILITY__ADVANCED
 
 
     def test_load_backup_files_submenu(self):

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -236,6 +236,38 @@ def test_ttynull_console_counts_as_silenced(tmp_path, monkeypatch):
     assert hardening.check_serial_console().state == hardening.STATE_PASS
 
 
+def test_virtual_terminal_console_is_not_a_serial_exposure(tmp_path, monkeypatch):
+    """console=tty1 is the framebuffer VT, not a port. A Pi that names no console
+    in its cmdline.txt can still be handed one by the firmware/DTB, and calling
+    that an open serial port is a false alarm (seedsigner#422)."""
+    root = tmp_path / "vt"
+    _write(root / "proc/cmdline", "root=/dev/mmcblk0p2 console=tty1 rootwait\n")
+    _point_module_at(monkeypatch, root)
+    check = hardening.check_serial_console()
+    assert check.state == hardening.STATE_PASS
+    # Still named in the detail, so the Test hardening screen stays diagnostic.
+    assert "tty1" in check.detail
+    assert "serial" not in hardening.open_exposures()
+
+
+def test_uart_console_fails_even_alongside_a_virtual_terminal(tmp_path, monkeypatch):
+    root = tmp_path / "vt_and_uart"
+    _write(root / "proc/cmdline", "console=tty1 console=ttyAMA0,115200 rootwait\n")
+    _point_module_at(monkeypatch, root)
+    check = hardening.check_serial_console()
+    assert check.state == hardening.STATE_FAIL
+    assert "ttyAMA0" in check.detail
+    # The VT is not what is open, so it must not pad the failure detail.
+    assert "tty1" not in check.detail
+
+
+def test_8250_uart_console_fails(tmp_path, monkeypatch):
+    root = tmp_path / "uart8250"
+    _write(root / "proc/cmdline", "console=ttyS0,115200 root=/dev/mmcblk0p2\n")
+    _point_module_at(monkeypatch, root)
+    assert hardening.check_serial_console().state == hardening.STATE_FAIL
+
+
 def test_dev_tools_detected_on_path(tmp_path, monkeypatch):
     root = tmp_path / "tools"
     bindir = root / "bin"


### PR DESCRIPTION
Fixes the Pi02W half of #422, and fixes the screen you would use to diagnose it.

Pairs with 3rdIteration/seedsigner-os#122 — that PR silences the console in the image, this one stops the check from misreading a virtual terminal as a serial port.

## 1. `check_serial_console` failed on any console, and called them all "serial"

The probe flagged every `console=` token that was not `ttynull` and reported it under the name `serial`, which is what produced:

> Unhardened Build / Not secure! / **Open: serial.**

A Pi whose `cmdline.txt` names no console still boots with whatever the firmware and DTB supply for that SoC, and that can be a plain framebuffer VT. `console=tty1` is not a port — there is nothing to clip onto, and `BR2_TARGET_GENERIC_GETTY` is unset in every SeedSigner defconfig, so there is no login on it either.

The probe now classifies the device:

| `console=` device | verdict |
|---|---|
| `ttynull` | silence — contributes nothing |
| `tty0`, `tty1`, … | reported in the detail, **not** failed |
| `ttyAMA0`, `ttyS0`, `ttyFIQ0`, `ttyUSB0`, `ttyGS0`, … | `STATE_FAIL`, as before |

`STATE_NA` on an unreadable `/proc/cmdline` is unchanged, and a failure still names the offending devices so the Test hardening screen stays diagnostic.

## 2. The Test hardening screen ran off the bottom of the display

Reported on the issue thread: the detail text — the one thing that says *which* check failed and *why* — was the part you could not read. A dozen results in a single column does not fit in 240x240.

New `PagedTextScreen` in `gui/screens/screen.py`: back button at the top, one advance button at the bottom, `More` until the last page and `Done` on it. General-purpose, for any read-only text that outgrows one screen. `HardeningTestScreen` uses it, and `ToolsNetworkInfoScreen` — which had grown its own copy of exactly this layout — now builds on it too instead of duplicating it.

Rendered locally at 240x240 through the screenshot renderer: `Test Hardening 1/5` with a `More` button, through to `5/5` with `Done`. The `Network Info` screen renders unchanged apart from the shorter page counter (`Network Info 1/2` rather than `Network Info (pt 1/2)`).

## Tests

- Three new cases in `tests/test_hardening.py`: VT-only passes and does not appear in `open_exposures()`; a UART alongside a VT still fails and names only the UART; `ttyS0` fails.
- `tests/test_flows_settings.py`: the existing flow test now exercises the back button, plus a new test that "More" advances one page, carries the same pages forward (probes run once per visit, not once per page), and that the last page returns to Settings > Advanced.
- `tests/base.py` gives the mocked `Renderer` real integer canvas dimensions — view code splits text into pages before any `Screen` exists, and MagicMocks do not subtract.

`pytest tests/` is green apart from 5 pre-existing `test_l10n` / `test_flows_l10n` failures that also fail on a clean `dev` checkout (no compiled translation catalogs locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)