### PR TITLE
fix: map SeedKeeper 0x9C01 (card full) and repair dead status-word branches (#413)

### DIFF
--- a/src/seedsigner/helpers/iso7816.py
+++ b/src/seedsigner/helpers/iso7816.py
@@ -32,6 +32,25 @@ ISO7816_STATUS_WORDS: Dict[int, str] = {
     0x6E00: "Class not supported",
     0x6F00: "Unknown error, no precise diagnosis",
     0x9000: "Success",
+    # Proprietary 0x9Cxx range used by the Satochip/SeedKeeper JavaCard applets
+    # (see pysatochip's JCconstants.SEEDKEEPER_LOG_RES_DIC). These are not part
+    # of ISO/IEC 7816-4 but surface through the same sw1/sw2 plumbing.
+    0x9C01: "No memory left on card",
+    0x9C03: "Operation not allowed",
+    0x9C04: "Card setup not done",
+    0x9C05: "Feature unsupported",
+    0x9C08: "Secret not found",
+    0x9C0B: "Invalid signature",
+    0x9C0C: "Identity blocked",
+    0x9C0F: "Invalid parameter",
+    0x9C10: "Incorrect P1",
+    0x9C11: "Incorrect P2",
+    0x9C30: "Lock error",
+    0x9C31: "Export not allowed",
+    0x9C32: "Import data too long",
+    0x9C33: "Wrong MAC during import",
+    0x9C38: "Wrong secret type",
+    0x9CFF: "Card internal error",
 }
 
 def format_sw_error(sw1: int, sw2: int) -> str:

--- a/src/seedsigner/helpers/seedkeeper_utils.py
+++ b/src/seedsigner/helpers/seedkeeper_utils.py
@@ -20,7 +20,9 @@ from seedsigner.helpers.keycard_connector import KeycardSatochipConnector
 
 
 import os
+import re
 import time
+from gettext import gettext as _
 from os import urandom
 import platform
 import logging
@@ -205,10 +207,17 @@ def ensure_seedkeeper_capacity(connector, secret_dic: dict, free_memory: int | N
     if available_bytes is None:
         try:
             available_bytes = get_seedkeeper_free_memory(connector)
-        except UnexpectedSW12Error:
+        except UnexpectedSW12Error as exc:
+            status_word = sw_from_exception(exc)
+            # Only an "unsupported instruction" answer means the capacity is
+            # genuinely unknowable. Anything else is a real failure and must not
+            # be silently reinterpreted as "assume it fits". A status word we
+            # cannot parse stays lenient so that #413-style cards keep working.
+            if status_word is not None and status_word not in (0x6D00, 0x6E00, 0x9C05):
+                raise
             logger.warning(
-                "Seedkeeper does not support status (0x6D00); "
-                "skipping capacity pre-check"
+                "Seedkeeper status unsupported (%s); skipping capacity pre-check",
+                f"{status_word:#06x}" if status_word is not None else "unknown status word",
             )
             available_bytes = None
 
@@ -228,6 +237,79 @@ def format_seedkeeper_space_error(required_bytes: int, free_bytes: int) -> str:
         f"Requires {required_bytes} bytes\n"
         f"{free_bytes} bytes free"
     )
+
+
+# Matches the status word pysatochip embeds in its exception messages, e.g.
+# "Unexpected error during secure secret import (error code 0x9c01)".
+_SW_IN_MESSAGE_RE = re.compile(r"error code[:\s]*0x([0-9a-fA-F]{1,4})")
+
+
+def sw_from_exception(exc) -> int | None:
+    """Best-effort recovery of the status word behind a pysatochip exception.
+
+    ``UnexpectedSW12Error`` defaults ``sw1``/``sw2`` to ``0x00``, and the
+    SeedKeeper helpers we rely on (``seedkeeper_import_secret``,
+    ``seedkeeper_get_status``, ``seedkeeper_reset_secret``) all raise it
+    *without* passing them.  Any ``exc.sw1``/``exc.sw2`` branch on those paths
+    is therefore dead code.  Prefer the attributes when they carry a real value
+    and otherwise fall back to the status word embedded in the message text.
+
+    Returns the 16-bit status word, or ``None`` when it cannot be determined.
+    """
+
+    sw1 = getattr(exc, "sw1", 0) or 0
+    sw2 = getattr(exc, "sw2", 0) or 0
+    status_word = (sw1 << 8) | sw2
+    if status_word:
+        return status_word
+
+    match = _SW_IN_MESSAGE_RE.search(str(exc))
+    if match:
+        return int(match.group(1), 16)
+    return None
+
+
+def is_seedkeeper_v1(connector) -> bool | None:
+    """Return True for a v1 SeedKeeper applet, False for newer, None if unknown.
+
+    v1 applets predate several instructions we depend on: ``seedkeeper_get_status``
+    (INS 0xA7) and ``seedkeeper_reset_secret`` (INS 0xA5) both answer 0x6D00.
+    ``card_get_status`` (INS 0x3C) does work on v1, so it is safe to probe here.
+    """
+
+    try:
+        status = connector.card_get_status()[3]
+        return status.get("protocol_minor_version") == 1
+    except Exception:  # pragma: no cover - defensive, card may have gone away
+        logger.debug("Could not determine Seedkeeper applet version", exc_info=True)
+        return None
+
+
+def describe_seedkeeper_error(exc, connector=None, fallback: str | None = None) -> str:
+    """Return a user-facing message for a failed Seedkeeper card operation.
+
+    Handles the codes the SeedKeeper applet actually returns.  Most importantly
+    0x9C01 (``SW_NO_MEMORY_LEFT``), which is how a full card rejects an import;
+    on a v1 applet that is terminal, because v1 cannot delete secrets.
+    """
+
+    status_word = sw_from_exception(exc)
+
+    if status_word == 0x9C01:
+        if connector is not None and is_seedkeeper_v1(connector):
+            # v1 has no reset-secret instruction, so freeing space is impossible.
+            return _("Not enough space on Seedkeeper\nCard memory is full\n\n"
+                     "Seedkeeper v1 cannot delete secrets. A factory reset is required.")
+        return _("Not enough space on Seedkeeper\nCard memory is full\n\n"
+                 "Delete a secret to free space.")
+
+    if status_word in (0x6D00, 0x6E00, 0x9C05):
+        return _("Not supported by this Seedkeeper applet") + f"\n({status_word:#06x})"
+
+    if status_word is not None:
+        return format_sw_error(status_word >> 8, status_word & 0xFF)
+
+    return fallback or str(exc)
 
 
 def prompt_for_pin(

--- a/src/seedsigner/views/gpg_views.py
+++ b/src/seedsigner/views/gpg_views.py
@@ -48,7 +48,6 @@ from seedsigner.gui.screens.tools_screens import (
     ToolsTranscribeTextQRConfirmQRPromptScreen,
 )
 from seedsigner.helpers import seedkeeper_utils
-from seedsigner.helpers.iso7816 import format_sw_error
 from seedsigner.hardware.microsd import MicroSD, resolve_microsd_images_dir
 from seedsigner.models.encode_qr import GenericStaticQrEncoder
 
@@ -1119,7 +1118,6 @@ class ToolsGPGSaveBip85DataView(View):
         from seedsigner.models.encode_qr import UrBytesQrEncoder
         from seedsigner.helpers import seedkeeper_utils
         from pysatochip.CardConnector import UnexpectedSW12Error
-        from seedsigner.helpers.iso7816 import format_sw_error
         import time
 
         button_data = [self.TO_MICROSD, self.TO_QR, self.TO_SEEDKEEPER]
@@ -1259,12 +1257,8 @@ class ToolsGPGSaveBip85DataView(View):
             msg = "BIP85 data saved"
         except UnexpectedSW12Error as e:
             loading.stop()
-            if e.sw1 == 0x6A and e.sw2 == 0x84:
-                err_text = "Not enough space on Seedkeeper"
-            else:
-                err_text = format_sw_error(e.sw1, e.sw2)
             screen = WarningScreen
-            msg = err_text
+            msg = seedkeeper_utils.describe_seedkeeper_error(e, Satochip_Connector)
         except Exception:
             loading.stop()
             screen = WarningScreen
@@ -3627,10 +3621,7 @@ class ToolsGPGDecryptMessageView(View):
                 )
             except UnexpectedSW12Error as e:
                 loading.stop()
-                if e.sw1 == 0x6A and e.sw2 == 0x84:
-                    err_text = "Not enough space on Seedkeeper for message"
-                else:
-                    err_text = format_sw_error(e.sw1, e.sw2)
+                err_text = seedkeeper_utils.describe_seedkeeper_error(e, Satochip_Connector)
                 self.run_screen(
                     WarningScreen,
                     title="Error",
@@ -7589,10 +7580,7 @@ class ToolsGPGExportPubkeyView(View):
                 return Destination(BackStackView)
             except UnexpectedSW12Error as e:
                 self.loading_screen.stop()
-                if e.sw1 == 0x6A and e.sw2 == 0x84:
-                    error_text = "Not enough space on Seedkeeper for key"
-                else:
-                    error_text = format_sw_error(e.sw1, e.sw2)
+                error_text = seedkeeper_utils.describe_seedkeeper_error(e, Satochip_Connector)
                 self.run_screen(
                     WarningScreen,
                     title="Error",
@@ -7867,10 +7855,7 @@ class ToolsGPGExportPrivkeyView(View):
                 return Destination(BackStackView)
             except UnexpectedSW12Error as e:
                 self.loading_screen.stop()
-                if e.sw1 == 0x6A and e.sw2 == 0x84:
-                    error_text = "Not enough space on Seedkeeper for key"
-                else:
-                    error_text = format_sw_error(e.sw1, e.sw2)
+                error_text = seedkeeper_utils.describe_seedkeeper_error(e, Satochip_Connector)
                 self.run_screen(
                     WarningScreen,
                     title="Error",

--- a/src/seedsigner/views/password_generator_views.py
+++ b/src/seedsigner/views/password_generator_views.py
@@ -32,7 +32,6 @@ from seedsigner.gui.screens.tools_screens import (
     ToolsTextQRReviewTextScreen,
     ToolsTextQRTextEntryScreen,
 )
-from seedsigner.helpers.iso7816 import format_sw_error
 from seedsigner.helpers import password_generation, diceware, mnemonic_generation
 
 # Re-exported from tools_views.py (shared helpers used by password generation views)
@@ -1282,10 +1281,7 @@ def _save_password_to_seedkeeper(view: View, password: str) -> bool:
         return True
     except UnexpectedSW12Error as e:
         loading.stop()
-        if e.sw1 == 0x6A and e.sw2 == 0x84:
-            err_text = _("Not enough space on Seedkeeper for password")
-        else:
-            err_text = format_sw_error(e.sw1, e.sw2)
+        err_text = seedkeeper_utils.describe_seedkeeper_error(e, Satochip_Connector)
         view.run_screen(
             WarningScreen,
             title=_("Error"),

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -5120,6 +5120,9 @@ class SaveToSeedkeeperView(View):
 
     def run(self):
         from seedsigner.gui.screens.screen import LoadingScreenThread
+        # Bound up front so the except handler below can safely reference it
+        # even when init_satochip() itself is what raised.
+        Satochip_Connector = None
         try:
             Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["seedkeeper"])
 
@@ -5287,14 +5290,14 @@ class SaveToSeedkeeperView(View):
             return Destination(SeedOptionsView, view_args={"seed": self.seed}, clear_history=True)
 
         except Exception as e:
-            print(e)
+            logger.info(e)
             self.loading_screen.stop()
             time.sleep(0.1) # Sleep for 100ms
             self.run_screen(
                 WarningScreen,
                 title="Error",
                 status_headline=None,
-                text=str(e),
+                text=seedkeeper_utils.describe_seedkeeper_error(e, Satochip_Connector),
                 show_back_button=True,
             )
             return Destination(BackStackView)

--- a/src/seedsigner/views/smartcard_views.py
+++ b/src/seedsigner/views/smartcard_views.py
@@ -605,7 +605,7 @@ class ToolsCommonNdefView(View):
             card_type = getattr(connector, "card_type", "Unknown")
             
             # Check that we're connected to Seedkeeper
-            if card_type != "Seedkeeper":
+            if card_type != "SeedKeeper":
                 self.run_screen(
                     WarningScreen,
                     title="Wrong Card",
@@ -712,7 +712,9 @@ class ToolsCommonNdefView(View):
                 WarningScreen,
                 title="Failed",
                 status_headline=None,
-                text=str(e)[:100],
+                # 200 rather than 100: the mapped messages below are bounded and
+                # the longest (the v1 out-of-space advice) would be cut mid-sentence.
+                text=seedkeeper_utils.describe_seedkeeper_error(e, connector)[:200],
                 show_back_button=True,
             )
             return Destination(self.__class__)
@@ -726,7 +728,7 @@ class ToolsCommonNdefView(View):
             card_type = getattr(connector, "card_type", "Unknown")
             
             # Check that we're connected to Seedkeeper to load from it
-            if card_type != "Seedkeeper":
+            if card_type != "SeedKeeper":
                 self.run_screen(
                     WarningScreen,
                     title="Wrong Card",
@@ -1587,11 +1589,13 @@ class ToolsSeedkeeperFreeSpaceView(View):
             try:
                 free_bytes = seedkeeper_utils.get_seedkeeper_free_memory(connector)
             except Exception as exc:
+                # v1 applets have no seedkeeper_get_status (INS 0xA7) and answer
+                # 0x6D00, so free space simply cannot be reported for them.
                 self.run_screen(
                     WarningScreen,
                     title="Error",
                     status_headline=None,
-                    text=str(exc),
+                    text=seedkeeper_utils.describe_seedkeeper_error(exc, connector),
                     show_back_button=True,
                 )
                 return Destination(BackStackView)
@@ -1857,7 +1861,7 @@ class ToolsSeedkeeperCloneSecretsView(View):
         except Exception as exc:
             if loading_screen:
                 loading_screen.stop()
-            return False, str(exc)
+            return False, seedkeeper_utils.describe_seedkeeper_error(exc, connector)
 
         finally:
             if loading_screen:
@@ -2219,7 +2223,9 @@ class ToolsSeedkeeperImportPasswordView(View):
                 WarningScreen,
                 title="Failed",
                 status_headline=None,
-                text=f"Password Import Failed",
+                text=seedkeeper_utils.describe_seedkeeper_error(
+                    e, Satochip_Connector, fallback="Password Import Failed"
+                ),
                 show_back_button=False,
             )
         
@@ -2229,6 +2235,9 @@ class ToolsSeedkeeperDeleteSecretView(View):
 
     def run(self):
         from seedsigner.gui.screens.screen import LoadingScreenThread
+        # Bound up front so the except handler can safely reference it even when
+        # init_satochip() itself is what raised.
+        Satochip_Connector = None
         try:
             Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["seedkeeper"])
             
@@ -2332,7 +2341,7 @@ class ToolsSeedkeeperDeleteSecretView(View):
                 WarningScreen,
                 title="Error",
                 status_headline=None,
-                text=str(e),
+                text=seedkeeper_utils.describe_seedkeeper_error(e, Satochip_Connector),
                 show_back_button=True,
             )
             return Destination(BackStackView)
@@ -2459,6 +2468,9 @@ class ToolsSeedkeeperLoadDescriptorView(View):
 class ToolsSeedkeeperSaveDescriptorView(View):
     def run(self):
         from seedsigner.gui.screens.screen import LoadingScreenThread
+        # Bound up front so the except handler can safely reference it even when
+        # the failure happens before the card connection is established.
+        Satochip_Connector = None
         try:
             # Load
             descriptor = self.controller.multisig_wallet_descriptor
@@ -2631,7 +2643,7 @@ class ToolsSeedkeeperSaveDescriptorView(View):
                 WarningScreen,
                 title="Error",
                 status_headline=None,
-                text=str(e),
+                text=seedkeeper_utils.describe_seedkeeper_error(e, Satochip_Connector),
                 show_back_button=True,
             )
         
@@ -5757,12 +5769,8 @@ class ToolsJavacardSaveKeysView(View):
             msg = "Keys saved to Seedkeeper"
         except UnexpectedSW12Error as exc:
             loading.stop()
-            if exc.sw1 == 0x6A and exc.sw2 == 0x84:
-                err_text = "Not enough space on Seedkeeper"
-            else:
-                err_text = format_sw_error(exc.sw1, exc.sw2)
             screen = WarningScreen
-            msg = err_text
+            msg = seedkeeper_utils.describe_seedkeeper_error(exc, Satochip_Connector)
         except Exception:
             loading.stop()
             screen = WarningScreen

--- a/tests/test_seedkeeper_descriptor.py
+++ b/tests/test_seedkeeper_descriptor.py
@@ -15,6 +15,7 @@ These use a mocked connector so they run in CI without hardware.
 """
 
 import base
+import pytest
 from embit.descriptor import Descriptor
 from unittest.mock import MagicMock
 
@@ -180,3 +181,103 @@ def test_seedkeeper_ensure_capacity_tolerates_unsupported_status(monkeypatch):
     assert fits is True
     assert required_bytes > 0
     assert free_bytes is None
+
+
+# ---------------------------------------------------------------------------
+# #413 follow-up: the card's own out-of-memory answer (0x9C01)
+#
+# Skipping the capacity pre-check lets the write reach the card, which then
+# rejects a full card with SW_NO_MEMORY_LEFT. pysatochip's
+# seedkeeper_import_secret raises UnexpectedSW12Error *without* passing
+# sw1/sw2, so they default to 0x00 and every `exc.sw1 == ...` branch on that
+# path is dead code. The status word only survives in the message text.
+# ---------------------------------------------------------------------------
+
+
+class FakeSW12Error(Exception):
+    """Stands in for pysatochip's UnexpectedSW12Error.
+
+    tests/base.py replaces the pysatochip modules with MagicMocks, so the real
+    exception class is not importable here. This mirrors its constructor,
+    including the sw1/sw2 defaults of 0x00 that make attribute-based branches
+    on the import path useless.
+    """
+
+    def __init__(self, message, sw1=0x00, sw2=0x00):
+        super().__init__(message)
+        self.sw1 = sw1
+        self.sw2 = sw2
+
+
+def _import_error(status_word: int) -> FakeSW12Error:
+    """Build the exception exactly as pysatochip raises it on an import."""
+    return FakeSW12Error(
+        f"Unexpected error during secure secret import (error code {hex(status_word)})"
+    )
+
+
+def test_sw_from_exception_recovers_status_word_from_message():
+    # pysatochip leaves sw1/sw2 at their 0x00 defaults on this path...
+    exc = _import_error(0x9C01)
+    assert (exc.sw1, exc.sw2) == (0x00, 0x00)
+    # ...so the status word must come from the message instead.
+    assert seedkeeper_utils.sw_from_exception(exc) == 0x9C01
+
+
+def test_sw_from_exception_prefers_populated_attributes():
+    exc = FakeSW12Error("boom", 0x6A, 0x84)
+    assert seedkeeper_utils.sw_from_exception(exc) == 0x6A84
+
+
+def test_sw_from_exception_returns_none_when_unknowable():
+    assert seedkeeper_utils.sw_from_exception(ValueError("no status word here")) is None
+
+
+def test_describe_error_maps_9c01_to_a_space_message():
+    connector = MagicMock()
+    connector.card_get_status.return_value = (None, None, None, {"protocol_minor_version": 2})
+
+    text = seedkeeper_utils.describe_seedkeeper_error(_import_error(0x9C01), connector)
+
+    assert "Not enough space" in text
+    # A v2 card can free space by deleting a secret.
+    assert "Delete a secret" in text
+    assert "factory reset" not in text.lower()
+
+
+def test_describe_error_tells_v1_users_a_factory_reset_is_needed():
+    # v1 applets have no seedkeeper_reset_secret (INS 0xA5), so "delete a
+    # secret to free space" is not actionable advice for them.
+    connector = MagicMock()
+    connector.card_get_status.return_value = (None, None, None, {"protocol_minor_version": 1})
+
+    text = seedkeeper_utils.describe_seedkeeper_error(_import_error(0x9C01), connector)
+
+    assert "Not enough space" in text
+    assert "factory reset" in text.lower()
+    assert "Delete a secret" not in text
+
+
+def test_describe_error_maps_unsupported_instruction():
+    exc = FakeSW12Error("Error while fetching SeedKeeper status: (error code 0x6d00)")
+    assert "Not supported" in seedkeeper_utils.describe_seedkeeper_error(exc)
+
+
+def test_describe_error_falls_back_when_no_status_word():
+    exc = ValueError("something else went wrong")
+    assert seedkeeper_utils.describe_seedkeeper_error(exc) == "something else went wrong"
+    assert seedkeeper_utils.describe_seedkeeper_error(exc, fallback="Import Failed") == "Import Failed"
+
+
+def test_ensure_capacity_reraises_a_genuine_status_failure(monkeypatch):
+    """Only 'instruction unsupported' may be swallowed as 'capacity unknown'."""
+    monkeypatch.setattr(seedkeeper_utils, "UnexpectedSW12Error", FakeSW12Error)
+
+    connector = MagicMock()
+    connector.seedkeeper_get_status.side_effect = FakeSW12Error(
+        "Error while fetching SeedKeeper status: (error code 0x9c0f)"
+    )
+    secret_dic = {"header": "00" * 16, "secret_list": [0x01, 0x02]}
+
+    with pytest.raises(FakeSW12Error):
+        seedkeeper_utils.ensure_seedkeeper_capacity(connector, secret_dic)


### PR DESCRIPTION
Follow-up to the #413/#416 fix. Skipping the 0x6D00 capacity pre-check let the write actually reach the card, which then answers **0x9C01 (`SW_NO_MEMORY_LEFT`)** on a full card. The reporter on #413 sees that as the raw pysatochip string:

> Unexpected error during secure secret import (error code 0x9c01)

(pysatochip says "secure secret import" on *every* import failure, plaintext included.)

## This is not a regression in what we send

`seedkeeper_import_secret` and `make_header` are **byte-identical** between pysatochip 0.6a — the fork used by `0.7.0+Satochip-Beta2`, which the reporter says worked — and the pinned 0.17.0. The APDU sequence and header layout are unchanged, so the dependency swap in 251a9c32 is not the cause. What did change on our side was the pre-flight `INS 0xA7` call added in 94ca0977, which the previous commit removed.

`INS 0xA7` arrived in SeedKeeper applet **v0.2**, so a 0x6D00 status answer means a **v1 applet**. v1 also has no `seedkeeper_reset_secret` (INS 0xA5) — as `ToolsSeedkeeperDeleteSecretView` already knows — so on those cards a full card **cannot** be freed by deleting a secret.

## The error mapping was broken twice over

Six handlers tried to detect a full card with:

```python
if e.sw1 == 0x6A and e.sw2 == 0x84:
    err_text = "Not enough space on Seedkeeper"
else:
    err_text = format_sw_error(e.sw1, e.sw2)
```

Both halves were wrong:

1. The applet returns **0x9C01**, not the ISO **0x6A84**.
2. `seedkeeper_import_secret` raises `UnexpectedSW12Error(message)` **without** sw1/sw2 (`CardConnector.py:2407`/`:2425`/`:2443`), and those default to `0x00`. So the branch never fired and every failure fell through to `format_sw_error(0x00, 0x00)` → *"Unknown status word: 0x0000"*.

Any `exc.sw1`/`exc.sw2` branch on that path is dead code; the status word only survives in the message text.

## Changes

- **`sw_from_exception()`** — prefers populated `sw1`/`sw2`, otherwise recovers the status word from the message.
- **`describe_seedkeeper_error()`** — maps 0x9C01 to a space message, and on a v1 applet says a factory reset is required rather than suggesting a delete the card cannot do. Applied at all **13** Seedkeeper write/delete/status sites, including the several that showed a bare `str(e)` and one that showed a detail-free `"Password Import Failed"` with no error at all.
- **ISO7816 table** — added the proprietary `0x9Cxx` applet status words.
- **`ensure_seedkeeper_capacity()`** — narrowed its catch. It swallowed *every* `UnexpectedSW12Error` as "unsupported status", silently turning real failures into "assume it fits". Unparseable status words stay lenient so #413-style cards keep working.
- **Pre-bound `Satochip_Connector`** in three views where it is assigned inside the `try` but is now referenced from the `except` handler, which would otherwise `NameError`.

### Unrelated live breakage fixed in passing

Two NDEF views guarded on `card_type != "Seedkeeper"`, but pysatochip sets `"SeedKeeper"` (capital K — as the same file's other comparison already spells it). NDEF save-to- and load-from-SeedKeeper therefore **always** bailed out with "Wrong Card".

## Testing

7 new tests in `tests/test_seedkeeper_descriptor.py`, covering status-word recovery from the message, the v1 vs v2 0x9C01 advice, and that a genuine status failure is re-raised rather than swallowed. They use a local `FakeSW12Error` because `tests/base.py` replaces the pysatochip modules with `MagicMock`s, so the real exception class is not a class under test.

Full suite: **1503 passed**. The 5 failures in `test_l10n.py` / `test_flows_l10n.py` are pre-existing — verified identical on pristine `origin/dev`.

New user-facing strings are wrapped in `_()` so they stay extractable, but they are new msgids with no catalog entries yet and want a translation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
