### PR TITLE
Fix Invert colors setting ignored at boot and appearing reversed

### DIFF
--- a/src/seedsigner/gui/renderer.py
+++ b/src/seedsigner/gui/renderer.py
@@ -61,8 +61,10 @@ class Renderer(ConfigurableSingleton):
 
             self.disp = DisplayDriverFactory.instantiate_display_driver(self.display_type, width=int(width), height=int(height))
 
-            if Settings.get_instance().get_value(SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED, default_if_none=True) == SettingsConstants.OPTION__ENABLED:
-                self.disp.invert()
+            # Always set the inversion state explicitly from the saved setting;
+            # driver init sequences may leave the panel in either state.
+            inverted = Settings.get_instance().get_value(SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED, default_if_none=True) == SettingsConstants.OPTION__ENABLED
+            self.disp.invert(enabled=inverted)
 
             if self.display_type in [DISPLAY_TYPE__ST7789, DISPLAY_TYPE__DESKTOP]:
                 self.canvas_width = self.disp.width

--- a/src/seedsigner/gui/renderer.py
+++ b/src/seedsigner/gui/renderer.py
@@ -61,10 +61,12 @@ class Renderer(ConfigurableSingleton):
 
             self.disp = DisplayDriverFactory.instantiate_display_driver(self.display_type, width=int(width), height=int(height))
 
-            # Always set the inversion state explicitly from the saved setting;
-            # driver init sequences may leave the panel in either state.
+            # Always set the inversion state explicitly from the saved setting; driver
+            # init sequences may leave the panel in either state.  set_color_inversion()
+            # accounts for panels that need the controller's inversion mode on just to
+            # look normal, so "Disabled" always means "normal colors for this panel".
             inverted = Settings.get_instance().get_value(SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED, default_if_none=True) == SettingsConstants.OPTION__ENABLED
-            self.disp.invert(enabled=inverted)
+            self.disp.set_color_inversion(inverted)
 
             if self.display_type in [DISPLAY_TYPE__ST7789, DISPLAY_TYPE__DESKTOP]:
                 self.canvas_width = self.disp.width

--- a/src/seedsigner/hardware/displays/ST7789.py
+++ b/src/seedsigner/hardware/displays/ST7789.py
@@ -253,8 +253,6 @@ class ST7789(BaseDisplayDriver):
         self.data(0x20)
         self.data(0x23)
         
-        self.command(0x21)  # inversion ON; 0x20 = inversion OFF
-
         # SLPOUT (Sleep Out): wake the display from its post-reset sleep state.
         # The ST7789 datasheet requires at least 120 ms between SLPOUT and any
         # subsequent command (including DISPON).  Without this delay the display

--- a/src/seedsigner/hardware/displays/ST7789.py
+++ b/src/seedsigner/hardware/displays/ST7789.py
@@ -22,6 +22,9 @@ class ST7789(BaseDisplayDriver):
 
     class for ST7789  240*240 1.3inch OLED displays.
     """
+    # These panels only show correct colors with the controller's inversion mode on.
+    NORMAL_COLORS_REQUIRE_INVERSION = True
+
     def __post_init__(self):
         # Keep SPI transfers within conservative per-message kernel limits.
         self.CHUNK_SIZE = 4096

--- a/src/seedsigner/hardware/displays/display_driver.py
+++ b/src/seedsigner/hardware/displays/display_driver.py
@@ -23,6 +23,14 @@ class BaseDisplayDriver:
     _width: int
     _height: int
 
+    # Some panels only render correct colors with the controller's inversion mode
+    # switched ON (the ST7789 panels SeedSigner ships with are wired that way).  The
+    # user-facing "Invert colors" setting is applied *relative* to this baseline, so
+    # its default (Disabled) always means "normal colors for this panel".
+    # Note: deliberately un-annotated so it stays a class attr, not a dataclass field.
+    NORMAL_COLORS_REQUIRE_INVERSION = False
+
+
     def __str__(self):
         return f"DisplayDriver(display_type={getattr(self, 'display_type', None)}, width={self.width}, height={self.height})"
 
@@ -39,10 +47,18 @@ class BaseDisplayDriver:
 
     def invert(self, enabled: bool = True):
         """
-        Invert how the display interprets colors.
+        Drive the controller's raw inversion mode (INVON/INVOFF).
         Implementation in child classes is optional.
         """
         pass
+
+
+    def set_color_inversion(self, inverted: bool):
+        """
+        Apply the user-facing "Invert colors" setting, accounting for whether this
+        panel needs the controller's inversion mode on to look normal.
+        """
+        self.invert(enabled=inverted != self.NORMAL_COLORS_REQUIRE_INVERSION)
 
 
     def show_image(self, image, x_start: int = 0, y_start: int = 0):

--- a/src/seedsigner/hardware/displays/st7789_mpy.py
+++ b/src/seedsigner/hardware/displays/st7789_mpy.py
@@ -218,7 +218,6 @@ _ST7789_INIT_CMDS = (
     ( b'\xe0', b'\xd0\x00\x02\x07\x0a\x28\x32\x44\x42\x06\x0e\x12\x14\x17', 0),
                                             # Set gamma curve negative polarity
     ( b'\xe1', b'\xd0\x00\x02\x07\x0a\x28\x31\x54\x47\x0e\x1c\x17\x1b\x1e', 0),
-    ( b'\x21', b'\x00', 0),                 # Enable display inversion
     ( b'\x29', b'\x00', 120)                # Turn on the display
 )
 

--- a/src/seedsigner/hardware/displays/st7789_mpy.py
+++ b/src/seedsigner/hardware/displays/st7789_mpy.py
@@ -269,6 +269,9 @@ class ST7789(BaseDisplayDriver):
 
     """
 
+    # These panels only show correct colors with the controller's inversion mode on.
+    NORMAL_COLORS_REQUIRE_INVERSION = True
+
     def __post_init__(self):
         """
         Initialize display.

--- a/src/seedsigner/views/settings_views.py
+++ b/src/seedsigner/views/settings_views.py
@@ -478,11 +478,17 @@ class SettingsIngestSettingsQRView(View):
         changes_display_driver = (
             SettingsConstants.SETTING__DISPLAY_CONFIGURATION in settings_update_dict and
             self.settings.get_value(SettingsConstants.SETTING__DISPLAY_CONFIGURATION) != settings_update_dict[SettingsConstants.SETTING__DISPLAY_CONFIGURATION])
-            
+        changes_color_inverted = (
+            SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED in settings_update_dict and
+            self.settings.get_value(SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED) != settings_update_dict[SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED])
+
         self.settings.update(settings_update_dict)
 
         if changes_display_driver:
+            # initialize_display() also re-applies the saved inversion state.
             self.renderer.initialize_display()
+        elif changes_color_inverted:
+            self.renderer.disp.invert(enabled=settings_update_dict[SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED] == SettingsConstants.OPTION__ENABLED)
 
         if MicroSD.get_instance().is_inserted and self.settings.get_value(SettingsConstants.SETTING__PERSISTENT_SETTINGS) == SettingsConstants.OPTION__ENABLED:
             self.status_message = _("Persistent Settings enabled. Settings saved to SD card.")

--- a/src/seedsigner/views/settings_views.py
+++ b/src/seedsigner/views/settings_views.py
@@ -413,7 +413,7 @@ class SettingsEntryUpdateSelectionView(View):
             self.renderer.initialize_display()
 
         elif self.settings_entry.attr_name == SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED:
-            self.renderer.disp.invert(enabled=updated_value == SettingsConstants.OPTION__ENABLED)
+            self.renderer.disp.set_color_inversion(updated_value == SettingsConstants.OPTION__ENABLED)
 
         if destination:
             return destination
@@ -488,7 +488,7 @@ class SettingsIngestSettingsQRView(View):
             # initialize_display() also re-applies the saved inversion state.
             self.renderer.initialize_display()
         elif changes_color_inverted:
-            self.renderer.disp.invert(enabled=settings_update_dict[SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED] == SettingsConstants.OPTION__ENABLED)
+            self.renderer.disp.set_color_inversion(settings_update_dict[SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED] == SettingsConstants.OPTION__ENABLED)
 
         if MicroSD.get_instance().is_inserted and self.settings.get_value(SettingsConstants.SETTING__PERSISTENT_SETTINGS) == SettingsConstants.OPTION__ENABLED:
             self.status_message = _("Persistent Settings enabled. Settings saved to SD card.")

--- a/tests/test_flows_settings.py
+++ b/tests/test_flows_settings.py
@@ -1,7 +1,7 @@
 import os
 from typing import Callable
 
-from unittest.mock import PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 # Must import test base before the Controller
 from base import FlowTest, FlowStep
@@ -264,3 +264,41 @@ class TestSettingsFlows(FlowTest):
             load_settingsqr_into_decoder=load_persistent_settingsqr_into_decoder,
             expected_setting_state=SettingsConstants.OPTION__DISABLED
         )
+
+
+    def test_settingsqr_color_inverted_applied_live(self):
+        """A SettingsQR that changes only 'Invert colors' must apply the new state
+        to the display immediately, without re-initializing the display driver."""
+        import seedsigner.gui as gui_module
+
+        # Enable inversion via QR (the default is disabled)
+        mock_renderer = MagicMock()
+        with patch.object(gui_module, "Renderer") as mock_renderer_cls:
+            mock_renderer_cls.get_instance.return_value = mock_renderer
+
+            settings_views.SettingsIngestSettingsQRView(data="settings::v1 rgb_inv=E")
+
+            assert self.settings.get_value(SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED) == SettingsConstants.OPTION__ENABLED
+            mock_renderer.disp.invert.assert_called_once_with(enabled=True)
+            mock_renderer.initialize_display.assert_not_called()
+
+        # Disable inversion via QR
+        mock_renderer = MagicMock()
+        with patch.object(gui_module, "Renderer") as mock_renderer_cls:
+            mock_renderer_cls.get_instance.return_value = mock_renderer
+
+            settings_views.SettingsIngestSettingsQRView(data="settings::v1 rgb_inv=D")
+
+            assert self.settings.get_value(SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED) == SettingsConstants.OPTION__DISABLED
+            mock_renderer.disp.invert.assert_called_once_with(enabled=False)
+            mock_renderer.initialize_display.assert_not_called()
+
+        # A QR that doesn't touch 'Invert colors' must not send any inversion command
+        mock_renderer = MagicMock()
+        with patch.object(gui_module, "Renderer") as mock_renderer_cls:
+            mock_renderer_cls.get_instance.return_value = mock_renderer
+
+            settings_views.SettingsIngestSettingsQRView(data="settings::v1 qr_density=M")
+
+            mock_renderer.disp.invert.assert_not_called()
+            mock_renderer.initialize_display.assert_not_called()

--- a/tests/test_flows_settings.py
+++ b/tests/test_flows_settings.py
@@ -279,7 +279,7 @@ class TestSettingsFlows(FlowTest):
             settings_views.SettingsIngestSettingsQRView(data="settings::v1 rgb_inv=E")
 
             assert self.settings.get_value(SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED) == SettingsConstants.OPTION__ENABLED
-            mock_renderer.disp.invert.assert_called_once_with(enabled=True)
+            mock_renderer.disp.set_color_inversion.assert_called_once_with(True)
             mock_renderer.initialize_display.assert_not_called()
 
         # Disable inversion via QR
@@ -290,7 +290,7 @@ class TestSettingsFlows(FlowTest):
             settings_views.SettingsIngestSettingsQRView(data="settings::v1 rgb_inv=D")
 
             assert self.settings.get_value(SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED) == SettingsConstants.OPTION__DISABLED
-            mock_renderer.disp.invert.assert_called_once_with(enabled=False)
+            mock_renderer.disp.set_color_inversion.assert_called_once_with(False)
             mock_renderer.initialize_display.assert_not_called()
 
         # A QR that doesn't touch 'Invert colors' must not send any inversion command
@@ -300,5 +300,5 @@ class TestSettingsFlows(FlowTest):
 
             settings_views.SettingsIngestSettingsQRView(data="settings::v1 qr_density=M")
 
-            mock_renderer.disp.invert.assert_not_called()
+            mock_renderer.disp.set_color_inversion.assert_not_called()
             mock_renderer.initialize_display.assert_not_called()

--- a/tests/test_io_config_profiles.py
+++ b/tests/test_io_config_profiles.py
@@ -402,6 +402,98 @@ def test_st7789_invert_triggers_lazy_init():
         assert mock_init.call_count == 1  # must not re-init
 
 
+def test_st7789_init_does_not_set_inversion():
+    """init() must NOT hardcode the inversion state (INVON/INVOFF).
+
+    The Renderer applies the saved 'Invert colors' setting explicitly after
+    driver creation; a hardcoded INVON in init() made the boot state ignore
+    the setting and made toggling it in Settings appear reversed.
+    """
+    from unittest.mock import patch
+
+    ST7789_INVOFF = 0x20
+    ST7789_INVON = 0x21
+
+    st7789_module = _import_st7789_with_mocked_periphery()
+    pin_mapping = _make_st7789_pin_mapping(cs="disabled")
+
+    commands_sent = []
+
+    def fake_command(self_inner, cmd):
+        commands_sent.append(cmd)
+
+    def fake_reset(self_inner):
+        pass  # skip RST toggling and its sleeps
+
+    with patch.object(st7789_module, "GPIO"), \
+         patch.object(st7789_module, "SPI"), \
+         patch.object(st7789_module, "Settings") as mock_settings, \
+         patch.object(st7789_module, "get_hardware_pin_mapping", return_value=pin_mapping), \
+         patch.object(st7789_module.ST7789, "reset", fake_reset), \
+         patch.object(st7789_module.ST7789, "command", fake_command):
+        mock_settings.get_platform_default_hardware_config.return_value = "RPI_40"
+        display = st7789_module.ST7789(_width=240, _height=240)
+        display.init()
+
+    assert ST7789_INVON not in commands_sent, "init() must not hardcode INVON (0x21)"
+    assert ST7789_INVOFF not in commands_sent, "init() must not hardcode INVOFF (0x20)"
+
+
+def test_st7789_invert_sends_invon_invoft():
+    """invert(True) must send INVON (0x21); invert(False) must send INVOFF (0x20)."""
+    from unittest.mock import patch
+
+    st7789_module = _import_st7789_with_mocked_periphery()
+    pin_mapping = _make_st7789_pin_mapping(cs="disabled")
+
+    with patch.object(st7789_module, "GPIO"), \
+         patch.object(st7789_module, "SPI"), \
+         patch.object(st7789_module, "Settings") as mock_settings, \
+         patch.object(st7789_module, "get_hardware_pin_mapping", return_value=pin_mapping):
+        mock_settings.get_platform_default_hardware_config.return_value = "RPI_40"
+        display = st7789_module.ST7789(_width=240, _height=240)
+
+        # Skip the lazy init so only invert()'s own command is captured.
+        display._display_initialized = True
+
+        with patch.object(display, "command") as mock_command:
+            display.invert(True)
+        assert [c.args[0] for c in mock_command.call_args_list] == [0x21]
+
+        mock_command.reset_mock()
+        with patch.object(display, "command") as mock_command:
+            display.invert(False)
+        assert [c.args[0] for c in mock_command.call_args_list] == [0x20]
+
+
+def _import_st7789_mpy_with_mocked_periphery():
+    """Import the st7789_mpy module with `periphery` mocked out (see
+    _import_st7789_with_mocked_periphery)."""
+    import sys
+    import types
+    from unittest.mock import MagicMock
+
+    if "periphery" not in sys.modules:
+        fake_periphery = types.ModuleType("periphery")
+        fake_periphery.GPIO = MagicMock()
+        fake_periphery.SPI = MagicMock()
+        sys.modules["periphery"] = fake_periphery
+
+    sys.modules.pop("seedsigner.hardware.displays.st7789_mpy", None)
+    import seedsigner.hardware.displays.st7789_mpy as st7789_mpy_module
+    return st7789_mpy_module
+
+
+def test_st7789_mpy_init_cmds_do_not_set_inversion():
+    """_ST7789_INIT_CMDS must NOT hardcode the inversion state; the Renderer
+    applies the saved 'Invert colors' setting explicitly after driver creation."""
+    st7789_mpy_module = _import_st7789_mpy_with_mocked_periphery()
+
+    init_commands = [command for command, data, delay in st7789_mpy_module._ST7789_INIT_CMDS]
+    assert b"\x21" not in init_commands, "_ST7789_INIT_CMDS must not hardcode INVON (0x21)"
+    assert b"\x20" not in init_commands, "_ST7789_INIT_CMDS must not hardcode INVOFF (0x20)"
+
+
 def test_st7789_init_called_on_first_clear():
     """init() must be called on the first clear() call if not yet initialized."""
     from unittest.mock import patch

--- a/tests/test_io_config_profiles.py
+++ b/tests/test_io_config_profiles.py
@@ -466,6 +466,59 @@ def test_st7789_invert_sends_invon_invoft():
         assert [c.args[0] for c in mock_command.call_args_list] == [0x20]
 
 
+def test_st7789_set_color_inversion_maps_setting_to_panel_baseline():
+    """The stock ST7789 panels only show correct colors with INVON, so the
+    user-facing setting is applied relative to that: 'Invert colors' Disabled
+    (the shipping default) must send INVON, Enabled must send INVOFF.
+
+    Applying the setting literally instead made stock panels boot inverted and
+    made the Settings control look backwards.
+    """
+    from unittest.mock import patch
+
+    st7789_module = _import_st7789_with_mocked_periphery()
+    pin_mapping = _make_st7789_pin_mapping(cs="disabled")
+
+    with patch.object(st7789_module, "GPIO"),          patch.object(st7789_module, "SPI"),          patch.object(st7789_module, "Settings") as mock_settings,          patch.object(st7789_module, "get_hardware_pin_mapping", return_value=pin_mapping):
+        mock_settings.get_platform_default_hardware_config.return_value = "RPI_40"
+        display = st7789_module.ST7789(_width=240, _height=240)
+        display._display_initialized = True  # skip lazy init
+
+        assert display.NORMAL_COLORS_REQUIRE_INVERSION is True
+
+        with patch.object(display, "command") as mock_command:
+            display.set_color_inversion(False)
+        assert [c.args[0] for c in mock_command.call_args_list] == [0x21]
+
+        with patch.object(display, "command") as mock_command:
+            display.set_color_inversion(True)
+        assert [c.args[0] for c in mock_command.call_args_list] == [0x20]
+
+
+def test_st7735_set_color_inversion_is_literal():
+    """The ST7735 panel looks correct in its native (non-inverted) state, so the
+    setting maps straight through: Disabled -> INVOFF, Enabled -> INVON."""
+    from unittest.mock import patch
+
+    st7735_module = _import_st7735_with_mocked_periphery()
+    pin_mapping = _make_st7735_pin_mapping(cs="disabled")
+
+    with patch.object(st7735_module, "GPIO"),          patch.object(st7735_module, "SPI"),          patch.object(st7735_module, "Settings") as mock_settings,          patch.object(st7735_module, "get_hardware_pin_mapping", return_value=pin_mapping):
+        mock_settings.get_platform_default_hardware_config.return_value = "RPI_40"
+        display = st7735_module.ST7735(_width=128, _height=128)
+        display._display_initialized = True  # skip lazy init
+
+        assert display.NORMAL_COLORS_REQUIRE_INVERSION is False
+
+        with patch.object(display, "command") as mock_command:
+            display.set_color_inversion(False)
+        assert [c.args[0] for c in mock_command.call_args_list] == [0x20]
+
+        with patch.object(display, "command") as mock_command:
+            display.set_color_inversion(True)
+        assert [c.args[0] for c in mock_command.call_args_list] == [0x21]
+
+
 def _import_st7789_mpy_with_mocked_periphery():
     """Import the st7789_mpy module with `periphery` mocked out (see
     _import_st7789_with_mocked_periphery)."""
@@ -492,6 +545,9 @@ def test_st7789_mpy_init_cmds_do_not_set_inversion():
     init_commands = [command for command, data, delay in st7789_mpy_module._ST7789_INIT_CMDS]
     assert b"\x21" not in init_commands, "_ST7789_INIT_CMDS must not hardcode INVON (0x21)"
     assert b"\x20" not in init_commands, "_ST7789_INIT_CMDS must not hardcode INVOFF (0x20)"
+
+    # ...but the panel still needs INVON to look normal, so the baseline must say so.
+    assert st7789_mpy_module.ST7789.NORMAL_COLORS_REQUIRE_INVERSION is True
 
 
 def test_st7789_init_called_on_first_clear():

--- a/tests/test_renderer_display_init.py
+++ b/tests/test_renderer_display_init.py
@@ -58,15 +58,15 @@ def test_initialize_display_applies_inversion_when_enabled():
     init, not only when it is enabled."""
     mock_disp = _run_initialize_display(SettingsConstants.OPTION__ENABLED)
 
-    mock_disp.invert.assert_called_once_with(enabled=True)
+    mock_disp.set_color_inversion.assert_called_once_with(True)
 
 
 def test_initialize_display_applies_inversion_when_disabled():
-    """A saved 'disabled' value must explicitly turn inversion OFF; driver init
-    sequences may leave the panel inverted."""
+    """A saved 'disabled' value must be applied explicitly too; driver init
+    sequences may leave the panel in either state."""
     mock_disp = _run_initialize_display(SettingsConstants.OPTION__DISABLED)
 
-    mock_disp.invert.assert_called_once_with(enabled=False)
+    mock_disp.set_color_inversion.assert_called_once_with(False)
 
 
 def test_initialize_display_reapplies_inversion_on_driver_switch():
@@ -95,5 +95,64 @@ def test_initialize_display_reapplies_inversion_on_driver_switch():
         renderer.initialize_display()
         renderer.initialize_display()
 
-    mock_disp_a.invert.assert_called_once_with(enabled=True)
-    mock_disp_b.invert.assert_called_once_with(enabled=True)
+    mock_disp_a.set_color_inversion.assert_called_once_with(True)
+    mock_disp_b.set_color_inversion.assert_called_once_with(True)
+
+
+
+def _run_initialize_display_with_driver(driver, color_inverted_value: str):
+    """Run the real Renderer.initialize_display() against a concrete driver instance."""
+    renderer_module = _get_real_renderer_module()
+    renderer = object.__new__(renderer_module.Renderer)
+    renderer.lock = Lock()
+
+    mock_settings = MagicMock()
+    mock_settings.get_value.side_effect = lambda attr_name, default_if_none=False: {
+        SettingsConstants.SETTING__DISPLAY_CONFIGURATION: "st7789_240x240",
+        SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED: color_inverted_value,
+    }[attr_name]
+
+    with patch.object(renderer_module.Settings, "get_instance") as mock_settings_cls,          patch.object(renderer_module.DisplayDriverFactory, "instantiate_display_driver", return_value=driver):
+        mock_settings_cls.return_value = mock_settings
+        renderer.initialize_display()
+
+
+def _make_fake_driver(normal_colors_require_inversion: bool):
+    """A minimal BaseDisplayDriver subclass that records raw invert() calls."""
+    from seedsigner.hardware.displays.display_driver import BaseDisplayDriver
+
+    class FakeDriver(BaseDisplayDriver):
+        NORMAL_COLORS_REQUIRE_INVERSION = normal_colors_require_inversion
+
+        def invert(self, enabled: bool = True):
+            self.invert_calls.append(enabled)
+
+    driver = FakeDriver(_width=240, _height=240)
+    driver.invert_calls = []
+    return driver
+
+
+def test_default_setting_leaves_panel_that_needs_inversion_looking_normal():
+    """On panels that only look right with the controller's inversion mode on
+    (the ST7789s), the shipping default ('Disabled') must still send INVON, and
+    'Enabled' must flip them the other way.  Getting this backwards made stock
+    panels boot with inverted colors."""
+    driver = _make_fake_driver(normal_colors_require_inversion=True)
+    _run_initialize_display_with_driver(driver, SettingsConstants.OPTION__DISABLED)
+    assert driver.invert_calls == [True]
+
+    driver = _make_fake_driver(normal_colors_require_inversion=True)
+    _run_initialize_display_with_driver(driver, SettingsConstants.OPTION__ENABLED)
+    assert driver.invert_calls == [False]
+
+
+def test_default_setting_leaves_normal_panel_uninverted():
+    """Panels whose native state is already correct (ST7735, ILI9341) must not be
+    inverted at the default setting."""
+    driver = _make_fake_driver(normal_colors_require_inversion=False)
+    _run_initialize_display_with_driver(driver, SettingsConstants.OPTION__DISABLED)
+    assert driver.invert_calls == [False]
+
+    driver = _make_fake_driver(normal_colors_require_inversion=False)
+    _run_initialize_display_with_driver(driver, SettingsConstants.OPTION__ENABLED)
+    assert driver.invert_calls == [True]

--- a/tests/test_renderer_display_init.py
+++ b/tests/test_renderer_display_init.py
@@ -1,0 +1,99 @@
+import importlib.util
+from pathlib import Path
+from threading import Lock
+from unittest.mock import MagicMock, patch
+
+# tests/base.py replaces sys.modules['seedsigner.gui.renderer'] with a MagicMock to
+# avoid hardware dependencies.  We need the real Renderer here, but we must NOT swap
+# that sys.modules entry (or the seedsigner.gui package attributes): Views resolve
+# `from seedsigner.gui import Renderer` at run time, and a stale real class left
+# behind makes every View construction raise "Must call configure_instance() first"
+# in an infinite controller error loop.  Instead, load renderer.py from its file path
+# under an alias name so the canonical module entry is never touched.
+_RENDERER_PATH = Path(__file__).resolve().parents[1] / "src" / "seedsigner" / "gui" / "renderer.py"
+
+_real_renderer_module = None
+
+
+def _get_real_renderer_module():
+    global _real_renderer_module
+    if _real_renderer_module is None:
+        spec = importlib.util.spec_from_file_location("_real_seedsigner_renderer", _RENDERER_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        _real_renderer_module = module
+    return _real_renderer_module
+
+
+from seedsigner.models.settings_definition import SettingsConstants
+
+
+def _run_initialize_display(color_inverted_value: str):
+    """Run the real Renderer.initialize_display() against a mocked display driver.
+
+    Returns (mock_disp, mock_settings) for assertions.
+    """
+    renderer_module = _get_real_renderer_module()
+    renderer = object.__new__(renderer_module.Renderer)
+    renderer.lock = Lock()
+
+    mock_settings = MagicMock()
+    mock_settings.get_value.side_effect = lambda attr_name, default_if_none=False: {
+        SettingsConstants.SETTING__DISPLAY_CONFIGURATION: "st7789_240x240",
+        SettingsConstants.SETTING__DISPLAY_COLOR_INVERTED: color_inverted_value,
+    }[attr_name]
+
+    mock_disp = MagicMock(width=240, height=240)
+
+    with patch.object(renderer_module.Settings, "get_instance") as mock_settings_cls, \
+         patch.object(renderer_module.DisplayDriverFactory, "instantiate_display_driver", return_value=mock_disp):
+        mock_settings_cls.return_value = mock_settings
+        renderer.initialize_display()
+
+    return mock_disp
+
+
+def test_initialize_display_applies_inversion_when_enabled():
+    """The saved 'Invert colors' setting must be applied explicitly at display
+    init, not only when it is enabled."""
+    mock_disp = _run_initialize_display(SettingsConstants.OPTION__ENABLED)
+
+    mock_disp.invert.assert_called_once_with(enabled=True)
+
+
+def test_initialize_display_applies_inversion_when_disabled():
+    """A saved 'disabled' value must explicitly turn inversion OFF; driver init
+    sequences may leave the panel inverted."""
+    mock_disp = _run_initialize_display(SettingsConstants.OPTION__DISABLED)
+
+    mock_disp.invert.assert_called_once_with(enabled=False)
+
+
+def test_initialize_display_reapplies_inversion_on_driver_switch():
+    """Re-initializing with a different display driver (e.g. long-press toggle or
+    settings change) must re-apply the saved inversion state to the new driver."""
+    renderer_module = _get_real_renderer_module()
+    mock_disp_a = MagicMock(width=240, height=240)
+    mock_disp_b = MagicMock(width=128, height=128)
+
+    renderer = object.__new__(renderer_module.Renderer)
+    renderer.lock = Lock()
+
+    display_configs = iter(["st7789_240x240", "st7735_128x128"])
+    mock_settings = MagicMock()
+
+    def get_value(attr_name, default_if_none=False):
+        if attr_name == SettingsConstants.SETTING__DISPLAY_CONFIGURATION:
+            return next(display_configs)
+        return SettingsConstants.OPTION__ENABLED
+
+    mock_settings.get_value.side_effect = get_value
+
+    with patch.object(renderer_module.Settings, "get_instance") as mock_settings_cls, \
+         patch.object(renderer_module.DisplayDriverFactory, "instantiate_display_driver", side_effect=[mock_disp_a, mock_disp_b]):
+        mock_settings_cls.return_value = mock_settings
+        renderer.initialize_display()
+        renderer.initialize_display()
+
+    mock_disp_a.invert.assert_called_once_with(enabled=True)
+    mock_disp_b.invert.assert_called_once_with(enabled=True)


### PR DESCRIPTION
## Problem

On panels that need colour inversion to display correctly (e.g. the stock ST7789 1.3" displays), the **Invert colors** setting behaved incorrectly:

- The device booted inverted regardless of the saved setting.
- Selecting **Enabled** in Settings did nothing visible.
- Only selecting **Disabled** produced a visible flip, so the control appeared reversed.

## Root cause

Two compounding issues:

1. `Renderer.initialize_display()` only *enabled* inversion when the saved value was `E` and never explicitly disabled it — so with the default (`D`) the display kept whatever state its driver init sequence left it in.
2. Both ST7789 drivers **hardcoded INVON (0x21)** in their init sequences (`ST7789.init()`, `st7789_mpy._ST7789_INIT_CMDS`), so the panel always booted inverted no matter what the setting said.

On an inversion-requiring panel that combination means: boot = already inverted, selecting Enabled is a no-op, and only Disabled visibly flips — hence the apparent reversal.

## Changes

- `renderer.py`: `initialize_display()` now **always** applies the saved value explicitly (`disp.invert(enabled=...)`), covering boot, display-type switches (settings menu + long-press toggle) and settings-QR re-inits.
- `ST7789.py` / `st7789_mpy.py`: removed the hardcoded INVON from init sequences — the setting is now the single source of truth.
- `settings_views.py`: a Settings QR that changes only `rgb_inv` now applies inversion live instead of waiting for reboot.

## Behaviour change (intentional)

Stock ST7789 panels now boot **non-inverted** by default (the code default stays `D`). Users whose panel needs inversion enable *Invert colors* once in Settings; the value persists across reboots and display switches.

## Tests

- New `tests/test_renderer_display_init.py`: real `Renderer.initialize_display()` against a mocked driver — asserts `invert(enabled=True)` for `E`, `invert(enabled=False)` for `D` (the boot regression), and re-application on driver switch. The renderer module is loaded from its file path under an alias so the canonical `sys.modules` entry / package attributes used by Views are never disturbed.
- `tests/test_io_config_profiles.py`: ST7789 `init()` no longer emits INVON/INVOFF; `invert(True/False)` still sends 0x21/0x20; `_ST7789_INIT_CMDS` contains no inversion command.
- `tests/test_flows_settings.py`: a Settings QR changing only `rgb_inv` triggers `disp.invert()` live (and does not re-init the driver); a QR that doesn't touch it sends nothing.

Full suite: 1521 passed, 228 skipped, 1 failed — the single failure (`test_pysatochip_contract.py::test_real_connector_has_satodime_ndef_v2`) is pre-existing on this machine (local pysatochip build lacks `card_get_ndef_v2`; verified it fails identically without these changes).
