### PR TITLE
Satochip: gate Enable 2FA behind confirmations; back on QR cancels before write

### DIFF
--- a/src/seedsigner/gui/screens/screen.py
+++ b/src/seedsigner/gui/screens/screen.py
@@ -890,6 +890,11 @@ class LargeButtonScreen(BaseTopNavScreen):
 class QRDisplayScreen(BaseScreen):
     qr_encoder: BaseQrEncoder = None
 
+    # When True, exiting via the back key returns RET_CODE__BACK_BUTTON instead of
+    # None, so a View can treat "back" as cancellation. Off by default to preserve
+    # the existing "any input exits" contract for all other callers.
+    cancel_on_back: bool = False
+
     class QRDisplayThread(BaseThread):
         def __init__(self, qr_encoder: BaseQrEncoder, qr_brightness: ThreadsafeCounter, tips_start_time: ThreadsafeCounter):
             from seedsigner.gui.renderer import Renderer
@@ -1032,6 +1037,7 @@ class QRDisplayScreen(BaseScreen):
     def _run(self):
         from seedsigner.models.settings import Settings
 
+        exit_input = None
         while True:
             user_input = self.hw_inputs.wait_for(
                 [
@@ -1048,17 +1054,21 @@ class QRDisplayScreen(BaseScreen):
 
             elif user_input == HardwareButtonsConstants.KEY_UP:
                 # Incrase QR code background brightness
-                self.qr_brightness.set_value(min(self.qr_brightness.cur_count + 31, 255))
+                self.qr_brightness.set_value(min(255, self.qr_brightness.cur_count + 31))
                 self.tips_start_time.set_value(time.time_ns())
 
             else:
                 # Any other input exits the screen
+                exit_input = user_input
                 self.threads[-1].stop()
                 while self.threads[-1].is_alive():
                     time.sleep(0.01)
                 break
 
         Settings.get_instance().set_value(SettingsConstants.SETTING__QR_BRIGHTNESS, self.qr_brightness.cur_count)
+
+        if self.cancel_on_back and exit_input == HardwareButtonsConstants.KEY_LEFT:
+            return RET_CODE__BACK_BUTTON
 
 
 

--- a/src/seedsigner/helpers/seedkeeper_utils.py
+++ b/src/seedsigner/helpers/seedkeeper_utils.py
@@ -74,6 +74,27 @@ def show_incorrect_pin_warning(parent_view, connector=None, sw1: int | None = No
     )
 
 
+def satochip_2fa_blocks_signing(parent_view, connector) -> bool:
+    """Show a warning and return True if signing must be refused because the card has 2FA enabled.
+
+    ``init_satochip()`` already calls ``card_get_status()``, which populates
+    ``needs_2FA`` on pysatochip connectors (True when status byte 8 is non-zero).
+    The keycard backend connector has no such attribute and older connectors may
+    leave it unset, so a falsy default keeps this safe for all of them.
+    """
+    if not getattr(connector, "needs_2FA", False):
+        return False
+
+    parent_view.run_screen(
+        WarningScreen,
+        title=_("2FA Enabled"),
+        status_headline=None,
+        text=_("Signing while 2FA is enabled\nis not currently supported."),
+        show_back_button=False,
+    )
+    return True
+
+
 def _requested_satochip_flow(init_card_filter) -> bool:
     if init_card_filter is None:
         return False

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -181,6 +181,10 @@ class PSBTSelectSeedView(View):
             if not connector:
                 return Destination(PSBTSelectSeedView, clear_history=True)
 
+            # A card with 2FA enabled cannot sign from SeedSigner (no phone-app code flow).
+            if seedkeeper_utils.satochip_2fa_blocks_signing(self, connector):
+                return Destination(PSBTSelectSeedView, clear_history=True)
+
             psbt = self.controller.psbt
             is_multisig_psbt = False
             try:

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -224,6 +224,11 @@ class SeedSelectSeedView(View):
             connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
             if not connector:
                 return Destination(BackStackView)
+
+            # A card with 2FA enabled cannot sign from SeedSigner (no phone-app code flow).
+            if seedkeeper_utils.satochip_2fa_blocks_signing(self, connector):
+                return Destination(BackStackView)
+
             self.controller.sign_message_with_satochip = True
             self.controller.sign_message_data["seed"] = None
             return Destination(SeedSignMessageConfirmMessageView)

--- a/src/seedsigner/views/smartcard_views.py
+++ b/src/seedsigner/views/smartcard_views.py
@@ -3761,52 +3761,86 @@ class ToolsSatochipImportSeedView(View):
 class ToolsSatochipEnable2FAView(View):
     def run(self):
         from os import urandom
-        import binascii
-        from seedsigner.gui.screens.screen import LoadingScreenThread
-        key = urandom(20)
-        # Avoid logging the 2FA key value
-        logger.info("2FA key generated")
+        from seedsigner.gui.screens.screen import LoadingScreenThread, QRDisplayScreen
+        from seedsigner.models.encode_qr import GenericStaticQrEncoder
 
         Satochip_Connector = seedkeeper_utils.init_satochip(self, init_card_filter=["satochip"])
 
         if not Satochip_Connector:
             return Destination(BackStackView)
-        
+
+        # init_satochip() already called card_get_status(), which populates needs_2FA.
+        if getattr(Satochip_Connector, "needs_2FA", False):
+            self.run_screen(
+                WarningScreen,
+                title="Already Enabled",
+                status_headline=None,
+                text="2FA is already enabled on this card.",
+                show_back_button=False,
+            )
+            return Destination(BackStackView)
+
+        # Enabling 2FA cannot be undone from SeedSigner (there is no UI for
+        # card_reset_2FA_key), so require an explicit confirmation with the lockout
+        # risk spelled out before generating or writing any key.
+        confirm = self.run_screen(
+            WarningScreen,
+            title="Enable 2FA?",
+            status_headline=None,
+            text="Signing will require a code from your phone app. Losing it can lock you out.",
+            show_back_button=False,
+            button_data=[ButtonOption("Enable"), ButtonOption("Cancel")],
+        )
+        if confirm != 0:
+            return Destination(BackStackView)
+
+        key = urandom(20)
+        # Avoid logging the 2FA key value
+        logger.info("2FA key generated")
+
         try:
             self.run_screen(
                 WarningScreen,
                 title="Warning",
                 status_headline=None,
-                text=f"Scan the following QR code with the Satochip 2FA app before proceeding (You will not see this code again...)",
+                text="Scan with the Satochip 2FA app before proceeding.\nYou will not see this code again.",
                 show_back_button=False,
             )
-            from seedsigner.gui.screens.screen import QRDisplayScreen
-            from seedsigner.models.encode_qr import GenericStaticQrEncoder
 
             qr_encoder = GenericStaticQrEncoder(data=binascii.hexlify(key).decode())
 
-            self.run_screen(
+            # Back on the QR screen aborts before anything is written to the card.
+            if self.run_screen(
                 QRDisplayScreen,
                 qr_encoder=qr_encoder,
+                cancel_on_back=True,
+            ) == RET_CODE__BACK_BUTTON:
+                return self._show_2fa_cancelled()
+
+            # Final gate immediately before the irreversible write.
+            confirm = self.run_screen(
+                WarningScreen,
+                title="Confirm",
+                status_headline=None,
+                text="You scanned the pairing code. Enable 2FA on this card?",
+                show_back_button=False,
+                button_data=[ButtonOption("Enable"), ButtonOption("Cancel")],
             )
+            if confirm != 0:
+                return self._show_2fa_cancelled()
 
-            self.loading_screen = LoadingScreenThread(text="Enabling 2FA\n\n\n\n\n\n")
-            self.loading_screen.start()
-
-            Satochip_Connector.card_set_2FA_key(key, 0)
-
-            self.loading_screen.stop()
+            with LoadingScreenThread(text="Enabling 2FA\n\n\n\n\n\n"):
+                Satochip_Connector.card_set_2FA_key(key, 0)
 
             logger.info("Success: 2FA Key Imported and Enabled")
             self.run_screen(
                 LargeIconStatusScreen,
                 title="Success",
                 status_headline=None,
-                text=f"2FA Enabled",
+                text="2FA Enabled",
                 show_back_button=False,
             )
         except Exception as e:
-            self.loading_screen.stop()
             logger.info("Enable 2fa failed:", str(e))
             self.run_screen(
                 WarningScreen,
@@ -3816,6 +3850,16 @@ class ToolsSatochipEnable2FAView(View):
                 show_back_button=False,
             )
 
+        return Destination(BackStackView)
+
+    def _show_2fa_cancelled(self):
+        self.run_screen(
+            WarningScreen,
+            title="Cancelled",
+            status_headline=None,
+            text="2FA was not enabled. Remove the code from your phone app if you added it.",
+            show_back_button=False,
+        )
         return Destination(BackStackView)
 
 

--- a/tests/test_flows_menu_navigation.py
+++ b/tests/test_flows_menu_navigation.py
@@ -697,6 +697,36 @@ class TestMenuNavigationFlows(FlowTest):
             FlowStep(ToolsSmartcardMenuView),
         ])
 
+    def test_smartcard_satochip_advanced_enable_2fa(self, monkeypatch):
+        """Tools → Smartcard → Satochip → Advanced → Enable 2FA → Cancel.
+
+        Exercises ToolsSatochipEnable2FAView.run() (which references the pysatochip
+        connector via init_satochip) and verifies cancelling at the first confirmation
+        returns to the Advanced menu without writing a key to the card.
+        """
+        from seedsigner.helpers import seedkeeper_utils
+        from seedsigner.views.smartcard_views import (
+            ToolsSmartcardMenuView, ToolsSatochipView, ToolsSatochipAdvancedView,
+            ToolsSatochipEnable2FAView,
+        )
+
+        class MockConnector:
+            needs_2FA = False
+            def card_set_2FA_key(self, *args):
+                raise AssertionError("card_set_2FA_key should not be called on cancel")
+
+        monkeypatch.setattr(seedkeeper_utils, "init_satochip", lambda *a, **k: MockConnector())
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.SMARTCARD),
+            FlowStep(ToolsSmartcardMenuView, button_data_selection=ToolsSmartcardMenuView.SATOCHIP),
+            FlowStep(ToolsSatochipView, button_data_selection=ToolsSatochipView.ADVANCED),
+            FlowStep(ToolsSatochipAdvancedView, button_data_selection=ToolsSatochipAdvancedView.ENABLE_2FA),
+            FlowStep(ToolsSatochipEnable2FAView, screen_return_value=1),  # "Cancel" at first confirmation
+            FlowStep(ToolsSatochipAdvancedView),
+        ])
+
     def test_smartcard_keycard(self):
         """Tools → Smartcard → KeyCard → BACK."""
         from seedsigner.views.smartcard_views import (

--- a/tests/test_flows_psbt.py
+++ b/tests/test_flows_psbt.py
@@ -321,6 +321,39 @@ class TestPSBTSatochip(FlowTest):
         assert controller.psbt_parser is None
         assert controller.psbt_sign_with_satochip is False
 
+    def test_satochip_2fa_enabled_blocks_signing(self, monkeypatch):
+        """A card with 2FA enabled should warn and return to selection without signing."""
+        from seedsigner.helpers import seedkeeper_utils
+
+        def load_psbt_into_decoder(view: scan_views.ScanView):
+            view.decoder.add_data(
+                "cHNidP8BAHECAAAAAX9/d6VyI7nvVTyhLBfqu05za2AJ2Z0dKMC0cUX+S2U7AQAAAAD9////AgeHAAAAAAAAFgAUOnNPuZMD1sQudt3+7LvHBUvGhyd//gAAAAAAABYAFGO9QLvu4V9/hz6ZjbIGMrqsEiIYAjQTAAABAR+ghgEAAAAAABYAFKawrgcT62jmIVQwyHPCV0thmJWbAQDBAQAAAAABAYeHL9UQlz/jEKUuNNY3LTeQRjudjBinsP2L0ppvgRt0AAAAAAD/////AnbP3rsPAAAAIlEgtgmCioGjfKwp6f8rOoI4OPb+ZV8db581J9IizZPskl2ghgEAAAAAABYAFKawrgcT62jmIVQwyHPCV0thmJWbAUDCBlMh9VjZN2NdU9Wabi0o3Ct1q9YHTsJRLAkLfUuIHB+BE+ucR4bdGAJG5nBhCWOmCXbpRwKP1INRYvkuQ2fHAAAAACIGA2+PEYHyVy6nhYwAx5SJKBIWXjsWgjhhf/2FEWqXgxnoEKNOC3gAAACAAAAAAAAAAAAAACICA0SBeeHxfHdny6rUnQJuteAnQ7shSydexjJCkSJarn3mEKNOC3gAAACAAQAAAAEAAAAA"
+            )
+
+        class MockConnector:
+            needs_2FA = True
+
+        monkeypatch.setattr(seedkeeper_utils, "init_satochip", lambda *args, **kwargs: MockConnector())
+
+        controller = Controller.get_instance()
+        controller.storage.seeds = []
+        controller.psbt_parser = None
+        controller.psbt_sign_with_satochip = False
+        controller.Satochip_Connector = None
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_psbt_into_decoder),
+            # No seeds loaded -> index 0 is the SATOCHIP option. screen_return_value (not
+            # button_data_selection) because the View shows a second, non-button Screen
+            # (the 2FA warning) during this step.
+            FlowStep(psbt_views.PSBTSelectSeedView, screen_return_value=0),
+            FlowStep(psbt_views.PSBTSelectSeedView),
+        ])
+
+        assert controller.psbt_parser is None
+        assert controller.psbt_sign_with_satochip is False
+
 
 class TestPSBTMultisigDescriptorMismatch(BaseTest):
 

--- a/tests/test_satochip_2fa_signing_block.py
+++ b/tests/test_satochip_2fa_signing_block.py
@@ -1,0 +1,98 @@
+"""
+    Tests for the 2FA signing guard (satochip_2fa_blocks_signing).
+
+    A Satochip card with 2FA enabled cannot sign from SeedSigner (there is no
+    phone-app code flow), so both signing entry points refuse to continue and
+    show a warning instead. These tests cover:
+
+      * the helper itself (enabled / disabled / unset / attribute-missing connectors)
+      * message-signing flow: selecting "Use Satochip card" with a 2FA-enabled
+        card stops before the confirm screen
+
+    The PSBT signing variant of this guard is covered by
+    TestPSBTSatochip.test_satochip_2fa_enabled_blocks_signing in tests/test_flows_psbt.py.
+"""
+
+from unittest.mock import Mock
+
+from base import BaseTest
+
+
+class FakeView:
+    def __init__(self):
+        self.run_screen = Mock()
+
+
+class Connector:
+    def __init__(self, needs_2fa):
+        self.needs_2FA = needs_2fa
+
+
+def test_guard_blocks_signing_when_2fa_enabled():
+    from seedsigner.gui.screens.screen import WarningScreen
+    from seedsigner.helpers.seedkeeper_utils import satochip_2fa_blocks_signing
+
+    view = FakeView()
+
+    assert satochip_2fa_blocks_signing(view, Connector(needs_2fa=True)) is True
+
+    args, kwargs = view.run_screen.call_args
+    assert args[0] is WarningScreen
+    assert kwargs["title"] == "2FA Enabled"
+    assert "Signing while 2FA is enabled" in kwargs["text"]
+
+
+def test_guard_allows_signing_when_2fa_disabled():
+    from seedsigner.helpers.seedkeeper_utils import satochip_2fa_blocks_signing
+
+    view = FakeView()
+
+    assert satochip_2fa_blocks_signing(view, Connector(needs_2fa=False)) is False
+    view.run_screen.assert_not_called()
+
+
+def test_guard_allows_signing_when_needs_2fa_unset():
+    """pysatochip leaves needs_2FA as None until card_get_status() has run."""
+    from seedsigner.helpers.seedkeeper_utils import satochip_2fa_blocks_signing
+
+    view = FakeView()
+
+    assert satochip_2fa_blocks_signing(view, Connector(needs_2fa=None)) is False
+    view.run_screen.assert_not_called()
+
+
+def test_guard_allows_signing_when_attribute_missing():
+    """The keycard backend connector has no needs_2FA attribute at all."""
+    from seedsigner.helpers.seedkeeper_utils import satochip_2fa_blocks_signing
+
+    view = FakeView()
+
+    assert satochip_2fa_blocks_signing(view, object()) is False
+    view.run_screen.assert_not_called()
+
+
+class TestSatochipMessageSigning2FAGuard(BaseTest):
+
+    def test_select_satochip_with_2fa_card_stops_before_confirm(self, monkeypatch):
+        from seedsigner.controller import Controller
+        from seedsigner.helpers import seedkeeper_utils
+        from seedsigner.views import seed_views
+        from seedsigner.views.view import BackStackView
+
+        class MockConnector:
+            needs_2FA = True
+
+        monkeypatch.setattr(seedkeeper_utils, "init_satochip", lambda *args, **kwargs: MockConnector())
+
+        view = seed_views.SeedSelectSeedView(flow=Controller.FLOW__SIGN_MESSAGE)
+        # No seeds loaded -> button_data[0] is the SATOCHIP option; the warning
+        # screen's return value is ignored by the View.
+        view.run_screen = Mock(return_value=0)
+
+        destination = view.run()
+
+        assert destination.View_cls == BackStackView
+        assert self.controller.sign_message_with_satochip is False
+
+        args, kwargs = view.run_screen.call_args
+        assert kwargs["title"] == "2FA Enabled"

--- a/tests/test_satochip_enable_2fa.py
+++ b/tests/test_satochip_enable_2fa.py
@@ -1,0 +1,184 @@
+"""
+    Flow tests for ToolsSatochipEnable2FAView.
+
+    Enabling 2FA on a Satochip card is effectively irreversible from within SeedSigner
+    (nothing in the app calls card_reset_2FA_key), so the View gates the key write
+    behind two explicit confirmations and treats BACK on the pairing QR screen as
+    cancellation. These tests cover:
+
+      * cancel at the first confirmation -> nothing is written to the card
+      * full success path -> card_set_2FA_key called exactly once with a 20-byte key
+      * card already requires 2FA -> short-circuits before any key is generated
+      * (real Screens) BACK on the QR screen cancels before the write
+      * (real Screens) cancel at the final confirmation after scanning cancels before the write
+"""
+
+import pytest
+
+from base import FlowStep, FlowTest
+from ui_driver import UISession
+
+from seedsigner.helpers import seedkeeper_utils
+from seedsigner.views import tools_views
+from seedsigner.views.smartcard_views import (
+    ToolsSatochipAdvancedView,
+    ToolsSatochipEnable2FAView,
+    ToolsSatochipView,
+    ToolsSmartcardMenuView,
+)
+from seedsigner.views.view import MainMenuView
+
+
+class MockSatochipConnector:
+    """Spy stand-in for the pysatochip CardConnector used by the 2FA flow."""
+
+    def __init__(self, needs_2fa=False):
+        self.needs_2FA = needs_2fa
+        self.set_2fa_calls = []
+
+    def card_set_2FA_key(self, hmacsha160_key, amount_limit=0):
+        self.set_2fa_calls.append((hmacsha160_key, amount_limit))
+        return (b"", 0x90, 0x00)
+
+
+class TestSatochipEnable2FA(FlowTest):
+
+    def _mock_connector(self, monkeypatch, needs_2fa=False):
+        connector = MockSatochipConnector(needs_2fa=needs_2fa)
+        monkeypatch.setattr(seedkeeper_utils, "init_satochip", lambda *args, **kwargs: connector)
+        return connector
+
+    def _menu_steps(self):
+        return [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.SMARTCARD),
+            FlowStep(ToolsSmartcardMenuView, button_data_selection=ToolsSmartcardMenuView.SATOCHIP),
+            FlowStep(ToolsSatochipView, button_data_selection=ToolsSatochipView.ADVANCED),
+            FlowStep(ToolsSatochipAdvancedView, button_data_selection=ToolsSatochipAdvancedView.ENABLE_2FA),
+        ]
+
+    def test_cancel_at_first_confirmation_writes_nothing(self, monkeypatch):
+        connector = self._mock_connector(monkeypatch)
+
+        self.run_sequence([
+            *self._menu_steps(),
+            FlowStep(ToolsSatochipEnable2FAView, screen_return_value=1),  # "Cancel"
+            FlowStep(ToolsSatochipAdvancedView),
+        ])
+
+        assert connector.set_2fa_calls == []
+
+    def test_full_success_writes_key_once(self, monkeypatch):
+        connector = self._mock_connector(monkeypatch)
+
+        self.run_sequence([
+            *self._menu_steps(),
+            # 0 selects "Enable" on both confirmations; the QR screen's return value is ignored
+            FlowStep(ToolsSatochipEnable2FAView, screen_return_value=0),
+            FlowStep(ToolsSatochipAdvancedView),
+        ])
+
+        assert len(connector.set_2fa_calls) == 1
+        key, amount_limit = connector.set_2fa_calls[0]
+        assert isinstance(key, (bytes, bytearray)) and len(key) == 20
+        assert amount_limit == 0
+
+    def test_already_enabled_short_circuits(self, monkeypatch):
+        connector = self._mock_connector(monkeypatch, needs_2fa=True)
+
+        self.run_sequence([
+            *self._menu_steps(),
+            FlowStep(ToolsSatochipEnable2FAView, screen_return_value=0),
+            FlowStep(ToolsSatochipAdvancedView),
+        ])
+
+        assert connector.set_2fa_calls == []
+
+
+class TestSatochipEnable2FARealScreens(FlowTest):
+    """Drive the real confirmation + QR Screens via UISession (real _run() input loops)."""
+
+    def _mock_connector(self, monkeypatch):
+        connector = MockSatochipConnector(needs_2fa=False)
+        monkeypatch.setattr(seedkeeper_utils, "init_satochip", lambda *args, **kwargs: connector)
+        return connector
+
+    def _menu_steps(self):
+        return [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.SMARTCARD),
+            FlowStep(ToolsSmartcardMenuView, button_data_selection=ToolsSmartcardMenuView.SATOCHIP),
+            FlowStep(ToolsSatochipView, button_data_selection=ToolsSatochipView.ADVANCED),
+            FlowStep(ToolsSatochipAdvancedView, button_data_selection=ToolsSatochipAdvancedView.ENABLE_2FA),
+        ]
+
+    def test_back_on_qr_cancels_before_write(self, monkeypatch):
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+        connector = self._mock_connector(monkeypatch)
+
+        script = (
+            [K.KEY_PRESS]      # first confirmation -> "Enable" (index 0)
+            + [K.KEY_PRESS]    # pairing instruction -> "I understand"
+            + [K.KEY_LEFT]     # QR screen -> BACK cancels before anything is written
+            + [K.KEY_PRESS]    # "Cancelled" info screen -> dismiss
+        )
+
+        session = UISession(script=script)
+        self.run_sequence([
+            *self._menu_steps(),
+            FlowStep(ToolsSatochipEnable2FAView, real_screens=True),
+            FlowStep(ToolsSatochipAdvancedView),
+        ], ui_session=session)
+
+        assert connector.set_2fa_calls == []
+        assert len(session.renderer.frames) > 0
+
+    def test_cancel_at_final_confirmation_after_scan(self, monkeypatch):
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+        connector = self._mock_connector(monkeypatch)
+
+        script = (
+            [K.KEY_PRESS]              # first confirmation -> "Enable" (index 0)
+            + [K.KEY_PRESS]            # pairing instruction -> "I understand"
+            + [K.KEY_PRESS]            # QR screen -> click to continue after scanning
+            + [K.KEY_DOWN, K.KEY_PRESS]  # final confirmation -> "Cancel" (index 1)
+            + [K.KEY_PRESS]            # "Cancelled" info screen -> dismiss
+        )
+
+        session = UISession(script=script)
+        self.run_sequence([
+            *self._menu_steps(),
+            FlowStep(ToolsSatochipEnable2FAView, real_screens=True),
+            FlowStep(ToolsSatochipAdvancedView),
+        ], ui_session=session)
+
+        assert connector.set_2fa_calls == []
+        assert len(session.renderer.frames) > 0
+
+    def test_full_success_with_real_screens(self, monkeypatch):
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+        connector = self._mock_connector(monkeypatch)
+
+        script = (
+            [K.KEY_PRESS]      # first confirmation -> "Enable" (index 0)
+            + [K.KEY_PRESS]    # pairing instruction -> "I understand"
+            + [K.KEY_PRESS]    # QR screen -> click to continue after scanning
+            + [K.KEY_PRESS]    # final confirmation -> "Enable" (index 0)
+            + [K.KEY_PRESS]    # Success screen -> OK
+        )
+
+        session = UISession(script=script)
+        self.run_sequence([
+            *self._menu_steps(),
+            FlowStep(ToolsSatochipEnable2FAView, real_screens=True),
+            FlowStep(ToolsSatochipAdvancedView),
+        ], ui_session=session)
+
+        assert len(connector.set_2fa_calls) == 1
+        key, amount_limit = connector.set_2fa_calls[0]
+        assert isinstance(key, (bytes, bytearray)) and len(key) == 20
+        assert amount_limit == 0
+        assert len(session.renderer.frames) > 0


### PR DESCRIPTION
## Problem

The Satochip **Enable 2FA** flow wrote the 2FA key to the card with no confirmation, and pressing BACK on the pairing QR screen did *not* cancel — card_set_2FA_key() ran unconditionally. Since nothing in SeedSigner calls card_reset_2FA_key, an accidental enablement is effectively irreversible from within the app (only external tooling can undo it).

## Changes

- **ToolsSatochipEnable2FAView** (src/seedsigner/views/smartcard_views.py)
  - Short-circuits with an info screen when the card already requires 2FA (
eeds_2FA, populated by init_satochip's existing card_get_status() call) instead of failing with a generic error on SW 