### PR TITLE
fix: a newly created seed never reached the Seeds menu

### DIFF
--- a/src/seedsigner/gui/keyboard.py
+++ b/src/seedsigner/gui/keyboard.py
@@ -228,6 +228,13 @@ class Keyboard:
         self.deactivated_background_color = GUIConstants.BACKGROUND_COLOR
         self.highlight_color = highlight_color
 
+        # `additional_keys` may arrive as a list of key dicts or as a code->key dict
+        # (Keyboard.ADDITIONAL_KEYS, which is what KeyboardScreen defaults to).
+        # Iterating the dict form yields code *strings*, so normalize to the key dicts
+        # once here rather than at each use below.
+        if isinstance(additional_keys, dict):
+            additional_keys = list(additional_keys.values())
+
         # Does the specified layout work?
         additional_key_spaces = 0
         for additional_key in additional_keys:

--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1631,9 +1631,16 @@ class SeedDiscardView(View):
 
     def __init__(self, seed: Seed = None):
         super().__init__()
-        self.seed = seed
-        if self.seed is None:
+        # `seed=None` is the caller's way of saying "the seed I mean is the pending
+        # one that hasn't been stored yet". Resolve it for display, but remember
+        # which kind it was: a pending seed is not in storage.seeds, so discarding
+        # it means clear_pending_seed(), not discard_seed().
+        if seed is None:
+            self.is_pending_seed = True
             self.seed = self.controller.storage.pending_seed
+        else:
+            self.is_pending_seed = False
+            self.seed = seed
 
 
     def run(self):
@@ -1653,16 +1660,16 @@ class SeedDiscardView(View):
 
         if button_data[selected_menu_num] == self.KEEP:
             # Use skip_current_view=True to prevent BACK from landing on this warning screen
-            if self.seed is not None:
-                return Destination(SeedOptionsView, view_args={"seed": self.seed}, skip_current_view=True)
-            else:
+            if self.is_pending_seed:
                 return Destination(SeedFinalizeView, skip_current_view=True)
+            else:
+                return Destination(SeedOptionsView, view_args={"seed": self.seed}, skip_current_view=True)
 
         elif button_data[selected_menu_num] == self.DISCARD:
-            if self.seed is not None:
-                self.controller.discard_seed(self.seed)
-            else:
+            if self.is_pending_seed:
                 self.controller.storage.clear_pending_seed()
+            else:
+                self.controller.discard_seed(self.seed)
             return Destination(MainMenuView, clear_history=True)
 
 
@@ -2699,9 +2706,17 @@ class SeedWordsView(View):
 
     def __init__(self, seed: Seed, bip85_data: dict = None, page_index: int = 0, share_index: int | None = None):
         super().__init__()
-        self.seed = seed
-        if self.seed is None:
+        # `seed=None` means "the pending seed, not yet in storage" -- the new-seed
+        # flows (dice/camera entropy, SLIP-39 generate) hand that sentinel down the
+        # whole View chain so the last step knows to call finalize_pending_seed().
+        # Resolve it to display the words, but remember that it was pending and put
+        # the sentinel back before routing onward (see run()).
+        if seed is None:
+            self.is_pending_seed = True
             self.seed = self.controller.storage.get_pending_seed()
+        else:
+            self.is_pending_seed = False
+            self.seed = seed
         self.bip85_data = bip85_data
         self.page_index = page_index
         self.share_index = share_index
@@ -2736,7 +2751,7 @@ class SeedWordsView(View):
 
         button_data = []
         num_pages = int(len(mnemonic)/words_per_page)
-        if self.page_index < num_pages - 1 or self.seed is None:
+        if self.page_index < num_pages - 1 or self.is_pending_seed:
             button_data.append(self.NEXT)
         else:
             button_data.append(self.DONE)
@@ -2753,8 +2768,12 @@ class SeedWordsView(View):
         if selected_menu_num == RET_CODE__BACK_BUTTON:
             return Destination(BackStackView)
 
+        if self.is_pending_seed:
+            # Restore the sentinel so the next View still knows this seed is pending
+            self.seed = None
+
         if button_data[selected_menu_num] == self.NEXT:
-            if self.seed is None and self.page_index == num_pages - 1:
+            if self.is_pending_seed and self.page_index == num_pages - 1:
                 return Destination(
                     SeedWordsBackupTestPromptView,
                     view_args=dict(seed=self.seed, bip85_data=self.bip85_data, share_index=self.share_index),
@@ -2943,9 +2962,15 @@ class SeedWordsBackupTestView(View):
         consistent screenshot results).
         """
         super().__init__()
-        self.seed = seed
-        if self.seed is None:
+        # See SeedWordsView.__init__(): `seed=None` is the "still pending" sentinel
+        # and has to survive this View, or the backup test's exit routes the user to
+        # SeedOptionsView instead of SeedFinalizeView and the seed is never stored.
+        if seed is None:
+            self.is_pending_seed = True
             self.seed = self.controller.storage.get_pending_seed()
+        else:
+            self.is_pending_seed = False
+            self.seed = seed
         self.bip85_data = bip85_data
         self.share_index = share_index
 
@@ -2997,6 +3022,10 @@ class SeedWordsBackupTestView(View):
             is_button_text_centered=True,
         )
 
+        if self.is_pending_seed:
+            # Restore the sentinel so the next View still knows this seed is pending
+            self.seed = None
+
         if button_data[selected_menu_num] == real_word:
             self.confirmed_list.append(self.cur_index)
             if len(self.confirmed_list) == len(self.mnemonic_list):
@@ -3009,7 +3038,7 @@ class SeedWordsBackupTestView(View):
                 # Continue testing the remaining words
                 return Destination(
                     SeedWordsBackupTestView,
-                    view_args=dict(seed=self.seed, confirmed_list=self.confirmed_list, bip85_data=self.bip85_data, share_index=self.share_index),
+                    view_args=dict(seed=self.seed, confirmed_list=list(self.confirmed_list), bip85_data=self.bip85_data, share_index=self.share_index),
                 )
 
         else:
@@ -3021,7 +3050,7 @@ class SeedWordsBackupTestView(View):
                         bip85_data=self.bip85_data,
                         cur_index=self.cur_index,
                         wrong_word=button_data[selected_menu_num].button_label,
-                        confirmed_list=self.confirmed_list,
+                        confirmed_list=list(self.confirmed_list),
                         share_index=self.share_index,
                     )
                 )

--- a/tests/test_real_screen_flows_seed.py
+++ b/tests/test_real_screen_flows_seed.py
@@ -1,0 +1,1341 @@
+"""
+    End-to-end flow tests for the seed workflows, running the *real* Screens via
+    tests.ui_driver (UISession + FlowStep(real_screens=True)) and driving them with
+    scripted button input.
+
+    Two things distinguish these from tests/test_flows_seed*.py:
+
+    * The Screens are real, so screen-construction and input-handling bugs surface
+      here instead of on-device.
+
+    * Every workflow starts from its **real entry point** -- MainMenuView, then the
+      menus a user actually walks -- rather than being dropped into the middle with a
+      pre-built Seed in `initial_destination_view_args`. That shortcut is what let the
+      pending-seed regression through: the mocked tests all entered the backup flow at
+      SeedOptionsView with an already-finalized seed, which is precisely the branch
+      that still worked, while the create-a-new-seed branch silently stopped storing
+      the seed at all.
+
+    Seed-creation tests therefore assert on `controller.storage.seeds` -- where the
+    seed has to land for the Seeds menu to list it -- and not merely on which View the
+    flow ended at. The broken flow ended on the right View, showing the right
+    fingerprint, with nothing stored.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+# Must import test base before the Controller (sets up the hardware mocks)
+import base  # noqa: F401
+from base import FlowStep, FlowTest
+from ui_driver import TypeKeys, UISession, make_noise_frame, select, type_words
+
+from seedsigner.gui.screens.screen import RET_CODE__BACK_BUTTON
+from seedsigner.models.settings import SettingsConstants
+from seedsigner.models.seed import Seed, Slip39Seed
+from seedsigner.views import seed_views, tools_views
+from seedsigner.views.view import MainMenuView
+
+
+# A 12-word mnemonic used wherever a test needs to load a known seed.
+MNEMONIC_12 = "blush twice taste dawn feed second opinion lazy thumb play neglect impact".split()
+
+# 50 dice rolls (the requirement for a 12-word mnemonic). Deterministic, and varied
+# enough to clear mnemonic_generation.dice_entropy_is_sufficient()'s entropy floor,
+# which a run of identical rolls would not.
+DICE_ROLLS_12 = ("123456" * 9)[:50]
+
+# The first 11 words of MNEMONIC_12; the tool computes the 12th.
+ELEVEN_WORDS = MNEMONIC_12[:11]
+
+
+@contextmanager
+def no_shuffle():
+    """
+    Pin SeedWordsBackupTestView's correct answer to button_data[0].
+
+    The view shuffles its four candidate words, so without this the right answer sits
+    at a random index and Select() would have to guess.
+    """
+    with patch("seedsigner.views.seed_views.random.shuffle", lambda seq: None):
+        yield
+
+
+class SeedFlowTest(FlowTest):
+    """Shared setup for the seed workflows."""
+
+    def setup_method(self):
+        super().setup_method()
+        # The dire warning screens are an extra interstitial on nearly every one of
+        # these flows and are covered on their own in tests/test_flows_seed.py; turning
+        # them off keeps each script about the workflow under test.
+        self.settings.set_value(
+            SettingsConstants.SETTING__DIRE_WARNINGS, SettingsConstants.OPTION__DISABLED
+        )
+
+    def store_seed(self, mnemonic=None) -> Seed:
+        """A seed already loaded into storage, as if a previous flow had finalized it."""
+        seed = Seed(mnemonic=mnemonic or MNEMONIC_12)
+        self.controller.storage.set_pending_seed(seed)
+        return self.controller.storage.finalize_pending_seed()
+
+    def assert_one_seed_stored(self) -> Seed:
+        """The flow put exactly one seed where the Seeds menu reads from."""
+        seeds = self.controller.storage.seeds
+        assert len(seeds) == 1, f"expected the new seed in storage.seeds, found {seeds!r}"
+        assert self.controller.storage.pending_seed is None, "pending seed was not cleared"
+        return seeds[0]
+
+
+
+class TestCreateSeedFlows(SeedFlowTest):
+    """
+    Tools > New seed. These are the flows the pending-seed regression broke: the seed
+    was generated and displayed, but never reached storage.seeds.
+    """
+
+    def dice_words_steps(self, num_words: int = 12) -> list:
+        """The FlowSteps from the main menu through the last page of seed words."""
+        return [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.DICE),
+            FlowStep(
+                tools_views.ToolsDiceEntropyMnemonicLengthView,
+                button_data_selection=tools_views.ToolsDiceEntropyMnemonicLengthView.TWELVE,
+            ),
+            FlowStep(tools_views.ToolsDiceEntropyEntryView, real_screens=True),
+            FlowStep(seed_views.SeedWordsWarningView, is_redirect=True),
+        ] + [
+            FlowStep(seed_views.SeedWordsView, real_screens=True)
+            for _ in range(num_words // 4)
+        ]
+
+    def test_dice_entropy_skip_backup_test_stores_seed(self):
+        """
+        Dice rolls > seed words > Skip the backup test > Finalize.
+
+        The seed must end up in storage.seeds; before the is_pending_seed fix this
+        flow routed to SeedOptionsView and never called finalize_pending_seed(), so
+        the new seed never appeared in the Seeds menu.
+        """
+        session = UISession(script=(
+            [TypeKeys(DICE_ROLLS_12)]
+            + select(*[seed_views.SeedWordsView.NEXT] * 3)
+            + select(seed_views.SeedWordsBackupTestPromptView.SKIP)
+            + select(seed_views.SeedFinalizeView.FINALIZE)
+        ))
+
+        self.run_sequence(
+            self.dice_words_steps() + [
+                FlowStep(seed_views.SeedWordsBackupTestPromptView, real_screens=True),
+                FlowStep(seed_views.SeedFinalizeView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            ui_session=session,
+        )
+
+        seed = self.assert_one_seed_stored()
+        assert len(seed.mnemonic_list) == 12
+        assert session.renderer.frames, "the real Screens never rendered"
+
+    def test_dice_entropy_verify_backup_test_stores_seed(self):
+        """The other exit from the backup test: verify every word, then Finalize."""
+        with no_shuffle():
+            session = UISession(script=(
+                [TypeKeys(DICE_ROLLS_12)]
+                + select(*[seed_views.SeedWordsView.NEXT] * 3)
+                + select(seed_views.SeedWordsBackupTestPromptView.VERIFY)
+                + select(*[0] * 12)  # the real word, pinned to slot 0 by no_shuffle()
+                + select(0)          # "OK" on the Backup Verified screen
+                + select(seed_views.SeedFinalizeView.FINALIZE)
+            ))
+
+            self.run_sequence(
+                self.dice_words_steps() + [
+                    FlowStep(seed_views.SeedWordsBackupTestPromptView, real_screens=True),
+                ] + [
+                    FlowStep(seed_views.SeedWordsBackupTestView, real_screens=True)
+                    for _ in range(12)
+                ] + [
+                    FlowStep(seed_views.SeedWordsBackupTestSuccessView, real_screens=True),
+                    FlowStep(seed_views.SeedFinalizeView, real_screens=True),
+                    FlowStep(seed_views.SeedOptionsView),
+                ],
+                ui_session=session,
+            )
+
+        self.assert_one_seed_stored()
+
+    def test_created_seed_is_listed_in_the_seeds_menu(self):
+        """
+        The user-visible symptom, asserted end to end: create a seed, then walk to
+        Seeds and find it there.
+        """
+        session = UISession(script=(
+            [TypeKeys(DICE_ROLLS_12)]
+            + select(*[seed_views.SeedWordsView.NEXT] * 3)
+            + select(seed_views.SeedWordsBackupTestPromptView.SKIP)
+            + select(seed_views.SeedFinalizeView.FINALIZE)
+        ))
+
+        self.run_sequence(
+            self.dice_words_steps() + [
+                FlowStep(seed_views.SeedWordsBackupTestPromptView, real_screens=True),
+                FlowStep(seed_views.SeedFinalizeView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            ui_session=session,
+        )
+        seed = self.assert_one_seed_stored()
+
+        # Now the part the user actually noticed: Seeds lists it.
+        fingerprint = seed.get_fingerprint(
+            self.settings.get_value(SettingsConstants.SETTING__NETWORK)
+        )
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+                FlowStep(seed_views.SeedsMenuView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            ui_session=UISession(script=select(f"{fingerprint} (BIP39)")),
+        )
+
+
+class TestCameraEntropyCreateSeedFlow(SeedFlowTest):
+    """
+    Tools > New seed (camera). Same pending-seed path as dice, reached through the
+    image-entropy views.
+
+    ToolsImageEntropyLivePreviewView is the one step left mocked: its screen drives the
+    physical camera's preview loop rather than responding to button input, so there is
+    nothing for a scripted press to exercise. It is handed the real PIL frames the
+    downstream hashing needs, and every screen after it is real.
+    """
+
+    def test_camera_entropy_stores_seed(self):
+        from seedsigner.gui.screens.tools_screens import ToolsImageEntropyLivePreviewScreen
+
+        frames = [
+            make_noise_frame(seed=i)
+            for i in range(ToolsImageEntropyLivePreviewScreen.PREVIEW_POOL_SIZE)
+        ]
+        final_image = make_noise_frame(seed=999).convert("RGB")
+
+        session = UISession(script=(
+            select(tools_views.ToolsImageEntropyMnemonicLengthView.TWELVE_WORDS)
+            + select(*[seed_views.SeedWordsView.NEXT] * 3)
+            + select(seed_views.SeedWordsBackupTestPromptView.SKIP)
+            + select(seed_views.SeedFinalizeView.FINALIZE)
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+                FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.IMAGE),
+                FlowStep(
+                    tools_views.ToolsImageEntropyLivePreviewView,
+                    screen_return_value=(frames, final_image),
+                ),
+                FlowStep(tools_views.ToolsImageEntropyFinalImageView, screen_return_value=0),
+                FlowStep(tools_views.ToolsImageEntropyMnemonicLengthView, real_screens=True),
+                FlowStep(seed_views.SeedWordsWarningView, is_redirect=True),
+            ] + [
+                FlowStep(seed_views.SeedWordsView, real_screens=True) for _ in range(3)
+            ] + [
+                FlowStep(seed_views.SeedWordsBackupTestPromptView, real_screens=True),
+                FlowStep(seed_views.SeedFinalizeView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            ui_session=session,
+        )
+
+        seed = self.assert_one_seed_stored()
+        assert len(seed.mnemonic_list) == 12
+        # The camera buffers must not outlive the flow.
+        assert self.controller.image_entropy_preview_frames is None
+        assert self.controller.image_entropy_final_image is None
+
+
+
+class TestCreateSlip39SeedFlow(SeedFlowTest):
+    """
+    Tools > SLIP39 seed (dice). Generates a share set rather than one mnemonic, so the
+    words + backup test run once per share before the seed is finalized -- the pending
+    sentinel has to survive every one of those laps.
+    """
+
+    def setup_method(self):
+        super().setup_method()
+        self.settings.set_value(
+            SettingsConstants.SETTING__SLIP39_SEEDS, SettingsConstants.OPTION__ENABLED
+        )
+
+    def test_slip39_dice_entropy_stores_seed(self):
+        num_shares, threshold, words_per_share = 2, 2, 20
+
+        # SeedSlip39CreateFromBytesView instantiates SeedBIP85SelectChildIndexScreen
+        # directly rather than through run_screen(), so FlowTest can't see it; stub it
+        # with the share count and threshold the user would key in.
+        with patch.object(seed_views.seed_screens, "SeedBIP85SelectChildIndexScreen") as index_screen:
+            index_screen.return_value.display.side_effect = [str(num_shares), str(threshold)]
+
+            pages_per_share = words_per_share // 4
+            script = [TypeKeys(DICE_ROLLS_12)]
+            steps = [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+                FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.SLIP39_DICE),
+                FlowStep(
+                    tools_views.ToolsDiceEntropyMnemonicLengthView,
+                    button_data_selection=tools_views.ToolsDiceEntropyMnemonicLengthView.TWENTY,
+                ),
+                FlowStep(tools_views.ToolsDiceEntropyEntryView, real_screens=True),
+                # Instantiates its index Screens directly, so run_screen() is never called.
+                FlowStep(seed_views.SeedSlip39CreateFromBytesView, is_redirect=True),
+            ]
+            for share in range(num_shares):
+                steps.append(FlowStep(seed_views.SeedWordsWarningView, is_redirect=True))
+                steps += [
+                    FlowStep(seed_views.SeedWordsView, real_screens=True)
+                    for _ in range(pages_per_share)
+                ]
+                steps.append(FlowStep(seed_views.SeedWordsBackupTestPromptView, real_screens=True))
+                script += select(*[seed_views.SeedWordsView.NEXT] * pages_per_share)
+                script += select(seed_views.SeedWordsBackupTestPromptView.SKIP)
+            steps += [
+                FlowStep(seed_views.SeedFinalizeView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ]
+            script += select(seed_views.SeedFinalizeView.FINALIZE)
+
+            self.run_sequence(steps, ui_session=UISession(script=script))
+
+        seed = self.assert_one_seed_stored()
+        assert isinstance(seed, Slip39Seed)
+        assert len(seed.mnemonic_list) == num_shares
+
+
+
+class TestCalcFinalWordFlows(SeedFlowTest):
+    """
+    Tools > Calc 12th/24th word. Both exits matter: Load finalizes the pending seed,
+    and Discard has to clear the *pending* seed rather than trying to remove it from
+    storage.seeds, where it has never been.
+    """
+
+    def init_pending_mnemonic(self, words=None, length=12):
+        """The state the tool reaches once the user has typed the first 11 words."""
+        words = words or ELEVEN_WORDS
+        self.controller.storage.init_pending_mnemonic(length)
+        for i, word in enumerate(words):
+            self.controller.storage.update_pending_mnemonic(word, i)
+
+    def calc_steps(self) -> list:
+        return [
+            FlowStep(
+                tools_views.ToolsCalcFinalWordFinalizePromptView,
+                button_data_selection=tools_views.ToolsCalcFinalWordFinalizePromptView.ZEROS,
+            ),
+            FlowStep(
+                tools_views.ToolsCalcFinalWordShowFinalWordView,
+                button_data_selection=tools_views.ToolsCalcFinalWordShowFinalWordView.NEXT,
+            ),
+        ]
+
+    def test_calc_final_word_load_stores_seed(self):
+        self.init_pending_mnemonic()
+
+        session = UISession(script=(
+            select(tools_views.ToolsCalcFinalWordDoneView.LOAD)
+            + select(seed_views.SeedFinalizeView.FINALIZE)
+        ))
+        self.run_sequence(
+            self.calc_steps() + [
+                FlowStep(tools_views.ToolsCalcFinalWordDoneView, real_screens=True),
+                FlowStep(seed_views.SeedFinalizeView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            ui_session=session,
+        )
+
+        seed = self.assert_one_seed_stored()
+        assert seed.mnemonic_list[:11] == ELEVEN_WORDS
+
+    def test_calc_final_word_discard_clears_pending_seed(self):
+        """
+        Discard on a seed that was never stored.
+
+        SeedDiscardView resolves `seed=None` to the pending seed, so before the
+        is_pending_seed fix it took the "already stored" branch and called
+        storage.seeds.remove() on a seed that is not in the list -- a ValueError that
+        dropped the user into the unhandled-exception screen. Nothing caught it,
+        because the existing flow test stops at SeedDiscardView without pressing
+        Discard.
+        """
+        self.init_pending_mnemonic()
+
+        session = UISession(script=(
+            select(tools_views.ToolsCalcFinalWordDoneView.DISCARD)
+            + select(seed_views.SeedDiscardView.DISCARD)
+        ))
+        self.run_sequence(
+            self.calc_steps() + [
+                FlowStep(tools_views.ToolsCalcFinalWordDoneView, real_screens=True),
+                FlowStep(seed_views.SeedDiscardView, real_screens=True),
+                FlowStep(MainMenuView),
+            ],
+            ui_session=session,
+        )
+
+        assert self.controller.storage.seeds == []
+        assert self.controller.storage.pending_seed is None
+
+    def test_calc_final_word_discard_then_keep_returns_to_finalize(self):
+        """The other button on the discard warning: Keep must route back to Finalize."""
+        self.init_pending_mnemonic()
+
+        session = UISession(script=(
+            select(tools_views.ToolsCalcFinalWordDoneView.DISCARD)
+            + select(seed_views.SeedDiscardView.KEEP)
+            + select(seed_views.SeedFinalizeView.FINALIZE)
+        ))
+        self.run_sequence(
+            self.calc_steps() + [
+                FlowStep(tools_views.ToolsCalcFinalWordDoneView, real_screens=True),
+                FlowStep(seed_views.SeedDiscardView, real_screens=True),
+                FlowStep(seed_views.SeedFinalizeView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            ui_session=session,
+        )
+
+        self.assert_one_seed_stored()
+
+
+class TestLoadSeedFlows(SeedFlowTest):
+    """Seeds > Load a seed. The word-entry keyboard is real here, one word at a time."""
+
+    def test_manual_12_word_entry_stores_seed(self):
+        session = UISession(script=(
+            type_words(MNEMONIC_12)
+            + select(seed_views.SeedFinalizeView.FINALIZE)
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+                FlowStep(seed_views.SeedsMenuView, is_redirect=True),  # no seeds yet -> LoadSeedView
+                FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_12WORD),
+            ] + [
+                FlowStep(seed_views.SeedMnemonicEntryView, real_screens=True)
+                for _ in MNEMONIC_12
+            ] + [
+                FlowStep(seed_views.SeedFinalizeView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            ui_session=session,
+        )
+
+        seed = self.assert_one_seed_stored()
+        assert seed.mnemonic_list == MNEMONIC_12
+
+    def test_manual_entry_back_from_first_word_cancels(self):
+        """
+        BACK out of word #1 abandons the mnemonic instead of leaving a half-built one
+        behind for the next flow to pick up.
+        """
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+            FlowStep(seed_views.SeedsMenuView, is_redirect=True),
+            FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_12WORD),
+            FlowStep(seed_views.SeedMnemonicEntryView, screen_return_value=RET_CODE__BACK_BUTTON),
+            FlowStep(seed_views.LoadSeedView),
+        ])
+
+        assert self.controller.storage.pending_mnemonic_length == 0
+        assert self.controller.storage.seeds == []
+
+
+
+class TestPassphraseFlows(SeedFlowTest):
+    """
+    SeedFinalizeView > Add passphrase. The passphrase is typed on the real
+    multi-keyboard screen, and the seed is only stored once it is reviewed.
+    """
+
+    PASSPHRASE = "hunter2"
+
+    def test_typed_passphrase_is_applied_and_seed_stored(self):
+        from seedsigner.gui.screens.seed_screens import SeedAddPassphraseScreen
+        from ui_driver import plan_text_entry_script
+
+        self.settings.set_value(
+            SettingsConstants.SETTING__PASSPHRASE, SettingsConstants.OPTION__ENABLED
+        )
+        self.controller.storage.set_pending_seed(Seed(mnemonic=MNEMONIC_12))
+
+        passphrase_script = plan_text_entry_script(
+            SeedAddPassphraseScreen, self.PASSPHRASE, passphrase="", title="Passphrase"
+        )
+        session = UISession(script=(
+            select(seed_views.SeedFinalizeView.TYPE_PASSPHRASE)
+            + passphrase_script
+            + select(seed_views.SeedReviewPassphraseView.DONE)
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(seed_views.SeedFinalizeView, real_screens=True),
+                FlowStep(seed_views.SeedAddPassphraseView, real_screens=True),
+                FlowStep(seed_views.SeedReviewPassphraseView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            ui_session=session,
+        )
+
+        seed = self.assert_one_seed_stored()
+        assert seed.passphrase == self.PASSPHRASE
+
+
+
+class TestSeedsMenuFlows(SeedFlowTest):
+    """Seeds > the in-memory seed list, and the options menu behind each entry."""
+
+    SECOND_MNEMONIC = (
+        "payment artist half drive borrow speak make crouch payment artist half drill"
+    ).split()
+
+    def fingerprint(self, seed) -> str:
+        return seed.get_fingerprint(self.settings.get_value(SettingsConstants.SETTING__NETWORK))
+
+    def test_seeds_menu_lists_every_loaded_seed(self):
+        first = self.store_seed()
+        second = self.store_seed(self.SECOND_MNEMONIC)
+
+        # Pick the second entry by its own fingerprint label, so a mis-ordered or
+        # mis-labelled list fails here rather than silently selecting the wrong seed.
+        session = UISession(script=select(f"{self.fingerprint(second)} (BIP39)"))
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+                FlowStep(seed_views.SeedsMenuView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            ui_session=session,
+        )
+        assert self.controller.storage.seeds == [first, second]
+
+    def test_seed_options_to_backup_menu(self):
+        seed = self.store_seed()
+        session = UISession(script=(
+            select(f"{self.fingerprint(seed)} (BIP39)")
+            + select(seed_views.SeedOptionsView.BACKUP)
+            + select(seed_views.SeedBackupView.VIEW_WORDS)
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+                FlowStep(seed_views.SeedsMenuView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView, real_screens=True),
+                FlowStep(seed_views.SeedBackupView, real_screens=True),
+                FlowStep(seed_views.SeedWordsWarningView, is_redirect=True),
+                FlowStep(seed_views.SeedWordsView),
+            ],
+            ui_session=session,
+        )
+
+
+
+class TestStoredSeedBackupFlows(SeedFlowTest):
+    """
+    Backup > View seed words on a seed that is *already* stored.
+
+    This is the branch the mocked tests already covered, and it must keep behaving:
+    an existing seed goes back to SeedOptionsView when the backup test finishes, and
+    must not be re-finalized or duplicated in storage.
+    """
+
+    def view_words_steps(self, num_words: int = 12) -> list:
+        return [
+            FlowStep(seed_views.SeedOptionsView, real_screens=True),
+            FlowStep(seed_views.SeedBackupView, real_screens=True),
+            FlowStep(seed_views.SeedWordsWarningView, is_redirect=True),
+        ] + [
+            FlowStep(seed_views.SeedWordsView, real_screens=True)
+            for _ in range(num_words // 4)
+        ]
+
+    def view_words_script(self, pages: int = 3) -> list:
+        return (
+            select(seed_views.SeedOptionsView.BACKUP)
+            + select(seed_views.SeedBackupView.VIEW_WORDS)
+            + select(*([seed_views.SeedWordsView.NEXT] * (pages - 1) + [seed_views.SeedWordsView.DONE]))
+        )
+
+    def test_stored_seed_backup_test_does_not_duplicate_the_seed(self):
+        seed = self.store_seed()
+
+        with no_shuffle():
+            session = UISession(script=(
+                self.view_words_script()
+                + select(seed_views.SeedWordsBackupTestPromptView.VERIFY)
+                + select(*[0] * 12)
+                + select(0)  # "OK" on the Backup Verified screen
+            ))
+            self.run_sequence(
+                self.view_words_steps() + [
+                    FlowStep(seed_views.SeedWordsBackupTestPromptView, real_screens=True),
+                ] + [
+                    FlowStep(seed_views.SeedWordsBackupTestView, real_screens=True)
+                    for _ in range(12)
+                ] + [
+                    FlowStep(seed_views.SeedWordsBackupTestSuccessView, real_screens=True),
+                    FlowStep(seed_views.SeedOptionsView),
+                ],
+                initial_destination_view_args=dict(seed=seed),
+                ui_session=session,
+            )
+
+        assert self.controller.storage.seeds == [seed]
+        assert self.controller.storage.pending_seed is None
+
+    def test_stored_seed_backup_test_wrong_word_then_retry(self):
+        seed = self.store_seed()
+
+        with no_shuffle():
+            session = UISession(script=(
+                self.view_words_script()
+                + select(seed_views.SeedWordsBackupTestPromptView.VERIFY)
+                + select(1)  # a decoy word
+                + select(seed_views.SeedWordsBackupTestMistakeView.RETRY)
+                + select(*[0] * 12)
+                + select(0)
+            ))
+            self.run_sequence(
+                self.view_words_steps() + [
+                    FlowStep(seed_views.SeedWordsBackupTestPromptView, real_screens=True),
+                    FlowStep(seed_views.SeedWordsBackupTestView, real_screens=True),
+                    FlowStep(seed_views.SeedWordsBackupTestMistakeView, real_screens=True),
+                ] + [
+                    FlowStep(seed_views.SeedWordsBackupTestView, real_screens=True)
+                    for _ in range(12)
+                ] + [
+                    FlowStep(seed_views.SeedWordsBackupTestSuccessView, real_screens=True),
+                    FlowStep(seed_views.SeedOptionsView),
+                ],
+                initial_destination_view_args=dict(seed=seed),
+                ui_session=session,
+            )
+
+        assert self.controller.storage.seeds == [seed]
+
+    def test_stored_seed_backup_test_skip(self):
+        seed = self.store_seed()
+
+        session = UISession(script=(
+            self.view_words_script()
+            + select(seed_views.SeedWordsBackupTestPromptView.SKIP)
+        ))
+        self.run_sequence(
+            self.view_words_steps() + [
+                FlowStep(seed_views.SeedWordsBackupTestPromptView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            initial_destination_view_args=dict(seed=seed),
+            ui_session=session,
+        )
+
+        assert self.controller.storage.seeds == [seed]
+
+
+
+class TestDiscardStoredSeedFlow(SeedFlowTest):
+    """SeedOptionsView > Discard, on a seed that really is in storage."""
+
+    def test_discard_removes_the_seed(self):
+        seed = self.store_seed()
+
+        session = UISession(script=(
+            select(seed_views.SeedOptionsView.DISCARD)
+            + select(seed_views.SeedDiscardView.DISCARD)
+        ))
+        self.run_sequence(
+            [
+                FlowStep(seed_views.SeedOptionsView, real_screens=True),
+                FlowStep(seed_views.SeedDiscardView, real_screens=True),
+                FlowStep(MainMenuView),
+            ],
+            initial_destination_view_args=dict(seed=seed),
+            ui_session=session,
+        )
+
+        assert self.controller.storage.seeds == []
+
+    def test_keep_returns_to_seed_options(self):
+        seed = self.store_seed()
+
+        session = UISession(script=(
+            select(seed_views.SeedOptionsView.DISCARD)
+            + select(seed_views.SeedDiscardView.KEEP)
+        ))
+        self.run_sequence(
+            [
+                FlowStep(seed_views.SeedOptionsView, real_screens=True),
+                FlowStep(seed_views.SeedDiscardView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            initial_destination_view_args=dict(seed=seed),
+            ui_session=session,
+        )
+
+        assert self.controller.storage.seeds == [seed]
+
+
+class TestExportXpubFlow(SeedFlowTest):
+    """SeedOptions > Export xpub, through to the QR on screen."""
+
+    def test_single_sig_native_segwit_export(self):
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+        seed = self.store_seed()
+        self.settings.set_value(
+            SettingsConstants.SETTING__SCRIPT_TYPES, [SettingsConstants.NATIVE_SEGWIT]
+        )
+        self.settings.set_value(
+            SettingsConstants.SETTING__XPUB_QR_FORMAT,
+            [SettingsConstants.XPUB_QR_FORMAT__SPECTER_LEGACY],
+        )
+
+        session = UISession(script=(
+            select(seed_views.SeedOptionsView.EXPORT_XPUB)
+            + select(seed_views.SeedExportXpubSigTypeView.SINGLE_SIG)
+            + select(0)          # "I Understand" on the export warning
+            + select(0)          # confirm the derivation details
+            + [K.KEY_PRESS]      # any click dismisses the QR display
+            + select(0)          # decline the verify-address offer
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(seed_views.SeedOptionsView, real_screens=True),
+                FlowStep(seed_views.SeedExportXpubSigTypeView, real_screens=True),
+                # Only one script type and one QR format are enabled, so both of these
+                # Views redirect straight through without drawing a Screen.
+                FlowStep(seed_views.SeedExportXpubScriptTypeView, is_redirect=True),
+                FlowStep(seed_views.SeedExportXpubQRFormatView, is_redirect=True),
+                FlowStep(seed_views.SeedExportXpubWarningView, real_screens=True),
+                FlowStep(seed_views.SeedExportXpubDetailsView, real_screens=True),
+                FlowStep(seed_views.SeedExportXpubQRDisplayView, real_screens=True),
+                FlowStep(seed_views.SeedExportXpubVerifyAddressView, real_screens=True),
+            ],
+            initial_destination_view_args=dict(seed=seed),
+            ui_session=session,
+        )
+
+        # Exporting must not disturb what is loaded.
+        assert self.controller.storage.seeds == [seed]
+
+
+
+class TestTranscribeSeedQRFlow(SeedFlowTest):
+    """Backup > Export as SeedQR, including the zoomed-in transcription screens."""
+
+    def test_transcribe_seedqr_to_confirm_prompt(self):
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+        seed = self.store_seed()
+
+        session = UISession(script=(
+            select(seed_views.SeedOptionsView.BACKUP)
+            + select(seed_views.SeedBackupView.EXPORT_SEEDQR)
+            + select(0)      # standard SeedQR format
+            + select(0)      # whole-QR screen: start transcribing
+            + [K.KEY_PRESS]  # any click exits the zoomed-in transcription view
+            + select(seed_views.SeedTranscribeSeedQRConfirmQRPromptView.DONE)
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(seed_views.SeedOptionsView, real_screens=True),
+                FlowStep(seed_views.SeedBackupView, real_screens=True),
+                FlowStep(seed_views.SeedTranscribeSeedQRFormatView, real_screens=True),
+                # Dire warnings are off in this suite's setup, so this View forwards
+                # straight through (the warning itself is covered in test_flows_seed.py).
+                FlowStep(seed_views.SeedTranscribeSeedQRWarningView, is_redirect=True),
+                FlowStep(seed_views.SeedTranscribeSeedQRWholeQRView, real_screens=True),
+                FlowStep(seed_views.SeedTranscribeSeedQRZoomedInView, real_screens=True),
+                FlowStep(seed_views.SeedTranscribeSeedQRConfirmQRPromptView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            initial_destination_view_args=dict(seed=seed),
+            ui_session=session,
+        )
+
+        assert self.controller.storage.seeds == [seed]
+
+
+
+class TestBip85ChildSeedFlow(SeedFlowTest):
+    """
+    SeedOptions > BIP-85 child seed. The child is a *new* pending seed derived from
+    the parent, so it runs through the same finalize path -- and must be stored
+    alongside the parent rather than replacing it.
+    """
+
+    def setup_method(self):
+        super().setup_method()
+        self.settings.set_value(
+            SettingsConstants.SETTING__BIP85_CHILD_SEEDS, SettingsConstants.OPTION__ENABLED
+        )
+
+    def test_bip85_child_is_stored_alongside_the_parent(self):
+        parent = self.store_seed()
+
+        session = UISession(script=(
+            select(seed_views.SeedOptionsView.BIP85_CHILD_SEED)
+            + select(seed_views.SeedBIP85SelectNumWordsView.WORDS_12)
+            + [TypeKeys("0")]  # child index, typed on the real keyboard
+            + select(seed_views.SeedWordsBackupTestPromptView.FINALIZE)
+            + select(seed_views.SeedFinalizeView.FINALIZE)
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(seed_views.SeedOptionsView, real_screens=True),
+                FlowStep(seed_views.SeedBIP85SelectNumWordsView, real_screens=True),
+                FlowStep(seed_views.SeedBIP85SelectChildIndexView, real_screens=True),
+                FlowStep(seed_views.SeedWordsBackupTestPromptView, real_screens=True),
+                FlowStep(seed_views.SeedFinalizeView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            initial_destination_view_args=dict(seed=parent),
+            ui_session=session,
+        )
+
+        seeds = self.controller.storage.seeds
+        assert len(seeds) == 2, f"expected parent + child, got {seeds!r}"
+        assert seeds[0] is parent
+        assert seeds[1].mnemonic_list != parent.mnemonic_list
+        assert self.controller.storage.pending_seed is None
+
+
+
+class TestSignMessageFlow(SeedFlowTest):
+    """
+    SeedOptions > Sign message. The message arrives by QR, so ScanView stays mocked
+    (there is no button input to drive a camera decode); every confirmation screen
+    after it is real.
+    """
+
+    DERIVATION_PATH = "m/84h/0h/0h/0/0"
+    MESSAGE = "I attest that I control this bitcoin address"
+
+    def test_sign_message_confirmations(self):
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+        from seedsigner.views import scan_views
+
+        self.settings.set_value(
+            SettingsConstants.SETTING__MESSAGE_SIGNING, SettingsConstants.OPTION__ENABLED
+        )
+        seed = self.store_seed()
+
+        def load_message(view):
+            view.decoder.add_data(f"signmessage {self.DERIVATION_PATH} ascii:{self.MESSAGE}")
+
+        session = UISession(script=(
+            select(0)        # SeedSelectSeedView: the one loaded seed
+            + select(0)      # SeedSignMessageConfirmMessageView: Next
+            + select(0)      # SeedSignMessageConfirmAddressView: Sign
+            + [K.KEY_PRESS]  # any click dismisses the signature QR
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+                FlowStep(scan_views.ScanView, before_run=load_message),
+                FlowStep(seed_views.SeedSignMessageStartView, is_redirect=True),
+                FlowStep(seed_views.SeedSelectSeedView, real_screens=True),
+                FlowStep(seed_views.SeedSignMessageConfirmMessageView, real_screens=True),
+                FlowStep(seed_views.SeedSignMessageConfirmAddressView, real_screens=True),
+                FlowStep(seed_views.SeedSignMessageSignedMessageQRView, real_screens=True),
+                FlowStep(MainMenuView),
+            ],
+            ui_session=session,
+        )
+
+        assert self.controller.storage.seeds == [seed]
+
+
+class TestEncryptedQRFlow(SeedFlowTest):
+    """Backup > Export as SeedQR > Encrypted, typing the key on the real keyboards."""
+
+    ENCRYPTION_KEY = "swordfish"
+    MNEMONIC_ID = "wallet1"
+
+    def setup_method(self):
+        super().setup_method()
+        self.settings.set_value(
+            SettingsConstants.SETTING__ENCRYPTED_QR, SettingsConstants.OPTION__ENABLED
+        )
+        # The default GCM/CBC/CTR modes route through SeedEncryptedQRnonECBModeView,
+        # which collects an IV from the camera -- no button input to drive. ECB has no
+        # IV, so it goes straight to the mnemonic ID prompt this test is about.
+        self.settings.set_value(
+            SettingsConstants.SETTING__ENCRYPTION_MODE, SettingsConstants.ENCRYPTION_MODE_ECB
+        )
+
+    def test_typed_encryption_key_and_mnemonic_id(self):
+        from seedsigner.gui.screens.scan_screens import ScanTypeEncryptionKeyScreen
+        from seedsigner.gui.screens.seed_screens import SeedEncryptedQRMnemonicIDScreen
+        from ui_driver import plan_text_entry_script
+
+        seed = self.store_seed()
+
+        key_script = plan_text_entry_script(
+            ScanTypeEncryptionKeyScreen, self.ENCRYPTION_KEY, encryptionkey=""
+        )
+        id_script = plan_text_entry_script(
+            SeedEncryptedQRMnemonicIDScreen, self.MNEMONIC_ID, mnemonic_id=""
+        )
+
+        session = UISession(script=(
+            select(seed_views.SeedOptionsView.BACKUP)
+            + select(seed_views.SeedBackupView.EXPORT_SEEDQR)
+            + select("Encrypted")
+            + select("Type encryption key")
+            + key_script
+            + select(0)          # accept the reviewed encryption key
+            + select("Assign custom ID")
+            + id_script
+            + select(0)          # accept the reviewed mnemonic ID
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(seed_views.SeedOptionsView, real_screens=True),
+                FlowStep(seed_views.SeedBackupView, real_screens=True),
+                FlowStep(seed_views.SeedTranscribeSeedQRFormatView, real_screens=True),
+                FlowStep(seed_views.SeedTranscribeSeedQRWarningView, is_redirect=True),
+                FlowStep(seed_views.SeedTranscribeSeedQRWholeQRView, real_screens=True),
+                FlowStep(seed_views.SeedEncryptedQRTypeEncryptionKeyView, real_screens=True),
+                FlowStep(seed_views.SeedEncryptedQRReviewEncryptionKeyView, real_screens=True),
+                FlowStep(seed_views.SeedEncryptedQRMnemonicIDPromptView, real_screens=True),
+                FlowStep(seed_views.SeedEncryptedQRMnemonicIDEntryView, real_screens=True),
+                FlowStep(seed_views.SeedEncryptedQRReviewMnemonicIDView, real_screens=True),
+            ],
+            initial_destination_view_args=dict(seed=seed),
+            ui_session=session,
+        )
+
+        assert self.controller.storage.seeds == [seed]
+
+
+
+class TestSlip39ShareFlows(SeedFlowTest):
+    """Loading a SLIP-39 seed from typed shares, and regenerating shares afterwards."""
+
+    def setup_method(self):
+        super().setup_method()
+        self.settings.set_value(
+            SettingsConstants.SETTING__SLIP39_SEEDS, SettingsConstants.OPTION__ENABLED
+        )
+
+    @staticmethod
+    def make_shares(threshold=2, count=3, extendable=True) -> list:
+        import shamir_mnemonic
+        return shamir_mnemonic.generate_mnemonics(
+            1, [(threshold, count)], bytes.fromhex("aa" * 16), extendable=extendable
+        )[0]
+
+    def test_typed_slip39_shares_combine_into_a_stored_seed(self):
+        shares = self.make_shares(threshold=2, count=3)
+        first, second = shares[0].split(), shares[1].split()
+
+        session = UISession(script=(
+            select("Enter 20 words")
+            + type_words(first)
+            + select(seed_views.SeedSlip39MoreSharesView.ADD)
+            + type_words(second)
+            + select(seed_views.SeedSlip39MoreSharesView.DONE)
+            + select(seed_views.SeedFinalizeView.FINALIZE)
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+                FlowStep(seed_views.SeedsMenuView, is_redirect=True),
+                FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_SLIP39),
+                FlowStep(seed_views.SeedSlip39MnemonicStartView, real_screens=True),
+            ] + [
+                FlowStep(seed_views.SeedSlip39ShareEntryView, real_screens=True)
+                for _ in first
+            ] + [
+                FlowStep(seed_views.SeedSlip39MoreSharesView, real_screens=True),
+            ] + [
+                FlowStep(seed_views.SeedSlip39ShareEntryView, real_screens=True)
+                for _ in second
+            ] + [
+                FlowStep(seed_views.SeedSlip39MoreSharesView, real_screens=True),
+                FlowStep(seed_views.SeedFinalizeView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            ui_session=session,
+        )
+
+        seed = self.assert_one_seed_stored()
+        assert isinstance(seed, Slip39Seed)
+
+    def test_regenerate_shares_on_a_stored_slip39_seed(self):
+        shares = self.make_shares(threshold=2, count=3)
+        seed = Slip39Seed(mnemonics=shares[:2])
+        self.controller.storage.set_pending_seed(seed)
+        self.controller.storage.finalize_pending_seed()
+
+        with patch.object(seed_views.seed_screens, "SeedBIP85SelectChildIndexScreen") as index_screen:
+            index_screen.return_value.display.side_effect = ["5", "3"]
+
+            session = UISession(script=(
+                select(seed_views.SeedOptionsView.BACKUP)
+                + select(seed_views.SeedBackupView.REGENERATE_SHARES)
+            ))
+            self.run_sequence(
+                [
+                    FlowStep(seed_views.SeedOptionsView, real_screens=True),
+                    FlowStep(seed_views.SeedBackupView, real_screens=True),
+                    # Instantiates its index Screens directly, bypassing run_screen().
+                    FlowStep(seed_views.SeedSlip39RegenerateSharesView, is_redirect=True),
+                    FlowStep(seed_views.SeedWordsWarningView),
+                ],
+                initial_destination_view_args=dict(seed=seed),
+                ui_session=session,
+            )
+
+        assert len(seed.mnemonic_list) == 5
+        assert self.controller.storage.seeds == [seed]
+
+
+
+class TestElectrumSeedEntryFlow(SeedFlowTest):
+    """Seeds > Load a seed > Enter Electrum seed."""
+
+    # A real Electrum segwit seed (generated by Electrum v4.5.5); a BIP-39 phrase
+    # would fail Electrum's own checksum.
+    ELECTRUM_MNEMONIC = (
+        "bomb congress scorpion mutual word stamp tongue valid permit salmon yellow spy"
+    ).split()
+
+    def setup_method(self):
+        super().setup_method()
+        self.settings.set_value(
+            SettingsConstants.SETTING__ELECTRUM_SEEDS, SettingsConstants.OPTION__ENABLED
+        )
+
+    def test_electrum_entry_stores_seed(self):
+        session = UISession(script=(
+            select(0)  # "I Understand" on the Electrum warning
+            + type_words(self.ELECTRUM_MNEMONIC)
+            + select(seed_views.SeedFinalizeView.FINALIZE)
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+                FlowStep(seed_views.SeedsMenuView, is_redirect=True),
+                FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TYPE_ELECTRUM),
+                FlowStep(seed_views.SeedElectrumMnemonicStartView, real_screens=True),
+            ] + [
+                FlowStep(seed_views.SeedMnemonicEntryView, real_screens=True)
+                for _ in self.ELECTRUM_MNEMONIC
+            ] + [
+                FlowStep(seed_views.SeedFinalizeView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            ui_session=session,
+        )
+
+        seed = self.assert_one_seed_stored()
+        assert seed.mnemonic_list == self.ELECTRUM_MNEMONIC
+
+
+
+class TestHardwareWalletBackupFlows(SeedFlowTest):
+    """
+    Seeds > Load a seed > a hardware-wallet backup on the microSD card.
+
+    The card is a real temp directory swapped in for MicroSD.get_microsd_dir(), so the
+    Views do their actual file discovery and decoding.
+    """
+
+    def setup_method(self):
+        super().setup_method()
+        # Each backup type is behind its own setting; LoadSeedView omits the option
+        # entirely when it is disabled.
+        for setting in (
+            SettingsConstants.SETTING__BITBOX_BACKUP,
+            SettingsConstants.SETTING__PASSPORT_BACKUP,
+            SettingsConstants.SETTING__TAPSIGNER_BACKUP,
+        ):
+            self.settings.set_value(setting, SettingsConstants.OPTION__ENABLED)
+
+    def use_microsd(self, monkeypatch, tmp_path):
+        from seedsigner.hardware.microsd import MicroSD
+        monkeypatch.setattr(MicroSD, "get_microsd_dir", staticmethod(lambda: tmp_path))
+        return tmp_path
+
+    def test_tapsigner_backup_loads_the_xprv(self, monkeypatch, tmp_path):
+        from Cryptodome.Cipher import AES
+        from embit import bip32
+
+        card = self.use_microsd(monkeypatch, tmp_path)
+
+        # A real TAPSIGNER backup: AES-CTR over "<xprv>\n<derivation path>\n".
+        key_hex = "00112233445566778899aabbccddeeff"
+        root = bip32.HDKey.from_seed(Seed(mnemonic=MNEMONIC_12).seed_bytes)
+        plaintext = f"{root.to_base58()}\nm/84h/0h/0h\n".encode()
+        cipher = AES.new(bytes.fromhex(key_hex), AES.MODE_CTR, nonce=b"", initial_value=0)
+        (card / "backup.aes").write_bytes(cipher.encrypt(plaintext))
+
+        session = UISession(script=(
+            select(0)             # the one backup file on the card
+            + [TypeKeys(key_hex)]  # the backup key, typed on the real keyboard
+            + select(0)           # accept the summary
+            + select(seed_views.SeedFinalizeView.FINALIZE)
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+                FlowStep(seed_views.SeedsMenuView, is_redirect=True),
+                FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.TAPSIGNER_BACKUP),
+                FlowStep(seed_views.SeedTapsignerBackupSelectView, real_screens=True),
+                FlowStep(seed_views.SeedTapsignerBackupKeyEntryView, real_screens=True),
+                FlowStep(seed_views.SeedTapsignerBackupSummaryView, real_screens=True),
+                FlowStep(seed_views.SeedFinalizeView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            ui_session=session,
+        )
+
+        self.assert_one_seed_stored()
+
+    def test_passport_code_entry_screen_opens(self, monkeypatch, tmp_path):
+        """
+        Reaching the Passport code entry at all is the assertion here.
+
+        Both this View and SeedTapsignerBackupKeyEntryView instantiate a bare
+        KeyboardScreen, whose custom_additional_keys defaults to the
+        Keyboard.ADDITIONAL_KEYS *dict*. Keyboard.__init__ iterated that expecting key
+        dicts, so it read `"<code string>"["size"]` and raised TypeError before the
+        screen could draw -- these two screens crashed on device. The flow backs out
+        via the top nav once the keyboard is up.
+        """
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+        card = self.use_microsd(monkeypatch, tmp_path)
+        (card / "backup.7z").write_bytes(b"not a real archive")
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+                FlowStep(seed_views.SeedsMenuView, is_redirect=True),
+                FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.PASSPORT_BACKUP),
+                FlowStep(seed_views.SeedPassportBackupSelectView, real_screens=True),
+                FlowStep(seed_views.SeedPassportBackupCodeEntryView, real_screens=True),
+                FlowStep(seed_views.SeedPassportBackupSelectView),
+            ],
+            # Pick the one backup file, then KEY_UP to the back arrow and click it.
+            ui_session=UISession(script=select(0) + [K.KEY_UP, K.KEY_PRESS]),
+        )
+
+        assert self.controller.storage.seeds == []
+
+    @pytest.mark.parametrize(
+        "option, view",
+        [
+            ("TAPSIGNER_BACKUP", "SeedTapsignerBackupSelectView"),
+            ("BITBOX_BACKUP", "SeedBitbox02BackupSelectView"),
+            ("PASSPORT_BACKUP", "SeedPassportBackupSelectView"),
+        ],
+    )
+    def test_no_backup_files_warns_instead_of_crashing(self, monkeypatch, tmp_path, option, view):
+        """An empty card must reach the warning screen, not an exception."""
+        self.use_microsd(monkeypatch, tmp_path)
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+                FlowStep(seed_views.SeedsMenuView, is_redirect=True),
+                FlowStep(seed_views.LoadSeedView, button_data_selection=getattr(seed_views.LoadSeedView, option)),
+                FlowStep(getattr(seed_views, view), real_screens=True),
+                FlowStep(seed_views.LoadSeedView),
+            ],
+            ui_session=UISession(script=select(0)),  # "OK" on the warning
+        )
+
+        assert self.controller.storage.seeds == []
+
+
+class TestScanSeedQRFlow(SeedFlowTest):
+    """
+    Seeds > Load a seed > Scan a SeedQR.
+
+    The ScanView step stays mocked -- it decodes camera frames rather than button
+    input -- but the finalize screens after it are real, and the seed must land in
+    storage exactly as the typed and generated paths do.
+    """
+
+    def test_scanned_seedqr_is_stored(self):
+        from seedsigner.views import scan_views
+
+        def load_seedqr(view):
+            # A 12-word SeedQR: eleven "abandon" indices plus the checksum word.
+            view.decoder.add_data("0000" * 11 + "0003")
+
+        session = UISession(script=select(seed_views.SeedFinalizeView.FINALIZE))
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SEEDS),
+                FlowStep(seed_views.SeedsMenuView, is_redirect=True),
+                FlowStep(seed_views.LoadSeedView, button_data_selection=seed_views.LoadSeedView.SEED_QR),
+                FlowStep(scan_views.ScanSeedQRView, before_run=load_seedqr),
+                FlowStep(seed_views.SeedFinalizeView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView),
+            ],
+            ui_session=session,
+        )
+
+        seed = self.assert_one_seed_stored()
+        assert seed.mnemonic_list[0] == "abandon"
+
+
+
+class TestAddressVerificationFlow(SeedFlowTest):
+    """
+    Tools > Verify address. The address arrives by QR (ScanView stays mocked); the
+    seed picker and the verification screens are real.
+    """
+
+    def test_singlesig_address_verifies_against_the_loaded_seed(self):
+        from seedsigner.views import scan_views
+
+        self.settings.set_value(
+            SettingsConstants.SETTING__NETWORK, SettingsConstants.REGTEST
+        )
+        seed = self.store_seed(["abandon"] * 11 + ["about"])
+
+        def load_address(view):
+            # Native segwit regtest receive address at index 6 of this seed.
+            view.decoder.add_data("bcrt1q4e9q5taxnsvc6m0uxv6h75mkzvnkxeqk6l90u2")
+
+        session = UISession(script=select(0))  # the one loaded seed
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+                FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.VERIFY_ADDRESS),
+                FlowStep(scan_views.ScanAddressView, before_run=load_address),
+                FlowStep(seed_views.AddressVerificationStartView, is_redirect=True),
+                FlowStep(seed_views.SeedSelectSeedView, real_screens=True),
+                FlowStep(seed_views.SeedAddressVerificationView),
+                FlowStep(seed_views.SeedAddressVerificationSuccessView),
+            ],
+            ui_session=session,
+        )
+
+        assert self.controller.storage.seeds == [seed]
+
+
+
+class TestPendingSeedSentinel(SeedFlowTest):
+    """
+    Unit-level guards for the sentinel itself.
+
+    `seed=None` means "the pending seed, not yet stored". Views that resolve it for
+    display must hand the sentinel onward, or the last step of the flow cannot tell a
+    brand new seed from one that is already in storage -- and stops storing it. These
+    assert the contract directly, so a regression names the responsible View instead
+    of surfacing as a puzzling end-of-flow assertion.
+    """
+
+    def pending_seed(self) -> Seed:
+        seed = Seed(mnemonic=MNEMONIC_12)
+        self.controller.storage.set_pending_seed(seed)
+        return seed
+
+    def test_seed_words_view_resolves_but_preserves_the_sentinel(self):
+        pending = self.pending_seed()
+
+        view = seed_views.SeedWordsView(seed=None)
+        assert view.is_pending_seed is True
+        assert view.seed is pending  # resolved, so the words can be displayed
+
+        with patch.object(seed_views.SeedWordsView, "run_screen", return_value=0):
+            destination = view.run()
+        assert destination.view_args["seed"] is None, "the sentinel must survive this View"
+
+    def test_seed_words_view_keeps_a_real_seed(self):
+        stored = self.store_seed()
+
+        view = seed_views.SeedWordsView(seed=stored)
+        assert view.is_pending_seed is False
+
+        with patch.object(seed_views.SeedWordsView, "run_screen", return_value=0):
+            destination = view.run()
+        assert destination.view_args["seed"] is stored
+
+    def test_backup_test_view_resolves_but_preserves_the_sentinel(self):
+        pending = self.pending_seed()
+
+        view = seed_views.SeedWordsBackupTestView(seed=None, rand_seed=0)
+        assert view.is_pending_seed is True
+        assert view.seed is pending
+
+        with no_shuffle(), patch.object(seed_views.SeedWordsBackupTestView, "run_screen", return_value=0):
+            destination = view.run()
+        assert destination.view_args["seed"] is None
+
+    def test_backup_test_view_copies_the_confirmed_list(self):
+        """
+        Each Destination must carry its own list. Destination.__eq__ compares
+        view_args, so a shared mutable list makes every stacked backup-test
+        Destination compare equal and collapses the back stack.
+        """
+        self.pending_seed()
+
+        view = seed_views.SeedWordsBackupTestView(seed=None, rand_seed=0)
+        with no_shuffle(), patch.object(seed_views.SeedWordsBackupTestView, "run_screen", return_value=0):
+            destination = view.run()
+
+        assert destination.view_args["confirmed_list"] is not view.confirmed_list
+        assert destination.view_args["confirmed_list"] == view.confirmed_list
+
+    def test_discard_view_distinguishes_pending_from_stored(self):
+        pending = self.pending_seed()
+
+        view = seed_views.SeedDiscardView()
+        assert view.is_pending_seed is True
+        assert view.seed is pending
+
+        stored = self.store_seed(
+            "payment artist half drive borrow speak make crouch payment artist half drill".split()
+        )
+        assert seed_views.SeedDiscardView(seed=stored).is_pending_seed is False
+
+    def test_discard_view_clears_a_pending_seed_without_touching_storage(self):
+        """
+        The pending seed is not in storage.seeds, so discarding it must call
+        clear_pending_seed(); discard_seed() would raise ValueError from list.remove().
+        """
+        self.pending_seed()
+
+        view = seed_views.SeedDiscardView()
+        with patch.object(seed_views.SeedDiscardView, "run_screen", return_value=1):  # DISCARD
+            view.run()
+
+        assert self.controller.storage.pending_seed is None
+        assert self.controller.storage.seeds == []

--- a/tests/ui_driver.py
+++ b/tests/ui_driver.py
@@ -16,6 +16,10 @@
       * ScriptedHardwareButtons: plays back a flat script of key presses, one per
         wait_for() call, across all screens in the flow. check_for_low() is served
         from a separate per-call poll feed for screens that poll instead of block.
+        An entry may also be a DeferredInput token (Select, TypeWord), resolved one
+        key at a time against the *live* Screen -- so a test says which option the
+        user picked or which word they typed, rather than a KEY_DOWN count that
+        silently rots when a menu or keyboard gains an entry.
       * MockCameraFeed: Camera stand-in playing back scripted frames (preview reads
         peek at the head; entropy reads consume).
 
@@ -46,6 +50,285 @@ from base import BaseTest  # noqa: F401
 class ScriptExhaustedError(Exception):
     """The screen asked for input (or a camera frame) the script didn't provide."""
     pass
+
+
+
+class ScriptSelectionError(Exception):
+    """A deferred script token couldn't be resolved against the screen asking for input."""
+    pass
+
+
+
+class DeferredInput:
+    """
+    A script entry that decides its keys from the *live* Screen rather than up front.
+
+    ScriptedHardwareButtons calls next_key() once per wait_for(); the token stays at
+    the head of the script until it returns None, at which point it is dropped and the
+    script moves on. Because each key is chosen after seeing the screen's real state,
+    these tokens self-correct instead of encoding a fixed key count that quietly means
+    something different the next time a menu or keyboard layout changes.
+    """
+
+    # Guards a token that can never reach its target against looping forever.
+    max_keys = 400
+
+    def __init__(self):
+        self._emitted = 0
+
+    def next_key(self, screen, watched_keys=None):
+        self._emitted += 1
+        if self._emitted > self.max_keys:
+            raise ScriptSelectionError(
+                f"{self} gave up after {self.max_keys} keys without reaching its target "
+                f"on {type(screen).__name__}"
+            )
+        return self._next_key(screen, watched_keys)
+
+    def _next_key(self, screen, watched_keys):
+        raise NotImplementedError
+
+
+
+class Select(DeferredInput):
+    """
+    "Pick this option on whatever ButtonListScreen is running."
+
+    `option` may be a ButtonOption (matched by identity, then by button_label), a
+    plain label string, or an int index.
+    """
+
+    def __init__(self, option, click_key: str = None):
+        super().__init__()
+        self.option = option
+        self.click_key = click_key
+        self._clicked = False
+
+    def __repr__(self):
+        return f"Select({getattr(self.option, 'button_label', self.option)!r})"
+
+    def _index_in(self, button_data: list) -> int:
+        option = self.option
+        if isinstance(option, int):
+            if not 0 <= option < len(button_data):
+                raise ScriptSelectionError(
+                    f"{self}: index out of range for {len(button_data)} buttons"
+                )
+            return option
+
+        for i, entry in enumerate(button_data):
+            if entry is option:
+                return i
+
+        label = getattr(option, "button_label", option)
+        matches = [i for i, entry in enumerate(button_data)
+                   if getattr(entry, "button_label", entry) == label]
+        if len(matches) == 1:
+            return matches[0]
+        if not matches:
+            available = [getattr(entry, "button_label", entry) for entry in button_data]
+            raise ScriptSelectionError(f"{self} is not on this screen; options are {available}")
+        raise ScriptSelectionError(f"{self} is ambiguous: matches indices {matches}")
+
+    def _next_key(self, screen, watched_keys):
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+        if self._clicked:
+            return None
+
+        button_data = getattr(screen, "button_data", None)
+        if button_data is None:
+            raise ScriptSelectionError(
+                f"{self} was scripted, but the screen asking for input is "
+                f"{type(screen).__name__}, which has no button_data. Only "
+                f"ButtonListScreen-style screens can be driven by Select(); script "
+                f"explicit key constants for the rest."
+            )
+
+        # ButtonListScreen owns the highlighted row, and some screens pre-select one,
+        # so read it rather than assuming the list starts at the top.
+        if getattr(getattr(screen, "top_nav", None), "is_selected", False):
+            # Focus sits on the BACK/power arrow; KEY_DOWN drops back into the list
+            # without moving the selection.
+            return K.KEY_DOWN
+
+        target = self._index_in(button_data)
+        current = getattr(screen, "selected_button", 0)
+
+        if target != current:
+            from seedsigner.gui.screens.screen import LargeButtonScreen
+            if isinstance(screen, LargeButtonScreen):
+                # 2-wide grid: UP/DOWN move by a whole row, LEFT/RIGHT within one.
+                if target // 2 != current // 2:
+                    return K.KEY_DOWN if target > current else K.KEY_UP
+                return K.KEY_RIGHT if target > current else K.KEY_LEFT
+            # ButtonListScreen: a flat list walked one row at a time.
+            return K.KEY_DOWN if target > current else K.KEY_UP
+
+        self._clicked = True
+        click = self.click_key or K.KEY_PRESS
+        if watched_keys is not None and click not in watched_keys:
+            usable = [k for k in watched_keys if k in K.KEYS__ANYCLICK]
+            if not usable:
+                raise ScriptSelectionError(
+                    f"{self}: screen isn't watching a click key ({watched_keys})"
+                )
+            click = usable[0]
+        return click
+
+
+
+class TypeWord(DeferredInput):
+    """
+    "Type this BIP-39 word on the running SeedMnemonicEntryScreen and select it."
+
+    Walks the real keyboard to each letter in turn and locks it in, then scrolls the
+    autocomplete list to the word and presses KEY2 to choose it. Every step is decided
+    from the screen's own live state (`letters`, `keyboard.selected_key`,
+    `possible_words`), so the letter-activation behaviour never has to be mirrored
+    here -- which is exactly the part that would go stale.
+    """
+
+    def __init__(self, word: str):
+        super().__init__()
+        self.word = word
+        self._selected = False
+
+    def __repr__(self):
+        return f"TypeWord({self.word!r})"
+
+    def _next_key(self, screen, watched_keys):
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+        if self._selected:
+            return None
+
+        keyboard = getattr(screen, "keyboard", None)
+        if keyboard is None or not hasattr(screen, "possible_words"):
+            raise ScriptSelectionError(
+                f"{self} was scripted, but the screen asking for input is "
+                f"{type(screen).__name__}, not a SeedMnemonicEntryScreen."
+            )
+
+        # The screen keeps locked-in letters in `letters[:-1]`; `letters[-1]` is
+        # whichever key the cursor is merely hovering over.
+        locked = "".join(screen.letters[:-1]) if screen.letters else ""
+
+        if len(locked) < len(self.word):
+            if not self.word.startswith(locked):
+                raise ScriptSelectionError(
+                    f"{self}: the screen already holds {locked!r}, which is not a prefix "
+                    f"of the word"
+                )
+            return self._key_toward(keyboard, self.word[len(locked)])
+
+        # Whole word is entered; pick it out of the autocomplete list.
+        possible = list(screen.possible_words)
+        if self.word not in possible:
+            raise ScriptSelectionError(
+                f"{self}: not among the screen's matches after typing it ({possible[:5]})"
+            )
+        target = possible.index(self.word)
+        current = screen.selected_possible_words_index
+        if current > target:
+            return K.KEY1   # scroll the matches list up
+        if current < target:
+            return K.KEY3   # scroll the matches list down
+
+        self._selected = True
+        return K.KEY2       # choose the highlighted match
+
+    def _key_toward(self, keyboard, letter: str):
+        """One step toward `letter`, or the click that locks it in."""
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+        target = _find_key(keyboard, letter)
+        if target is None:
+            raise ScriptSelectionError(f"{self}: {letter!r} is not on the keyboard")
+
+        return _step_toward(keyboard, target) or K.KEY_PRESS
+
+
+
+class TypeKeys(DeferredInput):
+    """
+    "Type this string on the running KeyboardScreen."
+
+    `text` is what the screen should end up holding, i.e. the *output* values -- for
+    ToolsDiceEntropyEntryScreen that is "1".."6", not the dice glyphs its keys display
+    (the screen's keys_to_values map is used to find the key for each value).
+
+    Presses KEY3 to save at the end when the screen has a save button; screens that
+    auto-return at return_after_n_chars (dice entropy) simply exit on the final press.
+    """
+
+    def __init__(self, text: str):
+        super().__init__()
+        self.text = text
+        self._pressed = 0
+        self._saved = False
+        self._done = False
+
+    def __repr__(self):
+        preview = self.text if len(self.text) <= 12 else self.text[:12] + "..."
+        return f"TypeKeys({preview!r})"
+
+    def _next_key(self, screen, watched_keys):
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+        if self._done:
+            return None
+
+        if self._pressed >= len(self.text):
+            # Everything is typed. A screen with a save button still needs the click;
+            # one that auto-returns on the last character has already exited, so by now
+            # `screen` is the next screen and this token is simply finished.
+            if not self._saved and getattr(screen, "show_save_button", False) and hasattr(screen, "user_input"):
+                self._saved = True
+                return K.KEY3
+            self._done = True
+            return None
+
+        keyboard = getattr(screen, "keyboard", None)
+        if keyboard is None or not hasattr(screen, "user_input"):
+            raise ScriptSelectionError(
+                f"{self} was scripted, but the screen asking for input is "
+                f"{type(screen).__name__}, not a KeyboardScreen."
+            )
+
+        value = self.text[self._pressed]
+        key_char = self._key_char_for(screen, value)
+        target = _find_key(keyboard, key_char)
+        if target is None:
+            raise ScriptSelectionError(f"{self}: no key produces {value!r} on this keyboard")
+
+        move = _step_toward(keyboard, target)
+        if move is None:
+            self._pressed += 1
+            return K.KEY_PRESS
+        return move
+
+    @staticmethod
+    def _key_char_for(screen, value: str) -> str:
+        """The key's display character for an output `value` (they differ on dice)."""
+        mapping = getattr(screen, "keys_to_values", None)
+        if not mapping:
+            return value
+        for key_char, mapped in mapping.items():
+            if mapped == value:
+                return key_char
+        raise ScriptSelectionError(f"{value!r} is not in this screen's keys_to_values map")
+
+
+
+def select(*options) -> list:
+    """Shorthand for a run of Select() tokens: `select(A, B, C)`."""
+    return [Select(option) for option in options]
+
+
+def type_words(words) -> list:
+    """Shorthand for a run of TypeWord() tokens, one per mnemonic word."""
+    return [TypeWord(word) for word in words]
 
 
 
@@ -83,10 +366,13 @@ class ScriptedHardwareButtons(MagicMock):
     check_for_low(), for screens that poll rather than block (e.g. image entropy).
     """
 
-    def __init__(self, script=None, poll_responses=None):
+    def __init__(self, script=None, poll_responses=None, screen_provider=None):
         super().__init__()
         self._script = list(script or [])
         self._polls = list(poll_responses or [])
+        # Returns the Screen currently asking for input, so DeferredInput tokens can
+        # be resolved against its real state. Supplied by UISession.
+        self._screen_provider = screen_provider or (lambda: None)
         self.override_ind = False
         # A real float: background threads (e.g. WipeTimerThread) read this and do
         # arithmetic on it; a bare MagicMock attribute would raise TypeError there.
@@ -106,12 +392,23 @@ class ScriptedHardwareButtons(MagicMock):
             self.override_ind = False
             from seedsigner.hardware.buttons import HardwareButtonsConstants
             return HardwareButtonsConstants.OVERRIDE
-        if not self._script:
-            raise ScriptExhaustedError(
-                "wait_for() called but the button script is exhausted; the screen is "
-                "waiting for input the test didn't provide"
-            )
-        return self._script.pop(0)
+
+        while True:
+            if not self._script:
+                raise ScriptExhaustedError(
+                    "wait_for() called but the button script is exhausted; the screen is "
+                    "waiting for input the test didn't provide"
+                )
+            entry = self._script[0]
+            if not isinstance(entry, DeferredInput):
+                return self._script.pop(0)
+
+            key = entry.next_key(self._screen_provider(), keys)
+            if key is None:
+                # Token is finished; drop it and serve whatever comes next.
+                self._script.pop(0)
+                continue
+            return key
 
     def check_for_low(self, key=None, keys=None):
         if not self._polls:
@@ -166,16 +463,48 @@ class UISession:
 
     def __init__(self, script=None, poll_responses=None, camera_frames=None, canvas_size=(240, 240)):
         self.renderer = make_test_renderer(*canvas_size)
-        self.buttons = ScriptedHardwareButtons(script=script, poll_responses=poll_responses)
+        # The Screen currently running, so DeferredInput tokens can be resolved
+        # against its real state (see _track_screen below).
+        self.current_screen = None
+        self.buttons = ScriptedHardwareButtons(
+            script=script,
+            poll_responses=poll_responses,
+            screen_provider=lambda: self.current_screen,
+        )
         self.camera = MockCameraFeed(camera_frames) if camera_frames is not None else None
+
+    @property
+    def remaining_script(self) -> list:
+        """
+        What the flow never consumed. A non-empty list at the end of a test means the
+        flow asked for less input than the test scripted -- i.e. it did not go where
+        the test says it went.
+        """
+        return self.buttons.remaining_script
+
+    def _track_screen(self, real_display):
+        """Wrap BaseScreen.display() so DeferredInput tokens can see the live Screen."""
+        session = self
+
+        def display(screen_self, *args, **kwargs):
+            previous = session.current_screen
+            session.current_screen = screen_self
+            try:
+                return real_display(screen_self, *args, **kwargs)
+            finally:
+                session.current_screen = previous
+
+        return display
 
     def __enter__(self):
         from seedsigner.gui.renderer import Renderer
+        from seedsigner.gui.screens.screen import BaseScreen
         from seedsigner.hardware.buttons import HardwareButtons, HardwareButtonsConstants
 
         self._patches = [
             patch.object(Renderer, "get_instance", return_value=self.renderer),
             patch.object(HardwareButtons, "get_instance", return_value=self.buttons),
+            patch.object(BaseScreen, "display", self._track_screen(BaseScreen.display)),
         ]
         if self.camera is not None:
             from seedsigner.hardware.camera import Camera
@@ -271,6 +600,40 @@ def _find_key(keyboard, char):
 
 
 
+def _step_toward(keyboard, target_key):
+    """
+    The single key press that moves the keyboard's selection toward `target_key`,
+    or None once it is already there.
+
+    Vertical moves keep the current column and skip any row that has no key in it
+    (Keyboard.get_key_below/above). So when the target row has no key in the column
+    we are standing in, going "down" jumps straight past that row and coming back
+    "up" jumps past it again -- an oscillation that never terminates. Step sideways
+    onto a column the target row actually has before moving vertically.
+
+    Callers apply the returned key to the real Keyboard (or let the real Screen do
+    it) and call again, so the walk always reflects the keyboard's actual state.
+    """
+    from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+    if keyboard.get_selected_key() is target_key:
+        return None
+
+    cur_x = keyboard.selected_key["x"]
+    cur_y = keyboard.selected_key["y"]
+
+    if cur_y != target_key.index_y:
+        if keyboard.get_key_at(cur_x, target_key.index_y) is None:
+            # This column doesn't exist in the target row; slide along the current
+            # row first (these keyboards auto-wrap right, so this always terminates).
+            return K.KEY_RIGHT
+        return K.KEY_DOWN if target_key.index_y > cur_y else K.KEY_UP
+
+    # Right row: RIGHT cycles through it.
+    return K.KEY_RIGHT
+
+
+
 def plan_keyboard_script(keyboard, text) -> list:
     """
     Compute the joystick + KEY_PRESS sequence that types `text` on a single Keyboard.
@@ -285,30 +648,26 @@ def plan_keyboard_script(keyboard, text) -> list:
     if Keyboard.WRAP_RIGHT not in keyboard.auto_wrap:
         raise ValueError("plan_keyboard_script() requires a keyboard with WRAP_RIGHT auto-wrap")
 
+    # Any layout is crossed in far fewer moves than this; the cap turns a layout the
+    # walk cannot solve into a named error instead of a hang.
+    max_moves_per_char = 200
+
     script = []
     for char in text:
         target_key = _find_key(keyboard, char)
         if target_key is None:
             raise ValueError(f"Character {char!r} is not on this keyboard's layout")
 
-        # Move vertically toward the target row. We only ever move within range, so
-        # an EXIT here means the plan is wrong (e.g. a screen without vertical keys).
-        while keyboard.selected_key["y"] != target_key.index_y:
-            move = HardwareButtonsConstants.KEY_DOWN if target_key.index_y > keyboard.selected_key["y"] else HardwareButtonsConstants.KEY_UP
+        for _ in range(max_moves_per_char):
+            move = _step_toward(keyboard, target_key)
+            if move is None:
+                break
             ret = keyboard.update_from_input(move)
             if ret in Keyboard.EXIT_DIRECTIONS:
-                raise ValueError(f"Vertical navigation exited the keyboard while planning {char!r}")
+                raise ValueError(f"Navigation exited the keyboard while planning {char!r}")
             script.append(move)
-
-        # Move horizontally within the row; with WRAP_RIGHT, RIGHT cycles through every key.
-        row = keyboard.keys[keyboard.selected_key["y"]]
-        cur_pos = row.index(keyboard.get_selected_key())
-        tgt_pos = row.index(target_key)
-        for _ in range((tgt_pos - cur_pos) % len(row)):
-            ret = keyboard.update_from_input(HardwareButtonsConstants.KEY_RIGHT)
-            if ret in Keyboard.EXIT_DIRECTIONS:
-                raise ValueError(f"Horizontal navigation exited the keyboard while planning {char!r}")
-            script.append(HardwareButtonsConstants.KEY_RIGHT)
+        else:
+            raise ValueError(f"Could not navigate to {char!r} in {max_moves_per_char} moves")
 
         if _CHAR_TO_KEY_CODE.get(char, char) != keyboard.get_selected_key().code:
             raise ValueError(f"Keyboard simulation failed to land on {char!r}")


### PR DESCRIPTION
## Problem

Creating a new seed (Tools → Dice, Tools → Camera entropy, or SLIP-39 generate) walks the user through the words and the backup verification test, ends on a `SeedOptionsView` showing the correct fingerprint — and never adds the seed to `controller.storage.seeds`. The new seed does not appear under **Seeds**.

Because the flow ends on the right screen with the right fingerprint, the failure is invisible until the user goes looking for the seed.

### Root cause

The generate-new-seed flows signal *"this seed is pending, not yet stored"* by passing the sentinel `view_args={"seed": None}` down the View chain. Downstream views branch on `seed is None` to choose between "call `finalize_pending_seed()`" and "this seed is already stored".

`SeedWordsView.__init__` and `SeedWordsBackupTestView.__init__` resolved that sentinel into a real `Seed` for display and then forwarded the **resolved object**. From there every view took the already-stored branch, `SeedFinalizeView` was never reached, and `SeedStorage.finalize_pending_seed()` — the only place `storage.seeds.append()` happens — was never called.

Both exits from the backup test are affected: **Verify** (via `SeedWordsBackupTestSuccessView`) and **Skip** (via `SeedWordsBackupTestPromptView`).

### Provenance

Introduced by `6efd9d33` "Adopt upstream's Seed-object view API" — the mechanical `seed_num` → `seed` rewrite that followed the 118-commit upstream merge `6654d9c8`. Upstream guards exactly this with an `is_pending_seed` flag in three views (`git show 65e312c9:src/seedsigner/views/seed_views.py`); the rewrite dropped it. `grep -rn "is_pending_seed" src/ tests/` returned nothing on `dev`.

It is **not** caused by `b20a7d49` (back stack): that unwind only mutates `self.back_stack` after `run()` and never stops a View from executing.

## Changes

### 1. Restore the pending-seed sentinel — `src/seedsigner/views/seed_views.py`

Reinstate upstream's `is_pending_seed` flag at the three `__init__` sites that resolve the sentinel, and put the sentinel back before routing onward. Matching upstream's shape keeps future `upstream/dev` merges clean.

- **`SeedWordsView`** — flag in `__init__`; `self.seed = None` restored before the `NEXT`/`DONE` branches. This also revives two lines that had become dead code, fixing the last page reading "Done" instead of "Next" for a pending seed.
- **`SeedWordsBackupTestView`** — same, so `SeedWordsBackupTestSuccessView`, the next `SeedWordsBackupTestView`, and `SeedWordsBackupTestMistakeView` all receive the sentinel. Those three views already implemented both branches correctly and needed no changes.
- **`SeedDiscardView`** — the same defect here was a **crash**, not a silent drop. Reached with no args from `ToolsCalcFinalWordDoneView` (Tools → Calc 12th/24th word → Discard), it resolved `self.seed` to the pending seed, took the "already stored" branch, and called `storage.seeds.remove()` on a seed that was never in the list → `ValueError` → unhandled-exception screen. The existing flow test stopped at `SeedDiscardView` without ever pressing Discard.
- **`confirmed_list`** is now passed as a copy. Since `b20a7d49`, `Destination.__eq__` compares `view_args`; sharing one mutable list made every stacked backup-test `Destination` compare equal, collapsing the verification chain in the Controller's back-stack unwind. Latent today only because that screen sets `show_back_button=False`.

### 2. `Keyboard` crashed on `KeyboardScreen`'s own default — `src/seedsigner/gui/keyboard.py`

Found by the new tests. `Keyboard.__init__` iterates `additional_keys` and reads `additional_key["size"]`, but `KeyboardScreen.custom_additional_keys` defaults to `Keyboard.ADDITIONAL_KEYS`, which is a **dict keyed by code string**. Iterating it yields strings, so any bare `KeyboardScreen` raised `TypeError: string indices must be integers` at construction.

Two views were affected and crashed on device:

- `SeedTapsignerBackupKeyEntryView` (Load a seed → TAPSIGNER backup → key entry)
- `SeedPassportBackupCodeEntryView` (Load a seed → Passport backup → code entry)

`ToolsDiceEntropyEntryScreen` carries a comment describing this exact hazard and works around it locally; this fixes the root cause instead, normalizing the dict form once in `Keyboard.__init__` so both call shapes work.

### 3. Real-screen coverage for every seed workflow — `tests/`

The regression shipped because no test drove a seed from a real creation entry point through to storage. `tests/test_flows_seed_backup.py` does cover the backup test, but always via `store_bip39_seed()` — a seed already put through `finalize_pending_seed()` — entering at `SeedOptionsView`. That is precisely the branch that still worked.

**`tests/ui_driver.py`** gains deferred input tokens, resolved one key at a time against the *live* Screen rather than planned up front, so a test says what the user did instead of encoding a `KEY_DOWN` count that rots silently when a menu gains an entry:

- `Select(option)` — pick a `ButtonOption` on the running `ButtonListScreen` / `LargeButtonScreen`
- `TypeWord(word)` — type and choose a word on `SeedMnemonicEntryScreen`
- `TypeKeys(text)` — type on any `KeyboardScreen` (maps through `keys_to_values`, e.g. dice glyphs)

`UISession` now tracks the running Screen (wrapping `BaseScreen.display`) so those tokens can read its real state, and exposes `remaining_script` so a flow that consumed less input than scripted fails loudly.

It also fixes an **infinite loop in the existing `plan_keyboard_script`**: vertical moves keep the current column and skip rows that have no key in it, so a target row without a key in the current column made the walk oscillate forever. Typing `"swordfish"` on `ScanTypeEncryptionKeyScreen` hung outright; the existing tests happened to use strings that avoided it. Navigation now steps sideways onto a valid column first, via a shared `_step_toward()` used by the planner and both typing tokens, with a step budget that turns any residual pathology into a named error rather than a hang.

**`tests/test_real_screen_flows_seed.py`** — 39 tests, one per workflow, each driven from its real entry point rather than dropped into the middle with a pre-built seed:

| Workflow | Covers |
|---|---|
| Create seed — dice | Verify and Skip exits; seed reaches `storage.seeds`; appears in the Seeds menu |
| Create seed — camera entropy | same, plus the camera buffers being cleared |
| Create SLIP-39 seed | words + backup test once per share, then finalize |
| Calc 12th/24th word | Load → finalize; Discard → the `ValueError` above; Discard → Keep |
| Load seed — manual entry | 12 words on the real keyboard; BACK from word #1 cancels |
| Load seed — Electrum | real Electrum seed through word entry |
| Load seed — SLIP-39 shares | two typed shares combined into a stored seed |
| Load seed — SeedQR | scan mocked, finalize real |
| Passphrase | typed on the real multi-keyboard, applied, then stored |
| Seeds menu | every loaded seed listed and selectable by its own fingerprint |
| View words + backup test | stored seeds; wrong word → retry; Skip; no duplication in storage |
| Export xpub | sig type → script type → format → warning → details → QR |
| SeedQR transcription | format, warning, whole-QR, zoomed-in pan, confirm prompt |
| Encrypted QR | encryption key and mnemonic ID typed on the real keyboards |
| BIP-85 child seed | child stored *alongside* the parent |
| SLIP-39 regenerate shares | on a stored extendable seed |
| Sign message | scan mocked; confirm message / address / signature QR real |
| Address verification | scan mocked; seed picker and verification real |
| Discard seed | stored seed removed; Keep returns to options |
| Hardware wallet backups | TAPSIGNER backup decoded off a real temp microSD; empty-card warning for TAPSIGNER / BitBox02 / Passport |
| Pending-seed sentinel | unit-level guards on all three views, so a regression names the culprit |

Creation tests assert on `controller.storage.seeds`, not on which View the flow ended at — the broken flow ended on the right View.

**Deliberately left on mocked `FlowTest`:** SeedKeeper / Specter-DIY / smartcard import paths, which need card-connector mocks that `tests/test_flows_smartcard_hardware.py` and `tests/test_seedkeeper_*.py` already provide; and the camera-driven steps (`ScanView`, the image-entropy live preview), which respond to frames rather than button input. Those steps stay mocked while every screen around them is real.

## Verification

**13 of the 39 new tests fail on the current `dev`** and pass with the fix — the creation flows, the two Discard paths, and all six sentinel guards. Another 2 fail without the `Keyboard` fix. The rest cover branches these bugs did not touch and pass either way.

Full suite, before and after:

```
PYTHONPATH=src python -m pytest -q
before:  22 failed, 1506 passed, 228 skipped
after:   22 failed, 1544 passed, 228 skipped
```

The failure sets are byte-identical — no new failures, 38 more passing tests. All 22 are pre-existing and unrelated: 20 in `test_gpg_message.py` from `ModuleNotFoundError: No module named 'tools'`, plus `test_psbt_refusal_screens.py::TestBlockAnchor::test_shipped_json_is_plausible` and `test_pysatochip_contract.py::test_real_connector_has_satodime_ndef_v2`. They reproduce identically with these changes stashed.

Manual check on hardware, for each creation entry point and both backup-test exits:

1. Tools → New seed → complete the flow → land on `SeedOptionsView`
2. Back to the main menu → **Seeds** → the new fingerprint is listed
3. Tools → Calc 12th/24th word → Discard → returns to the main menu with no crash
4. Seeds → Load a seed → TAPSIGNER backup → the key entry screen opens instead of crashing

## Note on the base branch

Targets `feature/satochip-enable-2fa-safeguards` (#431) so it merges after it, per the stacking request. Retarget to `dev` if #431 lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
