### PR TITLE
test: extend real-screen menu-walking coverage to every remaining workflow

### DIFF
--- a/tests/real_screen_fixtures.py
+++ b/tests/real_screen_fixtures.py
@@ -1,0 +1,201 @@
+"""
+    Shared hardware stand-ins for the real-screen flow suites
+    (``test_real_screen_flows*.py``).
+
+    Each of these existed in exactly one test file before; they live here so the
+    per-area suites reuse one stand-in rather than growing their own slightly
+    different copy. Nothing here mocks a *View* or a *Screen* -- the point of these
+    suites is that the real ones run. These only stand in for the things a desktop
+    test run genuinely does not have: a smartcard, a microSD card, a camera.
+
+    **The card seam matters.** `satochip_connector()` patches
+    ``seedkeeper_utils.init_satochip``, which is the single point every card-backed
+    flow goes through. Tests must not reach past it into connector internals: keeping
+    that one seam is what lets the backend be swapped later for a jcardsim-backed
+    simulator running the real applets, without rewriting any test.
+"""
+
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Must import test base before the Controller (sets up the hardware module mocks)
+import base  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Smartcard
+# ---------------------------------------------------------------------------
+
+class MockSatochipConnector:
+    """
+    Spy stand-in for the pysatochip ``CardConnector``.
+
+    Records what the flow asked the card to do so a test can assert on the write
+    that matters (or on there having been none), and returns the ``(data, sw1, sw2)``
+    shape the real connector returns.
+    """
+
+    def __init__(self, needs_2fa=False, label="TestCard", is_seeded=True):
+        self.needs_2FA = needs_2fa
+        self.card_label = label
+        self.is_seeded = is_seeded
+        # Call logs, for assertions
+        self.set_2fa_calls = []
+        self.pin_changes = []
+        self.label_changes = []
+        self.reset_calls = 0
+
+    def card_set_2FA_key(self, hmacsha160_key, amount_limit=0):
+        self.set_2fa_calls.append((hmacsha160_key, amount_limit))
+        return (b"", 0x90, 0x00)
+
+    def card_change_PIN(self, pin_nbr, old_pin, new_pin):
+        self.pin_changes.append((pin_nbr, old_pin, new_pin))
+        return (b"", 0x90, 0x00)
+
+    def card_set_label(self, label):
+        self.label_changes.append(label)
+        return True
+
+    def card_get_label(self):
+        return (b"", 0x90, 0x00, self.card_label)
+
+    def card_reset_factory(self):
+        self.reset_calls += 1
+        return (b"", 0xFF, 0x00)
+
+
+@contextmanager
+def satochip_connector(monkeypatch, **kwargs):
+    """
+    Make every card-backed flow talk to a `MockSatochipConnector`.
+
+    Patches the one seam (`seedkeeper_utils.init_satochip`) rather than any
+    connector internal -- see the module docstring.
+    """
+    from seedsigner.helpers import seedkeeper_utils
+
+    connector = MockSatochipConnector(**kwargs)
+    monkeypatch.setattr(seedkeeper_utils, "init_satochip", lambda *a, **kw: connector)
+    yield connector
+
+
+class FakePyGP:
+    """
+    Stand-in for the ``pygp`` native module used by the JavaCard DIY views.
+
+    Reports one installed applet (Satochip) so the uninstall flow reaches its applet
+    picker, and accepts every card operation without touching hardware.
+    """
+
+    SECURITY_LEVEL_C_MAC = 1
+
+    def terminal(self): pass
+    def card(self): pass
+    def auth(self, **kwargs): pass
+    def get_loaded_package_aids(self): return ["5361746F43686970"]
+    def get_package_module_map(self): return {}
+    def get_installed_application_aids(self): return []
+    def delete_package(self, aid): pass
+    def install_capfile(self, *args, **kwargs): return {}
+    def get_cap_info(self, path): raise AssertionError("not expected in this flow")
+
+
+def javacard_diy_patchers(cap_dir=None) -> list:
+    """Context managers that let the JavaCard DIY views run without a card."""
+    patchers = [
+        patch.dict(sys.modules, {"pygp": FakePyGP()}),
+        patch("seedsigner.helpers.seedkeeper_utils.restart_pn532"),
+    ]
+    if cap_dir is not None:
+        patchers += [
+            patch("seedsigner.views.smartcard_views._get_internal_cap_dir", return_value=cap_dir),
+            patch("seedsigner.hardware.microsd.MicroSD.get_microsd_dir", return_value=cap_dir.parent),
+        ]
+    return patchers
+
+
+# ---------------------------------------------------------------------------
+# microSD
+# ---------------------------------------------------------------------------
+
+def use_microsd(monkeypatch, tmp_path: Path) -> Path:
+    """Point `MicroSD.get_microsd_dir()` at a real temp directory."""
+    from seedsigner.hardware.microsd import MicroSD
+
+    monkeypatch.setattr(MicroSD, "get_microsd_dir", staticmethod(lambda: tmp_path))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# GPG
+# ---------------------------------------------------------------------------
+
+def gpg_is_available() -> bool:
+    import importlib.util
+    import shutil
+
+    return shutil.which("gpg") is not None and importlib.util.find_spec("pgpy") is not None
+
+
+GPG_AVAILABLE = gpg_is_available()
+
+requires_gpg = pytest.mark.skipif(
+    not GPG_AVAILABLE, reason="gpg binary and/or pgpy not available"
+)
+
+
+@pytest.fixture
+def gnupghome(monkeypatch):
+    """An isolated, *short*-path GNUPGHOME, exported to the environment.
+
+    gpg-agent listens on a unix socket at ``$GNUPGHOME/S.gpg-agent``, so the homedir
+    is bound by the ~108 byte ``sun_path`` limit. pytest's ``tmp_path`` blows past
+    that on CI runners and gpg then fails every secret-key operation with "failed to
+    start gpg-agent ...: General error". Rooting the keyring directly under the system
+    temp dir keeps it well inside the limit.
+    """
+    from test_gpg_message import _msys2_path
+
+    # ignore_cleanup_errors: on Windows a lingering gpg-agent can still hold the
+    # keyring open when the test ends.
+    with tempfile.TemporaryDirectory(prefix="ss-gnupg-", ignore_cleanup_errors=True) as home:
+        home = _msys2_path(home)
+        monkeypatch.setenv("GNUPGHOME", home)
+        yield home
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers reused across suites
+# ---------------------------------------------------------------------------
+
+@contextmanager
+def no_shuffle():
+    """
+    Pin `SeedWordsBackupTestView`'s correct answer to ``button_data[0]``.
+
+    The view shuffles its four candidate words, so without this the right answer sits
+    at a random index and `Select()` would have to guess.
+    """
+    with patch("seedsigner.views.seed_views.random.shuffle", lambda seq: None):
+        yield
+
+
+@contextmanager
+def index_screen(return_value):
+    """
+    Stub `SeedBIP85SelectChildIndexScreen`, which several views instantiate and
+    ``.display()`` directly instead of going through ``run_screen()`` -- so FlowTest
+    cannot see them and the FlowStep needs ``is_redirect=True``.
+    """
+    from seedsigner.views import seed_views
+
+    values = return_value if isinstance(return_value, list) else [return_value]
+    with patch.object(seed_views.seed_screens, "SeedBIP85SelectChildIndexScreen") as mock:
+        mock.return_value.display.side_effect = values
+        yield mock

--- a/tests/test_real_screen_flows_gpg.py
+++ b/tests/test_real_screen_flows_gpg.py
@@ -1,0 +1,189 @@
+"""
+    Real-screen flow tests for GPG Tools.
+
+    gpg_views.py is the largest view module in the app (64 View classes) and 36 of them
+    were never named in any test: the whole Subkey, UID, Secure Messaging, Export and
+    SmartGPG submenus. The two existing real-screen GPG tests
+    (test_real_screen_flows.py) cover only the BIP-85 derive and generate-new keyboard
+    prompts.
+
+    These run against a real gpg binary in an isolated GNUPGHOME, so they exercise the
+    actual subprocess calls rather than a stand-in. CI installs gnupg2, so this is real
+    coverage there too; the GPG_AVAILABLE guard only skips environments without it.
+
+    SmartGPG needs a physical OpenPGP card, so only its menu and no-card error paths are
+    covered here.
+"""
+
+import subprocess
+
+import pytest
+
+# Must import test base before the Controller (sets up the hardware mocks)
+import base  # noqa: F401
+from base import FlowStep, FlowTest
+from real_screen_fixtures import gnupghome, requires_gpg  # noqa: F401  (fixture)
+from ui_driver import Back, UISession, select
+
+# tools_views must be imported first: it is a facade that star-imports gpg_views,
+# and reaching gpg_views directly first hits a circular import.
+from seedsigner.views import tools_views
+from seedsigner.views import gpg_views
+from seedsigner.views.view import MainMenuView
+
+
+pytestmark = requires_gpg
+
+
+def generate_test_key(gnupghome: str, uid: str = "Flow Test <flow@example.com>") -> str:
+    """Put one real secret key in the isolated keyring; returns its fingerprint."""
+    import os
+
+    env = dict(os.environ, GNUPGHOME=gnupghome)
+    subprocess.run(
+        ["gpg", "--batch", "--pinentry-mode", "loopback", "--passphrase", "",
+         "--quick-generate-key", uid, "default", "default", "never"],
+        capture_output=True, text=True, env=env, check=True,
+    )
+    listed = subprocess.run(
+        ["gpg", "--batch", "--with-colons", "--list-secret-keys"],
+        capture_output=True, text=True, env=env, check=True,
+    )
+    for line in listed.stdout.splitlines():
+        if line.startswith("fpr:"):
+            return line.split(":")[9]
+    raise AssertionError(f"no key generated:\n{listed.stdout}")
+
+
+class GPGFlowTest(FlowTest):
+
+    def gpg_steps(self, *options) -> list:
+        """From the main menu into GPG Tools, then down `options` worth of menus."""
+        return [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.GPG),
+        ]
+
+
+
+class TestGPGViewKeysFlow(GPGFlowTest):
+    """
+    GPG Tools > View Keys. Read-only, pure ButtonListScreens, and the easiest real GPG
+    walk -- but the whole chain (key list, key details, subkey list, subkey details) was
+    unwalked.
+    """
+
+    def test_walk_a_real_keys_details_and_subkeys(self, gnupghome):
+        generate_test_key(gnupghome)
+
+        session = UISession(script=(
+            select(gpg_views.ToolsGPGMenuView.VIEW_KEYS)
+            + select(0)  # the one key in the keyring
+            + select(0)  # its details -> subkeys
+            + select(0)  # the one subkey
+            + [Back()]
+        ))
+
+        self.run_sequence(
+            self.gpg_steps() + [
+                FlowStep(gpg_views.ToolsGPGMenuView, real_screens=True),
+                FlowStep(gpg_views.ToolsGPGViewKeysView, real_screens=True),
+                FlowStep(gpg_views.ToolsGPGKeyDetailsView, real_screens=True),
+                FlowStep(gpg_views.ToolsGPGKeySubkeysView, real_screens=True),
+                FlowStep(gpg_views.ToolsGPGSubkeyDetailsView, real_screens=True),
+                FlowStep(gpg_views.ToolsGPGKeySubkeysView),
+            ],
+            ui_session=session,
+        )
+
+        assert session.renderer.frames, "the real GPG screens never rendered"
+
+    def test_empty_keyring_warns(self, gnupghome):
+        """No keys is a warning, not an empty list the user can get stuck in."""
+        session = UISession(script=(
+            select(gpg_views.ToolsGPGMenuView.VIEW_KEYS)
+            + select(0)  # "OK" on the no-keys warning
+        ))
+
+        self.run_sequence(
+            self.gpg_steps() + [
+                FlowStep(gpg_views.ToolsGPGMenuView, real_screens=True),
+                FlowStep(gpg_views.ToolsGPGViewKeysView, real_screens=True),
+                FlowStep(gpg_views.ToolsGPGMenuView),
+            ],
+            ui_session=session,
+        )
+
+
+
+class TestGPGSubmenuNavigation(GPGFlowTest):
+    """
+    The submenus themselves. Every one of these was among the 36 gpg_views classes
+    never named in a test, so a screen-construction error in any of them would only
+    have shown up on device.
+    """
+
+    @pytest.mark.parametrize(
+        "menu_option, submenu_view",
+        [
+            (gpg_views.ToolsGPGMenuView.FILE_OPS, gpg_views.ToolsGPGFileOpsMenuView),
+            (gpg_views.ToolsGPGMenuView.IMPORT, gpg_views.ToolsGPGImportMenuView),
+            (gpg_views.ToolsGPGMenuView.EXPORT, gpg_views.ToolsGPGExportMenuView),
+            (gpg_views.ToolsGPGMenuView.MESSAGE, gpg_views.ToolsGPGMessageMenuView),
+            (gpg_views.ToolsGPGMenuView.SMART_GPG, gpg_views.ToolsGPGSmartMenuView),
+            (gpg_views.ToolsGPGMenuView.ADVANCED, gpg_views.ToolsGPGAdvancedMenuView),
+        ],
+    )
+    def test_submenu_opens_and_backs_out(self, gnupghome, menu_option, submenu_view):
+        session = UISession(script=select(menu_option) + [Back()])
+
+        self.run_sequence(
+            self.gpg_steps() + [
+                FlowStep(gpg_views.ToolsGPGMenuView, real_screens=True),
+                FlowStep(submenu_view, real_screens=True),
+                FlowStep(gpg_views.ToolsGPGMenuView),
+            ],
+            ui_session=session,
+        )
+
+    @pytest.mark.parametrize(
+        "advanced_option, submenu_view",
+        [
+            (gpg_views.ToolsGPGAdvancedMenuView.SUBKEY_OPS, gpg_views.ToolsGPGSubkeyMenuView),
+            (gpg_views.ToolsGPGAdvancedMenuView.UID_OPS, gpg_views.ToolsGPGUidMenuView),
+            (gpg_views.ToolsGPGAdvancedMenuView.BIP85_META, gpg_views.ToolsGPGBip85MetadataMenuView),
+        ],
+    )
+    def test_advanced_submenu_opens_and_backs_out(self, gnupghome, advanced_option, submenu_view):
+        session = UISession(script=(
+            select(gpg_views.ToolsGPGMenuView.ADVANCED)
+            + select(advanced_option)
+            + [Back()]
+        ))
+
+        self.run_sequence(
+            self.gpg_steps() + [
+                FlowStep(gpg_views.ToolsGPGMenuView, real_screens=True),
+                FlowStep(gpg_views.ToolsGPGAdvancedMenuView, real_screens=True),
+                FlowStep(submenu_view, real_screens=True),
+                FlowStep(gpg_views.ToolsGPGAdvancedMenuView),
+            ],
+            ui_session=session,
+        )
+
+    def test_sign_submenu_under_file_ops(self, gnupghome):
+        session = UISession(script=(
+            select(gpg_views.ToolsGPGMenuView.FILE_OPS)
+            + select(gpg_views.ToolsGPGFileOpsMenuView.SIGN)
+            + [Back()]
+        ))
+
+        self.run_sequence(
+            self.gpg_steps() + [
+                FlowStep(gpg_views.ToolsGPGMenuView, real_screens=True),
+                FlowStep(gpg_views.ToolsGPGFileOpsMenuView, real_screens=True),
+                FlowStep(gpg_views.ToolsGPGSignMenuView, real_screens=True),
+                FlowStep(gpg_views.ToolsGPGFileOpsMenuView),
+            ],
+            ui_session=session,
+        )

--- a/tests/test_real_screen_flows_psbt.py
+++ b/tests/test_real_screen_flows_psbt.py
@@ -1,0 +1,231 @@
+"""
+    Real-screen flow tests for PSBT signing.
+
+    tests/test_flows_psbt.py already covers this routing thoroughly -- but with
+    View.run_screen() mocked, so not one PSBT Screen is ever constructed. These are the
+    screens that do the heaviest layout and text-fitting work in the app: the overview
+    diagram, the input/output maths, per-address detail pages, change verification. A
+    separate StubRenderer harness exists (tests/test_psbt_refusal_screens.py) precisely
+    because that layout is a live risk, and it can only check screens in isolation.
+
+    Here the whole flow runs with real Screens and scripted button input. Only the
+    initial camera decode is mocked -- ScanView deliberately exposes `self.decoder` for
+    exactly this (scan_views.py:99) -- and once controller.psbt is populated the rest of
+    the flow needs no hardware at all.
+"""
+
+import pytest
+
+# Must import test base before the Controller (sets up the hardware mocks)
+import base  # noqa: F401
+from base import FlowStep, FlowTest
+from ui_driver import Back, UISession, select
+
+from seedsigner.models.settings import SettingsConstants
+from seedsigner.views import psbt_views, scan_views, seed_views
+from seedsigner.views.view import MainMenuView
+
+
+# A regtest single-sig P2WPKH PSBT: 2 inputs, 4 outputs (1 external + 3 change),
+# 272 sat fee. Same vector as tests/test_flows_psbt.py, which documents it in full.
+PSBT_2IN_4OUT = (
+    "cHNidP8BANgCAAAAAsTXZs3fz/dmGb6M80+jjvJZdYya+cw5bT/dGuhZFdSlAAAAAAD9////qo6xg/UZ"
+    "AvUkcbse1F+C9zbP/FeZNjThx7SCIn6eMCgBAAAAAP3///8EQOIBAAAAAAAWABSkZPM7kLcTRE2En1t3"
+    "3/0RCHgMjQXYnnYAAAAAFgAUKMaPRKXdY4m8iKrE9j+rycskJU1A4gEAAAAAABYAFPYc9wiHRrYKAZYL"
+    "LztREAwpPBIwipVcAwAAAAAWABSiFuiJIa4NrxLUBVQNS0NIun6DDtoRAABPAQQ1h88DBcQGZIAAAAA+"
+    "0J+jlNL3dpWwlnBi8Dx+Ipg4e6uvB3HdjzFPX7r9CAOOlAIxgII+/xCcj+XoEenKH7wj5s5wlu7Q7CCZ"
+    "WFLGLhA5Su0UVAAAgAEAAIAAAACAAAEA7QIAAAAEE6njX/fnvn7hbkKIRcxzNYFOSfbCdNeWnd7Fe/1U"
+    "cQ0BAAAAAP3///8TqeNf9+e+fuFuQohFzHM1gU5J9sJ015ad3sV7/VRxDQMAAAAA/f///xOp41/3575+"
+    "4W5CiEXMczWBTkn2wnTXlp3exXv9VHENBAAAAAD9////E6njX/fnvn7hbkKIRcxzNYFOSfbCdNeWnd7F"
+    "e/1UcQ0GAAAAAP3///8CUnheAwAAAAAWABRCfygPJ+Fjsx4BknYvvm3A3qKn2xJ/XQcAAAAAF6kU1I4T"
+    "Ast5nAj15ey7vwe5cM3OFq+HlhEAAAEBH1J4XgMAAAAAFgAUQn8oDyfhY7MeAZJ2L75twN6ip9sBAwQB"
+    "AAAAIgYCo7sfm78RQY3B5n0ac/QF8VtMAzFnci+h5D1MtpgRY7oYOUrtFFQAAIABAACAAAAAgAEAAAAG"
+    "AAAAAAEAcQIAAAABxY7wh0nsfJQfzWrD/9rN9BYsM+iOmPaO6I0ANFgO/PcAAAAAAP3///8CptiUAAAA"
+    "AAAWABRIm4HhQY/TzOjeWSPRrbuJo9MlW826oHYAAAAAFgAU0z+0L2QSLGtyQTn8FhbCpcI7jbliAQAA"
+    "AQEfzbqgdgAAAAAWABTTP7QvZBIsa3JBOfwWFsKlwjuNuQEDBAEAAAAiBgITHmebEANk81CraV4xZIpq"
+    "kNjjw0tIvezl1Ism1NRH3Rg5Su0UVAAAgAEAAIAAAACAAQAAAAAAAAAAIgICuTT7WnuiUTpObjWnZFHz"
+    "IeEvW9PTB+1LLVFNQJVFeIIYOUrtFFQAAIABAACAAAAAgAEAAAAHAAAAACICAk8f3hpc5C35chgSg+Pe"
+    "2zZ9IhHREd4aKW2+yAMRIFeqGDlK7RRUAACAAQAAgAAAAIABAAAACQAAAAAAIgIDjt1CjvrnMMnjbmTN"
+    "KUAYoKEDRbmKjNjbq+6Ppqj3bqQYOUrtFFQAAIABAACAAAAAgAEAAAAIAAAAAA=="
+)
+
+# The SeedQR for the key that signs the PSBT above, and the mnemonic it encodes
+# (four digits per word, each an index into the BIP-39 wordlist).
+SEEDQR_FOR_PSBT = "080115060387063104071857067618681125136207731354"
+MNEMONIC_FOR_PSBT = (
+    "goddess rough corn exclude cream trial fee trumpet million prevent gaze power"
+).split()
+
+
+def load_psbt(view):
+    view.decoder.add_data(PSBT_2IN_4OUT)
+
+
+def load_seedqr(view):
+    view.decoder.add_data(SEEDQR_FOR_PSBT)
+
+
+def record_sig_count(into: list):
+    """
+    A `before_run` hook that snapshots how many inputs are signed.
+
+    PSBTFinalizeView signs `controller.psbt` in place, so sampling this on the
+    following View is what proves the flow actually signed rather than merely
+    reaching the QR screen.
+    """
+    def hook(view):
+        from seedsigner.models.psbt_parser import PSBTParser
+
+        into.append(PSBTParser.sig_count(view.controller.psbt))
+
+    return hook
+
+
+class PSBTFlowTest(FlowTest):
+    """Shared setup: regtest, and a seed already loaded unless a test says otherwise."""
+
+    def setup_method(self):
+        super().setup_method()
+        self.settings.set_value(
+            SettingsConstants.SETTING__NETWORK, SettingsConstants.REGTEST
+        )
+
+    def load_signing_seed(self):
+        """The seed the test PSBT is signed with, already in storage."""
+        from seedsigner.models.seed import Seed
+
+        seed = Seed(mnemonic=MNEMONIC_FOR_PSBT)
+        self.controller.storage.set_pending_seed(seed)
+        return self.controller.storage.finalize_pending_seed()
+
+
+
+class TestPSBTSigningFlow(PSBTFlowTest):
+    """Scan → select seed → review → approve → signed QR, all on real Screens."""
+
+    def review_steps(self) -> list:
+        """The review chain: overview, maths, one external address, three changes."""
+        return [
+            FlowStep(psbt_views.PSBTOverviewView, real_screens=True),
+            FlowStep(psbt_views.PSBTMathView, real_screens=True),
+            FlowStep(psbt_views.PSBTAddressDetailsView, real_screens=True),
+            FlowStep(psbt_views.PSBTChangeDetailsView, real_screens=True),
+            FlowStep(psbt_views.PSBTChangeDetailsView, real_screens=True),
+            FlowStep(psbt_views.PSBTChangeDetailsView, real_screens=True),
+        ]
+
+    def review_script(self) -> list:
+        return (
+            select(0)  # PSBTOverviewView: continue
+            + select(0)  # PSBTMathView: continue
+            + select(0)  # PSBTAddressDetailsView: next
+            + select(psbt_views.PSBTChangeDetailsView.NEXT)
+            + select(psbt_views.PSBTChangeDetailsView.NEXT)
+            + select(psbt_views.PSBTChangeDetailsView.NEXT)
+        )
+
+    def test_scan_psbt_then_scan_seed_and_sign(self):
+        """The full first-time path: no seed loaded, so the flow scans one."""
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+        signatures = []
+        session = UISession(script=(
+            select(psbt_views.PSBTSelectSeedView.SCAN_SEED)
+            + select(seed_views.SeedFinalizeView.FINALIZE)
+            + self.review_script()
+            + select(psbt_views.PSBTFinalizeView.APPROVE_PSBT)
+            + [K.KEY_PRESS]  # any click dismisses the signed-PSBT QR
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+                FlowStep(scan_views.ScanView, before_run=load_psbt),
+                FlowStep(psbt_views.PSBTSelectSeedView, real_screens=True),
+                FlowStep(scan_views.ScanSeedQRView, before_run=load_seedqr),
+                FlowStep(seed_views.SeedFinalizeView, real_screens=True),
+                FlowStep(seed_views.SeedOptionsView, is_redirect=True),
+            ] + self.review_steps() + [
+                FlowStep(psbt_views.PSBTFinalizeView, real_screens=True),
+                FlowStep(
+                    psbt_views.PSBTSignedQRDisplayView,
+                    real_screens=True,
+                    before_run=record_sig_count(signatures),
+                ),
+                FlowStep(MainMenuView),
+            ],
+            ui_session=session,
+        )
+
+        # The scanned seed really was loaded, and both inputs really were signed.
+        assert len(self.controller.storage.seeds) == 1
+        assert self.controller.storage.seeds[0].mnemonic_list == MNEMONIC_FOR_PSBT
+        assert signatures == [2], f"expected both inputs signed, got {signatures}"
+        assert session.renderer.frames, "the real PSBT Screens never rendered"
+
+    def test_scan_psbt_with_seed_already_loaded(self):
+        """The common repeat path: pick the loaded seed off the list."""
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+        seed = self.load_signing_seed()
+
+        signatures = []
+        session = UISession(script=(
+            select(0)  # the one loaded seed, listed above the scan/type options
+            + self.review_script()
+            + select(psbt_views.PSBTFinalizeView.APPROVE_PSBT)
+            + [K.KEY_PRESS]
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+                FlowStep(scan_views.ScanView, before_run=load_psbt),
+                FlowStep(psbt_views.PSBTSelectSeedView, real_screens=True),
+            ] + self.review_steps() + [
+                FlowStep(psbt_views.PSBTFinalizeView, real_screens=True),
+                FlowStep(
+                    psbt_views.PSBTSignedQRDisplayView,
+                    real_screens=True,
+                    before_run=record_sig_count(signatures),
+                ),
+                FlowStep(MainMenuView),
+            ],
+            ui_session=session,
+        )
+
+        assert self.controller.storage.seeds == [seed]
+        assert signatures == [2], f"expected both inputs signed, got {signatures}"
+
+    def test_back_out_of_the_review_chain(self):
+        """
+        BACK must walk back up the review chain rather than stranding the user.
+
+        The change-detail pages are re-entered with different view_args, so this also
+        exercises the Controller's back-stack handling of repeated Views.
+        """
+        self.load_signing_seed()
+
+        session = UISession(script=(
+            select(0)      # select the loaded seed
+            + select(0)    # overview: continue
+            + select(0)    # maths: continue
+            + [Back()]     # back out of the first address detail page
+            + select(0)    # maths again: continue
+            + select(0)    # address details again
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+                FlowStep(scan_views.ScanView, before_run=load_psbt),
+                FlowStep(psbt_views.PSBTSelectSeedView, real_screens=True),
+                FlowStep(psbt_views.PSBTOverviewView, real_screens=True),
+                FlowStep(psbt_views.PSBTMathView, real_screens=True),
+                FlowStep(psbt_views.PSBTAddressDetailsView, real_screens=True),
+                FlowStep(psbt_views.PSBTMathView, real_screens=True),
+                FlowStep(psbt_views.PSBTAddressDetailsView, real_screens=True),
+                FlowStep(psbt_views.PSBTChangeDetailsView),
+            ],
+            ui_session=session,
+        )

--- a/tests/test_real_screen_flows_seed.py
+++ b/tests/test_real_screen_flows_seed.py
@@ -889,6 +889,7 @@ class TestEncryptedQRFlow(SeedFlowTest):
         )
 
     def test_typed_encryption_key_and_mnemonic_id(self):
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
         from seedsigner.gui.screens.scan_screens import ScanTypeEncryptionKeyScreen
         from seedsigner.gui.screens.seed_screens import SeedEncryptedQRMnemonicIDScreen
         from ui_driver import plan_text_entry_script
@@ -911,7 +912,9 @@ class TestEncryptedQRFlow(SeedFlowTest):
             + select(0)          # accept the reviewed encryption key
             + select("Assign custom ID")
             + id_script
-            + select(0)          # accept the reviewed mnemonic ID
+            + select("Proceed")   # accept the reviewed mnemonic ID
+            + select("Transcribe mode")
+            + [K.KEY_PRESS]       # the zoomed-in transcription view exits on any click
         ))
 
         self.run_sequence(
@@ -926,6 +929,9 @@ class TestEncryptedQRFlow(SeedFlowTest):
                 FlowStep(seed_views.SeedEncryptedQRMnemonicIDPromptView, real_screens=True),
                 FlowStep(seed_views.SeedEncryptedQRMnemonicIDEntryView, real_screens=True),
                 FlowStep(seed_views.SeedEncryptedQRReviewMnemonicIDView, real_screens=True),
+                FlowStep(seed_views.SeedEncryptedQRTranscribeModePromptView, real_screens=True),
+                FlowStep(seed_views.SeedEncryptedQRTranscribeModeView, real_screens=True),
+                FlowStep(seed_views.SeedTranscribeEncryptedQRZoomedInView, real_screens=True),
             ],
             initial_destination_view_args=dict(seed=seed),
             ui_session=session,

--- a/tests/test_real_screen_flows_settings.py
+++ b/tests/test_real_screen_flows_settings.py
@@ -1,0 +1,282 @@
+"""
+    Real-screen flow tests for Settings.
+
+    tests/test_flows_settings.py and the all-entries loops in
+    tests/test_flows_menu_navigation.py walk these views thoroughly, but mocked. Three
+    of the most interesting ones are *explicitly skipped* by those loops because they
+    do not behave like a plain toggle: SettingsEntryUpdateSelectionView's multiselect
+    checkboxes, SettingPBKDF2IterationsView's keyboard, and LocaleSelectionView. Those
+    are exactly the ones whose Screens have custom Button classes and custom input
+    handling, so mocked coverage says the least about them.
+
+    Here they run for real. Left alone deliberately: IOTestView (a GPIO input loop),
+    SCARDTestView / NFCTestView (card reader and libnfc), and RestartPCSCView (os.system
+    on the pcscd service) -- none of those are button-driven UI.
+"""
+
+import pytest
+
+# Must import test base before the Controller (sets up the hardware mocks)
+import base  # noqa: F401
+from base import FlowStep, FlowTest
+from ui_driver import Back, UISession, TypeKeys, select
+
+from seedsigner.models.settings import Settings, SettingsConstants
+from seedsigner.models.settings_definition import SettingsDefinition
+from seedsigner.views import settings_views
+from seedsigner.views.view import MainMenuView
+
+
+class SettingsFlowTest(FlowTest):
+
+    def entry_label(self, attr_name: str) -> str:
+        """The button label Settings shows for a settings attribute."""
+        return SettingsDefinition.get_settings_entry(attr_name).display_name
+
+    def advanced_steps(self) -> list:
+        """
+        FlowSteps from the main menu into the Advanced settings list.
+
+        SettingsMenuView re-enters itself with a different `visibility`, so Advanced is
+        the same View class a second time rather than a distinct one.
+        """
+        return [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SETTINGS),
+            FlowStep(settings_views.SettingsMenuView, real_screens=True),
+            FlowStep(settings_views.SettingsMenuView, real_screens=True),
+        ]
+
+    def advanced_script(self, attr: str) -> list:
+        """Open Advanced, then the editor for `attr`."""
+        return select(settings_views.SettingsMenuView.ADVANCED) + select(self.entry_label(attr))
+
+
+
+class TestSettingsEntryUpdate(SettingsFlowTest):
+    """The settings editor itself -- the view every settings change goes through."""
+
+    def test_toggle_an_enabled_disabled_setting(self):
+        attr = SettingsConstants.SETTING__DIRE_WARNINGS
+        self.settings.set_value(attr, SettingsConstants.OPTION__ENABLED)
+
+        session = UISession(script=(
+            self.advanced_script(attr)
+            + select("Disabled")
+            + [Back()]  # a *changed* single-select re-enters the editor; BACK exits
+        ))
+
+        self.run_sequence(
+            self.advanced_steps() + [
+                FlowStep(settings_views.SettingsEntryUpdateSelectionView, real_screens=True),
+                FlowStep(settings_views.SettingsEntryUpdateSelectionView, real_screens=True),
+                FlowStep(settings_views.SettingsMenuView),
+            ],
+            ui_session=session,
+        )
+
+        assert self.settings.get_value(attr) == SettingsConstants.OPTION__DISABLED
+
+    def test_multiselect_checkbox_toggles(self):
+        """
+        A multiselect entry uses CheckboxButton and re-enters itself after each
+        selection, so the screen is rebuilt with updated `checked_buttons` every time.
+        Deselect one script type and confirm it really left the stored list.
+        """
+        attr = SettingsConstants.SETTING__SCRIPT_TYPES
+        entry = SettingsDefinition.get_settings_entry(attr)
+        assert entry.type == SettingsConstants.TYPE__MULTISELECT
+
+        self.settings.set_value(
+            attr, [SettingsConstants.NATIVE_SEGWIT, SettingsConstants.NESTED_SEGWIT]
+        )
+        nested_label = dict(SettingsConstants.ALL_SCRIPT_TYPES)[SettingsConstants.NESTED_SEGWIT]
+
+        session = UISession(script=(
+            self.advanced_script(attr)
+            + select(nested_label)  # untick it
+            + [Back()]              # the editor re-enters itself after each toggle
+        ))
+
+        self.run_sequence(
+            self.advanced_steps() + [
+                FlowStep(settings_views.SettingsEntryUpdateSelectionView, real_screens=True),
+                FlowStep(settings_views.SettingsEntryUpdateSelectionView, real_screens=True),
+                FlowStep(settings_views.SettingsMenuView),
+            ],
+            ui_session=session,
+        )
+
+        remaining = self.settings.get_value(attr)
+        assert SettingsConstants.NESTED_SEGWIT not in remaining
+        assert SettingsConstants.NATIVE_SEGWIT in remaining
+
+    def test_emptying_a_required_multiselect_warns(self):
+        """
+        Deselecting the last option of a required multiselect must reach
+        SettingsSelectionRequiredWarningView rather than storing an empty list.
+        """
+        attr = SettingsConstants.SETTING__SCRIPT_TYPES
+        self.settings.set_value(attr, [SettingsConstants.NATIVE_SEGWIT])
+        only_label = dict(SettingsConstants.ALL_SCRIPT_TYPES)[SettingsConstants.NATIVE_SEGWIT]
+
+        session = UISession(script=(
+            self.advanced_script(attr)
+            + select(only_label)  # untick the only remaining option
+            + [Back()]            # BACK on an empty required list triggers the warning
+            + select(0)           # "Return to setting"
+            + select(only_label)  # tick it again so the setting is left usable
+            + [Back()]
+        ))
+
+        self.run_sequence(
+            self.advanced_steps() + [
+                FlowStep(settings_views.SettingsEntryUpdateSelectionView, real_screens=True),
+                FlowStep(settings_views.SettingsEntryUpdateSelectionView, real_screens=True),
+                FlowStep(settings_views.SettingsSelectionRequiredWarningView, real_screens=True),
+                FlowStep(settings_views.SettingsEntryUpdateSelectionView, real_screens=True),
+                FlowStep(settings_views.SettingsEntryUpdateSelectionView, real_screens=True),
+                FlowStep(settings_views.SettingsMenuView),
+            ],
+            ui_session=session,
+        )
+
+        assert self.settings.get_value(attr), "a required multiselect must not end up empty"
+
+
+
+class TestPBKDF2IterationsSetting(SettingsFlowTest):
+    """
+    SettingPBKDF2IterationsView is a KeyboardScreen, not a list -- one of the entries
+    the mocked all-entries loops skip.
+    """
+
+    def test_type_a_new_iteration_count(self):
+        attr = SettingsConstants.SETTING__ENCRYPTION_ITER
+        # The screen stores units of 10k and rejects anything outside 1..50, and it
+        # comes up pre-filled with the current value -- hence clear_first.
+        new_value = "12"
+
+        session = UISession(script=(
+            self.advanced_script(attr)
+            + [TypeKeys(new_value, clear_first=True)]
+        ))
+
+        self.run_sequence(
+            self.advanced_steps() + [
+                FlowStep(settings_views.SettingPBKDF2IterationsView, real_screens=True),
+                FlowStep(settings_views.SettingsMenuView),
+            ],
+            ui_session=session,
+        )
+
+        assert str(self.settings.get_value(attr)) == new_value
+
+
+
+class TestLocaleSelection(SettingsFlowTest):
+    """LocaleSelectionView -- the other entry the mocked loops skip."""
+
+    def test_locale_list_renders_and_selects(self):
+        attr = SettingsConstants.SETTING__LOCALE
+        original = self.settings.get_value(attr)
+        display_name = dict(SettingsConstants.ALL_LOCALES)[original]
+
+        session = UISession(script=(
+            select(self.entry_label(attr))
+            + select(display_name)  # re-pick the current locale: no translation reload
+        ))
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SETTINGS),
+                FlowStep(settings_views.SettingsMenuView, real_screens=True),
+                FlowStep(settings_views.LocaleSelectionView, real_screens=True),
+                FlowStep(settings_views.SettingsMenuView),
+            ],
+            ui_session=session,
+        )
+
+        assert self.settings.get_value(attr) == original
+
+
+
+class TestSettingsInfoScreens(SettingsFlowTest):
+    """
+    The read-only screens under Settings. Several are plain BaseTopNavScreens with no
+    button list, so they are left by the back arrow -- which is what Back() is for.
+    """
+
+    def test_version_screen(self):
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SETTINGS),
+                FlowStep(settings_views.SettingsMenuView, real_screens=True),
+                FlowStep(settings_views.VersionView, real_screens=True),
+                FlowStep(settings_views.SettingsMenuView),
+            ],
+            ui_session=UISession(script=select(settings_views.SettingsMenuView.VERSION) + [Back()]),
+        )
+
+    def test_donate_screen(self):
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SETTINGS),
+                FlowStep(settings_views.SettingsMenuView, real_screens=True),
+                FlowStep(settings_views.DonateView, real_screens=True),
+                FlowStep(settings_views.SettingsMenuView),
+            ],
+            ui_session=UISession(script=select(settings_views.SettingsMenuView.DONATE) + [Back()]),
+        )
+
+    def test_system_and_memory_info(self):
+        for option, view in (
+            (settings_views.SettingsMenuView.SYSTEM_INFO, settings_views.SystemInfoView),
+            (settings_views.SettingsMenuView.MEMORY_INFO, settings_views.MemoryInfoView),
+        ):
+            self.run_sequence(
+                [
+                    FlowStep(MainMenuView, button_data_selection=MainMenuView.SETTINGS),
+                    FlowStep(settings_views.SettingsMenuView, real_screens=True),
+                    FlowStep(settings_views.SettingsMenuView, real_screens=True),
+                    FlowStep(view, real_screens=True),
+                    FlowStep(settings_views.SettingsMenuView),
+                ],
+                ui_session=UISession(script=(
+                    select(settings_views.SettingsMenuView.HARDWARE)
+                    + select(option)
+                    + [Back()]
+                )),
+            )
+
+    def test_hardening_report_pages(self):
+        """HardeningTestView renders a PagedTextScreen; walk it and back out."""
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SETTINGS),
+                FlowStep(settings_views.SettingsMenuView, real_screens=True),
+                FlowStep(settings_views.SettingsMenuView, real_screens=True),
+                FlowStep(settings_views.HardeningTestView, real_screens=True),
+                FlowStep(settings_views.SettingsMenuView),
+            ],
+            ui_session=UISession(script=(
+                select(settings_views.SettingsMenuView.ADVANCED)
+                + select(settings_views.SettingsMenuView.TEST_HARDENING)
+                + [Back()]
+            )),
+        )
+
+    def test_load_backup_files_submenu(self):
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.SETTINGS),
+                FlowStep(settings_views.SettingsMenuView, real_screens=True),
+                FlowStep(settings_views.SettingsMenuView, real_screens=True),
+                FlowStep(settings_views.LoadBackupFilesSettingsView, real_screens=True),
+                FlowStep(settings_views.SettingsEntryUpdateSelectionView),
+            ],
+            ui_session=UISession(script=(
+                select(settings_views.SettingsMenuView.ADVANCED)
+                + select(settings_views.SettingsMenuView.LOAD_BACKUP_FILES)
+                + select(0)
+            )),
+        )

--- a/tests/test_real_screen_flows_smartcard.py
+++ b/tests/test_real_screen_flows_smartcard.py
@@ -1,0 +1,203 @@
+"""
+    Real-screen flow tests for Smartcard Tools.
+
+    smartcard_views.py is 61 View classes and 33 of them were never named in any test.
+    The only operational coverage that existed is tests/test_flows_smartcard_hardware.py,
+    which **skips unless a physical reader and card are present** and covers just
+    SeedKeeper-save and Satochip-import; everything else was menu-entry-and-BACK in the
+    mocked navigation suite.
+
+    These need no hardware. Card-backed views go through the one seam every flow uses --
+    `seedkeeper_utils.init_satochip` -- so the stand-in can later be swapped for a
+    jcardsim-backed simulator running the real applets without touching these tests.
+
+    Two views here need no card at all and are covered directly: ToolsCommonFilterView
+    (it only mutates a controller attribute) and ToolsDIYMountStatusView (it reads a log
+    file).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+# Must import test base before the Controller (sets up the hardware mocks)
+import base  # noqa: F401
+from base import FlowStep, FlowTest
+from real_screen_fixtures import javacard_diy_patchers, satochip_connector
+from ui_driver import Back, UISession, select
+
+# tools_views must be imported first: it is a facade that star-imports smartcard_views.
+from seedsigner.views import tools_views
+from seedsigner.views import smartcard_views
+from seedsigner.models.settings import SettingsConstants
+from seedsigner.views.view import MainMenuView
+
+
+class SmartcardFlowTest(FlowTest):
+
+    def setup_method(self):
+        super().setup_method()
+        # Each card type is behind its own setting; the menu omits any that are off.
+        for setting in (
+            SettingsConstants.SETTING__SMARTCARD_SUPPORT,
+            SettingsConstants.SETTING__SATOCHIP_SUPPORT,
+            SettingsConstants.SETTING__KEYCARD_SUPPORT,
+            SettingsConstants.SETTING__SPECTER_DIY_SUPPORT,
+        ):
+            self.settings.set_value(setting, SettingsConstants.OPTION__ENABLED)
+
+    def smartcard_steps(self) -> list:
+        return [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=tools_views.ToolsMenuView.SMARTCARD),
+        ]
+
+
+
+class TestSmartcardMenuNavigation(SmartcardFlowTest):
+    """
+    Every top-level smartcard submenu, opened for real and backed out of. A screen that
+    cannot construct shows up here rather than on a device with a card in it.
+    """
+
+    @pytest.mark.parametrize(
+        "menu_option, submenu_view",
+        [
+            (smartcard_views.ToolsSmartcardMenuView.COMMON, smartcard_views.ToolsCommonView),
+            (smartcard_views.ToolsSmartcardMenuView.SATOCHIP, smartcard_views.ToolsSatochipView),
+            (smartcard_views.ToolsSmartcardMenuView.KEYCARD, smartcard_views.ToolsKeycardView),
+            (smartcard_views.ToolsSmartcardMenuView.SEEDKEEPER, smartcard_views.ToolsSeedkeeperView),
+            (smartcard_views.ToolsSmartcardMenuView.SPECTER_DIY, smartcard_views.ToolsSpecterDIYView),
+            (smartcard_views.ToolsSmartcardMenuView.Satochip_DIY, smartcard_views.ToolsSatochipDIYView),
+        ],
+    )
+    def test_submenu_opens_and_backs_out(self, menu_option, submenu_view):
+        session = UISession(script=select(menu_option) + [Back()])
+
+        self.run_sequence(
+            self.smartcard_steps() + [
+                FlowStep(smartcard_views.ToolsSmartcardMenuView, real_screens=True),
+                FlowStep(submenu_view, real_screens=True),
+                FlowStep(smartcard_views.ToolsSmartcardMenuView),
+            ],
+            ui_session=session,
+        )
+
+    @pytest.mark.parametrize(
+        "parent_option, parent_view, advanced_view",
+        [
+            (
+                smartcard_views.ToolsSmartcardMenuView.SATOCHIP,
+                smartcard_views.ToolsSatochipView,
+                smartcard_views.ToolsSatochipAdvancedView,
+            ),
+            (
+                smartcard_views.ToolsSmartcardMenuView.KEYCARD,
+                smartcard_views.ToolsKeycardView,
+                smartcard_views.ToolsKeycardAdvancedView,
+            ),
+        ],
+    )
+    def test_advanced_submenu_opens_and_backs_out(self, parent_option, parent_view, advanced_view):
+        session = UISession(script=(
+            select(parent_option)
+            + select(parent_view.ADVANCED)
+            + [Back()]
+        ))
+
+        self.run_sequence(
+            self.smartcard_steps() + [
+                FlowStep(smartcard_views.ToolsSmartcardMenuView, real_screens=True),
+                FlowStep(parent_view, real_screens=True),
+                FlowStep(advanced_view, real_screens=True),
+                FlowStep(parent_view),
+            ],
+            ui_session=session,
+        )
+
+
+
+class TestCardFilterFlow(SmartcardFlowTest):
+    """
+    Common Functions > Device Filter. This one needs no card -- it only narrows which
+    card types later flows will accept -- and it was never named in any test.
+    """
+
+    def test_choosing_a_filter_records_it(self):
+        session = UISession(script=(
+            select(smartcard_views.ToolsSmartcardMenuView.COMMON)
+            + select(smartcard_views.ToolsCommonView.FILTER)
+            + select("Satochip")  # untick it
+            + [Back()]            # the view loops until BACK, which commits the filter
+        ))
+
+        self.run_sequence(
+            self.smartcard_steps() + [
+                FlowStep(smartcard_views.ToolsSmartcardMenuView, real_screens=True),
+                FlowStep(smartcard_views.ToolsCommonView, real_screens=True),
+                FlowStep(smartcard_views.ToolsCommonFilterView, real_screens=True),
+                FlowStep(smartcard_views.ToolsCommonView),
+            ],
+            ui_session=session,
+        )
+
+        # BACK commits whatever is still ticked; deselecting one leaves the other two.
+        assert self.controller.tools_common_card_filter == ["seedkeeper", "satodime"]
+
+
+
+class TestDIYMountStatusFlow(SmartcardFlowTest):
+    """DIY Tools > Mount Status reads a log file, not a card."""
+
+    def test_mount_status_renders(self, tmp_path):
+        log = tmp_path / "diy-mount.log"
+        log.write_text("mount ok\n", encoding="utf-8")
+
+        session = UISession(script=(
+            select(smartcard_views.ToolsSmartcardMenuView.Satochip_DIY)
+            + select(smartcard_views.ToolsSatochipDIYView.MOUNT_STATUS)
+            + select(0)
+        ))
+
+        with patch.object(smartcard_views, "DIY_MOUNT_LOG", str(log), create=True):
+            self.run_sequence(
+                self.smartcard_steps() + [
+                    FlowStep(smartcard_views.ToolsSmartcardMenuView, real_screens=True),
+                    FlowStep(smartcard_views.ToolsSatochipDIYView, real_screens=True),
+                    FlowStep(smartcard_views.ToolsDIYMountStatusView, real_screens=True),
+                    FlowStep(smartcard_views.ToolsSatochipDIYView),
+                ],
+                ui_session=session,
+            )
+
+
+
+class TestJavacardKeysFlow(SmartcardFlowTest):
+    """
+    DIY Tools > Card Keys. ToolsJavacardKeysView and its five children were all
+    unnamed in any test; the pygp stand-in lets the menu run without a card.
+    """
+
+    def test_keys_menu_opens_and_backs_out(self):
+        session = UISession(script=(
+            select(smartcard_views.ToolsSmartcardMenuView.Satochip_DIY)
+            + select(smartcard_views.ToolsSatochipDIYView.MANAGE_KEYS)
+            + [Back()]
+        ))
+
+        patchers = javacard_diy_patchers()
+        for p in patchers:
+            p.start()
+        try:
+            self.run_sequence(
+                self.smartcard_steps() + [
+                    FlowStep(smartcard_views.ToolsSmartcardMenuView, real_screens=True),
+                    FlowStep(smartcard_views.ToolsSatochipDIYView, real_screens=True),
+                    FlowStep(smartcard_views.ToolsJavacardKeysView, real_screens=True),
+                    FlowStep(smartcard_views.ToolsSatochipDIYView),
+                ],
+                ui_session=session,
+            )
+        finally:
+            for p in reversed(patchers):
+                p.stop()

--- a/tests/test_real_screen_flows_tools.py
+++ b/tests/test_real_screen_flows_tools.py
@@ -1,0 +1,319 @@
+"""
+    Real-screen flow tests for the Tools menu.
+
+    The password generator is the standout gap here: it had no flow test at all before
+    this, only unit-level view tests, despite producing a secret the user is expected to
+    keep. Address Explorer and Verify Address had deep mocked coverage but no real
+    screens, and the MicroSD tools and Network Info were only ever entered and backed
+    out of.
+
+    Anything that writes to a block device is stubbed -- these tests walk the
+    confirmation screens, never the `dd`.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+# Must import test base before the Controller (sets up the hardware mocks)
+import base  # noqa: F401
+from base import FlowStep, FlowTest
+from real_screen_fixtures import use_microsd
+from ui_driver import Back, TypeKeys, UISession, select
+
+from seedsigner.models.seed import Seed
+from seedsigner.models.settings import SettingsConstants
+# tools_views must be imported first: it is a facade that star-imports the others,
+# and reaching password_generator_views directly first hits a circular import.
+from seedsigner.views import tools_views
+from seedsigner.views import microsd_views, seed_views
+from seedsigner.views import password_generator_views as pw_views
+from seedsigner.views.view import MainMenuView
+
+
+MNEMONIC_12 = "blush twice taste dawn feed second opinion lazy thumb play neglect impact".split()
+
+
+class ToolsFlowTest(FlowTest):
+
+    def setup_method(self):
+        super().setup_method()
+        self.settings.set_value(
+            SettingsConstants.SETTING__DIRE_WARNINGS, SettingsConstants.OPTION__DISABLED
+        )
+
+    def store_seed(self) -> Seed:
+        seed = Seed(mnemonic=MNEMONIC_12)
+        self.controller.storage.set_pending_seed(seed)
+        return self.controller.storage.finalize_pending_seed()
+
+    def tools_steps(self, option) -> list:
+        return [
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+            FlowStep(tools_views.ToolsMenuView, button_data_selection=option),
+        ]
+
+
+
+class TestPasswordGeneratorFlow(ToolsFlowTest):
+    """
+    Tools > Password Generator, end to end.
+
+    This flow produces a secret the user keeps, and until now had no flow test at all.
+    The System RNG entropy source needs no camera and no dice, so it exercises the
+    whole chain without mocking anything.
+    """
+
+    def test_base64_password_from_system_rng(self):
+        session = UISession(script=(
+            select("Base64")
+            + select("64 bits")
+            + select("System RNG")
+            + select("Next")  # review the generated password -> Next
+        ))
+
+        self.run_sequence(
+            self.tools_steps(tools_views.ToolsMenuView.PASSWORD_GENERATOR) + [
+                FlowStep(pw_views.ToolsPasswordGeneratorTypeView, real_screens=True),
+                FlowStep(pw_views.ToolsPasswordStrengthView, real_screens=True),
+                FlowStep(pw_views.ToolsPasswordEntropySourceView, real_screens=True),
+                FlowStep(pw_views.ToolsPasswordGenerateView, real_screens=True),
+                FlowStep(pw_views.ToolsPasswordReviewView, real_screens=True),
+                FlowStep(pw_views.ToolsPasswordSaveView),
+            ],
+            ui_session=session,
+        )
+
+        assert session.renderer.frames, "the real password screens never rendered"
+
+    def test_diceware_password_asks_for_a_separator(self):
+        """The diceware types add a word-separator step the other types skip."""
+        session = UISession(script=(
+            select("Diceware-EFF Short")
+            + select("64 bits")
+            + select("System RNG")
+            + select(0)       # separator choice
+            + select("Next")  # review the generated password -> Next
+        ))
+
+        self.run_sequence(
+            self.tools_steps(tools_views.ToolsMenuView.PASSWORD_GENERATOR) + [
+                FlowStep(pw_views.ToolsPasswordGeneratorTypeView, real_screens=True),
+                FlowStep(pw_views.ToolsPasswordStrengthView, real_screens=True),
+                FlowStep(pw_views.ToolsPasswordEntropySourceView, real_screens=True),
+                # Diceware needs a separator, so the RNG view routes on to that prompt.
+                FlowStep(pw_views.ToolsPasswordHardwareRngEntropyView, is_redirect=True),
+                FlowStep(pw_views.ToolsPasswordWordSeparatorView, real_screens=True),
+                FlowStep(pw_views.ToolsPasswordGenerateView, real_screens=True),
+                FlowStep(pw_views.ToolsPasswordReviewView, real_screens=True),
+                FlowStep(pw_views.ToolsPasswordSaveView),
+            ],
+            ui_session=session,
+        )
+
+    def test_custom_type_offers_the_random_options(self):
+        """
+        `ToolsPasswordRandomOptionsView` is reachable only from the Custom type, and
+        was one of the views never named in any test.
+        """
+        session = UISession(script=(
+            select("Custom")
+            + select("64 bits")
+            + select(0) + select(0) + select(0) + select(0)  # four Yes/No prompts
+        ))
+
+        self.run_sequence(
+            self.tools_steps(tools_views.ToolsMenuView.PASSWORD_GENERATOR) + [
+                FlowStep(pw_views.ToolsPasswordGeneratorTypeView, real_screens=True),
+                FlowStep(pw_views.ToolsPasswordStrengthView, real_screens=True),
+                FlowStep(pw_views.ToolsPasswordRandomOptionsView, real_screens=True),
+                FlowStep(pw_views.ToolsPasswordEntropySourceView),
+            ],
+            ui_session=session,
+        )
+
+
+
+class TestAddressExplorerFlow(ToolsFlowTest):
+    """Tools > Address explorer, driven off an already-loaded seed."""
+
+    def test_receive_address_list_and_detail(self):
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+        seed = self.store_seed()
+        self.settings.set_value(
+            SettingsConstants.SETTING__SCRIPT_TYPES, [SettingsConstants.NATIVE_SEGWIT]
+        )
+
+        session = UISession(script=(
+            select(0)  # the loaded seed, first in the source list
+            + select(tools_views.ToolsAddressExplorerAddressTypeView.RECEIVE)
+            + select(0)  # the first address in the list
+            + [K.KEY_PRESS]  # the address detail is a QR display: any click exits
+        ))
+
+        self.run_sequence(
+            self.tools_steps(tools_views.ToolsMenuView.ADDRESS_EXPLORER) + [
+                FlowStep(tools_views.ToolsAddressExplorerSelectSourceView, real_screens=True),
+                # Only one script type is enabled, so the script-type prompt is skipped.
+                FlowStep(seed_views.SeedExportXpubScriptTypeView, is_redirect=True),
+                FlowStep(tools_views.ToolsAddressExplorerAddressTypeView, real_screens=True),
+                FlowStep(tools_views.ToolsAddressExplorerAddressListView, real_screens=True),
+                FlowStep(tools_views.ToolsAddressExplorerAddressView, real_screens=True),
+                FlowStep(tools_views.ToolsAddressExplorerAddressListView),
+            ],
+            ui_session=session,
+        )
+
+        assert self.controller.storage.seeds == [seed]
+
+
+
+class TestTextQRFlow(ToolsFlowTest):
+    """
+    Tools > Text QR Code. The encode path already has real-screen coverage in
+    test_real_screen_flows.py; this covers the decode side and the menu itself.
+    """
+
+    TEXT = "hello from a text QR"
+
+    def test_decode_a_scanned_text_qr(self):
+        """
+        Unlike ScanView, ToolsTextQRScanQRCodeView builds its own local DecodeQR and
+        calls ScanScreen(...).display() directly, so there is no `view.decoder` to
+        inject into. Stand in for the camera at those two points instead; the review
+        screen after it is real.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from seedsigner.views import gpg_views
+
+        decoder = MagicMock()
+        decoder.is_complete = True
+        decoder.is_nonUTF8 = False
+        decoder.get_text.return_value = self.TEXT
+
+        session = UISession(script=select("Decode QR code"))
+
+        with patch("seedsigner.gui.screens.scan_screens.ScanScreen"), \
+                patch("seedsigner.models.decode_qr.DecodeQR", return_value=decoder):
+            self.run_sequence(
+                self.tools_steps(tools_views.ToolsMenuView.TEXTQRCODE) + [
+                    FlowStep(tools_views.ToolsTextQRView, real_screens=True),
+                    FlowStep(gpg_views.ToolsTextQRScanQRCodeView, is_redirect=True),
+                    FlowStep(gpg_views.ToolsTextQRReviewTextView2, real_screens=True),
+                ],
+                ui_session=session,
+            )
+
+
+
+class TestClearDescriptorFlow(ToolsFlowTest):
+    """Tools > Clear Multisig Descriptor -- a one-screen flow with real state to check."""
+
+    def test_clearing_removes_the_loaded_descriptor(self):
+        """
+        Clearing is handled inside ToolsMenuView.run() itself -- menu selection and
+        the confirmation status screen are two run_screen() calls on the same View --
+        so that step has to run for real rather than being mocked.
+        """
+        self.controller.multisig_wallet_descriptor = object()
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, button_data_selection=MainMenuView.TOOLS),
+                FlowStep(tools_views.ToolsMenuView, real_screens=True),
+                FlowStep(MainMenuView),
+            ],
+            ui_session=UISession(script=(
+                select(tools_views.ToolsMenuView.CLEAR_DESCRIPTOR)
+                + select(0)  # acknowledge the "descriptor cleared" status screen
+            )),
+        )
+
+        assert self.controller.multisig_wallet_descriptor is None
+
+
+
+class TestMicroSDToolsFlow(ToolsFlowTest):
+    """
+    Tools > MicroSD Tools. Every child here wraps a destructive `dd`/`sha256sum`
+    subprocess, so these walk the menus and confirmation screens and stop before any
+    write -- which is also all a user can do without a card present.
+    """
+
+    def setup_method(self):
+        super().setup_method()
+        # Without this the menu short-circuits to its "not supported on desktop"
+        # warning before reaching any of the tools. That path is covered on its own
+        # in test_desktop_mode_blocks_the_tools below.
+        self._desktop_patch = patch(
+            "seedsigner.hardware.microsd.MicroSD.is_desktop_mode", return_value=False
+        )
+        self._desktop_patch.start()
+
+        # There is no block device here, and these tools would `dd` to it if there
+        # were. Reporting "no card" is the honest desktop answer and still walks the
+        # views' own warning screens.
+        self._device_patch = patch(
+            "seedsigner.views.microsd_views.find_sd_card_device", return_value=None
+        )
+        self._device_patch.start()
+
+    def teardown_method(self):
+        self._device_patch.stop()
+        self._desktop_patch.stop()
+        super().teardown_method()
+
+    def test_desktop_mode_blocks_the_tools(self):
+        """On desktop the menu must warn and stay put rather than run `dd`."""
+        self._desktop_patch.stop()
+        with patch("seedsigner.hardware.microsd.MicroSD.is_desktop_mode", return_value=True):
+            self.run_sequence(
+                self.tools_steps(tools_views.ToolsMenuView.MICROSD) + [
+                    # The warning is raised inside the menu View itself: menu
+                    # selection and warning are two run_screen() calls on the same
+                    # View, which then re-enters itself so the user stays put.
+                    FlowStep(microsd_views.ToolsMicroSDMenuView, real_screens=True),
+                    FlowStep(microsd_views.ToolsMicroSDMenuView),
+                ],
+                ui_session=UISession(script=(
+                    select(microsd_views.ToolsMicroSDMenuView.WIPE_ZERO)
+                    + select(0)  # "OK" on the unavailable warning
+                )),
+            )
+        self._desktop_patch.start()
+
+    def test_wipe_zero_confirmation_screen(self):
+        """
+        Entering the wipe tool must reach its confirmation, not start wiping. There is
+        no card here, so the view stops at its own warning -- which is the screen worth
+        knowing renders and takes input.
+        """
+        self.run_sequence(
+            self.tools_steps(tools_views.ToolsMenuView.MICROSD) + [
+                FlowStep(microsd_views.ToolsMicroSDMenuView, real_screens=True),
+                FlowStep(microsd_views.ToolsMicroSDWipeZeroView, real_screens=True),
+                FlowStep(microsd_views.ToolsMicroSDMenuView),
+            ],
+            ui_session=UISession(script=(
+                select(microsd_views.ToolsMicroSDMenuView.WIPE_ZERO)
+                + [Back()]  # leave the size picker without starting a wipe
+            )),
+        )
+
+    def test_verify_image_warning_precedes_the_check(self):
+        """The verify tool must put its warning up before it reads the card."""
+        self.run_sequence(
+            self.tools_steps(tools_views.ToolsMenuView.MICROSD) + [
+                FlowStep(microsd_views.ToolsMicroSDMenuView, real_screens=True),
+                FlowStep(microsd_views.ToolsMicroSDVerifyWarningView, real_screens=True),
+                FlowStep(microsd_views.ToolsMicroSDVerifyView, real_screens=True),
+                FlowStep(MainMenuView),
+            ],
+            ui_session=UISession(script=(
+                select(microsd_views.ToolsMicroSDMenuView.VERIFY_IMAGE)
+                + select(0)  # "I Understand" on the warning
+                + select(0)  # "no card" result
+            )),
+        )

--- a/tests/test_real_screen_flows_view.py
+++ b/tests/test_real_screen_flows_view.py
@@ -1,0 +1,209 @@
+"""
+    Real-screen flow tests for the top-level views: the power menu, the error
+    interstitials, and the testing-build Home screen.
+
+    Two of these had no coverage at all. `RebootToLoaderView` ("Reboot to flash mode")
+    is never reached by any existing test, and neither is the testing-build variant of
+    MainMenuView -- when is_testing_build_enabled() is set, Home swaps its four buttons
+    for I/O Test / Test Smartcard / Flash Applet / Settings, and no test has ever turned
+    that flag on, so three buttons and their routing were unwalked.
+
+    The restart and reboot views spawn threads that kill the process or drive a ctypes
+    reboot. Both already short-circuit when the renderer reports it is the screenshot
+    generator, which is the seam these tests use rather than patching the threads out.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+# Must import test base before the Controller (sets up the hardware mocks)
+import base  # noqa: F401
+from base import FlowStep, FlowTest
+from ui_driver import UISession, select
+
+from seedsigner.gui.screens.screen import RET_CODE__POWER_BUTTON
+from seedsigner.models.settings import Settings, SettingsConstants
+from seedsigner.views import settings_views
+from seedsigner.views.view import (
+    MainMenuView,
+    NotYetImplementedView,
+    OptionDisabledView,
+    PowerOffView,
+    PowerOptionsView,
+    RebootToLoaderView,
+    RestartView,
+)
+
+
+class TestPowerOptionsFlow(FlowTest):
+    """The power menu, driven on real Screens."""
+
+    def test_power_off(self):
+        session = UISession(script=select(PowerOptionsView.POWER_OFF))
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, screen_return_value=RET_CODE__POWER_BUTTON),
+                FlowStep(PowerOptionsView, real_screens=True),
+                FlowStep(PowerOffView),  # returns BackStackView
+                FlowStep(PowerOptionsView),
+            ],
+            ui_session=session,
+        )
+        assert session.renderer.frames, "the real power screens never rendered"
+
+    def test_restart(self):
+        session = UISession(script=select(PowerOptionsView.RESET))
+        # RestartView short-circuits its process-killing thread when the renderer says
+        # it is the screenshot generator -- the same seam, rather than patching the
+        # thread out and testing something the device never runs.
+        session.renderer.is_screenshot_generator = True
+
+        self.run_sequence(
+            [
+                FlowStep(MainMenuView, screen_return_value=RET_CODE__POWER_BUTTON),
+                FlowStep(PowerOptionsView, real_screens=True),
+                FlowStep(RestartView, real_screens=True),
+            ],
+            ui_session=session,
+        )
+
+    def test_reboot_to_flash_mode_on_luckfox(self):
+        """
+        "Reboot to flash mode" only appears on the Luckfox profiles, and had no test at
+        all -- so neither the extra button nor the third-option layout switch (three
+        options fall back from LargeButtonScreen to ButtonListScreen) was ever
+        exercised.
+        """
+        session = UISession(script=select(PowerOptionsView.REBOOT_LOADER))
+        session.renderer.is_screenshot_generator = True
+
+        with patch.object(Settings, "RUNTIME_PROFILE", PowerOptionsView.LUCKFOX_PROFILES[0]):
+            self.run_sequence(
+                [
+                    FlowStep(MainMenuView, screen_return_value=RET_CODE__POWER_BUTTON),
+                    FlowStep(PowerOptionsView, real_screens=True),
+                    FlowStep(RebootToLoaderView, real_screens=True),
+                ],
+                ui_session=session,
+            )
+
+    def test_flash_mode_is_hidden_off_luckfox(self):
+        """The same menu on a non-Luckfox profile must not offer it."""
+        captured = {}
+
+        def capture(view):
+            original = view.run_screen
+
+            def spy(screen_cls, **kwargs):
+                captured["button_data"] = kwargs.get("button_data")
+                return original(screen_cls, **kwargs)
+
+            view.run_screen = spy
+
+        with patch.object(Settings, "RUNTIME_PROFILE", "pi_zero"):
+            self.run_sequence([
+                FlowStep(MainMenuView, screen_return_value=RET_CODE__POWER_BUTTON),
+                FlowStep(PowerOptionsView, before_run=capture,
+                         button_data_selection=PowerOptionsView.POWER_OFF),
+                FlowStep(PowerOffView),
+                FlowStep(PowerOptionsView),
+            ])
+
+        assert PowerOptionsView.REBOOT_LOADER not in captured["button_data"]
+
+
+
+class TestTestingBuildMainMenu(FlowTest):
+    """
+    Home swaps its whole button set on a testing build
+    (`is_testing_build_enabled()`, view.py). No test has ever enabled it, so the
+    I/O Test / Test Smartcard / Flash Applet branch was never walked.
+    """
+
+    def test_testing_build_swaps_the_home_buttons(self, monkeypatch):
+        monkeypatch.setenv("SEEDSIGNER_TESTING_BUILD", "1")
+
+        captured = {}
+
+        def capture(view):
+            original = view.run_screen
+
+            def spy(screen_cls, **kwargs):
+                captured["button_data"] = kwargs.get("button_data")
+                captured["title"] = kwargs.get("title")
+                return original(screen_cls, **kwargs)
+
+            view.run_screen = spy
+
+        self.run_sequence([
+            FlowStep(MainMenuView, before_run=capture,
+                     button_data_selection=MainMenuView.SETTINGS),
+            FlowStep(settings_views.SettingsMenuView),
+        ])
+
+        assert captured["button_data"] == [
+            MainMenuView.IO_TEST,
+            MainMenuView.TEST_SMARTCARD,
+            MainMenuView.FLASH_APPLET,
+            MainMenuView.SETTINGS,
+        ]
+        assert MainMenuView.SCAN not in captured["button_data"]
+
+    def test_normal_build_shows_the_usual_home(self):
+        captured = {}
+
+        def capture(view):
+            original = view.run_screen
+
+            def spy(screen_cls, **kwargs):
+                captured["button_data"] = kwargs.get("button_data")
+                return original(screen_cls, **kwargs)
+
+            view.run_screen = spy
+
+        self.run_sequence([
+            FlowStep(MainMenuView, before_run=capture,
+                     button_data_selection=MainMenuView.SETTINGS),
+            FlowStep(settings_views.SettingsMenuView),
+        ])
+
+        assert MainMenuView.IO_TEST not in captured["button_data"]
+        assert MainMenuView.SCAN in captured["button_data"]
+
+
+
+class TestErrorInterstitials(FlowTest):
+    """The shared error/notice screens, rendered for real."""
+
+    def test_not_yet_implemented(self):
+        session = UISession(script=select(0))
+
+        self.run_sequence(
+            [
+                FlowStep(NotYetImplementedView, real_screens=True),
+                FlowStep(MainMenuView),
+            ],
+            ui_session=session,
+        )
+
+    def test_option_disabled_offers_the_setting(self):
+        """
+        OptionDisabledView routes the user to the setting that blocked them, which is
+        the branch worth checking renders and routes.
+        """
+        session = UISession(script=select(OptionDisabledView.UPDATE_SETTING))
+
+        self.run_sequence(
+            [
+                FlowStep(
+                    OptionDisabledView,
+                    real_screens=True,
+                ),
+            ],
+            initial_destination_view_args=dict(
+                settings_attr=SettingsConstants.SETTING__MESSAGE_SIGNING
+            ),
+            ui_session=session,
+        )

--- a/tests/ui_driver.py
+++ b/tests/ui_driver.py
@@ -260,11 +260,18 @@ class TypeKeys(DeferredInput):
 
     Presses KEY3 to save at the end when the screen has a save button; screens that
     auto-return at return_after_n_chars (dice entropy) simply exit on the final press.
+
+    `clear_first` backspaces the screen empty before typing. Some KeyboardScreens are
+    pre-filled with the current value (e.g. SettingPBFDK2IterationsScreen shows the
+    stored iteration count), so without it the typed text is *appended* to what is
+    already there.
     """
 
-    def __init__(self, text: str):
+    def __init__(self, text: str, clear_first: bool = False):
         super().__init__()
         self.text = text
+        self.clear_first = clear_first
+        self._cleared = not clear_first
         self._pressed = 0
         self._saved = False
         self._done = False
@@ -296,6 +303,13 @@ class TypeKeys(DeferredInput):
                 f"{type(screen).__name__}, not a KeyboardScreen."
             )
 
+        if not self._cleared:
+            # Latch once empty: user_input becomes non-empty again as soon as we start
+            # typing, and without the latch that would restart the clearing.
+            if screen.user_input:
+                return self._key_toward_code(keyboard, "DEL")
+            self._cleared = True
+
         value = self.text[self._pressed]
         key_char = self._key_char_for(screen, value)
         target = _find_key(keyboard, key_char)
@@ -307,6 +321,19 @@ class TypeKeys(DeferredInput):
             self._pressed += 1
             return K.KEY_PRESS
         return move
+
+    def _key_toward_code(self, keyboard, code: str):
+        """One step toward the key with this `code` (e.g. the DEL key), or its press."""
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+        target = next(
+            (key for row in keyboard.keys for key in row if key.code == code), None
+        )
+        if target is None:
+            raise ScriptSelectionError(
+                f"{self}: this keyboard has no {code!r} key to clear with"
+            )
+        return _step_toward(keyboard, target) or K.KEY_PRESS
 
     @staticmethod
     def _key_char_for(screen, value: str) -> str:

--- a/tests/ui_driver.py
+++ b/tests/ui_driver.py
@@ -321,6 +321,50 @@ class TypeKeys(DeferredInput):
 
 
 
+class Back(DeferredInput):
+    """
+    "Leave the running screen by its back arrow."
+
+    The plain BaseTopNavScreen info screens (Donate, Battery Info, System Info, Memory
+    Info, Version) have no button list for Select() to work with: they exit by moving
+    focus onto the top nav with KEY_LEFT/KEY_UP and clicking it
+    (see BaseTopNavScreen._run). Works on ButtonListScreen-style screens too, where it
+    is the "press BACK" gesture rather than choosing an option.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._clicked = False
+
+    def __repr__(self):
+        return "Back()"
+
+    def _next_key(self, screen, watched_keys):
+        from seedsigner.hardware.buttons import HardwareButtonsConstants as K
+
+        if self._clicked:
+            return None
+
+        top_nav = getattr(screen, "top_nav", None)
+        if top_nav is None:
+            raise ScriptSelectionError(
+                f"Back() was scripted, but {type(screen).__name__} has no top nav to "
+                f"back out of."
+            )
+        if not getattr(top_nav, "show_back_button", False):
+            raise ScriptSelectionError(
+                f"Back() was scripted, but {type(screen).__name__} has no back button "
+                f"(show_back_button is False)."
+            )
+
+        if not top_nav.is_selected:
+            return K.KEY_UP
+
+        self._clicked = True
+        return K.KEY_PRESS
+
+
+
 def select(*options) -> list:
     """Shorthand for a run of Select() tokens: `select(A, B, C)`."""
     return [Select(option) for option in options]
@@ -448,6 +492,31 @@ class MockCameraFeed(MagicMock):
 
 
 
+def _assert_screen_can_exit(screen) -> None:
+    """
+    Fail fast on a screen that can never return.
+
+    BaseTopNavScreen._run() spins on time.sleep(0.1) when a screen has neither a back
+    nor a power button -- on device that is a screen you leave by other means, but in a
+    test it is an unkillable loop that never asks for input, so the run would hang
+    instead of failing. Name the problem instead.
+    """
+    from seedsigner.gui.screens.screen import BaseTopNavScreen
+
+    if type(screen)._run is not BaseTopNavScreen._run:
+        return  # has its own input loop; not the spinning case
+
+    top_nav = getattr(screen, "top_nav", None)
+    if top_nav is None:
+        return
+    if not getattr(top_nav, "show_back_button", False) and not getattr(top_nav, "show_power_button", False):
+        raise ScriptSelectionError(
+            f"{type(screen).__name__} has no back or power button, so its _run() loops "
+            f"forever without ever asking for input. It cannot be driven by a UISession."
+        )
+
+
+
 class UISession:
     """
     Context manager that swaps the hardware singletons for test stand-ins.
@@ -487,6 +556,7 @@ class UISession:
         session = self
 
         def display(screen_self, *args, **kwargs):
+            _assert_screen_can_exit(screen_self)
             previous = session.current_screen
             session.current_screen = screen_self
             try:


### PR DESCRIPTION
## Why

[PR #434](https://github.com/3rdIteration/seedsigner/pull/434) added the real-screen harness and 39 tests for the seed workflows. That suite found **three bugs beyond the one it was written for** — the `SeedDiscardView` `ValueError`, the `Keyboard.__init__` crash that made TAPSIGNER and Passport code entry unreachable on device, and an infinite loop in the pre-existing `plan_keyboard_script`. This extends the same treatment to the rest of the app.

The gap was measurable: of **321 View classes, 97 were never named in any test** — a `grep`-level bar, so the real gap was larger. `tests/test_flows_menu_navigation.py` does walk nearly every menu, but mocked, and mostly "enter the view, press BACK". It proves routing, not that a screen can construct or take input. That is exactly the blind spot the `Keyboard` crash lived in.

## What's here

**53 new tests in 6 files**, each starting at `MainMenuView` and walking the menus a user walks, on real Screens with scripted button input.

| Suite | Covers |
|---|---|
| `test_real_screen_flows_psbt.py` | Scan → select seed → overview → maths → address details → three change pages → finalize → signed QR, plus BACK through the review chain |
| `test_real_screen_flows_settings.py` | The multiselect checkbox editor, `SettingPBKDF2IterationsView`, `LocaleSelectionView`, the required-selection warning, and the read-only info screens |
| `test_real_screen_flows_tools.py` | Password generator end to end, Address Explorer, Text QR decode, Clear Descriptor, MicroSD tools |
| `test_real_screen_flows_view.py` | Power menu including Reboot-to-flash-mode, and the testing-build Home screen |
| `test_real_screen_flows_gpg.py` | View Keys end to end against a real key, plus every GPG and Advanced submenu |
| `test_real_screen_flows_smartcard.py` | Every smartcard submenu, the card filter, DIY mount status, JavaCard keys |

Highlights of what had **no** coverage at all before:

- **PSBT screens had zero real-screen coverage**, despite doing the heaviest layout and text-fitting work in the app — a separate `StubRenderer` harness exists (`test_psbt_refusal_screens.py`) precisely because that layout is a live risk, and it can only check screens in isolation. These tests assert on `PSBTParser.sig_count(controller.psbt)` sampled after finalize, so they prove the PSBT was actually **signed**, not merely that the flow reached the QR screen.
- **The password generator had no flow test at all** — only unit-level view tests — despite producing a secret the user keeps. Now covered type → strength → entropy source → generate → review, including `ToolsPasswordRandomOptionsView`, reachable only from the Custom type.
- **Three settings views are explicitly *skipped*** by the existing all-entries loops because they don't behave like a plain toggle. Those are exactly the ones with custom Button classes and custom input handling, so mocked coverage said least about them.
- **`RebootToLoaderView` ("Reboot to flash mode") was never reached by any test.** It only appears on Luckfox profiles, and adding it takes the menu to three options, which switches the layout from `LargeButtonScreen` to `ButtonListScreen` — so neither the button nor the fallback was exercised.
- **The testing-build Home screen was never walked.** `MainMenuView` swaps Scan/Seeds/Tools for I/O Test / Test Smartcard / Flash Applet when `is_testing_build_enabled()`, and no test had ever set it.
- **GPG:** 36 of 64 views unnamed. Now walks View Keys end to end against a real key generated into an isolated `GNUPGHOME` (so the actual `gpg --list-secret-keys` subprocess runs), plus every submenu.
- **Smartcard:** 33 of 61 unnamed. The only operational coverage was `test_flows_smartcard_hardware.py`, which **skips unless a physical reader and card are present**.

## Harness changes — `tests/ui_driver.py`

- **`Back()`** — the plain `BaseTopNavScreen` info screens have no button list for `Select()`; they exit via the top nav.
- **`TypeKeys(..., clear_first=True)`** — some `KeyboardScreen`s come up pre-filled with the current value, so typed text would otherwise be appended to it. The clear latches once empty, since `user_input` goes non-empty again the moment typing starts.
- **`_assert_screen_can_exit()`** — `BaseTopNavScreen._run()` spins on `sleep(0.1)` when a screen has neither back nor power button, so a test landing on one would hang rather than fail. It now raises a named error instead — the same class of hang the `plan_keyboard_script` fix removed.
- **`tests/real_screen_fixtures.py`** collects the hardware stand-ins that each lived in a single test file: `MockSatochipConnector`, `FakePyGP`, the `gnupghome` fixture, `use_microsd`, `no_shuffle`, `index_screen`.

## Two things worth knowing

**GPG runs everywhere.** CI already installs `gnupg2`, so these are real coverage there, not skips.

**The card seam is deliberate.** Every card stand-in goes in behind the single `seedkeeper_utils.init_satochip` seam; no test reaches into connector internals. That is what lets the backend be swapped for a jcardsim-backed simulator running the real applets without rewriting a single test — see below.

## What stays mocked, deliberately

Camera decode steps (`ScanView`, the image-entropy live preview) respond to frames, not buttons; destructive microSD writes (`find_sd_card_device` reports no card, which is the honest desktop answer and still walks each view's warning screens); real card and OpenPGP-card operations; and the screensaver, which `tests/base.py` replaces with a `MagicMock` so it cannot be driven without changing the base harness.

## Residual

The never-named count drops **97 → 86**. The submenu walks reach the menus; most of what remains are leaf operations that genuinely need a card (31 in `smartcard_views`), an OpenPGP card or camera (31 in `gpg_views`), or a camera (`scan_views`). Covering those meaningfully is what the follow-up below is for, rather than padding the count with tests that assert nothing.

## Follow-up: jcardsim-backed applet simulator

Scoped but not in this PR. The findings, so it needn't be re-derived:

- **Don't write four simulators.** `pysatochip`, `keycard-py` and `pygp` all reach the card through **pyscard**, so one pyscard-shaped adapter pointed at a jcardsim socket serves all three — roughly 100–200 lines, the only genuinely new code.
- **A working harness already exists.** `specter-javacard/simulator.jar` *is* jcardsim, invoked by its `run_sim.py` as `java -jar simulator.jar -p 21111 -a <AID> -c <AppletClass> -u file://build/classes/<Applet>/`; its `card_proxy.py` documents the wire format (raw APDUs over TCP). `status-keycard` vendors jcardsim source and already uses it in its own gradle build.
- **Costs:** jcardsim runs compiled `.class` files, not the `.cap` files this repo ships, so the applets must be built; and those repos are not submodules here, so CI needs new checkout steps.
- **Why it earns its own PR:** it tests a different layer — real applet logic against the real client library, which is where this fork's recent status-word bugs actually lived (e.g. `49095f60`, the SeedKeeper `0x9C01` card-full mapping). The UI walk cannot see those.

## Verification

```
before:  2 failed, 1544 passed, 228 skipped
after:   2 failed, 1618 passed, 228 skipped
```

Same two pre-existing failures (`test_psbt_refusal_screens.py::TestBlockAnchor::test_shipped_json_is_plausible`, `test_pysatochip_contract.py::test_real_connector_has_satodime_ndef_v2`), none new. All 98 real-screen tests across the eight suites pass in ~2m10s.

One incidental fix to how the suite is run locally: putting the repo **root** on `PYTHONPATH` alongside `src` resolves the 20 `test_gpg_message.py` `ModuleNotFoundError: No module named 'tools'` failures that show up on a non-editable checkout. CI gets the same effect from `pip install -e .`.

## Base branch

Targets `fix/pending-seed-never-finalized` (#434) so it merges after it. Retarget to `dev` if that lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
