### PR TITLE
test: run the real JavaCard applets under jcardsim

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,31 @@ jobs:
           cache-dependency-path: |
             requirements.txt
             tests/requirements.txt
+      # The jcardsim tests run the real JavaCard applets. Without a JDK and the applet
+      # sources they skip with a reason rather than failing, so this is additive.
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "11"
+      - name: Check out JavaCard applet sources
+        run: |
+          mkdir -p "$HOME/applet-repos"
+          # Satochip-DIY is the aggregator: it carries the Satochip/SeedKeeper/Satodime
+          # sources *and* the JavaCard SDKs as submodules, so it needs --recursive.
+          git clone --recursive --depth 1 \
+            https://github.com/3rdIteration/Satochip-DIY.git \
+            "$HOME/applet-repos/Satochip-DIY"
+          # SeedKeeper is built at two tags (v0.1 and v0.2), so this one needs full
+          # history -- git archive cannot export a tag that was not fetched.
+          git clone --recursive \
+            https://github.com/Toporin/Seedkeeper-Applet.git \
+            "$HOME/applet-repos/Seedkeeper-Applet"
+          # Provides the jcardsim jar the simulator runs on, as well as the Keycard
+          # applet sources.
+          git clone --recursive --depth 1 \
+            https://github.com/status-im/status-keycard.git \
+            "$HOME/applet-repos/status-keycard"
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -67,6 +92,9 @@ jobs:
       - name: Test with pytest
         run: |
           mkdir -p artifacts
+          # Where the applet checkouts above landed. The jcardsim harness looks here for
+          # them and skips with a reason if any are missing, so this never breaks the run.
+          export SEEDSIGNER_APPLET_ROOT="$HOME/applet-repos"
           python -m pytest \
             --color=yes \
             --cov=seedsigner \

--- a/tests/jcardsim/__init__.py
+++ b/tests/jcardsim/__init__.py
@@ -19,4 +19,4 @@ from .simulator import (  # noqa: F401
     simulator_available,
     why_unavailable,
 )
-from .applets import APPLETS, AppletSpec, resolve_applet  # noqa: F401
+from .applets import APPLETS, AppletSpec, open_card, resolve_applet  # noqa: F401

--- a/tests/jcardsim/__init__.py
+++ b/tests/jcardsim/__init__.py
@@ -1,0 +1,22 @@
+"""
+    Run the real JavaCard applets under test, in jcardsim.
+
+    The real-screen suites stand in for the card at
+    ``seedkeeper_utils.init_satochip``; that proves the *screens* behave, but says
+    nothing about whether SeedSigner's client code and the applet agree. This package
+    closes that gap by putting the actual applet bytecode -- SeedKeeper, Satochip,
+    Keycard, SmartPGP -- behind SeedSigner's real client stacks, so a status word the
+    applet returns is the status word the app has to handle. That is where this fork's
+    recent card bugs actually were (e.g. the SeedKeeper 0x9C01 card-full mapping).
+
+    Everything here skips cleanly when Java or the applet sources are absent, so a
+    checkout without them still runs the rest of the suite.
+"""
+
+from .simulator import (  # noqa: F401
+    JCardSimUnavailable,
+    SimulatedCard,
+    simulator_available,
+    why_unavailable,
+)
+from .applets import APPLETS, AppletSpec, resolve_applet  # noqa: F401

--- a/tests/jcardsim/applets.py
+++ b/tests/jcardsim/applets.py
@@ -33,13 +33,37 @@ class AppletSpec:
     sources_rel: str               # package root of the .java sources, within the repo
     sdk_rel: str = "sdks/jc304_kit/lib/api_classic.jar"
     revision: str | None = None    # git tag/sha; None means the repo's working tree
-    install_params: str = ""       # hex, passed through to the applet's install()
+    install_params: str = ""       # hex, the "applet data" section of the install block
+    # How install() expects its parameters laid out. "gp" is the full GlobalPlatform
+    # [aidLen][aid][ctrlLen][ctrl][dataLen][data] that SeedKeeper and Satochip parse;
+    # "aid_only" is the [aidLen][aid] Keycard's install() expects (and is what
+    # status-keycard's own JUnit tests pass).
+    install_style: str = "gp"
+    # The AID jcardsim registers the applet under. Usually the same as `aid`, but
+    # Keycard registers under its *package* AID while its install block carries the
+    # *instance* AID -- which is exactly what status-keycard's own tests do.
+    install_aid: str = ""
     prebuilt_classes_rel: str | None = None  # use these if present and no revision pinned
+    # Jars/dirs the applet needs to compile and to load, e.g. Keycard's keycard-math.jar,
+    # a prebuilt JavaCard library the repo ships with no sources.
+    extra_classpath_rel: tuple[str, ...] = ()
     env_var: str = ""              # per-applet override for the repo location
 
     @property
     def repo_env_var(self) -> str:
         return self.env_var or f"SEEDSIGNER_APPLET_{self.name.upper()}_REPO"
+
+    @property
+    def registration_aid(self) -> str:
+        return self.install_aid or self.aid
+
+    def install_block(self) -> str:
+        """The install parameter block for this applet, as hex."""
+        aid = bytes.fromhex(self.aid)
+        data = bytes.fromhex(self.install_params) if self.install_params else b""
+        if self.install_style == "aid_only":
+            return (bytes([len(aid)]) + aid).hex()
+        return (bytes([len(aid)]) + aid + bytes([0, len(data)]) + data).hex()
 
 
 # SeedKeeper's install() recovers OM_SIZE from the install parameters and indexes into
@@ -94,15 +118,25 @@ APPLETS: dict[str, AppletSpec] = {
         aid="A000000804000101",
         sources_rel="src/main/java/im/status/keycard",
         prebuilt_classes_rel="build/classes/java/main",
+        extra_classpath_rel=("keycard-math/keycard-math.jar",),
+        install_style="aid_only",
+        install_aid="A0000008040001",  # package AID; the block carries the instance AID
     ),
-    # Only the built CAPs ship in javacard-cap/; the source has to be cloned. See
-    # docs/gpg_tools.md, which names ANSSI-FR/SmartPGP as the upstream.
+    # Only the built CAPs ship in javacard-cap/; the source has to be cloned from
+    # ANSSI-FR/SmartPGP (named in docs/gpg_tools.md).
+    #
+    # Not currently simulatable: its sources import javacard.security.NamedParameterSpec
+    # and XECKey, which are JavaCard 3.1, and jcardsim 3.0.5 implements 3.0.x and has
+    # neither class. Kept here so the plumbing is ready for a jcardsim with 3.1 support
+    # or an older SmartPGP revision -- see test_jcardsim_keycard.py.
     "smartpgp": AppletSpec(
         name="smartpgp",
         repo="SmartPGP",
         applet_class="fr.anssi.smartpgp.SmartPGPApplet",
-        aid="D276000124010304000000000000000000",
+        aid="D276000124010304AFAF000000000000",
+        install_aid="D27600012401",
         sources_rel="src/fr/anssi/smartpgp",
+        sdk_rel="oracle_javacard_sdks/jc310r20210706_kit/lib/api_classic.jar",
     ),
 }
 
@@ -146,7 +180,12 @@ def _java_sources(root: Path) -> list[str]:
     return [str(p) for p in sorted(root.rglob("*.java"))]
 
 
-def _compile(sources_root: Path, sdk_jar: Path, out: Path) -> None:
+def extra_classpath(spec: AppletSpec, repo: Path) -> list[Path]:
+    """Absolute paths for the spec's extra classpath entries that actually exist."""
+    return [repo / rel for rel in spec.extra_classpath_rel if (repo / rel).exists()]
+
+
+def _compile(sources_root: Path, sdk_jar: Path, out: Path, extra: list[Path] | None = None) -> None:
     """
     Compile the applet with javac directly.
 
@@ -160,12 +199,13 @@ def _compile(sources_root: Path, sdk_jar: Path, out: Path) -> None:
         raise JCardSimUnavailable(f"no .java sources under {sources_root}")
 
     out.mkdir(parents=True, exist_ok=True)
+    classpath = os.pathsep.join(str(p) for p in [sdk_jar, *(extra or [])])
     result = _run([
         "javac",
         # JavaCard applets are Java 1.x source; -source/-target 7 is the oldest modern
         # JDKs still accept, and is enough for this bytecode.
         "-source", "7", "-target", "7", "-nowarn",
-        "-cp", str(sdk_jar),
+        "-cp", classpath,
         "-d", str(out),
         *sources,
     ])
@@ -173,6 +213,22 @@ def _compile(sources_root: Path, sdk_jar: Path, out: Path) -> None:
         raise JCardSimUnavailable(
             f"javac failed for {sources_root.name}:\n{result.stderr.strip()[:2000]}"
         )
+
+
+def open_card(name: str, **kwargs):
+    """
+    A ready-to-start `SimulatedCard` for `name`, with its classpath worked out.
+
+    Prefer this over calling resolve_applet() and constructing the card by hand: some
+    applets need extra classpath entries to load at all, and forgetting them shows up as
+    a confusing failure inside the JVM.
+    """
+    from .simulator import SimulatedCard
+
+    spec, classes = resolve_applet(name)
+    repo = repo_path(spec)
+    extra = extra_classpath(spec, repo) if repo else []
+    return SimulatedCard(spec, classes, extra_classpath=extra, **kwargs)
 
 
 def resolve_applet(name: str) -> tuple[AppletSpec, Path]:
@@ -223,6 +279,6 @@ def resolve_applet(name: str) -> tuple[AppletSpec, Path]:
             f"JavaCard SDK jar not at {sdk_jar} (is the repo's sdks/ submodule checked out?)"
         )
 
-    _compile(sources_root, sdk_jar, out)
+    _compile(sources_root, sdk_jar, out, extra_classpath(spec, repo))
     marker.write_text(stamp, encoding="utf-8")
     return spec, out

--- a/tests/jcardsim/applets.py
+++ b/tests/jcardsim/applets.py
@@ -1,0 +1,228 @@
+"""
+    Which applets can be simulated, where their source lives, and how to build them.
+
+    Class names and AIDs are deliberately cross-checked against the registry the app
+    itself ships -- ``_JAVACARD_APPLETS`` in ``seedsigner.views.smartcard_views`` -- so
+    the two cannot silently drift apart. See ``test_registry_matches_the_app``.
+
+    Repositories are *never* mutated. A pinned revision is extracted with ``git archive``
+    into a build cache, so a contributor's working checkout of an applet repo is left
+    exactly as they had it. That is also what makes SeedKeeper v0.1 and v0.2 buildable
+    side by side from one repo.
+"""
+
+import os
+import shutil
+import subprocess
+import tarfile
+from dataclasses import dataclass, field
+from io import BytesIO
+from pathlib import Path
+
+from .simulator import JCardSimUnavailable, REPO_ROOT, SIBLING_ROOT
+
+BUILD_CACHE = REPO_ROOT / "tests" / "jcardsim" / "build" / "applets"
+
+
+@dataclass(frozen=True)
+class AppletSpec:
+    name: str
+    repo: str                      # directory name under SIBLING_ROOT
+    applet_class: str
+    aid: str                       # instance AID, hex
+    sources_rel: str               # package root of the .java sources, within the repo
+    sdk_rel: str = "sdks/jc304_kit/lib/api_classic.jar"
+    revision: str | None = None    # git tag/sha; None means the repo's working tree
+    install_params: str = ""       # hex, passed through to the applet's install()
+    prebuilt_classes_rel: str | None = None  # use these if present and no revision pinned
+    env_var: str = ""              # per-applet override for the repo location
+
+    @property
+    def repo_env_var(self) -> str:
+        return self.env_var or f"SEEDSIGNER_APPLET_{self.name.upper()}_REPO"
+
+
+# SeedKeeper's install() recovers OM_SIZE from the install parameters and indexes into
+# that array unconditionally, so it must be given some: 0x0FFF is the value its own
+# source comments use as the GlobalPlatform example.
+SEEDKEEPER_PARAMS = "0FFF"
+
+APPLETS: dict[str, AppletSpec] = {
+    # Both SeedKeeper versions are the same repo at two tags. v0.1 is the one this fork
+    # pins in tests/javacard-cap-legacy/, and the version whose status words (0x9C01 card
+    # full) have been the source of real bugs.
+    "seedkeeper_v02": AppletSpec(
+        name="seedkeeper_v02",
+        repo="Seedkeeper-Applet",
+        applet_class="org.seedkeeper.applet.SeedKeeper",
+        aid="536565644B656570657200",
+        sources_rel="src/main/java/org/seedkeeper/applet",
+        install_params=SEEDKEEPER_PARAMS,
+        prebuilt_classes_rel="build/classes/java/main",
+    ),
+    "seedkeeper_v01": AppletSpec(
+        name="seedkeeper_v01",
+        repo="Seedkeeper-Applet",
+        applet_class="org.seedkeeper.applet.SeedKeeper",
+        aid="536565644B656570657200",
+        # v0.1 predates the move to the gradle source layout, so its package root sits
+        # at src/ rather than src/main/java/.
+        sources_rel="src/org/seedkeeper/applet",
+        install_params=SEEDKEEPER_PARAMS,
+        revision="v0.1",
+    ),
+    # Satochip-DIY is the aggregator: the applet sources and the JavaCard SDKs are all
+    # submodules of it.
+    "satochip": AppletSpec(
+        name="satochip",
+        repo="Satochip-DIY",
+        applet_class="org.satochip.applet.CardEdge",
+        aid="5361746F4368697000",
+        sources_rel="applets/satochip/src/org/satochip/applet",
+    ),
+    "satodime": AppletSpec(
+        name="satodime",
+        repo="Satochip-DIY",
+        applet_class="org.satodime.applet.Satodime",
+        aid="5361746F44696D6500",
+        sources_rel="applets/satodime/src/org/satodime/applet",
+    ),
+    "keycard": AppletSpec(
+        name="keycard",
+        repo="status-keycard",
+        applet_class="im.status.keycard.KeycardApplet",
+        aid="A000000804000101",
+        sources_rel="src/main/java/im/status/keycard",
+        prebuilt_classes_rel="build/classes/java/main",
+    ),
+    # Only the built CAPs ship in javacard-cap/; the source has to be cloned. See
+    # docs/gpg_tools.md, which names ANSSI-FR/SmartPGP as the upstream.
+    "smartpgp": AppletSpec(
+        name="smartpgp",
+        repo="SmartPGP",
+        applet_class="fr.anssi.smartpgp.SmartPGPApplet",
+        aid="D276000124010304000000000000000000",
+        sources_rel="src/fr/anssi/smartpgp",
+    ),
+}
+
+
+def repo_path(spec: AppletSpec) -> Path | None:
+    """Where this applet's repo is, or None if it isn't anywhere we look."""
+    override = os.environ.get(spec.repo_env_var)
+    if override:
+        path = Path(override)
+        return path if path.is_dir() else None
+    path = SIBLING_ROOT / spec.repo
+    return path if path.is_dir() else None
+
+
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+
+
+def _export_revision(repo: Path, revision: str, dest: Path) -> None:
+    """
+    Extract `revision` into `dest` without touching the repo's working tree.
+
+    A contributor may well have an applet repo checked out on a branch they are working
+    on; checking out a tag under them would be rude and would break the other version's
+    build anyway. `git archive` sidesteps both problems.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(repo), "archive", revision],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise JCardSimUnavailable(
+            f"could not export {revision} from {repo}: {result.stderr.decode(errors='replace').strip()}"
+        )
+    dest.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(fileobj=BytesIO(result.stdout)) as tar:
+        tar.extractall(dest)
+
+
+def _java_sources(root: Path) -> list[str]:
+    return [str(p) for p in sorted(root.rglob("*.java"))]
+
+
+def _compile(sources_root: Path, sdk_jar: Path, out: Path) -> None:
+    """
+    Compile the applet with javac directly.
+
+    Not with the repo's own ant build: `Satochip-DIY/build.xml` sets no `classes=`
+    attribute on its <cap> elements, so ant-javacard compiles into a temp directory and
+    keeps only the CAP -- and jcardsim needs the .class files, not the CAP. Going
+    straight to javac also avoids needing ant installed at all.
+    """
+    sources = _java_sources(sources_root)
+    if not sources:
+        raise JCardSimUnavailable(f"no .java sources under {sources_root}")
+
+    out.mkdir(parents=True, exist_ok=True)
+    result = _run([
+        "javac",
+        # JavaCard applets are Java 1.x source; -source/-target 7 is the oldest modern
+        # JDKs still accept, and is enough for this bytecode.
+        "-source", "7", "-target", "7", "-nowarn",
+        "-cp", str(sdk_jar),
+        "-d", str(out),
+        *sources,
+    ])
+    if result.returncode != 0:
+        raise JCardSimUnavailable(
+            f"javac failed for {sources_root.name}:\n{result.stderr.strip()[:2000]}"
+        )
+
+
+def resolve_applet(name: str) -> tuple[AppletSpec, Path]:
+    """
+    Return the spec and a directory of compiled classes, building only if needed.
+
+    Raises JCardSimUnavailable with a specific reason -- which repo, which path -- so a
+    skipped test says what is actually missing rather than just "unavailable".
+    """
+    spec = APPLETS[name]
+    repo = repo_path(spec)
+    if repo is None:
+        raise JCardSimUnavailable(
+            f"{spec.repo} not found under {SIBLING_ROOT} (set {spec.repo_env_var})"
+        )
+
+    # Fast path: the repo has already built the classes we need and we are not pinned to
+    # a different revision. Seedkeeper-Applet ships in this state.
+    if spec.revision is None and spec.prebuilt_classes_rel:
+        prebuilt = repo / spec.prebuilt_classes_rel
+        if (prebuilt / Path(spec.applet_class.replace(".", "/") + ".class")).is_file():
+            return spec, prebuilt
+
+    out = BUILD_CACHE / spec.name / "classes"
+    marker = out / ".built"
+    stamp = f"{spec.revision or 'worktree'}\n"
+    if marker.is_file() and marker.read_text(encoding="utf-8") == stamp:
+        return spec, out
+
+    if out.exists():
+        shutil.rmtree(out)
+
+    if spec.revision:
+        export = BUILD_CACHE / spec.name / "src"
+        if export.exists():
+            shutil.rmtree(export)
+        _export_revision(repo, spec.revision, export)
+        sources_root = export / spec.sources_rel
+        sdk_jar = repo / spec.sdk_rel  # SDKs come from the working repo, not the export
+    else:
+        sources_root = repo / spec.sources_rel
+        sdk_jar = repo / spec.sdk_rel
+
+    if not sources_root.is_dir():
+        raise JCardSimUnavailable(f"applet sources not at {sources_root}")
+    if not sdk_jar.is_file():
+        raise JCardSimUnavailable(
+            f"JavaCard SDK jar not at {sdk_jar} (is the repo's sdks/ submodule checked out?)"
+        )
+
+    _compile(sources_root, sdk_jar, out)
+    marker.write_text(stamp, encoding="utf-8")
+    return spec, out

--- a/tests/jcardsim/java/SimLauncher.java
+++ b/tests/jcardsim/java/SimLauncher.java
@@ -55,38 +55,27 @@ public class SimLauncher {
         return out;
     }
 
-    /**
-     * The install parameter block a JavaCard applet's install() receives:
-     * [aidLen][aid...][ctrlLen][ctrl...][dataLen][data...]
-     * Applets that ignore parameters are unaffected; the ones that parse them need this
-     * shape to exist at all, which is the whole reason for this class.
-     */
-    private static byte[] installBlock(byte[] aid, byte[] data) {
-        byte[] block = new byte[1 + aid.length + 1 + 1 + data.length];
-        int i = 0;
-        block[i++] = (byte) aid.length;
-        System.arraycopy(aid, 0, block, i, aid.length);
-        i += aid.length;
-        block[i++] = 0;                      // control info length
-        block[i++] = (byte) data.length;     // applet data length
-        System.arraycopy(data, 0, block, i, data.length);
-        return block;
-    }
-
     private static class AppletSpec {
         final byte[] aid;
         final String className;
-        final byte[] params;
+        final byte[] installBlock;
 
         AppletSpec(String spec) {
-            // AID:class[:paramsHex]
+            // AID:class[:installBlockHex]
+            //
+            // The block is passed in whole rather than assembled here, because its shape
+            // is applet-specific: SeedKeeper and Satochip parse the full GlobalPlatform
+            // [aidLen][aid][ctrlLen][ctrl][dataLen][data], while Keycard's install()
+            // expects only [aidLen][aid]. Building it in Python keeps that decision
+            // somewhere legible instead of hidden in a Java helper.
             String[] parts = spec.split(":", 3);
             if (parts.length < 2) {
-                throw new IllegalArgumentException("--applet wants AID:class[:paramsHex], got " + spec);
+                throw new IllegalArgumentException(
+                    "--applet wants AID:class[:installBlockHex], got " + spec);
             }
             this.aid = hexToBytes(parts[0]);
             this.className = parts[1];
-            this.params = parts.length == 3 ? hexToBytes(parts[2]) : new byte[0];
+            this.installBlock = parts.length == 3 ? hexToBytes(parts[2]) : new byte[0];
         }
     }
 
@@ -104,13 +93,21 @@ public class SimLauncher {
             }
         }
         if (port == 0 || classesDir == null || applets.isEmpty()) {
-            System.err.println("usage: SimLauncher --port N --classes DIR --applet AID:class[:paramsHex] ...");
+            System.err.println("usage: SimLauncher --port N --classes CLASSPATH --applet AID:class[:paramsHex] ...");
             System.exit(2);
         }
 
         // The applet's own classes are loaded from the build output of its repo, so the
         // bytecode under test is exactly what would be converted into a CAP.
-        URL[] urls = { new File(classesDir).toURI().toURL() };
+        //
+        // This is a classpath, not one directory: Keycard's Crypto references
+        // BigNumberMath from keycard-math.jar, a prebuilt JavaCard library that has no
+        // sources in the repo, so the applet cannot be loaded without it alongside.
+        String[] entries = classesDir.split(java.io.File.pathSeparator);
+        URL[] urls = new URL[entries.length];
+        for (int i = 0; i < entries.length; i++) {
+            urls[i] = new File(entries[i]).toURI().toURL();
+        }
         ClassLoader loader = new URLClassLoader(urls, SimLauncher.class.getClassLoader());
 
         CardSimulator simulator = new CardSimulator();
@@ -118,9 +115,18 @@ public class SimLauncher {
         for (AppletSpec spec : applets) {
             AID aid = AIDUtil.create(spec.aid);
             Class<?> cls = loader.loadClass(spec.className);
-            byte[] block = installBlock(spec.aid, spec.params);
-            simulator.installApplet(aid, cls.asSubclass(javacard.framework.Applet.class),
-                                    block, (short) 0, (byte) block.length);
+            byte[] block = spec.installBlock;
+            try {
+                simulator.installApplet(aid, cls.asSubclass(javacard.framework.Applet.class),
+                                        block, (short) 0, (byte) block.length);
+            } catch (javacard.framework.CardRuntimeException e) {
+                // The applet's install() rejected us. The reason code is the only useful
+                // detail -- a bare SystemException says nothing about which resource or
+                // algorithm jcardsim could not provide.
+                System.err.println("install of " + spec.className + " failed: "
+                                   + e.getClass().getName() + " reason=" + e.getReason());
+                throw e;
+            }
             if (firstAid == null) {
                 firstAid = aid;
             }

--- a/tests/jcardsim/java/SimLauncher.java
+++ b/tests/jcardsim/java/SimLauncher.java
@@ -1,0 +1,188 @@
+// Launches one or more JavaCard applets inside jcardsim and serves APDUs over TCP.
+//
+// Why this exists rather than specter-javacard's bundled simulator.jar: that one calls
+// jcardsim's two-argument installApplet(aid, class), which supplies no install
+// parameters. Several of the applets we care about parse them in install() -- SeedKeeper
+// reads OM_SIZE out of them and indexes into the array unconditionally -- so they throw
+// SystemException before the simulator ever opens its port. This launcher builds the
+// standard [aidLen][aid][ctrlLen][ctrl][dataLen][data] block and uses the five-argument
+// form, the same way status-keycard's own JUnit tests do.
+//
+// The wire protocol is length-prefixed rather than raw: each frame is a 2-byte big-endian
+// length followed by that many bytes. specter's raw-stream version reads one APDU per
+// recv() with a 256-byte cap, which silently truncates anything larger (SeedKeeper secret
+// exports, RSA reads) and makes it look like an applet bug.
+
+import com.licel.jcardsim.smartcardio.CardSimulator;
+import com.licel.jcardsim.utils.AIDUtil;
+
+import javacard.framework.AID;
+
+import javax.smartcardio.CommandAPDU;
+import javax.smartcardio.ResponseAPDU;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SimLauncher {
+
+    private static final int MAX_FRAME = 65535;
+
+    private static String bytesToHex(byte[] b) {
+        StringBuilder sb = new StringBuilder();
+        for (byte x : b) {
+            sb.append(String.format("%02X", x));
+        }
+        return sb.toString();
+    }
+
+    private static byte[] hexToBytes(String hex) {
+        String s = hex.replace(" ", "").replace(":", "");
+        if (s.length() % 2 != 0) {
+            throw new IllegalArgumentException("odd-length hex: " + hex);
+        }
+        byte[] out = new byte[s.length() / 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = (byte) Integer.parseInt(s.substring(i * 2, i * 2 + 2), 16);
+        }
+        return out;
+    }
+
+    /**
+     * The install parameter block a JavaCard applet's install() receives:
+     * [aidLen][aid...][ctrlLen][ctrl...][dataLen][data...]
+     * Applets that ignore parameters are unaffected; the ones that parse them need this
+     * shape to exist at all, which is the whole reason for this class.
+     */
+    private static byte[] installBlock(byte[] aid, byte[] data) {
+        byte[] block = new byte[1 + aid.length + 1 + 1 + data.length];
+        int i = 0;
+        block[i++] = (byte) aid.length;
+        System.arraycopy(aid, 0, block, i, aid.length);
+        i += aid.length;
+        block[i++] = 0;                      // control info length
+        block[i++] = (byte) data.length;     // applet data length
+        System.arraycopy(data, 0, block, i, data.length);
+        return block;
+    }
+
+    private static class AppletSpec {
+        final byte[] aid;
+        final String className;
+        final byte[] params;
+
+        AppletSpec(String spec) {
+            // AID:class[:paramsHex]
+            String[] parts = spec.split(":", 3);
+            if (parts.length < 2) {
+                throw new IllegalArgumentException("--applet wants AID:class[:paramsHex], got " + spec);
+            }
+            this.aid = hexToBytes(parts[0]);
+            this.className = parts[1];
+            this.params = parts.length == 3 ? hexToBytes(parts[2]) : new byte[0];
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        int port = 0;
+        String classesDir = null;
+        List<AppletSpec> applets = new ArrayList<>();
+
+        for (int i = 0; i < args.length; i++) {
+            switch (args[i]) {
+                case "--port":    port = Integer.parseInt(args[++i]); break;
+                case "--classes": classesDir = args[++i]; break;
+                case "--applet":  applets.add(new AppletSpec(args[++i])); break;
+                default: throw new IllegalArgumentException("unknown argument: " + args[i]);
+            }
+        }
+        if (port == 0 || classesDir == null || applets.isEmpty()) {
+            System.err.println("usage: SimLauncher --port N --classes DIR --applet AID:class[:paramsHex] ...");
+            System.exit(2);
+        }
+
+        // The applet's own classes are loaded from the build output of its repo, so the
+        // bytecode under test is exactly what would be converted into a CAP.
+        URL[] urls = { new File(classesDir).toURI().toURL() };
+        ClassLoader loader = new URLClassLoader(urls, SimLauncher.class.getClassLoader());
+
+        CardSimulator simulator = new CardSimulator();
+        AID firstAid = null;
+        for (AppletSpec spec : applets) {
+            AID aid = AIDUtil.create(spec.aid);
+            Class<?> cls = loader.loadClass(spec.className);
+            byte[] block = installBlock(spec.aid, spec.params);
+            simulator.installApplet(aid, cls.asSubclass(javacard.framework.Applet.class),
+                                    block, (short) 0, (byte) block.length);
+            if (firstAid == null) {
+                firstAid = aid;
+            }
+        }
+        simulator.selectApplet(firstAid);
+
+        try (ServerSocket server = new ServerSocket(port)) {
+            // Announce readiness on stdout so the Python side can wait for a line rather
+            // than sleeping a fixed interval and hoping.
+            System.out.println("READY " + port);
+            System.out.flush();
+
+            while (true) {
+                try (Socket sock = server.accept()) {
+                    System.err.println("accepted " + sock.getRemoteSocketAddress());
+                    sock.setTcpNoDelay(true);
+                    DataInputStream in = new DataInputStream(sock.getInputStream());
+                    DataOutputStream out = new DataOutputStream(sock.getOutputStream());
+                    serve(simulator, in, out);
+                } catch (EOFException e) {
+                    // client hung up; wait for the next one
+                } catch (Throwable t) {
+                    System.err.println("connection failed: " + t);
+                    t.printStackTrace();
+                }
+            }
+        }
+    }
+
+    private static void serve(CardSimulator simulator, DataInputStream in, DataOutputStream out)
+            throws Exception {
+        while (true) {
+            int length;
+            try {
+                length = in.readUnsignedShort();
+            } catch (EOFException e) {
+                return;
+            }
+            if (length == 0 || length > MAX_FRAME) {
+                return;
+            }
+            byte[] apdu = new byte[length];
+            in.readFully(apdu);
+
+            byte[] response;
+            try {
+                ResponseAPDU r = simulator.transmitCommand(new CommandAPDU(apdu));
+                response = r.getBytes();
+            } catch (Throwable t) {
+                // Throwable, not Exception: applet code runs with -noverify, so a failure
+                // inside it can surface as an Error (VerifyError, NoClassDefFoundError for
+                // an unimplemented algorithm). Report it as 6F00 and keep the connection
+                // up, so the Python side sees a status word like a real card would rather
+                // than an opaque socket close.
+                System.err.println("transmit failed for " + bytesToHex(apdu) + ": " + t);
+                t.printStackTrace();
+                response = new byte[] { (byte) 0x6F, (byte) 0x00 };
+            }
+
+            out.writeShort(response.length);
+            out.write(response);
+            out.flush();
+        }
+    }
+}

--- a/tests/jcardsim/pcsc_shim.py
+++ b/tests/jcardsim/pcsc_shim.py
@@ -1,0 +1,151 @@
+"""
+    Put a simulated card in front of SeedSigner's real client stacks.
+
+    There is no single seam for this. The four clients reach PC/SC at different levels,
+    so each needs its own patch:
+
+    * ``pysatochip`` (Satochip, SeedKeeper) never calls ``readers()`` -- it uses
+      ``CardRequest``/``CardMonitor`` from pyscard's higher-level API and takes whichever
+      card turns up first. Patched in ``pysatochip.CardConnector``'s own namespace.
+    * ``keycard-py`` and the vendored SmartPGP module both do
+      ``readers()[0].createConnection()``. Patched at ``smartcard.System.readers``.
+    * ``pygp`` uses the low-level ``smartcard.scard`` ctypes binding. Not covered here --
+      and GlobalPlatform install/uninstall is not simulatable anyway, since jcardsim
+      installs applets programmatically and has no card manager.
+
+    Everything funnels into one `SimulatedCard.transmit`, which already returns pyscard's
+    ``(data, sw1, sw2)`` shape.
+"""
+
+from contextlib import ExitStack, contextmanager
+from unittest.mock import patch
+
+# A plausible JavaCard ATR. Nothing in SeedSigner parses it, but pysatochip's insert
+# observer compares one against the Windows Hello virtual-device ATR, so it must exist
+# and must not be that.
+SIMULATED_ATR = [0x3B, 0xF9, 0x18, 0x00, 0x00, 0x81, 0x31, 0xFE, 0x45, 0x4A, 0x43, 0x4F,
+                 0x50, 0x76, 0x32, 0x34, 0x31, 0xB7]
+
+
+class SimulatedConnection:
+    """pyscard `CardConnection`-shaped, backed by the jcardsim socket."""
+
+    def __init__(self, card):
+        self._card = card
+        self.connected = False
+
+    # pyscard surface ------------------------------------------------------
+    def connect(self, *args, **kwargs):
+        self.connected = True
+
+    def disconnect(self):
+        self.connected = False
+
+    def transmit(self, apdu, protocol=None):
+        return self._card.transmit(apdu)
+
+    def getATR(self):
+        return list(SIMULATED_ATR)
+
+    def getReader(self):
+        return "jcardsim simulator"
+
+    # Observers are a pyscard logging hook; pysatochip attaches one and never reads it.
+    def addObserver(self, observer):
+        pass
+
+    def deleteObserver(self, observer):
+        pass
+
+
+class SimulatedCardService:
+    """What `CardRequest.waitforcard()` hands back."""
+
+    def __init__(self, card):
+        self.connection = SimulatedConnection(card)
+        self.atr = list(SIMULATED_ATR)
+
+    def createConnection(self):
+        return self.connection
+
+
+class SimulatedReader:
+    """What `readers()` returns."""
+
+    def __init__(self, card):
+        self._card = card
+        self.name = "jcardsim simulator"
+
+    def createConnection(self):
+        return SimulatedConnection(self._card)
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return f"<SimulatedReader {self.name}>"
+
+
+@contextmanager
+def patched_pcsc(card):
+    """
+    Route every pyscard-based client at `card` for the duration of the block.
+
+    Applied narrowly and by name so a failure to patch shows up as the real client
+    raising, rather than as a test that silently talks to nothing.
+    """
+    service = SimulatedCardService(card)
+
+    class _CardRequest:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def waitforcard(self):
+            return service
+
+        def waitforcardevent(self):
+            return [service]
+
+    class _CardMonitor:
+        def addObserver(self, observer):
+            # Hand the observer the card straight away, the way pyscard would on insert.
+            # pysatochip's RemovalObserver uses this to set card_present and to read the
+            # CPLC/IIN/CIN, so skipping it would leave the connector half-initialised.
+            observer.update(self, ([service], []))
+
+        def deleteObserver(self, observer):
+            pass
+
+    with ExitStack() as stack:
+        # pysatochip: patched inside its own module, since that is where the names are
+        # bound (`from smartcard.CardRequest import CardRequest`).
+        try:
+            import pysatochip.CardConnector as cc  # noqa: F401
+
+            stack.enter_context(patch.object(cc, "CardRequest", _CardRequest))
+            stack.enter_context(patch.object(cc, "CardMonitor", _CardMonitor))
+        except ImportError:
+            pass
+
+        # keycard-py and the vendored SmartPGP module both go through readers()[0].
+        stack.enter_context(
+            patch("smartcard.System.readers", lambda *a, **kw: [SimulatedReader(card)])
+        )
+        try:
+            import keycard.transport as keycard_transport  # noqa: F401
+
+            stack.enter_context(
+                patch.object(keycard_transport, "readers", lambda *a, **kw: [SimulatedReader(card)])
+            )
+        except ImportError:
+            pass
+        try:
+            from seedsigner.helpers.smartpgp import commands as smartpgp_commands  # noqa: F401
+
+            stack.enter_context(
+                patch.object(smartpgp_commands, "readers", lambda *a, **kw: [SimulatedReader(card)])
+            )
+        except ImportError:
+            pass
+
+        yield card

--- a/tests/jcardsim/simulator.py
+++ b/tests/jcardsim/simulator.py
@@ -1,0 +1,214 @@
+"""
+    Start a jcardsim JVM holding one applet, and speak APDUs to it.
+
+    Three things here were learned the hard way and are the reason this does not just
+    reuse specter-javacard's `simulator.jar`:
+
+    * **Install parameters.** `simulator.jar`'s CLI calls jcardsim's two-argument
+      `installApplet(aid, class)`, which passes no install parameters. SeedKeeper's
+      `install()` indexes into that array unconditionally to recover OM_SIZE, so it
+      throws SystemException before the port ever opens. `java/SimLauncher.java` builds
+      the real `[aidLen][aid][ctrlLen][ctrl][dataLen][data]` block instead.
+
+    * **`-noverify`.** jcardsim's JavaCard API stubs predate stackmap frames, so the JVM
+      verifier rejects them with `VerifyError: Expecting a stackmap frame`.
+      status-keycard's own test setup passes `-noverify` for exactly this reason.
+
+    * **Framing.** The wire protocol is a 2-byte big-endian length followed by the
+      payload, in both directions, and both sides must reassemble. specter's version
+      reads one APDU per `recv()` with a 256-byte cap, which silently truncates larger
+      responses (SeedKeeper secret exports, RSA reads) into what looks like an applet
+      bug. `recv()` returning fewer bytes than asked for is normal, not an error.
+"""
+
+import os
+import shutil
+import socket
+import struct
+import subprocess
+import threading
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+LAUNCHER_SRC = Path(__file__).resolve().parent / "java" / "SimLauncher.java"
+
+# Where a sibling checkout of the applet/simulator repos is expected when the
+# environment does not say otherwise.
+SIBLING_ROOT = Path(os.environ.get("SEEDSIGNER_APPLET_ROOT", Path.home() / "Documents" / "GitHub"))
+
+# jcardsim 3.0.5 rather than the 3.0.4 shaded inside specter's simulator.jar: it is a
+# plain jar on disk, it is what status-keycard tests against, and its algorithm coverage
+# is the better of the two.
+JCARDSIM_JAR_ENV = "SEEDSIGNER_JCARDSIM_JAR"
+DEFAULT_JCARDSIM_JAR = SIBLING_ROOT / "status-keycard" / "jcardsim" / "jcardsim-3.0.5-SNAPSHOT.jar"
+
+_MAX_FRAME = 65535
+
+
+class JCardSimUnavailable(Exception):
+    """The simulator cannot run here (no Java, no jcardsim jar, no applet classes)."""
+
+
+def jcardsim_jar() -> Path:
+    override = os.environ.get(JCARDSIM_JAR_ENV)
+    return Path(override) if override else DEFAULT_JCARDSIM_JAR
+
+
+def why_unavailable() -> str | None:
+    """A human-readable reason the simulator can't run, or None if it can."""
+    if shutil.which("java") is None:
+        return "java not on PATH"
+    if shutil.which("javac") is None:
+        return "javac not on PATH (a JDK is needed to build the launcher)"
+    jar = jcardsim_jar()
+    if not jar.is_file():
+        return f"jcardsim jar not found at {jar} (set {JCARDSIM_JAR_ENV})"
+    return None
+
+
+def simulator_available() -> bool:
+    return why_unavailable() is None
+
+
+def _launcher_classes() -> Path:
+    """Compile SimLauncher.java once per session; returns the classes directory."""
+    out = REPO_ROOT / "tests" / "jcardsim" / "build" / "classes"
+    stamp = out / "SimLauncher.class"
+    if stamp.is_file() and stamp.stat().st_mtime >= LAUNCHER_SRC.stat().st_mtime:
+        return out
+
+    out.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        ["javac", "-cp", str(jcardsim_jar()), "-d", str(out), str(LAUNCHER_SRC)],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise JCardSimUnavailable(f"could not compile SimLauncher: {result.stderr.strip()}")
+    return out
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class SimulatedCard:
+    """
+    A running applet, with a pyscard-shaped `transmit`.
+
+    `transmit` returns `(data, sw1, sw2)` -- the same shape pyscard's
+    `CardConnection.transmit` returns -- so the pcsc shim can hand this straight to
+    SeedSigner's client code.
+    """
+
+    def __init__(self, applet, classes_dir: Path, port: int | None = None, timeout: float = 30.0):
+        self.applet = applet
+        self.classes_dir = Path(classes_dir)
+        self.port = port or _free_port()
+        self.timeout = timeout
+        self._proc: subprocess.Popen | None = None
+        self._sock: socket.socket | None = None
+        self._stderr: list[str] = []
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self) -> "SimulatedCard":
+        reason = why_unavailable()
+        if reason:
+            raise JCardSimUnavailable(reason)
+        if not self.classes_dir.is_dir():
+            raise JCardSimUnavailable(f"applet classes not built at {self.classes_dir}")
+
+        spec = f"{self.applet.aid}:{self.applet.applet_class}"
+        if self.applet.install_params:
+            spec += f":{self.applet.install_params}"
+
+        cmd = [
+            "java", "-noverify",
+            "-cp", os.pathsep.join([str(_launcher_classes()), str(jcardsim_jar())]),
+            "SimLauncher",
+            "--port", str(self.port),
+            "--classes", str(self.classes_dir),
+            "--applet", spec,
+        ]
+        self._proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=1
+        )
+        threading.Thread(target=self._drain_stderr, daemon=True).start()
+
+        # Wait for the launcher's own READY line rather than sleeping and hoping.
+        line = self._proc.stdout.readline()
+        if not line.startswith("READY"):
+            self.stop()
+            detail = "".join(self._stderr[-25:]).strip()
+            raise JCardSimUnavailable(
+                f"{self.applet.name} did not start in jcardsim:\n{detail or line.strip()}"
+            )
+
+        self._sock = socket.create_connection(("127.0.0.1", self.port), timeout=self.timeout)
+        self._sock.settimeout(self.timeout)
+        return self
+
+    def _drain_stderr(self) -> None:
+        assert self._proc is not None and self._proc.stderr is not None
+        for line in self._proc.stderr:
+            self._stderr.append(line)
+
+    def stop(self) -> None:
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            finally:
+                self._sock = None
+        if self._proc is not None:
+            self._proc.kill()
+            self._proc.wait(timeout=10)
+            self._proc = None
+
+    def __enter__(self) -> "SimulatedCard":
+        return self.start()
+
+    def __exit__(self, *exc) -> None:
+        self.stop()
+
+    @property
+    def simulator_log(self) -> str:
+        """Whatever the JVM wrote to stderr -- applet stack traces land here."""
+        return "".join(self._stderr)
+
+    # -- transport ---------------------------------------------------------
+
+    def _recv_exact(self, n: int) -> bytes:
+        assert self._sock is not None
+        buf = b""
+        while len(buf) < n:
+            chunk = self._sock.recv(n - len(buf))
+            if not chunk:
+                raise ConnectionError(
+                    f"simulator closed the connection; log:\n{self.simulator_log}"
+                )
+            buf += chunk
+        return buf
+
+    def transmit_raw(self, apdu: bytes) -> bytes:
+        """Send one APDU, return the full response including SW1SW2."""
+        if self._sock is None:
+            raise RuntimeError("simulator is not running")
+        if len(apdu) > _MAX_FRAME:
+            raise ValueError(f"APDU too long for the frame header: {len(apdu)} bytes")
+        self._sock.sendall(struct.pack(">H", len(apdu)) + apdu)
+        (length,) = struct.unpack(">H", self._recv_exact(2))
+        return self._recv_exact(length)
+
+    def transmit(self, apdu) -> tuple[list[int], int, int]:
+        """pyscard-shaped: takes a list of ints, returns (data, sw1, sw2)."""
+        response = self.transmit_raw(bytes(apdu))
+        if len(response) < 2:
+            raise ConnectionError(f"short response from simulator: {response.hex()}")
+        return list(response[:-2]), response[-2], response[-1]
+
+    def select(self) -> tuple[list[int], int, int]:
+        """SELECT the applet by AID; the fresh-card starting point for every test."""
+        aid = bytes.fromhex(self.applet.aid)
+        return self.transmit([0x00, 0xA4, 0x04, 0x00, len(aid)] + list(aid))

--- a/tests/jcardsim/simulator.py
+++ b/tests/jcardsim/simulator.py
@@ -102,9 +102,12 @@ class SimulatedCard:
     SeedSigner's client code.
     """
 
-    def __init__(self, applet, classes_dir: Path, port: int | None = None, timeout: float = 30.0):
+    def __init__(self, applet, classes_dir: Path, port: int | None = None, timeout: float = 30.0,
+                 extra_classpath=()):
         self.applet = applet
         self.classes_dir = Path(classes_dir)
+        # Anything else the applet needs to load, e.g. Keycard's keycard-math.jar.
+        self.extra_classpath = [Path(p) for p in extra_classpath]
         self.port = port or _free_port()
         self.timeout = timeout
         self._proc: subprocess.Popen | None = None
@@ -120,16 +123,17 @@ class SimulatedCard:
         if not self.classes_dir.is_dir():
             raise JCardSimUnavailable(f"applet classes not built at {self.classes_dir}")
 
-        spec = f"{self.applet.aid}:{self.applet.applet_class}"
-        if self.applet.install_params:
-            spec += f":{self.applet.install_params}"
+        spec = (f"{self.applet.registration_aid}:{self.applet.applet_class}"
+                f":{self.applet.install_block()}")
 
         cmd = [
             "java", "-noverify",
             "-cp", os.pathsep.join([str(_launcher_classes()), str(jcardsim_jar())]),
             "SimLauncher",
             "--port", str(self.port),
-            "--classes", str(self.classes_dir),
+            "--classes", os.pathsep.join(
+                str(p) for p in [self.classes_dir, *self.extra_classpath]
+            ),
             "--applet", spec,
         ]
         self._proc = subprocess.Popen(

--- a/tests/test_jcardsim_keycard.py
+++ b/tests/test_jcardsim_keycard.py
@@ -1,0 +1,97 @@
+"""
+    Keycard and SmartPGP under jcardsim -- and the two reasons neither runs yet.
+
+    SeedKeeper and Satochip both work (see test_jcardsim_seedkeeper.py and
+    test_jcardsim_satochip.py): they compile from source, install, and answer real
+    status words through SeedSigner's own client stacks. These two do not, for reasons
+    that are specific and worth recording rather than leaving as a silent gap:
+
+    * **Keycard** compiles and loads, but its `install()` fails inside jcardsim. The
+      cause is unrecoverable from the outside: `Simulator.createApplet` catches whatever
+      the applet threw and rethrows a bare `SW_APPLET_CREATION_FAILED` (0x6444), so the
+      real reason never surfaces. It is not the install-parameter format -- all four
+      combinations of block style and registration AID fail identically. status-keycard
+      vendors jcardsim's full source, so surfacing the cause means building a patched
+      jcardsim, which is a bigger piece of work than it looks.
+
+    * **SmartPGP** cannot compile against this simulator's API at all. Its current
+      source imports `javacard.security.NamedParameterSpec` and `javacard.security.XECKey`,
+      which are JavaCard 3.1; jcardsim 3.0.5 implements 3.0.x and contains neither class.
+      Compiling against a 3.1 SDK would only move the failure to a NoClassDefFoundError
+      at load time. Simulating SmartPGP needs a jcardsim with 3.1 support, or an older
+      SmartPGP revision predating those imports.
+
+    These tests are written to *pass the moment either becomes possible*: they attempt
+    the real thing and skip with the specific diagnosis, rather than asserting the
+    failure and having to be rewritten when it is fixed.
+"""
+
+import pytest
+
+# Must import test base before the Controller (sets up the hardware mocks)
+import base  # noqa: F401
+
+from jcardsim import JCardSimUnavailable, open_card, why_unavailable
+
+
+pytestmark = pytest.mark.skipif(
+    why_unavailable() is not None, reason=f"jcardsim unavailable: {why_unavailable()}"
+)
+
+
+class TestKeycard:
+
+    def test_applet_compiles(self):
+        """
+        Keycard's sources do build, given keycard-math.jar.
+
+        Worth asserting separately from the install: the applet references
+        `im.status.keycard.math.BigNumberMath`, which the repo ships only as a compiled
+        JavaCard library with no sources, so the compile step is a real dependency
+        question and not a formality.
+        """
+        from jcardsim import resolve_applet
+
+        try:
+            spec, classes = resolve_applet("keycard")
+        except JCardSimUnavailable as exc:
+            pytest.skip(str(exc))
+
+        assert (classes / "im/status/keycard/KeycardApplet.class").is_file()
+
+    def test_applet_installs_and_selects(self):
+        try:
+            card = open_card("keycard")
+        except JCardSimUnavailable as exc:
+            pytest.skip(str(exc))
+
+        try:
+            with card:
+                _, sw1, sw2 = card.select()
+        except JCardSimUnavailable as exc:
+            # See the module docstring: jcardsim swallows the applet's own exception, so
+            # this is as much detail as exists.
+            pytest.skip(f"Keycard does not install in jcardsim 3.0.5: {exc}")
+
+        assert (sw1, sw2) == (0x90, 0x00)
+
+
+
+class TestSmartPGP:
+
+    def test_applet_installs_and_selects(self):
+        try:
+            card = open_card("smartpgp")
+        except JCardSimUnavailable as exc:
+            # Reached both when the repo is absent (the usual case -- only the built CAPs
+            # ship in javacard-cap/) and when the compile fails on the JavaCard 3.1 EC
+            # API that jcardsim does not implement.
+            pytest.skip(f"SmartPGP not simulatable: {exc}")
+
+        try:
+            with card:
+                _, sw1, sw2 = card.select()
+        except JCardSimUnavailable as exc:
+            pytest.skip(f"SmartPGP does not install in jcardsim 3.0.5: {exc}")
+
+        assert (sw1, sw2) == (0x90, 0x00)

--- a/tests/test_jcardsim_satochip.py
+++ b/tests/test_jcardsim_satochip.py
@@ -1,0 +1,148 @@
+"""
+    Satochip (and Satodime) as real applet bytecode in jcardsim, driven by SeedSigner's
+    real pysatochip client.
+
+    Unlike SeedKeeper, these applets are not prebuilt in their repo -- `Satochip-DIY`'s
+    ant build sets no `classes=` attribute, so it keeps only the CAP and discards the
+    .class files jcardsim needs. `tests/jcardsim/applets.py` compiles them with javac
+    instead, against the JavaCard SDK the repo already vendors.
+
+    The interesting result is that jcardsim's crypto is good enough for the real thing:
+    seed import and BIP32 xpub derivation both work, which means secp256k1, the
+    derivation itself, and the authentikey signature the client verifies are all
+    exercised here rather than stubbed.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Must import test base before the Controller (sets up the hardware mocks)
+import base  # noqa: F401
+
+# base.py stubs pysatochip so the ordinary suite runs cardless; these tests need it real.
+for _name in [m for m in sys.modules if m == "pysatochip" or m.startswith("pysatochip.")]:
+    if isinstance(sys.modules[_name], MagicMock):
+        del sys.modules[_name]
+
+from jcardsim import JCardSimUnavailable, SimulatedCard, resolve_applet, why_unavailable
+from jcardsim.pcsc_shim import patched_pcsc
+
+
+pytestmark = pytest.mark.skipif(
+    why_unavailable() is not None, reason=f"jcardsim unavailable: {why_unavailable()}"
+)
+
+PIN = list(b"1234")
+
+# A fixed 64-byte BIP32 seed, so the derived keys below are reproducible.
+TEST_SEED = bytes.fromhex("00" * 32 + "11" * 32)
+
+
+@pytest.fixture
+def satochip():
+    try:
+        spec, classes = resolve_applet("satochip")
+    except JCardSimUnavailable as exc:
+        pytest.skip(str(exc))
+    with SimulatedCard(spec, classes) as card:
+        card.select()
+        yield card
+
+
+@pytest.fixture
+def connector(satochip):
+    with patched_pcsc(satochip):
+        from pysatochip.CardConnector import CardConnector
+
+        yield CardConnector(card_filter=["satochip"])
+
+
+def setup_and_login(cc) -> None:
+    cc.card_setup(5, 1, PIN, PIN, 5, 1, PIN, PIN, 32, 32, 0x01, 0x01, 0x01)
+    cc.set_pin(0, PIN)
+    cc.card_verify_PIN()
+
+
+
+class TestSatochipBasics:
+
+    def test_card_is_recognised(self, connector):
+        assert connector.card_present
+        assert connector.card_type == "Satochip"
+
+    def test_setup_then_pin(self, connector):
+        response, sw1, sw2, _ = connector.card_get_status()
+        assert (sw1, sw2) == (0x90, 0x00)
+        assert connector.setup_done is False, "a fresh applet should not be set up"
+
+        setup_and_login(connector)
+        assert connector.card_get_status()[3]["setup_done"] is True
+
+    def test_wrong_pin_is_rejected(self, connector):
+        """A wrong PIN must fail rather than being quietly accepted."""
+        setup_and_login(connector)
+        connector.set_pin(0, list(b"9999"))
+        with pytest.raises(Exception):
+            connector.card_verify_PIN()
+
+
+
+class TestSatochipSeedAndDerivation:
+    """
+    The crypto path: importing a seed and deriving from it on-card.
+
+    pysatochip verifies the card's authentikey signature over the derived key, so a
+    success here means the applet's secp256k1 and BIP32 code really ran -- this is not
+    a stub returning canned bytes.
+    """
+
+    def test_import_seed_returns_the_authentikey(self, connector):
+        setup_and_login(connector)
+        authentikey = connector.card_bip32_import_seed(list(TEST_SEED))
+        assert authentikey is not None
+        assert hasattr(authentikey, "get_public_key_bytes")
+
+    @pytest.mark.parametrize(
+        "xtype, prefix",
+        [("standard", "xpub"), ("p2wpkh", "zpub")],
+    )
+    def test_derive_xpub(self, connector, xtype, prefix):
+        setup_and_login(connector)
+        connector.card_bip32_import_seed(list(TEST_SEED))
+
+        xpub = connector.card_bip32_get_xpub("m/84'/0'/0'", xtype, True)
+        assert xpub.startswith(prefix)
+
+    def test_derivation_is_deterministic(self, connector):
+        """The same path on the same seed must give the same key twice running."""
+        setup_and_login(connector)
+        connector.card_bip32_import_seed(list(TEST_SEED))
+
+        first = connector.card_bip32_get_xpub("m/84'/0'/0'", "standard", True)
+        second = connector.card_bip32_get_xpub("m/84'/0'/0'", "standard", True)
+        assert first == second
+
+    def test_different_paths_give_different_keys(self, connector):
+        setup_and_login(connector)
+        connector.card_bip32_import_seed(list(TEST_SEED))
+
+        first = connector.card_bip32_get_xpub("m/84'/0'/0'", "standard", True)
+        second = connector.card_bip32_get_xpub("m/84'/0'/1'", "standard", True)
+        assert first != second
+
+
+
+class TestSatodime:
+    """Satodime builds and installs from the same aggregator repo."""
+
+    def test_applet_selects(self):
+        try:
+            spec, classes = resolve_applet("satodime")
+        except JCardSimUnavailable as exc:
+            pytest.skip(str(exc))
+
+        with SimulatedCard(spec, classes) as card:
+            _, sw1, sw2 = card.select()
+            assert (sw1, sw2) == (0x90, 0x00)

--- a/tests/test_jcardsim_seedkeeper.py
+++ b/tests/test_jcardsim_seedkeeper.py
@@ -1,0 +1,226 @@
+"""
+    SeedKeeper v0.1 and v0.2, running as real applet bytecode in jcardsim, driven by
+    SeedSigner's real pysatochip client.
+
+    The real-screen suites stand in for the card, which proves the screens behave but
+    says nothing about whether SeedSigner and the applet agree on the wire. These tests
+    close that: every status word here came out of the actual applet.
+
+    The case that matters most is a full card. `describe_seedkeeper_error` gives a
+    different message for v0.1 than v0.2, because v0.1 has no reset-secret instruction
+    and so cannot free space -- a factory reset is the only way out. Until now that
+    branch, and the `is_seedkeeper_v1` check it turns on, could only be exercised
+    against a physical card. Here both versions are filled for real and the resulting
+    0x9C01 is put through SeedSigner's own error handling.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Must import test base before the Controller (sets up the hardware mocks)
+import base  # noqa: F401
+
+# base.py replaces pysatochip with MagicMocks so the ordinary suite can run without a
+# card. These tests need the real library, so drop the stubs before anything imports it.
+for _name in [m for m in sys.modules if m == "pysatochip" or m.startswith("pysatochip.")]:
+    if isinstance(sys.modules[_name], MagicMock):
+        del sys.modules[_name]
+
+from jcardsim import JCardSimUnavailable, SimulatedCard, resolve_applet, why_unavailable
+from jcardsim.applets import APPLETS
+from jcardsim.pcsc_shim import patched_pcsc
+
+
+pytestmark = pytest.mark.skipif(
+    why_unavailable() is not None, reason=f"jcardsim unavailable: {why_unavailable()}"
+)
+
+PIN = list(b"1234")
+VERSIONS = ["seedkeeper_v01", "seedkeeper_v02"]
+
+
+@pytest.fixture(params=VERSIONS)
+def seedkeeper(request):
+    """
+    A freshly installed SeedKeeper of each version.
+
+    Function-scoped on purpose: a card carries its state, and a test that inherited a
+    previous test's secrets or PIN would be reasoning about the wrong card.
+    """
+    try:
+        spec, classes = resolve_applet(request.param)
+    except JCardSimUnavailable as exc:
+        pytest.skip(str(exc))
+
+    with SimulatedCard(spec, classes) as card:
+        card.select()
+        card.version = request.param
+        yield card
+
+
+@pytest.fixture
+def connector(seedkeeper):
+    """SeedSigner's real pysatochip client, talking to the simulated card."""
+    with patched_pcsc(seedkeeper):
+        from pysatochip.CardConnector import CardConnector
+
+        cc = CardConnector(card_filter=["seedkeeper"])
+        cc.version = seedkeeper.version
+        yield cc
+
+
+def setup_and_login(cc) -> None:
+    """Take a blank card through setup and PIN verification."""
+    cc.card_setup(5, 1, PIN, PIN, 5, 1, PIN, PIN, 32, 32, 0x01, 0x01, 0x01)
+    cc.set_pin(0, PIN)
+    cc.card_verify_PIN()
+
+
+def import_password(cc, label: str, secret: bytes = b"pass") -> tuple[int, str]:
+    header = cc.make_header("Password", "Plaintext export allowed", label)
+    return cc.seedkeeper_import_secret(
+        {"header": header, "secret_list": [len(secret)] + list(secret)}
+    )
+
+
+
+class TestRegistryConsistency:
+    """The simulator must be pointed at the same applets the app installs."""
+
+    def test_class_names_and_aids_match_the_app(self):
+        """
+        `_JAVACARD_APPLETS` in smartcard_views is what the device builds and installs.
+        If the simulator registry drifts from it, these tests would be exercising an
+        applet the app never talks to.
+        """
+        from seedsigner.views.smartcard_views import _JAVACARD_APPLETS
+
+        app_seedkeeper = _JAVACARD_APPLETS["seedkeeper"]
+        for name in VERSIONS:
+            spec = APPLETS[name]
+            assert spec.applet_class == app_seedkeeper["applet_class"]
+            # The app records the package AID; the instance AID appends 00.
+            assert spec.aid.upper() == app_seedkeeper["aid"].upper() + "00"
+
+        app_satochip = _JAVACARD_APPLETS["satochip"]
+        assert APPLETS["satochip"].applet_class == app_satochip["applet_class"]
+        assert APPLETS["satochip"].aid.upper() == app_satochip["aid"].upper() + "00"
+
+
+
+class TestAppletResponds:
+    """Raw APDUs, before any client library is involved."""
+
+    def test_select_and_status(self, seedkeeper):
+        data, sw1, sw2 = seedkeeper.select()
+        assert (sw1, sw2) == (0x90, 0x00)
+
+        data, sw1, sw2 = seedkeeper.transmit([0xB0, 0x3C, 0x00, 0x00, 0x00])
+        assert (sw1, sw2) == (0x90, 0x00)
+        # First two bytes of the status block are the protocol version.
+        expected = 1 if seedkeeper.version == "seedkeeper_v01" else 2
+        assert data[0] == 0 and data[1] == expected
+
+    def test_listing_secrets_before_pin_is_refused(self, seedkeeper):
+        """An unauthenticated card must refuse to enumerate its secrets."""
+        _, sw1, sw2 = seedkeeper.transmit([0xB0, 0xA7, 0x00, 0x00, 0x00])
+        assert (sw1, sw2) == (0x9C, 0x20), "expected SW_UNAUTHORIZED before PIN"
+
+
+
+class TestSeedKeeperThroughPysatochip:
+    """The same card, through the client stack SeedSigner actually uses."""
+
+    def test_card_is_recognised(self, connector):
+        assert connector.card_present
+        assert connector.card_type == "SeedKeeper"
+
+    def test_protocol_version_distinguishes_the_two_applets(self, connector):
+        expected = 0x0001 if connector.version == "seedkeeper_v01" else 0x0002
+        assert connector.protocol_version == expected
+
+    def test_is_seedkeeper_v1_matches_the_applet(self, connector):
+        """
+        The v1 check drives a user-facing branch (a full v1 card needs a factory reset),
+        so it has to agree with the applet actually on the card.
+        """
+        from seedsigner.helpers.seedkeeper_utils import is_seedkeeper_v1
+
+        setup_and_login(connector)
+        assert is_seedkeeper_v1(connector) is (connector.version == "seedkeeper_v01")
+
+    def test_import_list_export_round_trip(self, connector):
+        setup_and_login(connector)
+
+        sid, fingerprint = import_password(connector, "sim-test", b"correct horse")
+        assert fingerprint
+
+        headers = connector.seedkeeper_list_secret_headers()
+        assert [h["label"] for h in headers] == ["sim-test"]
+        assert headers[0]["id"] == sid
+
+        exported = connector.seedkeeper_export_secret(sid)
+        assert exported["label"] == "sim-test"
+        # The stored blob is length-prefixed.
+        assert bytes(exported["secret_list"][1:]) == b"correct horse"
+
+    def test_secrets_accumulate(self, connector):
+        setup_and_login(connector)
+        for i in range(3):
+            import_password(connector, f"secret-{i}")
+        labels = sorted(h["label"] for h in connector.seedkeeper_list_secret_headers())
+        assert labels == ["secret-0", "secret-1", "secret-2"]
+
+
+
+class TestFullCard:
+    """
+    Filling a card for real, and checking SeedSigner says the right thing about it.
+
+    This is the path commit 49095f60 fixed: a full card answers 0x9C01, and the advice
+    that follows differs by applet version because v0.1 cannot delete secrets.
+    """
+
+    def fill_until_full(self, cc):
+        """Import until the applet refuses; returns the exception it raised."""
+        blob = [0x80] + [0x41] * 128
+        for i in range(400):
+            try:
+                cc.seedkeeper_import_secret({
+                    "header": cc.make_header("Data", "Plaintext export allowed", f"f{i}"),
+                    "secret_list": blob,
+                })
+            except Exception as exc:
+                return exc
+        pytest.fail("the card never filled up")
+
+    def test_full_card_reports_no_memory_left(self, connector):
+        from seedsigner.helpers.seedkeeper_utils import sw_from_exception
+
+        setup_and_login(connector)
+        exc = self.fill_until_full(connector)
+
+        assert sw_from_exception(exc) == 0x9C01, (
+            f"expected SW_NO_MEMORY_LEFT from a full card, got {exc!r}"
+        )
+
+    def test_full_card_advice_depends_on_the_applet_version(self, connector):
+        """
+        v0.1 has no reset-secret instruction, so "delete a secret" is useless advice --
+        it must tell the user a factory reset is required instead.
+        """
+        from seedsigner.helpers.seedkeeper_utils import describe_seedkeeper_error
+
+        setup_and_login(connector)
+        exc = self.fill_until_full(connector)
+
+        message = describe_seedkeeper_error(exc, connector=connector)
+        assert "memory is full" in message.lower()
+
+        if connector.version == "seedkeeper_v01":
+            assert "factory reset" in message.lower()
+        else:
+            assert "delete a secret" in message.lower()
+            assert "factory reset" not in message.lower()


### PR DESCRIPTION
## Why

[PR #435](https://github.com/3rdIteration/seedsigner/pull/435) left **86 View classes still never named in a test**, most of them leaf operations behind a card. Screen-walking can't reach those — they need something on the other end of the APDU.

The stand-ins in `tests/real_screen_fixtures.py` were deliberately kept behind one seam so this could replace them. This runs the **real applet bytecode** in jcardsim, against SeedSigner's **real client stacks**. Every status word asserted here came out of the applet itself.

## What works

**29 tests, 13s.** SeedKeeper **v0.1 and v0.2** and Satochip/Satodime all compile, install, and answer through the real `pysatochip` client.

The one that matters most is a full card. `describe_seedkeeper_error()` gives different advice for v0.1 than v0.2, because v0.1 has no reset-secret instruction and so cannot free space — a factory reset is the only way out. That branch, and the `is_seedkeeper_v1()` check that selects it, could previously only be exercised against a physical card. **Both versions are now filled for real, and the resulting `0x9C01` goes through SeedSigner's own error handling.** This is the path commit `49095f60` fixed.

Also covered: import/list/export round-trips, unauthenticated operations being refused (`9C20`), protocol version reported per applet, and — on Satochip — seed import and BIP32 derivation for both `xpub` and `zpub`. pysatochip verifies the card's authentikey signature over each derived key, so secp256k1 and the derivation really ran rather than being stubbed. **The crypto risk flagged in the plan largely did not materialise.**

## Three things that had to be solved

None were obvious, and all are documented at the top of the files that carry them:

- **Install parameters.** specter-javacard's `simulator.jar` calls jcardsim's two-argument `installApplet()`, passing none. SeedKeeper's `install()` indexes into that array unconditionally to recover `OM_SIZE`, so it throws `SystemException` before the port opens. `tests/jcardsim/java/SimLauncher.java` builds a real block instead. The shape turned out to be applet-specific — SeedKeeper and Satochip parse the full GlobalPlatform `[aidLen][aid][ctrlLen][ctrl][dataLen][data]`, Keycard's `install()` expects only `[aidLen][aid]` — so it is assembled in Python where that decision is legible.
- **`-noverify`.** jcardsim's JavaCard API stubs predate stackmap frames, so the JVM verifier rejects them outright. status-keycard passes the same flag.
- **Framing.** The socket protocol is length-prefixed and both ends must reassemble. specter's version reads one APDU per `recv()` with a 256-byte cap, which would silently truncate secret exports into what looks like an applet bug.

## Two corrections to the #435 write-up

- **There is no single pyscard seam.** `pysatochip` uses `CardRequest`/`CardMonitor`, not `readers()`; `keycard-py` and the vendored SmartPGP module use `readers()[0]`; `pygp` uses the low-level `smartcard.scard` ctypes binding. `pcsc_shim.py` patches each by name.
- **`VSmartCard` is absent from both vendored jcardsim copies**, so a system-wide virtual reader is not available without upstream licel/jcardsim plus a vpcd daemon. That is why the `gpg`-binary card views remain out of scope.

## What does not run, and why

Both are tested with a real attempt that skips carrying the diagnosis, so they will start passing the moment either becomes possible — rather than asserting the failure and needing a rewrite later.

- **Keycard** compiles (given `keycard-math.jar`, a prebuilt JavaCard library the repo ships with no sources) but its `install()` fails inside jcardsim. `Simulator.createApplet` catches the applet's exception and rethrows a bare `SW_APPLET_CREATION_FAILED` (`0x6444`), so the cause never surfaces. It is **not** the install-parameter format: all four combinations of block style and registration AID fail identically. status-keycard vendors jcardsim's full source, so surfacing the cause means building a patched jcardsim.
- **SmartPGP** cannot compile against this simulator's API at all. Its sources import `javacard.security.NamedParameterSpec` and `XECKey`, which are **JavaCard 3.1**; jcardsim 3.0.5 implements 3.0.x and contains neither class (`unzip -l | grep -c` returns 0). Compiling against a 3.1 SDK would only move the failure to a `NoClassDefFoundError` at load time. It needs a jcardsim with 3.1 support, or a SmartPGP revision predating those imports.

Also out of scope, and stated in the code: **GlobalPlatform install/uninstall is not simulatable** — jcardsim installs applets programmatically and has no card manager — so the `pygp` DIY flows stay on `FakePyGP`.

## Design notes

- **Applet repos are never mutated.** A pinned revision is extracted with `git archive` into a build cache, which is what lets SeedKeeper v0.1 and v0.2 build side by side from one repo without disturbing a contributor's checkout. (v0.1 also predates the move to the gradle source layout, so its package root differs.)
- **Registry drift is guarded.** `test_registry_matches_the_app` cross-checks the simulator's class names and AIDs against `_JAVACARD_APPLETS` in `smartcard_views.py`, so the tests cannot end up exercising an applet the app never talks to.
- **Everything skips cleanly** when Java or the applet sources are absent, with a reason naming what is missing.

## CI

The ubuntu `test` job gains JDK 11 and shallow checkouts of the applet repos. `Seedkeeper-Applet` is cloned with full history because it is built at two tags and `git archive` cannot export a tag that was never fetched. `SEEDSIGNER_APPLET_ROOT` points the harness at them.

## Verification

```
before:  2 failed, 1618 passed, 228 skipped
after:   2 failed, 1647 passed, 230 skipped
```

Same two pre-existing failures, none new — +29 passed and +2 skipped, exactly the new tests. The two remaining failures (`test_psbt_refusal_screens.py::TestBlockAnchor::test_shipped_json_is_plausible`, `test_pysatochip_contract.py::test_real_connector_has_satodime_ndef_v2`) predate this stack.

## Base branch

Targets `test/real-screen-coverage-everything` (#435), keeping the stack in order: #434 → #435 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
