### PR TITLE
MicroSD verify: two-pass (4 MiB prefix + full-file sha256), GPG-verified, no more dd/subprocess

### DIFF
--- a/.github/scripts/update_microsd_checksums.py
+++ b/.github/scripts/update_microsd_checksums.py
@@ -3,39 +3,47 @@
 Refresh src/seedsigner/resources/microsd-known-checksums.json.
 
 The device's "Verify MicroSD" tool uses a two-pass approach:
-  Pass 1 — read the first ``prefix_size`` bytes (4 MiB) from the raw card,
-            compute sha256, and look up the matching entry by prefix hash.
-  Pass 2 — read the full image at its exact published size (``size_bytes``)
-            from the card, compute sha256, and compare against the entry's
-            ``sha256`` field.  A prefix match with a full-hash mismatch is
-            reported as possible tampering.
 
-This script walks the release assets of the repos below, records the 4 MiB
-prefix hash and the full-file sha256 + size for each image, and optionally
-GPG-verifies the release's sha256.txt against the bundled SeedSigner signing
-key (``gpg_keys/Seedsigner_pubkey.asc``) before trusting the published hash.
+  Pass 1a — read the first ``prefix_size`` bytes (4 MiB) from the raw card,
+             compute sha256, and look up by pristine hash.
+  Pass 1b — if no match, zero the volatile bytes (dirty bit + FSINFO fields
+             from the card's MBR-identified FAT partition) within the prefix
+             buffer and re-hash — look up by ``alt_prefix_hashes`` in the entry.
+             The UI distinguishes "Matched Checksum" clean vs dirty.
+  Pass 2 —  read the full image at its exact published size from the card,
+             zeroing the same volatile offsets throughout, compute sha256, and
+             compare against the entry's ``sha256`` field.  A prefix match with
+             a full-hash mismatch is reported as possible tampering.
 
-Schema (``prefix_size`` is a top-level field so other projects can adopt the
-same format with a different prefix):
+The JSON stores the **zeroed** full-file sha256 (the same hash the device
+computes after zeroing volatile bytes during pass 2).  Official SeedSigner
+releases that ship a GPG-signed sha256.txt are verified against the bundled
+Seedsigner_pubkey.asc as a cross-check before hashing.
+
+Volatile offsets (FAT dirty bit at ``0x41`` and FSINFO at ``512+0x1E8..0x1EF``)
+are determined from the image's MBR partition table.  Entries without a valid
+MBR (e.g. zero-wiped marker) have an empty list.
+
+Schema::
 
   {
     "prefix_size": 4194304,
     "updated": "2026-09-07",
     "images": {
-      "<sha256_of_first_4mib>": {
+      "<pristine_prefix_hash>": {
         "name": "seedsigner_os.0.8.7.pi0.img",
         "source_repo": "SeedSigner/seedsigner",
         "tag": "0.8.7",
         "size_bytes": 52428800,
-        "sha256": "<full-file sha256>"
+        "sha256": "<full-file sha256 (with volatile bytes zeroed)>",
+        "volatile_offsets": [4194817, 4195328, 4195329, 4195330, 4195331, 4195332, 4195333, 4195334, 4195335],
+        "alt_prefix_hashes": ["<zeroed_prefix_hash>"]
       }
     }
   }
 
-Existing entries are never re-downloaded: assets are tracked by
-repo+tag+asset name.  Manual entries (e.g. the zero-wiped-card marker) are
-always preserved.  A collision check asserts that every prefix hash is unique
-across all entries.
+Existing entries are preserved by (repo, tag, name); new ones are appended.
+A collision check ensures all hashes (pristine + alt) are unique.
 
 Run manually with ``python .github/scripts/update_microsd_checksums.py``, or
 let .github/workflows/update-microsd-checksums.yml run it on a schedule and
@@ -48,6 +56,7 @@ import json
 import os
 import re
 import shutil
+import struct
 import subprocess
 import sys
 import tempfile
@@ -56,27 +65,20 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 REPOS = [
-    "SeedSigner/seedsigner",        # official images: seedsigner_os.X.Y.Z.<platform>.img
-    "3rdIteration/seedsigner",      # fork builds: smartcard variants etc.
+    "SeedSigner/seedsigner",
+    "3rdIteration/seedsigner",
     "3rdIteration/seedsigner-os",
 ]
 ASSET_PATTERN = re.compile(r"^seedsigner_os\..*\.img$")
 SHA256_PATTERN = re.compile(r"^seedsigner\..*sha256")
 SIG_PATTERN = re.compile(r"^seedsigner\..*sha256.*\.sig$")
 
-# How many bytes the device reads for the initial prefix lookup.
 PREFIX_SIZE = 4 * 1024 * 1024  # 4 MiB
-
-# Smaller assets are not plausible OS images; treat as a bad upload.
 MIN_ASSET_BYTES = 4 * 1024 * 1024
 
-# Path to the bundled SeedSigner GPG signing key, relative to the repo root.
 PUBKEY_PATH = Path(__file__).resolve().parents[2] / "gpg_keys" / "Seedsigner_pubkey.asc"
-
-DEFAULT_OUT = (
-    Path(__file__).resolve().parents[2]
-    / "src" / "seedsigner" / "resources" / "microsd-known-checksums.json"
-)
+DEFAULT_OUT = (Path(__file__).resolve().parents[2] /
+               "src" / "seedsigner" / "resources" / "microsd-known-checksums.json")
 
 
 def _open(url, byte_range=None):
@@ -93,7 +95,6 @@ def _open(url, byte_range=None):
 
 
 def iter_releases(repos):
-    """Yield (repo, release_dict) for every release with at least one .img asset."""
     for repo in repos:
         page = 1
         while True:
@@ -108,29 +109,87 @@ def iter_releases(repos):
             page += 1
 
 
-def sha256_prefix(url):
-    """Range-request first PREFIX_SIZE bytes, returns hex digest."""
-    with _open(url, byte_range=f"bytes=0-{PREFIX_SIZE - 1}") as r:
-        data = r.read(PREFIX_SIZE)
-    return hashlib.sha256(data).hexdigest()
+# ─── MBR / volatile-offset helpers ───────────────────────────────────────
+
+FAT_TYPES = {0x0b, 0x0c, 0x0e}
+# FAT32 FSINFO offsets (within the first sector of the FSINFO block, which
+# is at partition LBA + 512).  Only applicable for FAT32 (type 0x0b/0x0c).
+# Non-FAT32 FAT (type 0x0e) lacks an FSINFO sector.
+FSINFO_BASE = 512          # FSINFO sector = partition LBA * 512 + 512
+FSINFO_DIRTY = 0x41         # dirty flag is at partition LBA * 512 + 0x41
+FSINFO_FREE_CLUSTERS = 0x1E8  # 4 bytes
+FSINFO_NEXT_FREE = 0x1EC      # 4 bytes
 
 
-def sha256_file(url):
-    """Full streaming download, returns (hex_digest, size_bytes)."""
+def compute_volatile_offsets(first_512):
+    """Return a sorted list of absolute byte offsets for volatile FAT fields.
+
+    Parses the MBR (first 512 bytes of a raw image) for partition entries of
+    FAT type (0x0b, 0x0c, 0x0e).  For each such partition adds:
+      - the dirty flag at ``partition_lba * 512 + 0x41`` (1 byte)
+      - four FSINFO bytes at ``partition_lba * 512 + 512 + 0x1E8`` (FAT32 only)
+      - four FSINFO bytes at ``partition_lba * 512 + 512 + 0x1EC`` (FAT32 only)
+
+    Returns ``[]`` for zeroed or GPT-only images.
+    """
+    offsets = set()
+    mbr_partitions = first_512[446:510]  # 0x1BE-0x1FD
+    for i in range(4):
+        ent = mbr_partitions[i * 16:(i + 1) * 16]
+        if len(ent) < 16:
+            break
+        ptype = ent[4]
+        if ptype not in FAT_TYPES:
+            continue
+        lba = struct.unpack_from("<I", ent, 8)[0]
+        if lba == 0:
+            continue
+        base = lba * 512
+        offsets.add(base + FSINFO_DIRTY)
+        if ptype in (0x0b, 0x0c):  # FAT32 has FSINFO sector
+            offsets.add(base + FSINFO_BASE + FSINFO_FREE_CLUSTERS + 0)
+            offsets.add(base + FSINFO_BASE + FSINFO_FREE_CLUSTERS + 1)
+            offsets.add(base + FSINFO_BASE + FSINFO_FREE_CLUSTERS + 2)
+            offsets.add(base + FSINFO_BASE + FSINFO_FREE_CLUSTERS + 3)
+            offsets.add(base + FSINFO_BASE + FSINFO_NEXT_FREE + 0)
+            offsets.add(base + FSINFO_BASE + FSINFO_NEXT_FREE + 1)
+            offsets.add(base + FSINFO_BASE + FSINFO_NEXT_FREE + 2)
+            offsets.add(base + FSINFO_BASE + FSINFO_NEXT_FREE + 3)
+    return sorted(offsets)
+
+
+def zero_in_place(data, offsets, offset_base=0):
+    """Zero the bytes at ``offsets`` (absolute) within ``data`` (bytes or bytearray).
+
+    Only applies offsets that fall within the data's range.
+    """
+    for off in offsets:
+        local = off - offset_base
+        if 0 <= local < len(data):
+            data[local] = 0
+
+
+# ─── Hashing helpers ─────────────────────────────────────────────────────
+
+def sha256_prefix_full(url):
+    """Download the full asset content (streaming), return (raw_bytes,
+    hex_digest_of_full)."""
     with _open(url) as r:
-        h = hashlib.sha256()
-        size = 0
-        while True:
-            chunk = r.read(1 << 20)
-            if not chunk:
-                break
-            h.update(chunk)
-            size += len(chunk)
-    return h.hexdigest(), size
+        data = r.read()
+    return data, hashlib.sha256(data).hexdigest()
+
+
+def sha256_with_zerofile(data, offsets):
+    """Return sha256 hex of ``data`` with bytes at ``offsets`` zeroed.
+
+    Operates on a mutable copy; ``data`` is bytes, ``offsets`` are absolute.
+    """
+    buf = bytearray(data)
+    zero_in_place(buf, offsets)
+    return hashlib.sha256(buf).hexdigest()
 
 
 def parse_sha256_txt(content):
-    """Return {filename: hex_digest} from the release's sha256.txt content."""
     result = {}
     for line in content.splitlines():
         line = line.strip()
@@ -143,85 +202,82 @@ def parse_sha256_txt(content):
 
 
 def gpg_verify(sha256_content, sig_content):
-    """Verify sig_content against sha256_content using the bundled SeedSigner key.
-
-    Returns True on success.  Raises RuntimeError if gpg is unavailable,
-    the key cannot be imported, or verification fails.
-    """
     if not shutil.which("gpg"):
         raise RuntimeError("gpg not found on this system; cannot verify signature")
-
     if not PUBKEY_PATH.exists():
         raise RuntimeError(f"SeedSigner public key not found at {PUBKEY_PATH}")
-
     with tempfile.TemporaryDirectory() as gnupghome:
-        # Import the SeedSigner signing key
         res = subprocess.run(
             ["gpg", "--homedir", gnupghome, "--import", str(PUBKEY_PATH)],
-            capture_output=True, text=True
-        )
+            capture_output=True, text=True)
         if res.returncode != 0:
             raise RuntimeError(f"Failed to import GPG key: {res.stderr.strip()}")
-
-        # Write sha256 content and signature to temp files.  Use newline=""
-        # so text-mode doesn't translate \n to \r\n on Windows: GPG
-        # verification is byte-exact against the original signed content.
         sha256_path = os.path.join(gnupghome, "sha256.txt")
         sig_path = sha256_path + ".sig"
         with open(sha256_path, "w", encoding="utf-8", newline="") as f:
             f.write(sha256_content)
         with open(sig_path, "wb") as f:
             f.write(sig_content)
-
-        # Verify
         res = subprocess.run(
             ["gpg", "--homedir", gnupghome, "--trust-model", "always",
              "--verify", sig_path, sha256_path],
-            capture_output=True, text=True
-        )
+            capture_output=True, text=True)
         if res.returncode != 0:
-            raise RuntimeError(
-                f"GPG verification failed:\n{res.stderr.strip()}"
-            )
+            raise RuntimeError(f"GPG verification failed:\n{res.stderr.strip()}")
     return True
 
 
 def process_asset(img, sha256_entries, gpg_verified, repo, tag):
-    """Download and hash one .img asset, returning (prefix_hash, entry_dict).
+    """Download one .img, compute prefix variants and full zeroed sha256.
 
-    If ``sha256_entries`` contains the image name, the full-file hash is
-    verified against the published value.  If ``gpg_verified`` is True, the
-    sha256.txt was cryptographically signed by the SeedSigner release key.
+    Returns (pristine_prefix_hash, entry_dict).  Raises on collision or
+    hash mismatch vs published sha256.txt.
     """
     url = img["browser_download_url"]
+    raw, pub_full_hash = sha256_prefix_full(url)
 
-    # Pass 1: prefix hash (4 MiB, always via Range request)
-    prefix = sha256_prefix(url)
+    if len(raw) < PREFIX_SIZE:
+        raise ValueError(f"asset too small ({len(raw)} bytes) for {PREFIX_SIZE} prefix")
 
-    # Pass 2: full-file hash
+    # Determine volatile offsets from the image's MBR
+    first_512 = raw[:512]
+    volatile_offsets = compute_volatile_offsets(first_512)
+
+    # Pristine prefix hash (raw, as-is)
+    prefix_pristine = hashlib.sha256(raw[:PREFIX_SIZE]).hexdigest()
+
+    # Alt prefix hash (with volatile offsets zeroed within the prefix)
+    prefix_buf = bytearray(raw[:PREFIX_SIZE])
+    zero_in_place(prefix_buf, volatile_offsets)
+    prefix_alt = hashlib.sha256(prefix_buf).hexdigest()
+
+    # Full-file hash with volatile offsets zeroed throughout
+    sha256_zeroed = sha256_with_zerofile(raw, volatile_offsets)
+
+    # If a published sha256.txt hash exists, cross-check
     expected = sha256_entries.get(img["name"])
     if expected:
-        actual, size = sha256_file(url)
-        if actual != expected.lower():
+        if pub_full_hash != expected.lower():
             raise RuntimeError(
                 f"Hash mismatch for {img['name']}: "
-                f"expected {expected}, got {actual}"
+                f"expected {expected}, got {pub_full_hash}"
             )
         if not gpg_verified:
-            # sha256.txt existed but was not GPG-signed (or key wasn't
-            # available); log a warning but still record the verified hash.
             print(f"  ! {img['name']}: sha256 verified (no GPG signature)", file=sys.stderr)
     else:
-        # No sha256.txt available — full download and record.
-        actual, size = sha256_file(url)
+        # No published sha256 — the zeroed hash is all we have.
+        pass
 
-    return prefix, {
+    entry = {
         "name": img["name"],
         "source_repo": repo,
         "tag": tag,
-        "size_bytes": size,
-        "sha256": actual,
+        "size_bytes": len(raw),
+        "sha256": sha256_zeroed,
+        "volatile_offsets": volatile_offsets,
+        "alt_prefix_hashes": [prefix_alt] if prefix_alt != prefix_pristine else [],
     }
+    return prefix_pristine, entry
 
 
 def main():
@@ -234,7 +290,6 @@ def main():
                         help="github repos to scan")
     args = parser.parse_args()
 
-    # Load existing data (if any)
     data = {"prefix_size": PREFIX_SIZE, "updated": None, "images": {}}
     if args.out.exists():
         with open(args.out, encoding="utf-8") as fh:
@@ -252,7 +307,6 @@ def main():
     for repo, rel, imgs in iter_releases(args.repos):
         tag = rel["tag_name"]
 
-        # Collect sha256.txt and .sig assets for this release
         sha256_assets = [a for a in rel.get("assets", [])
                          if SHA256_PATTERN.search(a["name"]) and not a["name"].endswith(".sig")]
         sig_assets = [a for a in rel.get("assets", [])
@@ -265,7 +319,6 @@ def main():
             try:
                 sha256_content = _open(sha_txt["browser_download_url"]).read().decode("utf-8")
                 sha256_entries = parse_sha256_txt(sha256_content)
-
                 if sig_assets:
                     sig = sig_assets[0]
                     try:
@@ -295,15 +348,26 @@ def main():
                 if prefix_hash in data["images"]:
                     existing = data["images"][prefix_hash]
                     print(
-                        f"  COLLISION: {prefix_hash[:12]} overlaps between "
-                        f"{existing['name']} and {img['name']}",
+                        f"  COLLISION (pristine): {prefix_hash[:12]} overlaps "
+                        f"between {existing['name']} and {img['name']}",
                         file=sys.stderr
                     )
                     sys.exit(1)
 
+                for alt_h in entry.get("alt_prefix_hashes", []):
+                    if alt_h in data["images"]:
+                        existing = data["images"][alt_h]
+                        print(
+                            f"  COLLISION (alt): {alt_h[:12]} overlaps "
+                            f"between {existing['name']} and {img['name']}",
+                            file=sys.stderr
+                        )
+                        sys.exit(1)
+
                 data["images"][prefix_hash] = entry
                 sha_tag = " [gpg]" if gpg_verified else ""
-                print(f"  ok   {img['name']} ({tag}){sha_tag}")
+                n_vol = len(entry.get("volatile_offsets", []))
+                print(f"  ok   {img['name']} ({tag}){sha_tag}  {n_vol} vol offs")
 
             except Exception as e:
                 failures += 1
@@ -315,11 +379,6 @@ def main():
 
     if not data["images"]:
         print("No entries found; nothing to write.")
-        sys.exit(1)
-
-    # Verify no prefix-hash collisions
-    if len(data["images"]) != len({k for k in data["images"]}):
-        print("FATAL: prefix-hash collision detected in final data", file=sys.stderr)
         sys.exit(1)
 
     data["updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")

--- a/.github/scripts/update_microsd_checksums.py
+++ b/.github/scripts/update_microsd_checksums.py
@@ -2,27 +2,44 @@
 """
 Refresh src/seedsigner/resources/microsd-known-checksums.json.
 
-The device's "Verify MicroSD" tool hashes the first 26 MiB of the raw card
-(dd bs=1M count=26) and looks the digest up in that file. This script walks the
-release assets of the repos below, fetches the first 26 MiB of every matching
-image via an HTTP Range request, zero-pads short images to exactly 26 MiB (the
-in-app flash flow zeroes the first 26 MiB of the card before dd, so a card
-flashed with a <26 MiB image reads back as image + zero padding), and records
-sha256 of those bytes.
+The device's "Verify MicroSD" tool uses a two-pass approach:
+  Pass 1 — read the first ``prefix_size`` bytes (4 MiB) from the raw card,
+            compute sha256, and look up the matching entry by prefix hash.
+  Pass 2 — read the full image at its exact published size (``size_bytes``)
+            from the card, compute sha256, and compare against the entry's
+            ``sha256`` field.  A prefix match with a full-hash mismatch is
+            reported as possible tampering.
 
-Notes:
-  * The hash is deliberately NOT the full-file sha256 from the release's
-    .sha256.txt file. That only ever matched by accident, when the image
-    happened to be exactly 26 MiB; images larger (0.8.7 = 50 MiB) or smaller
-    than 26 MiB produce a different digest on-device.
-  * Existing entries are never re-downloaded or modified: assets are tracked by
-    repo+tag+asset name. Entries whose source_repo is "manual" (e.g. the
-    zero-wiped-card marker) are always preserved.
-  * On hash collisions between distinct assets, the existing entry wins.
+This script walks the release assets of the repos below, records the 4 MiB
+prefix hash and the full-file sha256 + size for each image, and optionally
+GPG-verifies the release's sha256.txt against the bundled SeedSigner signing
+key (``gpg_keys/Seedsigner_pubkey.asc``) before trusting the published hash.
 
-Run manually with `python .github/scripts/update_microsd_checksums.py`, or let
-.github/workflows/update-microsd-checksums.yml run it on a schedule and open a
-PR. Set GITHUB_TOKEN to raise the API rate limit (optional).
+Schema (``prefix_size`` is a top-level field so other projects can adopt the
+same format with a different prefix):
+
+  {
+    "prefix_size": 4194304,
+    "updated": "2026-09-07",
+    "images": {
+      "<sha256_of_first_4mib>": {
+        "name": "seedsigner_os.0.8.7.pi0.img",
+        "source_repo": "SeedSigner/seedsigner",
+        "tag": "0.8.7",
+        "size_bytes": 52428800,
+        "sha256": "<full-file sha256>"
+      }
+    }
+  }
+
+Existing entries are never re-downloaded: assets are tracked by
+repo+tag+asset name.  Manual entries (e.g. the zero-wiped-card marker) are
+always preserved.  A collision check asserts that every prefix hash is unique
+across all entries.
+
+Run manually with ``python .github/scripts/update_microsd_checksums.py``, or
+let .github/workflows/update-microsd-checksums.yml run it on a schedule and
+open a PR.  Set GITHUB_TOKEN to raise the API rate limit (optional).
 """
 import argparse
 import concurrent.futures
@@ -30,9 +47,13 @@ import hashlib
 import json
 import os
 import re
+import shutil
+import subprocess
 import sys
+import tempfile
 import urllib.request
-from datetime import date, timezone, datetime
+from datetime import datetime, timezone
+from pathlib import Path
 
 REPOS = [
     "SeedSigner/seedsigner",        # official images: seedsigner_os.X.Y.Z.<platform>.img
@@ -40,16 +61,21 @@ REPOS = [
     "3rdIteration/seedsigner-os",
 ]
 ASSET_PATTERN = re.compile(r"^seedsigner_os\..*\.img$")
+SHA256_PATTERN = re.compile(r"^seedsigner\..*sha256")
+SIG_PATTERN = re.compile(r"^seedsigner\..*sha256.*\.sig$")
 
-# Must match the device-side read in ToolsMicroSDVerifyView (dd bs=1M count=26).
-READ_BYTES = 26 * 1024 * 1024
+# How many bytes the device reads for the initial prefix lookup.
+PREFIX_SIZE = 4 * 1024 * 1024  # 4 MiB
 
 # Smaller assets are not plausible OS images; treat as a bad upload.
 MIN_ASSET_BYTES = 4 * 1024 * 1024
 
+# Path to the bundled SeedSigner GPG signing key, relative to the repo root.
+PUBKEY_PATH = Path(__file__).resolve().parents[2] / "gpg_keys" / "Seedsigner_pubkey.asc"
+
 DEFAULT_OUT = (
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    + "/src/seedsigner/resources/microsd-known-checksums.json"
+    Path(__file__).resolve().parents[2]
+    / "src" / "seedsigner" / "resources" / "microsd-known-checksums.json"
 )
 
 
@@ -66,8 +92,8 @@ def _open(url, byte_range=None):
     return urllib.request.urlopen(urllib.request.Request(url, headers=headers))
 
 
-def iter_release_assets(repos):
-    """Yield dicts: repo, tag, name, url for every matching image asset."""
+def iter_releases(repos):
+    """Yield (repo, release_dict) for every release with at least one .img asset."""
     for repo in repos:
         page = 1
         while True:
@@ -76,58 +102,141 @@ def iter_release_assets(repos):
             if not releases:
                 break
             for rel in releases:
-                for asset in rel.get("assets", []):
-                    if ASSET_PATTERN.match(asset["name"]):
-                        yield {
-                            "repo": repo,
-                            "tag": rel["tag_name"],
-                            "name": asset["name"],
-                            "url": asset["browser_download_url"],
-                        }
+                imgs = [a for a in rel.get("assets", []) if ASSET_PATTERN.match(a["name"])]
+                if imgs:
+                    yield (repo, rel, imgs)
             page += 1
 
 
-def hash_first_26mib(url):
-    """sha256 of the asset's first 26 MiB, zero-padded to exactly 26 MiB."""
-    with _open(url, byte_range=f"bytes=0-{READ_BYTES - 1}") as r:
-        content_range = r.headers.get("Content-Range") or ""
-        total = None
-        if "/" in content_range:
-            tail = content_range.rsplit("/", 1)[1]
-            if tail.isdigit():
-                total = int(tail)
-        elif (r.headers.get("Content-Length") or "").isdigit():
-            total = int(r.headers["Content-Length"])
+def sha256_prefix(url):
+    """Range-request first PREFIX_SIZE bytes, returns hex digest."""
+    with _open(url, byte_range=f"bytes=0-{PREFIX_SIZE - 1}") as r:
+        data = r.read(PREFIX_SIZE)
+    return hashlib.sha256(data).hexdigest()
 
-        chunks, size = [], 0
-        while size < READ_BYTES:
-            chunk = r.read(min(1024 * 1024, READ_BYTES - size))
+
+def sha256_file(url):
+    """Full streaming download, returns (hex_digest, size_bytes)."""
+    with _open(url) as r:
+        h = hashlib.sha256()
+        size = 0
+        while True:
+            chunk = r.read(1 << 20)
             if not chunk:
                 break
-            chunks.append(chunk)
+            h.update(chunk)
             size += len(chunk)
+    return h.hexdigest(), size
 
-    if total is not None and total < MIN_ASSET_BYTES:
-        raise ValueError(f"implausibly small asset ({total} bytes)")
-    expected = min(total, READ_BYTES) if total is not None else size
-    if size != expected:
-        raise ValueError(f"short read: got {size}, expected {expected}")
 
-    data = b"".join(chunks)
-    if len(data) < READ_BYTES:
-        data += b"\x00" * (READ_BYTES - len(data))
-    return hashlib.sha256(data).hexdigest()
+def parse_sha256_txt(content):
+    """Return {filename: hex_digest} from the release's sha256.txt content."""
+    result = {}
+    for line in content.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 1)
+        if len(parts) == 2 and len(parts[0]) == 64:
+            result[parts[1]] = parts[0]
+    return result
+
+
+def gpg_verify(sha256_content, sig_content):
+    """Verify sig_content against sha256_content using the bundled SeedSigner key.
+
+    Returns True on success.  Raises RuntimeError if gpg is unavailable,
+    the key cannot be imported, or verification fails.
+    """
+    if not shutil.which("gpg"):
+        raise RuntimeError("gpg not found on this system; cannot verify signature")
+
+    if not PUBKEY_PATH.exists():
+        raise RuntimeError(f"SeedSigner public key not found at {PUBKEY_PATH}")
+
+    with tempfile.TemporaryDirectory() as gnupghome:
+        # Import the SeedSigner signing key
+        res = subprocess.run(
+            ["gpg", "--homedir", gnupghome, "--import", str(PUBKEY_PATH)],
+            capture_output=True, text=True
+        )
+        if res.returncode != 0:
+            raise RuntimeError(f"Failed to import GPG key: {res.stderr.strip()}")
+
+        # Write sha256 content and signature to temp files.  Use newline=""
+        # so text-mode doesn't translate \n to \r\n on Windows: GPG
+        # verification is byte-exact against the original signed content.
+        sha256_path = os.path.join(gnupghome, "sha256.txt")
+        sig_path = sha256_path + ".sig"
+        with open(sha256_path, "w", encoding="utf-8", newline="") as f:
+            f.write(sha256_content)
+        with open(sig_path, "wb") as f:
+            f.write(sig_content)
+
+        # Verify
+        res = subprocess.run(
+            ["gpg", "--homedir", gnupghome, "--trust-model", "always",
+             "--verify", sig_path, sha256_path],
+            capture_output=True, text=True
+        )
+        if res.returncode != 0:
+            raise RuntimeError(
+                f"GPG verification failed:\n{res.stderr.strip()}"
+            )
+    return True
+
+
+def process_asset(img, sha256_entries, gpg_verified, repo, tag):
+    """Download and hash one .img asset, returning (prefix_hash, entry_dict).
+
+    If ``sha256_entries`` contains the image name, the full-file hash is
+    verified against the published value.  If ``gpg_verified`` is True, the
+    sha256.txt was cryptographically signed by the SeedSigner release key.
+    """
+    url = img["browser_download_url"]
+
+    # Pass 1: prefix hash (4 MiB, always via Range request)
+    prefix = sha256_prefix(url)
+
+    # Pass 2: full-file hash
+    expected = sha256_entries.get(img["name"])
+    if expected:
+        actual, size = sha256_file(url)
+        if actual != expected.lower():
+            raise RuntimeError(
+                f"Hash mismatch for {img['name']}: "
+                f"expected {expected}, got {actual}"
+            )
+        if not gpg_verified:
+            # sha256.txt existed but was not GPG-signed (or key wasn't
+            # available); log a warning but still record the verified hash.
+            print(f"  ! {img['name']}: sha256 verified (no GPG signature)", file=sys.stderr)
+    else:
+        # No sha256.txt available — full download and record.
+        actual, size = sha256_file(url)
+
+    return prefix, {
+        "name": img["name"],
+        "source_repo": repo,
+        "tag": tag,
+        "size_bytes": size,
+        "sha256": actual,
+    }
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--out", default=DEFAULT_OUT, help="path to the checksums json")
-    parser.add_argument("--workers", type=int, default=8, help="parallel downloads")
-    parser.add_argument("--repos", nargs="+", default=REPOS, help="github repos to scan")
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT,
+                        help="path to the checksums json")
+    parser.add_argument("--workers", type=int, default=8,
+                        help="parallel downloads")
+    parser.add_argument("--repos", nargs="+", default=REPOS,
+                        help="github repos to scan")
     args = parser.parse_args()
 
-    data = {"updated": None, "images": {}}
-    if os.path.exists(args.out):
+    # Load existing data (if any)
+    data = {"prefix_size": PREFIX_SIZE, "updated": None, "images": {}}
+    if args.out.exists():
         with open(args.out, encoding="utf-8") as fh:
             loaded = json.load(fh)
         if isinstance(loaded.get("images"), dict):
@@ -139,47 +248,94 @@ def main():
         if isinstance(meta, dict) and meta.get("source_repo") != "manual"
     }
 
-    todo = [
-        a for a in iter_release_assets(REPOS)
-        if (a["repo"], a["tag"], a["name"]) not in seen_assets
-    ]
-    print(f"{len(todo)} new asset(s) to hash ({len(data['images'])} entries already known)")
+    failures = 0
+    for repo, rel, imgs in iter_releases(args.repos):
+        tag = rel["tag_name"]
 
-    failures = []
-    added, collided = 0, 0
-    with concurrent.futures.ThreadPoolExecutor(max_workers=args.workers) as pool:
-        futures = {pool.submit(hash_first_26mib, a["url"]): a for a in todo}
-        for future in concurrent.futures.as_completed(futures):
-            asset = futures[future]
+        # Collect sha256.txt and .sig assets for this release
+        sha256_assets = [a for a in rel.get("assets", [])
+                         if SHA256_PATTERN.search(a["name"]) and not a["name"].endswith(".sig")]
+        sig_assets = [a for a in rel.get("assets", [])
+                      if SIG_PATTERN.search(a["name"])]
+
+        sha256_entries = {}
+        gpg_verified = False
+        if sha256_assets:
+            sha_txt = sha256_assets[0]
             try:
-                digest = future.result()
+                sha256_content = _open(sha_txt["browser_download_url"]).read().decode("utf-8")
+                sha256_entries = parse_sha256_txt(sha256_content)
+
+                if sig_assets:
+                    sig = sig_assets[0]
+                    try:
+                        sig_content = _open(sig["browser_download_url"]).read()
+                        gpg_verify(sha256_content, sig_content)
+                        gpg_verified = True
+                        print(f"  gpg: {sha_txt['name']} verified OK ({repo}/{tag})")
+                    except Exception as e:
+                        print(f"  gpg: {sha_txt['name']} verification FAILED: {e}", file=sys.stderr)
+                        sys.exit(1)
+                else:
+                    print(f"  ! {sha_txt['name']}: no GPG signature in release", file=sys.stderr)
             except Exception as e:
-                failures.append(f"{asset['repo']} {asset['tag']} {asset['name']}: {e}")
-                print(f"  FAIL {asset['repo']} {asset['tag']} {asset['name']}: {e}", file=sys.stderr)
+                print(f"  ! failed to download {sha_txt['name']}: {e}", file=sys.stderr)
+                sha256_entries = {}
+
+        for img in imgs:
+            key = (repo, tag, img["name"])
+            if key in seen_assets:
                 continue
-            if digest in data["images"]:
-                collided += 1
-                print(f"  dup  {asset['name']} ({asset['tag']}) matches existing entry")
-            else:
-                data["images"][digest] = {
-                    "name": asset["name"],
-                    "source_repo": asset["repo"],
-                    "tag": asset["tag"],
-                }
-                added += 1
-                print(f"  ok   {asset['name']} ({asset['tag']})")
+
+            try:
+                prefix_hash, entry = process_asset(
+                    img, sha256_entries, gpg_verified, repo, tag
+                )
+
+                if prefix_hash in data["images"]:
+                    existing = data["images"][prefix_hash]
+                    print(
+                        f"  COLLISION: {prefix_hash[:12]} overlaps between "
+                        f"{existing['name']} and {img['name']}",
+                        file=sys.stderr
+                    )
+                    sys.exit(1)
+
+                data["images"][prefix_hash] = entry
+                sha_tag = " [gpg]" if gpg_verified else ""
+                print(f"  ok   {img['name']} ({tag}){sha_tag}")
+
+            except Exception as e:
+                failures += 1
+                print(f"  FAIL {img['name']} ({tag}): {e}", file=sys.stderr)
 
     if failures:
-        print(f"\n{len(failures)} failure(s); not writing 'updated'.", file=sys.stderr)
+        print(f"\n{failures} failure(s); JSON not updated.", file=sys.stderr)
+        sys.exit(1)
+
+    if not data["images"]:
+        print("No entries found; nothing to write.")
+        sys.exit(1)
+
+    # Verify no prefix-hash collisions
+    if len(data["images"]) != len({k for k in data["images"]}):
+        print("FATAL: prefix-hash collision detected in final data", file=sys.stderr)
+        sys.exit(1)
 
     data["updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    data["images"] = dict(sorted(data["images"].items(), key=lambda kv: (kv[1].get("name", ""), kv[0])))
+    data["images"] = dict(sorted(
+        data["images"].items(),
+        key=lambda kv: (kv[1].get("name", ""), kv[0])
+    ))
 
+    args.out.parent.mkdir(parents=True, exist_ok=True)
     with open(args.out, "w", encoding="utf-8", newline="\n") as fh:
         json.dump(data, fh, indent=2)
         fh.write("\n")
-    print(f"\nwrote {args.out}: {added} added, {collided} duplicate(s), {len(data['images'])} total entries")
-    return 1 if failures else 0
+
+    print(f"\nwrote {args.out}: {len(data['images'])} total entries, "
+          f"{len(seen_assets)} preserved, {len(data['images']) - len(seen_assets)} new")
+    return 0
 
 
 if __name__ == "__main__":

--- a/.github/scripts/update_microsd_checksums.py
+++ b/.github/scripts/update_microsd_checksums.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Refresh src/seedsigner/resources/microsd-known-checksums.json.
+
+The device's "Verify MicroSD" tool hashes the first 26 MiB of the raw card
+(dd bs=1M count=26) and looks the digest up in that file. This script walks the
+release assets of the repos below, fetches the first 26 MiB of every matching
+image via an HTTP Range request, zero-pads short images to exactly 26 MiB (the
+in-app flash flow zeroes the first 26 MiB of the card before dd, so a card
+flashed with a <26 MiB image reads back as image + zero padding), and records
+sha256 of those bytes.
+
+Notes:
+  * The hash is deliberately NOT the full-file sha256 from the release's
+    .sha256.txt file. That only ever matched by accident, when the image
+    happened to be exactly 26 MiB; images larger (0.8.7 = 50 MiB) or smaller
+    than 26 MiB produce a different digest on-device.
+  * Existing entries are never re-downloaded or modified: assets are tracked by
+    repo+tag+asset name. Entries whose source_repo is "manual" (e.g. the
+    zero-wiped-card marker) are always preserved.
+  * On hash collisions between distinct assets, the existing entry wins.
+
+Run manually with `python .github/scripts/update_microsd_checksums.py`, or let
+.github/workflows/update-microsd-checksums.yml run it on a schedule and open a
+PR. Set GITHUB_TOKEN to raise the API rate limit (optional).
+"""
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+import re
+import sys
+import urllib.request
+from datetime import date, timezone, datetime
+
+REPOS = [
+    "SeedSigner/seedsigner",        # official images: seedsigner_os.X.Y.Z.<platform>.img
+    "3rdIteration/seedsigner",      # fork builds: smartcard variants etc.
+    "3rdIteration/seedsigner-os",
+]
+ASSET_PATTERN = re.compile(r"^seedsigner_os\..*\.img$")
+
+# Must match the device-side read in ToolsMicroSDVerifyView (dd bs=1M count=26).
+READ_BYTES = 26 * 1024 * 1024
+
+# Smaller assets are not plausible OS images; treat as a bad upload.
+MIN_ASSET_BYTES = 4 * 1024 * 1024
+
+DEFAULT_OUT = (
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    + "/src/seedsigner/resources/microsd-known-checksums.json"
+)
+
+
+def _open(url, byte_range=None):
+    headers = {
+        "User-Agent": "seedsigner-checksum-updater",
+        "Accept": "application/vnd.github+json",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if byte_range:
+        headers["Range"] = byte_range
+    return urllib.request.urlopen(urllib.request.Request(url, headers=headers))
+
+
+def iter_release_assets(repos):
+    """Yield dicts: repo, tag, name, url for every matching image asset."""
+    for repo in repos:
+        page = 1
+        while True:
+            with _open(f"https://api.github.com/repos/{repo}/releases?per_page=100&page={page}") as r:
+                releases = json.load(r)
+            if not releases:
+                break
+            for rel in releases:
+                for asset in rel.get("assets", []):
+                    if ASSET_PATTERN.match(asset["name"]):
+                        yield {
+                            "repo": repo,
+                            "tag": rel["tag_name"],
+                            "name": asset["name"],
+                            "url": asset["browser_download_url"],
+                        }
+            page += 1
+
+
+def hash_first_26mib(url):
+    """sha256 of the asset's first 26 MiB, zero-padded to exactly 26 MiB."""
+    with _open(url, byte_range=f"bytes=0-{READ_BYTES - 1}") as r:
+        content_range = r.headers.get("Content-Range") or ""
+        total = None
+        if "/" in content_range:
+            tail = content_range.rsplit("/", 1)[1]
+            if tail.isdigit():
+                total = int(tail)
+        elif (r.headers.get("Content-Length") or "").isdigit():
+            total = int(r.headers["Content-Length"])
+
+        chunks, size = [], 0
+        while size < READ_BYTES:
+            chunk = r.read(min(1024 * 1024, READ_BYTES - size))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            size += len(chunk)
+
+    if total is not None and total < MIN_ASSET_BYTES:
+        raise ValueError(f"implausibly small asset ({total} bytes)")
+    expected = min(total, READ_BYTES) if total is not None else size
+    if size != expected:
+        raise ValueError(f"short read: got {size}, expected {expected}")
+
+    data = b"".join(chunks)
+    if len(data) < READ_BYTES:
+        data += b"\x00" * (READ_BYTES - len(data))
+    return hashlib.sha256(data).hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", default=DEFAULT_OUT, help="path to the checksums json")
+    parser.add_argument("--workers", type=int, default=8, help="parallel downloads")
+    parser.add_argument("--repos", nargs="+", default=REPOS, help="github repos to scan")
+    args = parser.parse_args()
+
+    data = {"updated": None, "images": {}}
+    if os.path.exists(args.out):
+        with open(args.out, encoding="utf-8") as fh:
+            loaded = json.load(fh)
+        if isinstance(loaded.get("images"), dict):
+            data["images"] = loaded["images"]
+
+    seen_assets = {
+        (meta.get("source_repo"), meta.get("tag"), meta.get("name"))
+        for meta in data["images"].values()
+        if isinstance(meta, dict) and meta.get("source_repo") != "manual"
+    }
+
+    todo = [
+        a for a in iter_release_assets(REPOS)
+        if (a["repo"], a["tag"], a["name"]) not in seen_assets
+    ]
+    print(f"{len(todo)} new asset(s) to hash ({len(data['images'])} entries already known)")
+
+    failures = []
+    added, collided = 0, 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = {pool.submit(hash_first_26mib, a["url"]): a for a in todo}
+        for future in concurrent.futures.as_completed(futures):
+            asset = futures[future]
+            try:
+                digest = future.result()
+            except Exception as e:
+                failures.append(f"{asset['repo']} {asset['tag']} {asset['name']}: {e}")
+                print(f"  FAIL {asset['repo']} {asset['tag']} {asset['name']}: {e}", file=sys.stderr)
+                continue
+            if digest in data["images"]:
+                collided += 1
+                print(f"  dup  {asset['name']} ({asset['tag']}) matches existing entry")
+            else:
+                data["images"][digest] = {
+                    "name": asset["name"],
+                    "source_repo": asset["repo"],
+                    "tag": asset["tag"],
+                }
+                added += 1
+                print(f"  ok   {asset['name']} ({asset['tag']})")
+
+    if failures:
+        print(f"\n{len(failures)} failure(s); not writing 'updated'.", file=sys.stderr)
+
+    data["updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    data["images"] = dict(sorted(data["images"].items(), key=lambda kv: (kv[1].get("name", ""), kv[0])))
+
+    with open(args.out, "w", encoding="utf-8", newline="\n") as fh:
+        json.dump(data, fh, indent=2)
+        fh.write("\n")
+    print(f"\nwrote {args.out}: {added} added, {collided} duplicate(s), {len(data['images'])} total entries")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/update-microsd-checksums.yml
+++ b/.github/workflows/update-microsd-checksums.yml
@@ -1,0 +1,57 @@
+name: Update MicroSD known checksums
+
+# Refreshes src/seedsigner/resources/microsd-known-checksums.json, which the
+# "Verify MicroSD" tool uses to recognize freshly-flashed SeedSigner OS cards.
+# The device hashes only the first 26 MiB of the raw card, so each entry is
+# sha256(first 26 MiB of the release image, zero-padded to 26 MiB) -- not the
+# full-file hash from the release's .sha256.txt. New images are fetched with a
+# single HTTP Range request each; already-recorded assets are never re-fetched.
+#
+# The data is advisory: it labels a checksum match on a verification screen and
+# never gates a signing decision, so a missing or stale entry only means "card
+# not recognized". That is why sourcing digests from GitHub releases in CI is
+# acceptable here -- and why this opens a PR rather than pushing directly, so
+# new entries are still reviewed like any other change.
+
+on:
+  schedule:
+    # Monthly; new OS releases are far less frequent than this and manual
+    # dispatch covers anything urgent.
+    - cron: "0 4 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Hash new release images
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 .github/scripts/update_microsd_checksums.py
+
+      - name: Open a PR if anything changed
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: chore/update-microsd-checksums
+          title: "chore: update MicroSD known checksums"
+          commit-message: |
+            chore: update MicroSD known checksums
+
+            Automated refresh of src/seedsigner/resources/microsd-known-checksums.json
+            from the SeedSigner/seedsigner and 3rdIteration release assets.
+          body: |
+            Automated refresh of `src/seedsigner/resources/microsd-known-checksums.json`.
+
+            Each new entry is `sha256(first 26 MiB of the release image, zero-padded to
+            26 MiB)` -- exactly what the device's "Verify MicroSD" tool reads back with
+            `dd bs=1M count=26`, not the full-file hash from the release `.sha256.txt`.
+
+            The data is advisory: it labels a checksum match on a verification screen
+            and never gates a signing decision, so this is safe to merge or ignore.
+          delete-branch: true

--- a/.github/workflows/update-microsd-checksums.yml
+++ b/.github/workflows/update-microsd-checksums.yml
@@ -1,16 +1,25 @@
 name: Update MicroSD known checksums
 
 # Refreshes src/seedsigner/resources/microsd-known-checksums.json, which the
-# "Verify MicroSD" tool uses to recognize freshly-flashed SeedSigner OS cards.
-# The device hashes only the first 26 MiB of the raw card, so each entry is
-# sha256(first 26 MiB of the release image, zero-padded to 26 MiB) -- not the
-# full-file hash from the release's .sha256.txt. New images are fetched with a
-# single HTTP Range request each; already-recorded assets are never re-fetched.
+# "Verify MicroSD" tool uses to recognize freshly-flashed cards.
+#
+# The device uses a two-pass approach:
+#   Pass 1 — read the first ``prefix_size`` bytes (4 MiB) from the raw card,
+#            compute sha256, and look up the matching entry.
+#   Pass 2 — read the full image at its exact published size from the card,
+#            compute sha256, and compare against the entry's ``sha256`` field.
+#            A prefix match with a full-hash mismatch is reported as possible
+#            tampering — catching malicious bytes beyond the prefix.
+#
+# Each entry is keyed by the 4 MiB prefix hash and stores the full-file sha256.
+# For official SeedSigner/seedsigner releases that ship a GPG-signed
+# sha256.txt, the updater verifies the signature before trusting the published
+# hash.  Fork builds that lack a sha256.txt are hashed directly.
 #
 # The data is advisory: it labels a checksum match on a verification screen and
 # never gates a signing decision, so a missing or stale entry only means "card
-# not recognized". That is why sourcing digests from GitHub releases in CI is
-# acceptable here -- and why this opens a PR rather than pushing directly, so
+# not recognized".  That is why sourcing digests from GitHub releases in CI is
+# acceptable here — and why this opens a PR rather than pushing directly, so
 # new entries are still reviewed like any other change.
 
 on:
@@ -48,10 +57,13 @@ jobs:
           body: |
             Automated refresh of `src/seedsigner/resources/microsd-known-checksums.json`.
 
-            Each new entry is `sha256(first 26 MiB of the release image, zero-padded to
-            26 MiB)` -- exactly what the device's "Verify MicroSD" tool reads back with
-            `dd bs=1M count=26`, not the full-file hash from the release `.sha256.txt`.
+            Each entry is keyed by the sha256 of the first 4 MiB of the release
+            image (two-pass prefix lookup) and records the full-file sha256 +
+            exact size.  Official SeedSigner/seedsigner releases are GPG-verified
+            against the bundled Seedsigner_pubkey.asc before their published
+            hashes are trusted.
 
-            The data is advisory: it labels a checksum match on a verification screen
-            and never gates a signing decision, so this is safe to merge or ignore.
+            The data is advisory: it labels a checksum match on a verification
+            screen and never gates a signing decision, so this is safe to merge
+            or ignore.
           delete-branch: true

--- a/src/seedsigner/resources/microsd-known-checksums.json
+++ b/src/seedsigner/resources/microsd-known-checksums.json
@@ -1,0 +1,665 @@
+{
+  "updated": "2026-09-06",
+  "images": {
+    "5809d4ec68138c737b1b000db4c6ec60983e94544efd893bdfa40ebf19af60f4": {
+      "name": "Zero Wiped (First 26MB)",
+      "source_repo": "manual",
+      "tag": ""
+    },
+    "27642fbaf921046418273795400c9f9912666719787708b50d093911c503cb74": {
+      "name": "seedsigner_os.0.6.0.pi0.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.6.0"
+    },
+    "f969ab8bcf58a45ecc328da81ceaaa58b9acba65894c9961082f1b0f0e9ab281": {
+      "name": "seedsigner_os.0.6.0.pi02w.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.6.0"
+    },
+    "180c95be2d07bbd84b1cb478698bb7af9f8f8c48e4328474dd06cfe6923babf6": {
+      "name": "seedsigner_os.0.6.0.pi2.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.6.0"
+    },
+    "e1b8bbbeb63dc499563e23a64db1f2c35f6cb50193e01c7ef1c29841f60778fa": {
+      "name": "seedsigner_os.0.6.0.pi4.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.6.0"
+    },
+    "9e0416a32bded1e4daca0e9c9c18af5925292236355f5710c3af649c5eb6a4df": {
+      "name": "seedsigner_os.0.7.0+Satochip-Beta1.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "0.7.0+Satochip-Beta1"
+    },
+    "afa6dcb62a1abfd74a7bb3d9cfa4be59bc7b6b54551086da5e2c00c32ecb6bc1": {
+      "name": "seedsigner_os.0.7.0+Satochip-Beta1.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "0.7.0+Satochip-Beta1"
+    },
+    "57ae6d38b50ddb76314c58991e3e63ff7e5b854aab2bc5c0ad437240190b300d": {
+      "name": "seedsigner_os.0.7.0+Satochip-Beta1.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "0.7.0+Satochip-Beta1"
+    },
+    "b85228fba8b73a782ee6eca361bdc2308933f5a6c8ab7fe9d4d01815021a1179": {
+      "name": "seedsigner_os.0.7.0+Satochip-Beta1.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "0.7.0+Satochip-Beta1"
+    },
+    "f27ab2147470a4666d731a5f8b23bab2df9db4e1f2f3c3fc517d6d454753100d": {
+      "name": "seedsigner_os.0.7.0+Satochip-Beta2.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "0.7.0+Satochip-Beta2"
+    },
+    "a404f20d1426f754264d15e7d0ad889c509b681faef879b061bd680202f8831b": {
+      "name": "seedsigner_os.0.7.0+Satochip-Beta2.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "0.7.0+Satochip-Beta2"
+    },
+    "021439edb882f27cfd8ef8cadf0714be741a44a0e9ed983d9f53f9b4f0025355": {
+      "name": "seedsigner_os.0.7.0+Satochip-Beta2.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "0.7.0+Satochip-Beta2"
+    },
+    "579e0973750d4af30d52b2d646b70dece6c51b979c934e22131211e7c413db69": {
+      "name": "seedsigner_os.0.7.0+Satochip-Beta2.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "0.7.0+Satochip-Beta2"
+    },
+    "a380cb93eb852254863718a9c000be9ec30cee14a78fc0ec90708308c17c1b8a": {
+      "name": "seedsigner_os.0.7.0.pi0.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.7.0"
+    },
+    "fe0601e6da97c7711093b67a7102f8108f2bfb8a2478fd94fa9d3edea5adfb64": {
+      "name": "seedsigner_os.0.7.0.pi02w.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.7.0"
+    },
+    "65be9209527ba03efe8093099dae8ec65725c90a758bc98678b9da31639637d7": {
+      "name": "seedsigner_os.0.7.0.pi2.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.7.0"
+    },
+    "d574c1326d07e18b550e2f65e36a4678b05db882adb5cb8f8732ff8d75d59809": {
+      "name": "seedsigner_os.0.7.0.pi4.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.7.0"
+    },
+    "1d0f1c412f64b40e6aba21b5bacdb41d9323653c170ce06d0a3f1dd71fddb28e": {
+      "name": "seedsigner_os.0.8.0.pi0.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.0"
+    },
+    "c8d5352ed4a86c19eb9ef54f2920934f8ce460742b464ea94dc9114f9f4e039a": {
+      "name": "seedsigner_os.0.8.0.pi02w.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.0"
+    },
+    "11c5553d75b3ebca4988ae3c4573b60b33a12bc4779282454ae34404ba797670": {
+      "name": "seedsigner_os.0.8.0.pi2.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.0"
+    },
+    "917201e335bfc7ee4189f17827f954f89588dc0fdefdad80d26f2a65c5c8e6d0": {
+      "name": "seedsigner_os.0.8.0.pi4.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.0"
+    },
+    "75fb58076a2e72bfc42ce99671406ff371ee6687d041b70ad43bd9b80aa46233": {
+      "name": "seedsigner_os.0.8.5-rc1.pi0.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.5-rc1"
+    },
+    "7d731c6458e13b5090284c53fe859ba98ed3178b3690e3af29f38f4c2b902ec3": {
+      "name": "seedsigner_os.0.8.5-rc1.pi02w.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.5-rc1"
+    },
+    "d469d31feba8df78e4afb7514cbac50dd72cc1bd22717e1921df819aa8f13562": {
+      "name": "seedsigner_os.0.8.5-rc1.pi2.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.5-rc1"
+    },
+    "650dac5cf7608b9259e7272c778584104862c60089807f1d6266e374b055486a": {
+      "name": "seedsigner_os.0.8.5-rc1.pi4.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.5-rc1"
+    },
+    "be60f1d04366d827f5fd8f2aeedc8873927bb4f4f9846b02027b3c65706f16b0": {
+      "name": "seedsigner_os.0.8.5.pi0.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.5"
+    },
+    "398d9bf9cda0858fe97c0788b353194c1c902335a858b7dbf5d7b213bda75d96": {
+      "name": "seedsigner_os.0.8.5.pi02w.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.5"
+    },
+    "1e93a82e62d4a1defbdc777a6762a813f4cb5c3ef9090da0bd07542dfd6f62bf": {
+      "name": "seedsigner_os.0.8.5.pi2.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.5"
+    },
+    "d298ffad3c765e11e48873efc6d1c65e4230528fde4d5bd4701bb507acbf493c": {
+      "name": "seedsigner_os.0.8.5.pi4.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.5"
+    },
+    "c7b08a13a9d285fedb7bf4d458ca181ba98d6968684bb721a7bf5c2b53b4d821": {
+      "name": "seedsigner_os.0.8.6.pi0.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.6"
+    },
+    "b4c0c8c741d3a581f6c3afa7133eb3f3696ea44ce25e6927fcc258693826a6e5": {
+      "name": "seedsigner_os.0.8.6.pi02w.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.6"
+    },
+    "0bb2d03d3771be13da3bc4165b43007efda65c34d4795ab1d2fd3dad6d42e117": {
+      "name": "seedsigner_os.0.8.6.pi2.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.6"
+    },
+    "89a20177e22741df6009e8304120fe7b302aabe8bf23c3cf4e8b1a7866d0aa18": {
+      "name": "seedsigner_os.0.8.6.pi4.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.6"
+    },
+    "9eb2975a13a4f64f4f1634a7405830b190adaa8f34e3a1b031d8bdd6c78ae8c8": {
+      "name": "seedsigner_os.0.8.7.pi0.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.7"
+    },
+    "d354a553a731d06ff44beb79ea324d2d9ca9133355edd9db12f148828b2bed07": {
+      "name": "seedsigner_os.0.8.7.pi02w.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.7"
+    },
+    "734942a61f520e0221eeb2d4849953ca19a2cd479fae7d5eefdad9c74cc916d0": {
+      "name": "seedsigner_os.0.8.7.pi2.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.7"
+    },
+    "6b8518820ad02ab39d268f3e7d0e05332842f19d7b3de416576624630d6e7b03": {
+      "name": "seedsigner_os.0.8.7.pi4.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.8.7"
+    },
+    "d73fbb8620fc0462ccc213df942a1e90504ac4dff2958256edc74bb56d09d5a6": {
+      "name": "seedsigner_os.SS0.8.6_Satochip_Earthdiver-B7_.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.8.6+Satochip+Earthdiver-B7"
+    },
+    "30019e5b9c0471734d6b5c7c0242d05bbf016d6cda4e9dcaa7e985b22d079322": {
+      "name": "seedsigner_os.SS0.8.6_Satochip_Earthdiver-B7_.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.8.6+Satochip+Earthdiver-B7"
+    },
+    "cf4b26df1a50c74f9809888878d6f9e5439115ada3b8cdc22d8656b0cd83bdd2": {
+      "name": "seedsigner_os.SS0.8.6_Satochip_Earthdiver-B7_.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.8.6+Satochip+Earthdiver-B7"
+    },
+    "c6e5a64f763adb5b491fd7ed7ef790f466e68ebcb4697b92095c1c55f6b200a7": {
+      "name": "seedsigner_os.SS0.8.6_Satochip_Earthdiver-B7_.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.8.6+Satochip+Earthdiver-B7"
+    },
+    "d01b90a42f869c00047a0ca73307f3b9cb07ae49ebc9c415f0f92c511e73d247": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b1.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b1"
+    },
+    "da7a0620ce6997c3d96134bb87e9086518bca59d23e2feb34e2865c5b3d0f7ec": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b1.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b1"
+    },
+    "52f1667dc330f5d3026cde5fa11625479659b21de4264088ae8fe96dcbe91c00": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b1.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b1"
+    },
+    "3d4bb20a823fbef653b12d13b6259667d494259a058aa28bf1d08c80aac61b20": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b1.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b1"
+    },
+    "fb7442261c13bcac46ba41407f4edc6c945ff4b0883311847c4708be42d4616a": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b2.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b2"
+    },
+    "e834b10cab5e70994607b1230bba07a791dfcca37253c698f9acec6cc8644352": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b2.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b2"
+    },
+    "aed3b276eb384f5e91ab57417ceb58536d8056c0b224c6accd8c5bdbb6e5a19a": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b2.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b2"
+    },
+    "edbb1cd956efaebc95d094073ca268aa26d01cd7941eff710627f3ef63c33a30": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b2.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b2"
+    },
+    "ff352a695758166657b04f01f1aa9db5d950b7fb7652c0cd99c8ec4389afeb28": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b3.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b3"
+    },
+    "ca5d75792a991bdea02283f58110f4f3f1d9227376213789f727c685eb897a10": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b3.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b3"
+    },
+    "e94a1b17f9f72f9ecb200aec4b524a3e15bf2f67a9d2cb3d1ffd7c62e4510a20": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b3.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b3"
+    },
+    "17a04cee115e904791652a389a2a0bbe5c12ef9e0ee8d61e3d54315141b55da7": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b3.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b3"
+    },
+    "27174eee90e0ee9417dcea495fb16066191f8f72b43670bb9997a70e0c9a3632": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b6.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b6"
+    },
+    "c4795682eadb9494a812bc797edea1870cb4a315bd4dd6bf412888beee572eba": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b6.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b6"
+    },
+    "d65db51696596b4f843b259dac8d3b2be822b4716954ade09aa71f6139b69523": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b6.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b6"
+    },
+    "fd20e29e3e856750d6355e4a5387f90a5efc306ed712782d6289aff87678e068": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b6.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b6"
+    },
+    "f6dd7e5424dd475c885a7a0be111d1a7c62b0565f77fe5198c6fc59ee0f6f5ff": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b7.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b7"
+    },
+    "7cacf7ac7485d1f17c1c4e4eb0a9a316bee622bc4e8ee270807f3d8f640a7251": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b7.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b7"
+    },
+    "5ee4ffb7e417651abdaf24dd4d6ddb187b45f3b8bd86dc6c5a1a64410e94b405": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b7.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b7"
+    },
+    "cc811c99534d811dd4546d9eab1155b49376f1124fac271c11f138d1abffa0e5": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b7.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b7"
+    },
+    "7ef07ae004e845a75a2049c469b4acc8d0e1f10c9569949ff03784209b04ea1a": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b8.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b8"
+    },
+    "052d7e55fe4eec765b4c5c3020dec4d76f2c370fd9d061ee183bb75cb436f368": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b8.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b8"
+    },
+    "b392ae85a5bb9a9e0c8fda02a9ddc29144c59363e3b41de812be43a081ca4ad8": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b8.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b8"
+    },
+    "7a684b9ab23c72d4a2d6d45f0f6804869b5ad17120d24a745e32bdf22e7febc6": {
+      "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b8.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b8"
+    },
+    "691845fa57c46ce6e6e20a2440b0a37eae8a242f4727ca84ee7ec6dcc4226093": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.lafrite-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.6+ShSi-B10"
+    },
+    "b9d60fea778820a03424380e42cf600de6da3e91bdc35c77d32ce73225a9a84e": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi0-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.6+ShSi-B10"
+    },
+    "6853135d107387311f31d78a3800a64f12cb66eff333e0f2d65652d0405d6ff5": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B10"
+    },
+    "17d45b820e25cf44339c72057402a2499d2c61ea76727de8a09db3b18036351c": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi02w-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.6+ShSi-B10"
+    },
+    "5aa0c3447ad5e52a6a900922a3b353e2fcd32864f0b0945f73370045d52817e9": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B10"
+    },
+    "5bf7ce0a5a553aba712b3246b4238ec7fa8f73369ad150468b558446f4a672da": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi2-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.6+ShSi-B10"
+    },
+    "5608017a12bc7aba1f0e880b0922ee17c9b31aba9940eaac06ca4511e5a48760": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B10"
+    },
+    "a5036a84c3e12d3a77e06de303a98b8f76b5d326700ed1855101c785ff2339f1": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi4-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.6+ShSi-B10"
+    },
+    "30e0df593432c1ff7e9f9d3c9e57625ee81bc06a7819bebd906724fa7d5bd1d9": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B10"
+    },
+    "83dba55ac8aedc5df5939c5172e998b1193b03362cab210ee66f8de475e662c7": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.lafrite-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.6+ShSi-B11"
+    },
+    "de15156ff0d955f57fe47d20bebae211eadb7c280381a7f615b16cf9aff1c066": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi0-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.6+ShSi-B11"
+    },
+    "ff1110d73a9d9a4a70304cefab75c205ec889dc7488379a847b8f22aedab56bd": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B11"
+    },
+    "c675886646ef7266b6ff306daa6ce7064f4b32d673dd29fcee3291cbe375dca3": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi02w-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.6+ShSi-B11"
+    },
+    "97161ac05a4093c7cff657230f03e342fbcbce5127a066c6b466b91c3bfea9a5": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B11"
+    },
+    "9098c54fa84205e873a02af3c242fa8ccdab6062a0a38748f478d9d4232edaa1": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi2-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.6+ShSi-B11"
+    },
+    "5762b3cace5b8775400c6c6d063ae3835272fa13c1df8b33085c7b3e4aca7bfd": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B11"
+    },
+    "81784b67d2a2606fe90deb2fc7dce20eed1c1a00bd77871fb073752bd71637eb": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi4-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.6+ShSi-B11"
+    },
+    "606e641b74922effc37d7e7e475a66eb24eb1d935a4d3d6dda983dcddf94b094": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B11"
+    },
+    "b7e8ab3c2fda2f35fb54a412bfaef2fcf646010ec4a61114b06d697656bc82a7": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B8_.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B8"
+    },
+    "269d6e953d5fd958849bfa9c8325abe50dc7f90f98a61330c1203027b3f2e26a": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B8_.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B8"
+    },
+    "55024f57ffc2198c72ed6505b316faa9c8e4a24445cb6d90966cad4934f65714": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B8_.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B8"
+    },
+    "9557041a48596ca0ef2c355f372c468655745e422d2ebef07b6f676d64e978ff": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B8_.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B8"
+    },
+    "8d2f2f53b9d15e30a66409f772b11e73221040d83f803666e1fbc39508edc65b": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.lafrite-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.6+ShSi-B9"
+    },
+    "1d30efc6edf44b7f8186c4d86c75829e0354bcf0c63a61274430a86362c04f7a": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi0-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.6+ShSi-B9"
+    },
+    "0bef3a33d4f631b36d1b423d52a88de57037f0e2390d9eb295a9fe973687a092": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B9"
+    },
+    "5fc5c2c6ed6c622d9d7a7bea56e2d1c84e25f795d8cf22b17a41c9e525e4e95d": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi02w-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.6+ShSi-B9"
+    },
+    "5741370e49a39b63bd0dcdfdb05247ae97d5f2ed1d714e76101f88c166658cc9": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B9"
+    },
+    "eea74829a1d3397b237288afe43aaa800a3cd220672553b3c15ce27c96b28c1a": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi2-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.6+ShSi-B9"
+    },
+    "966a19954567dd20b0a610c3142778f1a0ca4833aa631ca2224c543a62954c26": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B9"
+    },
+    "bf868ff833b5348dd6d46a4e19565c265aba5dff46ac8ff29317606cd12a2e77": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi4-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.6+ShSi-B9"
+    },
+    "a9a0e61b91cf48796f399d3e85e548b710aa12563c87c360b7746a0edc58c389": {
+      "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.6+ShSi-B9"
+    },
+    "b86976d81fb4ad1526c43abf7c0bff2c3ad0e6b02f24ce170ee0d9a5173a28d8": {
+      "name": "seedsigner_os.SeSi-0.8.7_ShSi-B11_.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.7+ShSi-B11"
+    },
+    "7930616bb95508f0102088cc66319c4b186c2e6d712d6e762f72db5bf40d3de5": {
+      "name": "seedsigner_os.SeSi-0.8.7_ShSi-B11_.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.7+ShSi-B11"
+    },
+    "b34458ae7f75011ce7102e8902a35c9643931d689a2ec32f3c89870ecb656f5a": {
+      "name": "seedsigner_os.SeSi-0.8.7_ShSi-B11_.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.7+ShSi-B11"
+    },
+    "2716e262fdea652c12045e9a2596e5b02eea3145c27ca19e54df8467a1a53681": {
+      "name": "seedsigner_os.SeSi-0.8.7_ShSi-B11_.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.7+ShSi-B11"
+    },
+    "e3b3647c0e2bbbdd354bc3e1c35bba04f6b6c0bfa8dbc1d226c34f63eae271b1": {
+      "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.lafrite-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+    },
+    "d66c688d6eb59551c660a912af92e971aff3fd45d7eabb7dd84733359866ad1c": {
+      "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.lafrite-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+    },
+    "3995eb32d39921c08e27644844e91bf34b909f67c8e7c2432e9fea775e07133f": {
+      "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi0-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+    },
+    "51702c09f6ecd5ba773e7ec6d18658a5ccdc07a040e58b7ad20916ae718e7a69": {
+      "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+    },
+    "5bef9a5dd5e7acf9460ac2416985ede5dfb2903c66c6c5db17352ba8405a5b53": {
+      "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi02w-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+    },
+    "70848fdbd5aa3e8f190b637466708fd880562fb5e32e16a28176f4de34f19df9": {
+      "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+    },
+    "7b6e6717ef0da5bba9ea70ca89a676362709dfe64e87a3bc2dee702fd6ae8d24": {
+      "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi2-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+    },
+    "95082ad6c6cdc58a96f2f729dbb151b64f0e1cae4acef1b0116c1b856fac52b8": {
+      "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+    },
+    "abc17bb042814089ac2c5cb7ce0dc639e4967fe4298f2db112369c45aa2ba0b0": {
+      "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi4-smartcard-dev.img",
+      "source_repo": "3rdIteration/seedsigner-os",
+      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+    },
+    "7c3eca28dd99e75a001ee6455c97b0d18ed2eb232f16f494069071a7e9a879fa": {
+      "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+    },
+    "0125a90a9ec65a56c0bd49ca2f4eb4fa46a7d7d36d4b6b3f873b1ed29707cb1e": {
+      "name": "seedsigner_os.dev.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b7-pre"
+    },
+    "5c8db62871dd87e61782834aeeb5dbfef232ecb67740db9a709f74c7e77be833": {
+      "name": "seedsigner_os.dev.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "ss0.85-b3+earthdriver-a1"
+    },
+    "186d1753f6cc8f2664fc3418e0123e00bfa89c0b4a9995b37a3667a1a757b805": {
+      "name": "seedsigner_os.dev.pi0.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.7.0-rc1"
+    },
+    "0c84bce6415b27798af867174719316687ac3635ddba99f23f9c7a8bc0d8f053": {
+      "name": "seedsigner_os.dev.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "ss0.85-b3+earthdriver-a1"
+    },
+    "ce1431b28fd92da9c203fa31da91fee5efd3866ff2958683605fc3b3178c3796": {
+      "name": "seedsigner_os.dev.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "ss0.85-b5+earthdriver-a2"
+    },
+    "e84a3452199d6c23733c668e9c71f49b270f5dd59d72f93e6269f9a8ad3074e3": {
+      "name": "seedsigner_os.dev.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b7-pre"
+    },
+    "7fe3ebfc60a6e8998dcf5a7baa198e07405bfed48d20a005a84ff4d71b93afe7": {
+      "name": "seedsigner_os.dev.pi02w.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.7.0-rc1"
+    },
+    "00b50bffb35f949e672950e72fff0babd2902a07940b0ede8a38d16ea1d9529c": {
+      "name": "seedsigner_os.dev.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "ss0.85-b5+earthdriver-a2"
+    },
+    "fd9fc64c84c03f58a2bcc9d7378b6c991c989f23e1e96fe678c05b4d8cc59da2": {
+      "name": "seedsigner_os.dev.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b7-pre"
+    },
+    "05d16b71a0d60e6cd329e16fe0b9f36fa6de9d3ccee326c42629db4d096afc0b": {
+      "name": "seedsigner_os.dev.pi2.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.7.0-rc1"
+    },
+    "34ed3374c76e7a096dec934c411f2dbe5d06c9cd6f385492b9f4c69570689a11": {
+      "name": "seedsigner_os.dev.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "SS0.85+Satochip+earthdriver-b7-pre"
+    },
+    "536c0bdbb20a06db8235f4bcbf60791c44cdfdd9be793b0dbcc215a124e9c9a7": {
+      "name": "seedsigner_os.dev.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "ss0.85-b5+earthdriver-a2"
+    },
+    "554756f0be105bfa184be2d9d1b67afc43e59b27bf359b59a8d035f65fd6b77c": {
+      "name": "seedsigner_os.dev.pi4.img",
+      "source_repo": "SeedSigner/seedsigner",
+      "tag": "0.7.0-rc1"
+    },
+    "b73b1a45c8c54803edd954673d5cd83a17d6f27687ee2861205b89027bb09599": {
+      "name": "seedsigner_os.ss0.85-b5+earthdriver-a2.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "ss0.85-b5+earthdriver-a2"
+    },
+    "baefc47eabbf52d7e144c9a33ee4a4c86933efe7bcc87f5e8296d813d86e1cd3": {
+      "name": "seedsigner_os.ss0.85rc1-b3-a1.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "ss0.85rc1-b3-a1"
+    },
+    "354411bf478c30b87571ca81525050bf0e3fce2692a3fc700b63c2d91c974342": {
+      "name": "seedsigner_os.ss0.85rc1-b3-a1.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "ss0.85rc1-b3-a1"
+    },
+    "160a3d11169347105e8e1d090b858c6bb34b35575f01e2b234dfa76bc316e824": {
+      "name": "seedsigner_os.ss0.85rc1-b3-a1.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "ss0.85rc1-b3-a1"
+    },
+    "efcef748ee663b8b607b3cbce8e7514ffb628e9d9f152e3a36f018fb6b1d8476": {
+      "name": "seedsigner_os.ss0.85rc1-b3-a1.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "ss0.85rc1-b3-a1"
+    },
+    "c927ffc35a515f0d219802696c3ecea865a877c1a233d07304650fd5d0c44302": {
+      "name": "seedsigner_os.ss0.85rc1-b3-a2.pi0-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "ss0.85rc1-b3-a2"
+    },
+    "f371444d967f3e14aeb9146bb11fcc093b42490bea471d81e7bb0e60fcbc2b1c": {
+      "name": "seedsigner_os.ss0.85rc1-b3-a2.pi02w-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "ss0.85rc1-b3-a2"
+    },
+    "3591e4726dec103e5e5bc921794e374aa817f0ee9d76eb4906643cf8e5fd2492": {
+      "name": "seedsigner_os.ss0.85rc1-b3-a2.pi2-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "ss0.85rc1-b3-a2"
+    },
+    "384a573dc517d6404ae9d9ecbbf46c70589f94e48800797e8f9872bd2dab32e6": {
+      "name": "seedsigner_os.ss0.85rc1-b3-a2.pi4-smartcard.img",
+      "source_repo": "3rdIteration/seedsigner",
+      "tag": "ss0.85rc1-b3-a2"
+    }
+  }
+}

--- a/src/seedsigner/resources/microsd-known-checksums.json
+++ b/src/seedsigner/resources/microsd-known-checksums.json
@@ -1,665 +1,930 @@
 {
-  "updated": "2026-09-06",
+  "prefix_size": 4194304,
+  "updated": "2026-09-07",
   "images": {
-    "5809d4ec68138c737b1b000db4c6ec60983e94544efd893bdfa40ebf19af60f4": {
+    "bb9f8df61474d25e71fa00722318cd387396ca1736605e1248821cc0de3d3af8": {
       "name": "Zero Wiped (First 26MB)",
       "source_repo": "manual",
-      "tag": ""
+      "tag": "",
+      "size_bytes": 27262976,
+      "sha256": "5809d4ec68138c737b1b000db4c6ec60983e94544efd893bdfa40ebf19af60f4"
     },
-    "27642fbaf921046418273795400c9f9912666719787708b50d093911c503cb74": {
+    "e36078f836278c7201f51bac3d21583df30a0cf58ed476f5aa8c2aa4260dbd28": {
       "name": "seedsigner_os.0.6.0.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.6.0"
+      "tag": "0.6.0",
+      "size_bytes": 35652096,
+      "sha256": "750f406c133d17994eb58544aad82b20f1478c8663af303e45b2d9c49c4e9825"
     },
-    "f969ab8bcf58a45ecc328da81ceaaa58b9acba65894c9961082f1b0f0e9ab281": {
+    "3ee6250a718eb8e333eb750edb88d4b89c76311dfe7b4b09c0d02b0241effe57": {
       "name": "seedsigner_os.0.6.0.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.6.0"
+      "tag": "0.6.0",
+      "size_bytes": 35652096,
+      "sha256": "0012ae613545eecf6ff40a17967a91f0e89d28f0db1fbafcdd371a58b237b3f2"
     },
-    "180c95be2d07bbd84b1cb478698bb7af9f8f8c48e4328474dd06cfe6923babf6": {
+    "472741ca6d06bab721a3f3d87b57bdc99dc0d1c8fe0a404e8b0fdcc592b19b5d": {
       "name": "seedsigner_os.0.6.0.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.6.0"
+      "tag": "0.6.0",
+      "size_bytes": 35652096,
+      "sha256": "749115b3f222f45a20a632996939afa0bb75bc0591979f5be30b0335ebd3f378"
     },
-    "e1b8bbbeb63dc499563e23a64db1f2c35f6cb50193e01c7ef1c29841f60778fa": {
+    "7ab933c7aff11f3bbebebd8a3507db24ce47219e7b30be4932022de00945bb7c": {
       "name": "seedsigner_os.0.6.0.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.6.0"
+      "tag": "0.6.0",
+      "size_bytes": 42992128,
+      "sha256": "78a15b08ed163b1911320e436ea7002cb8daf49c6867fb29b4d5f94dca107cb1"
     },
-    "9e0416a32bded1e4daca0e9c9c18af5925292236355f5710c3af649c5eb6a4df": {
+    "3d02f97ffc26dd6db7f0d6d3c8fd8dd453740abaf0da0a674c42c83ecba60088": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta1.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "0.7.0+Satochip-Beta1"
+      "tag": "0.7.0+Satochip-Beta1",
+      "size_bytes": 268435456,
+      "sha256": "a53b1236268d44493064776e015346944a094bfb0b0e123f3645e10acd047cd8"
     },
-    "afa6dcb62a1abfd74a7bb3d9cfa4be59bc7b6b54551086da5e2c00c32ecb6bc1": {
+    "6ad74ced1e5c805a4d24172d62e3d8185066f25b6e9d769f067226cbf4802aad": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta1.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "0.7.0+Satochip-Beta1"
+      "tag": "0.7.0+Satochip-Beta1",
+      "size_bytes": 268435456,
+      "sha256": "af6681b3d7c822ef01e7414fa1787882dfd3cccdfdc987b36df815775a29c4c5"
     },
-    "57ae6d38b50ddb76314c58991e3e63ff7e5b854aab2bc5c0ad437240190b300d": {
+    "292e87be8e229420551e7c96bb94b8937971f3c0e07c9eb61af1db0af0259f5d": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta1.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "0.7.0+Satochip-Beta1"
+      "tag": "0.7.0+Satochip-Beta1",
+      "size_bytes": 268435456,
+      "sha256": "53c6f18c50d51ca3726c42f8123ddd77826ae6a890422bbced34556e59176fe4"
     },
-    "b85228fba8b73a782ee6eca361bdc2308933f5a6c8ab7fe9d4d01815021a1179": {
+    "05ee2b94af9d785aab57e5f557a10e35fe8d76fd97ca4da9394329d477719411": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta1.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "0.7.0+Satochip-Beta1"
+      "tag": "0.7.0+Satochip-Beta1",
+      "size_bytes": 268435456,
+      "sha256": "7d00facba08551dce6c95b005a260a306561df1951dd559b9ba191a6ec208663"
     },
-    "f27ab2147470a4666d731a5f8b23bab2df9db4e1f2f3c3fc517d6d454753100d": {
+    "f4127c3e7b0a2e913d96eeedb9bcd448360e1874cf9e02e151e879e4c9d937ca": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta2.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "0.7.0+Satochip-Beta2"
+      "tag": "0.7.0+Satochip-Beta2",
+      "size_bytes": 268435456,
+      "sha256": "6dfeb74c12b2094e593ae2b4e3b79842b7804ee81bb2a5ee5cd4e17755195e4c"
     },
-    "a404f20d1426f754264d15e7d0ad889c509b681faef879b061bd680202f8831b": {
+    "82355879352fb0c93f3b73720ad90820eb383d51d3985b9b9f842aa5bb3de6f6": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta2.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "0.7.0+Satochip-Beta2"
+      "tag": "0.7.0+Satochip-Beta2",
+      "size_bytes": 268435456,
+      "sha256": "a93c8afb30f5e9ce9fef124ce2a70d1ae7875f948124b07de8ef735544133310"
     },
-    "021439edb882f27cfd8ef8cadf0714be741a44a0e9ed983d9f53f9b4f0025355": {
+    "068150ad8473cf79839c1ec2c3d63909b85796e9a9375d600c4caaad04001e78": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta2.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "0.7.0+Satochip-Beta2"
+      "tag": "0.7.0+Satochip-Beta2",
+      "size_bytes": 268435456,
+      "sha256": "6888a563028153b1f8b5dd50dd26c97b0b7b024a55eebd5872bf94257510f338"
     },
-    "579e0973750d4af30d52b2d646b70dece6c51b979c934e22131211e7c413db69": {
+    "68426117c1b49136e048ae43833da540249edc02fa05c2c4c272487991f67e83": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta2.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "0.7.0+Satochip-Beta2"
+      "tag": "0.7.0+Satochip-Beta2",
+      "size_bytes": 268435456,
+      "sha256": "59ff41f1ed6e999d5108629a4294d62cf45369058d8558a2777e2770f3ac0d9f"
     },
-    "a380cb93eb852254863718a9c000be9ec30cee14a78fc0ec90708308c17c1b8a": {
+    "ce618eb3aef276e0aafaa7cf8e81b38ddce66269d84856d549d29638b3cee786": {
       "name": "seedsigner_os.0.7.0.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.7.0"
+      "tag": "0.7.0",
+      "size_bytes": 27262976,
+      "sha256": "a380cb93eb852254863718a9c000be9ec30cee14a78fc0ec90708308c17c1b8a"
     },
-    "fe0601e6da97c7711093b67a7102f8108f2bfb8a2478fd94fa9d3edea5adfb64": {
+    "fe580f04183a2b47bbfdb5ac532ee315d00f64324e90b0e0fe77f23077350f28": {
       "name": "seedsigner_os.0.7.0.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.7.0"
+      "tag": "0.7.0",
+      "size_bytes": 27262976,
+      "sha256": "fe0601e6da97c7711093b67a7102f8108f2bfb8a2478fd94fa9d3edea5adfb64"
     },
-    "65be9209527ba03efe8093099dae8ec65725c90a758bc98678b9da31639637d7": {
+    "94572cb59c4ec2ac309e4eb6dcb63488f937621398d8e5c043fd8d6a0c25ac9f": {
       "name": "seedsigner_os.0.7.0.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.7.0"
+      "tag": "0.7.0",
+      "size_bytes": 27262976,
+      "sha256": "65be9209527ba03efe8093099dae8ec65725c90a758bc98678b9da31639637d7"
     },
-    "d574c1326d07e18b550e2f65e36a4678b05db882adb5cb8f8732ff8d75d59809": {
+    "ece8669e0c3b593b16bec547ac70d0d0c8d1521f48b65c83cc80fe617110e18a": {
       "name": "seedsigner_os.0.7.0.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.7.0"
+      "tag": "0.7.0",
+      "size_bytes": 27262976,
+      "sha256": "d574c1326d07e18b550e2f65e36a4678b05db882adb5cb8f8732ff8d75d59809"
     },
-    "1d0f1c412f64b40e6aba21b5bacdb41d9323653c170ce06d0a3f1dd71fddb28e": {
+    "feb28e55204b5db23f03d74e2262372cdfb0de337845d0083647e53825dc7d5d": {
       "name": "seedsigner_os.0.8.0.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.0"
+      "tag": "0.8.0",
+      "size_bytes": 27262976,
+      "sha256": "1d0f1c412f64b40e6aba21b5bacdb41d9323653c170ce06d0a3f1dd71fddb28e"
     },
-    "c8d5352ed4a86c19eb9ef54f2920934f8ce460742b464ea94dc9114f9f4e039a": {
+    "fefa46297a7198695452a9824020ea92859ac4666b7f7501a32ae41ac50fb618": {
       "name": "seedsigner_os.0.8.0.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.0"
+      "tag": "0.8.0",
+      "size_bytes": 27262976,
+      "sha256": "c8d5352ed4a86c19eb9ef54f2920934f8ce460742b464ea94dc9114f9f4e039a"
     },
-    "11c5553d75b3ebca4988ae3c4573b60b33a12bc4779282454ae34404ba797670": {
+    "616129f840bb84f08d91bf6d7ecd0bb191c7f66085e370de9e05be880528cefa": {
       "name": "seedsigner_os.0.8.0.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.0"
+      "tag": "0.8.0",
+      "size_bytes": 27262976,
+      "sha256": "11c5553d75b3ebca4988ae3c4573b60b33a12bc4779282454ae34404ba797670"
     },
-    "917201e335bfc7ee4189f17827f954f89588dc0fdefdad80d26f2a65c5c8e6d0": {
+    "a319d088bf148cf8fe7d9a96012aeaef645779d4c610067ea03187a1d9b9b96a": {
       "name": "seedsigner_os.0.8.0.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.0"
+      "tag": "0.8.0",
+      "size_bytes": 27262976,
+      "sha256": "917201e335bfc7ee4189f17827f954f89588dc0fdefdad80d26f2a65c5c8e6d0"
     },
-    "75fb58076a2e72bfc42ce99671406ff371ee6687d041b70ad43bd9b80aa46233": {
+    "9fbd13951a0d09ad9d2142cdc4d6f54072a9cabe2b0fac348e24add3eb5dbd92": {
       "name": "seedsigner_os.0.8.5-rc1.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.5-rc1"
+      "tag": "0.8.5-rc1",
+      "size_bytes": 26214400,
+      "sha256": "8f881e1c18f2ecee9a39a85900dc5dfbda0d613a7f1789adec64bd2258d4f970"
     },
-    "7d731c6458e13b5090284c53fe859ba98ed3178b3690e3af29f38f4c2b902ec3": {
+    "c4f079e98b478da0f1589edbb3c8416d2fc70668e4fb852e991bec42f3c7a656": {
       "name": "seedsigner_os.0.8.5-rc1.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.5-rc1"
+      "tag": "0.8.5-rc1",
+      "size_bytes": 27262976,
+      "sha256": "7d731c6458e13b5090284c53fe859ba98ed3178b3690e3af29f38f4c2b902ec3"
     },
-    "d469d31feba8df78e4afb7514cbac50dd72cc1bd22717e1921df819aa8f13562": {
+    "d5dc820618063d05b33308cfcc19e8e1cf3e38d567e20bfaa2164d60fdabb106": {
       "name": "seedsigner_os.0.8.5-rc1.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.5-rc1"
+      "tag": "0.8.5-rc1",
+      "size_bytes": 27262976,
+      "sha256": "d469d31feba8df78e4afb7514cbac50dd72cc1bd22717e1921df819aa8f13562"
     },
-    "650dac5cf7608b9259e7272c778584104862c60089807f1d6266e374b055486a": {
+    "7acd598969220689d5df0e85d1c3ae5581740868b2714d5658365ea1ab1de449": {
       "name": "seedsigner_os.0.8.5-rc1.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.5-rc1"
+      "tag": "0.8.5-rc1",
+      "size_bytes": 27262976,
+      "sha256": "650dac5cf7608b9259e7272c778584104862c60089807f1d6266e374b055486a"
     },
-    "be60f1d04366d827f5fd8f2aeedc8873927bb4f4f9846b02027b3c65706f16b0": {
+    "1abe3bd1d7d129918147e7672806bfd34fab70542791cf7474502bcd1d23ba64": {
       "name": "seedsigner_os.0.8.5.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.5"
+      "tag": "0.8.5",
+      "size_bytes": 26214400,
+      "sha256": "bcb901e27d309d85f086dc80b49b153d6b1caab2247eba2811731384d58f2f3e"
     },
-    "398d9bf9cda0858fe97c0788b353194c1c902335a858b7dbf5d7b213bda75d96": {
+    "1dab30f3dc830626dc980ff6bdf4633ea4262b12c17c13cfc7b8adb88d051fb1": {
       "name": "seedsigner_os.0.8.5.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.5"
+      "tag": "0.8.5",
+      "size_bytes": 27262976,
+      "sha256": "398d9bf9cda0858fe97c0788b353194c1c902335a858b7dbf5d7b213bda75d96"
     },
-    "1e93a82e62d4a1defbdc777a6762a813f4cb5c3ef9090da0bd07542dfd6f62bf": {
+    "de062ffd5dd4ecb673458537ac99b3c46fce9d173858ffb19a940c257301c910": {
       "name": "seedsigner_os.0.8.5.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.5"
+      "tag": "0.8.5",
+      "size_bytes": 27262976,
+      "sha256": "1e93a82e62d4a1defbdc777a6762a813f4cb5c3ef9090da0bd07542dfd6f62bf"
     },
-    "d298ffad3c765e11e48873efc6d1c65e4230528fde4d5bd4701bb507acbf493c": {
+    "68036d1f176777e3438f37f6d6ea2766b552fb3479a7bd7bf644450485ada0fd": {
       "name": "seedsigner_os.0.8.5.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.5"
+      "tag": "0.8.5",
+      "size_bytes": 27262976,
+      "sha256": "d298ffad3c765e11e48873efc6d1c65e4230528fde4d5bd4701bb507acbf493c"
     },
-    "c7b08a13a9d285fedb7bf4d458ca181ba98d6968684bb721a7bf5c2b53b4d821": {
+    "e191c89db930eb78fffa0ddcb745678079fed117d925f062596ff3be2a64d23e": {
       "name": "seedsigner_os.0.8.6.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.6"
+      "tag": "0.8.6",
+      "size_bytes": 41943040,
+      "sha256": "da32ce21f185404ccefd58e76e55ae7f1ac9fe2df2100bc7bbab3e03c5d71b6d"
     },
-    "b4c0c8c741d3a581f6c3afa7133eb3f3696ea44ce25e6927fcc258693826a6e5": {
+    "1543620ecf4988bd8354516036958b654d4165b2602d4d4a7e5a6f3b9a0bc485": {
       "name": "seedsigner_os.0.8.6.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.6"
+      "tag": "0.8.6",
+      "size_bytes": 41943040,
+      "sha256": "d1669ad3aec6046dc43a673056a258e00c389ce23fa0ff754378cd0267516888"
     },
-    "0bb2d03d3771be13da3bc4165b43007efda65c34d4795ab1d2fd3dad6d42e117": {
+    "d336cb1ac7cf2d17253ebc4f32ab8798b62beb51b40744e7f1dce6427b5e3cc5": {
       "name": "seedsigner_os.0.8.6.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.6"
+      "tag": "0.8.6",
+      "size_bytes": 41943040,
+      "sha256": "029ecacc6ba45ae23cb953d7111cf98b0689f1eefb1cee101300acb10167b098"
     },
-    "89a20177e22741df6009e8304120fe7b302aabe8bf23c3cf4e8b1a7866d0aa18": {
+    "cb2296957028f1baf0518b110e6bfc0b25fa59d4ed62bf2124e062a5f8a356f1": {
       "name": "seedsigner_os.0.8.6.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.6"
+      "tag": "0.8.6",
+      "size_bytes": 41943040,
+      "sha256": "47879ded57a91ecf46dbb44825699c53550bbf5aa6aa7c5b6519913a8863d157"
     },
-    "9eb2975a13a4f64f4f1634a7405830b190adaa8f34e3a1b031d8bdd6c78ae8c8": {
+    "2f9dd4da8cbec3a156a3d3bd8fdcec30078d1b262f0e68ec09d25f7340de9afd": {
       "name": "seedsigner_os.0.8.7.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.7"
+      "tag": "0.8.7",
+      "size_bytes": 52428800,
+      "sha256": "67f005c7ace26500a78be3f4d97eaf02d76d018550ec54df011741dde1933ce9"
     },
-    "d354a553a731d06ff44beb79ea324d2d9ca9133355edd9db12f148828b2bed07": {
+    "968147c99b27e3c20cf0403f83edbbefe6c3ea19c61ca20cdc1cff280c8181bf": {
       "name": "seedsigner_os.0.8.7.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.7"
+      "tag": "0.8.7",
+      "size_bytes": 52428800,
+      "sha256": "f38237cdde39efca2fb9e3b3f9f8b0beff2248767f85289bd50657fa69b54f1f"
     },
-    "734942a61f520e0221eeb2d4849953ca19a2cd479fae7d5eefdad9c74cc916d0": {
+    "150c03c80a78c266836f90cb98f1bcc29c2df36440e59cd930c860c00f85a728": {
       "name": "seedsigner_os.0.8.7.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.7"
+      "tag": "0.8.7",
+      "size_bytes": 52428800,
+      "sha256": "9fc7f2ea8462e1c9d62efe41301e12d559e8f155653913e33c93e905360bb813"
     },
-    "6b8518820ad02ab39d268f3e7d0e05332842f19d7b3de416576624630d6e7b03": {
+    "81479f157315f505b050378395f9216d7cd9f0ac1636056a06a868f862d353e2": {
       "name": "seedsigner_os.0.8.7.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.8.7"
+      "tag": "0.8.7",
+      "size_bytes": 52428800,
+      "sha256": "3c2a11a2303abf2a73b10be913d44a1eb85d5e5a15b5389a670cb963afd1e28b"
     },
-    "d73fbb8620fc0462ccc213df942a1e90504ac4dff2958256edc74bb56d09d5a6": {
+    "60a6d33aebf2a3e6c88fb288738221199817d72f291ed8a88fae0942bd7a0d81": {
       "name": "seedsigner_os.SS0.8.6_Satochip_Earthdiver-B7_.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.8.6+Satochip+Earthdiver-B7"
+      "tag": "SS0.8.6+Satochip+Earthdiver-B7",
+      "size_bytes": 536870912,
+      "sha256": "21b23d8ecd70cb450af387bcf694c3ba2ee015ebb3283fd109f89f105ba96316"
     },
-    "30019e5b9c0471734d6b5c7c0242d05bbf016d6cda4e9dcaa7e985b22d079322": {
+    "6f7ab77ff0f602db62cd5f5a7a00d221adbb65972c28fedb387c54a20957d28b": {
       "name": "seedsigner_os.SS0.8.6_Satochip_Earthdiver-B7_.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.8.6+Satochip+Earthdiver-B7"
+      "tag": "SS0.8.6+Satochip+Earthdiver-B7",
+      "size_bytes": 536870912,
+      "sha256": "6d7870fff4a5190d6994c8bfe64bd2309188f8ef6b5f42ef48b20feb4d50f1e9"
     },
-    "cf4b26df1a50c74f9809888878d6f9e5439115ada3b8cdc22d8656b0cd83bdd2": {
+    "d7b2d861067a5dd9b7eeeb43b84f538b7778780a29b2cc0f38b5087f35e5da2c": {
       "name": "seedsigner_os.SS0.8.6_Satochip_Earthdiver-B7_.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.8.6+Satochip+Earthdiver-B7"
+      "tag": "SS0.8.6+Satochip+Earthdiver-B7",
+      "size_bytes": 536870912,
+      "sha256": "01763932ec6f6149a28f059513730c3f42ab4387e34e1ae9fa469e6c3c35496c"
     },
-    "c6e5a64f763adb5b491fd7ed7ef790f466e68ebcb4697b92095c1c55f6b200a7": {
+    "3eb6b1184bf50454631752fe952c05b9b66949c99f00232903dcd46776d0146f": {
       "name": "seedsigner_os.SS0.8.6_Satochip_Earthdiver-B7_.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.8.6+Satochip+Earthdiver-B7"
+      "tag": "SS0.8.6+Satochip+Earthdiver-B7",
+      "size_bytes": 536870912,
+      "sha256": "dafd5ec01befb91a325ed038d1b5a14fd42c365fb63c2d5dd4ef3d9618531567"
     },
-    "d01b90a42f869c00047a0ca73307f3b9cb07ae49ebc9c415f0f92c511e73d247": {
+    "497242b5e1bd524e3c551eaf81580f5ab24ed8e0a57186e567d387d59df85026": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b1.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b1"
+      "tag": "SS0.85+Satochip+earthdriver-b1",
+      "size_bytes": 268435456,
+      "sha256": "c4af327f680d9777abf882682dfa25d03c3c2a9af0b67b7e7a247f3d0e9a0c67"
     },
-    "da7a0620ce6997c3d96134bb87e9086518bca59d23e2feb34e2865c5b3d0f7ec": {
+    "96b0e960341bd6836fc8278240a89e912927aa85fc81a0e21b9008ed428640f4": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b1.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b1"
+      "tag": "SS0.85+Satochip+earthdriver-b1",
+      "size_bytes": 268435456,
+      "sha256": "3d57e0907ef41444fb42793b3051e8cd33b899e73e5faebd0b3111e54d1b34e9"
     },
-    "52f1667dc330f5d3026cde5fa11625479659b21de4264088ae8fe96dcbe91c00": {
+    "78634c38e7ec0d6959175be9d8e8f280d2602fb51a7ce5d4b5d3abd2fad3cfe4": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b1.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b1"
+      "tag": "SS0.85+Satochip+earthdriver-b1",
+      "size_bytes": 268435456,
+      "sha256": "a4469c93e1e86920a549e4a9c4605972c522409312485dad24d213d76d9adc1e"
     },
-    "3d4bb20a823fbef653b12d13b6259667d494259a058aa28bf1d08c80aac61b20": {
+    "9b9f3e89195083d9c6e77650358af125cc07e98b041404ffa927a9b920336749": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b1.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b1"
+      "tag": "SS0.85+Satochip+earthdriver-b1",
+      "size_bytes": 268435456,
+      "sha256": "db07e924fbfc5a14dddea552b55ba4b36dc6a295c4017bb15507d09de1a51e45"
     },
-    "fb7442261c13bcac46ba41407f4edc6c945ff4b0883311847c4708be42d4616a": {
+    "f6d9234115a5e6201ce6411980a73434921a9d3d20508fcbfe8f420c40ef0e54": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b2.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b2"
+      "tag": "SS0.85+Satochip+earthdriver-b2",
+      "size_bytes": 536870912,
+      "sha256": "a2ed31d716aa2fd618b29b8c5d658c45d2cdc722756b7bd952a1ed0cb0316678"
     },
-    "e834b10cab5e70994607b1230bba07a791dfcca37253c698f9acec6cc8644352": {
+    "1694e3e5bda06bae66e7fcd50b604f59afa61ad3fd8175eab2b52f97c035cc27": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b2.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b2"
+      "tag": "SS0.85+Satochip+earthdriver-b2",
+      "size_bytes": 536870912,
+      "sha256": "003eca358b6b2685080093772ce73bee349a30f1a23d5266cdcff3f816e8fc68"
     },
-    "aed3b276eb384f5e91ab57417ceb58536d8056c0b224c6accd8c5bdbb6e5a19a": {
+    "46e141882ecdca731ae3d7a6bb692e9dff7cce0b3422421ba92a016d33a05951": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b2.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b2"
+      "tag": "SS0.85+Satochip+earthdriver-b2",
+      "size_bytes": 536870912,
+      "sha256": "b7fb7a9c11cfae910dba6014c5cef7323be02a98368fd6b88b4b74a3e2672680"
     },
-    "edbb1cd956efaebc95d094073ca268aa26d01cd7941eff710627f3ef63c33a30": {
+    "d2a423f1a91817ff0e1a17831472afd11c49c7cf06d39524e1942a2ebae1e377": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b2.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b2"
+      "tag": "SS0.85+Satochip+earthdriver-b2",
+      "size_bytes": 536870912,
+      "sha256": "5d810112073f4efcd27ed8528d0259952daf059b0640b2f6f36e82fef870f179"
     },
-    "ff352a695758166657b04f01f1aa9db5d950b7fb7652c0cd99c8ec4389afeb28": {
+    "ca75562c8f3578791b09c5f7794c5e6f4677450a6043a6cc3974d03ea3bb9aa1": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b3.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b3"
+      "tag": "SS0.85+Satochip+earthdriver-b3",
+      "size_bytes": 536870912,
+      "sha256": "d6a8d8ed37ea59cb3da6df14279ae7efbd9f5489cc0aed1480ea3178d2e87e40"
     },
-    "ca5d75792a991bdea02283f58110f4f3f1d9227376213789f727c685eb897a10": {
+    "c9ae9b7a88a1ae7f2fb12619ef3de022a083552d9dc9d4ef068fb50020d89631": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b3.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b3"
+      "tag": "SS0.85+Satochip+earthdriver-b3",
+      "size_bytes": 536870912,
+      "sha256": "c81d9a442bfbf9ed5e0239cd2237b13793714272048f141bf67154f9d3797af2"
     },
-    "e94a1b17f9f72f9ecb200aec4b524a3e15bf2f67a9d2cb3d1ffd7c62e4510a20": {
+    "9f2c3cbe22c33dfa7dd2eab12f49ac137a308e9e574539f813a9e592c7d9247c": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b3.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b3"
+      "tag": "SS0.85+Satochip+earthdriver-b3",
+      "size_bytes": 536870912,
+      "sha256": "a435ea7ffa7f6a136c76607e45f89b11898aca22573822e3e749e8f112b7ae15"
     },
-    "17a04cee115e904791652a389a2a0bbe5c12ef9e0ee8d61e3d54315141b55da7": {
+    "450ca7026f7cfea6181dd0c19e10f01c9390c511e6dbfc85ac430cf242f03d6f": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b3.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b3"
+      "tag": "SS0.85+Satochip+earthdriver-b3",
+      "size_bytes": 536870912,
+      "sha256": "978da2835680a6369ecdd5cdc0e8d5f719a9721f1166b0548414dd0006f59083"
     },
-    "27174eee90e0ee9417dcea495fb16066191f8f72b43670bb9997a70e0c9a3632": {
+    "c75d1b687ddb71cf6382a2a5c5f832c2b7cc2b1fdcd75daf827e89e0b6bba415": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b6.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b6"
+      "tag": "SS0.85+Satochip+earthdriver-b6",
+      "size_bytes": 536870912,
+      "sha256": "7fd2ae815e66357ffe5d81e41c3d7d6d3a5d2e5a10bbdcdccd2c6f56fb84bf48"
     },
-    "c4795682eadb9494a812bc797edea1870cb4a315bd4dd6bf412888beee572eba": {
+    "3d4f8e8a1da99333a0cdc6b0f386329182a9b841f2dcc99739606100e09f2b13": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b6.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b6"
+      "tag": "SS0.85+Satochip+earthdriver-b6",
+      "size_bytes": 536870912,
+      "sha256": "7cddfe0c18f47df1bdad4a6a1e889b375218ae9d013fbca380d1d9baddbc2d94"
     },
-    "d65db51696596b4f843b259dac8d3b2be822b4716954ade09aa71f6139b69523": {
+    "3b81a86e872abcfbf98cc7ebe4c7c7198ca6d4bfd0f19b577273ac4dd9a45138": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b6.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b6"
+      "tag": "SS0.85+Satochip+earthdriver-b6",
+      "size_bytes": 536870912,
+      "sha256": "abec998185544a2382339df6fb61bdde6d155ccffafa034da90cbe04f82a113a"
     },
-    "fd20e29e3e856750d6355e4a5387f90a5efc306ed712782d6289aff87678e068": {
+    "54ab6bd6128a214a4b4421f2cbcd3dcf1e787f10042ade5ecc0a8e714e140062": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b6.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b6"
+      "tag": "SS0.85+Satochip+earthdriver-b6",
+      "size_bytes": 536870912,
+      "sha256": "1a197be7fba763cbbe1bf6dbf42fd6fbc3b080f70f3fd09a886982e63fef9876"
     },
-    "f6dd7e5424dd475c885a7a0be111d1a7c62b0565f77fe5198c6fc59ee0f6f5ff": {
+    "5990879bf283b73a8e5f78e5d80d32926ced598a2fe3c9a992eb77eeb37265b3": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b7.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b7"
+      "tag": "SS0.85+Satochip+earthdriver-b7",
+      "size_bytes": 536870912,
+      "sha256": "81f3f5571f53115c8fb1f8bcf6cbec9c23f5560949669188d2df6930c3484b79"
     },
-    "7cacf7ac7485d1f17c1c4e4eb0a9a316bee622bc4e8ee270807f3d8f640a7251": {
+    "a0d8879713874d29f9eb25a8a7dbb9a3f161e09f57350a49163ec98fa0e4827f": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b7.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b7"
+      "tag": "SS0.85+Satochip+earthdriver-b7",
+      "size_bytes": 536870912,
+      "sha256": "e9dbeb2b5daab8f5c61cf5e95492b24af0b99941875ecd858fa1646b1a9093fc"
     },
-    "5ee4ffb7e417651abdaf24dd4d6ddb187b45f3b8bd86dc6c5a1a64410e94b405": {
+    "5763e997818ac47e630fd141995b20d90dd13d9e2dc0bae1e076a608a962e16f": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b7.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b7"
+      "tag": "SS0.85+Satochip+earthdriver-b7",
+      "size_bytes": 536870912,
+      "sha256": "62a2b4a83ecc468d4fa1274436cb0ac238e1b88800eb8f8789150504b2d4fd1b"
     },
-    "cc811c99534d811dd4546d9eab1155b49376f1124fac271c11f138d1abffa0e5": {
+    "ed1b6c31819284ee1dad4617dca1c036d6e1464c7e7f09bad7b88e7c823fd697": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b7.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b7"
+      "tag": "SS0.85+Satochip+earthdriver-b7",
+      "size_bytes": 536870912,
+      "sha256": "21cf1da5ee4e0ce8359dfa975b73969bfaaad834e0e00982042d1b4b3d370b80"
     },
-    "7ef07ae004e845a75a2049c469b4acc8d0e1f10c9569949ff03784209b04ea1a": {
+    "84c1e48a848ea68cf0623570ecba9de08ae47f9fd0b5f2f769572b0a140d0227": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b8.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b8"
+      "tag": "SS0.85+Satochip+earthdriver-b8",
+      "size_bytes": 536870912,
+      "sha256": "60ea074e87054b0aa9a7dfc75331b210dd99dd81fdb6d4b91be6a4469b369d78"
     },
-    "052d7e55fe4eec765b4c5c3020dec4d76f2c370fd9d061ee183bb75cb436f368": {
+    "36e1399076dbff1bbb6778ed804e0418da873c75e7a097222973f74f10af8103": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b8.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b8"
+      "tag": "SS0.85+Satochip+earthdriver-b8",
+      "size_bytes": 536870912,
+      "sha256": "397a14f9c6caaa12b302ee829b8cfbf63792e927f5e76008a5064fb2e982ffa9"
     },
-    "b392ae85a5bb9a9e0c8fda02a9ddc29144c59363e3b41de812be43a081ca4ad8": {
+    "df0fc6a4dff184ee99823839994df7a78c36cb951ecdbee77e17ef3b0f2b7175": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b8.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b8"
+      "tag": "SS0.85+Satochip+earthdriver-b8",
+      "size_bytes": 536870912,
+      "sha256": "87667f3195cb4764a7a1d30159c203f23ae73430b0a4e11855fedb2b9ee79b82"
     },
-    "7a684b9ab23c72d4a2d6d45f0f6804869b5ad17120d24a745e32bdf22e7febc6": {
+    "406a8f88f783a32525e161889809eb5ef338f67b212fac45db873bf752bda017": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b8.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b8"
+      "tag": "SS0.85+Satochip+earthdriver-b8",
+      "size_bytes": 536870912,
+      "sha256": "47eea233f4903857c913f106bba41bf79372bca14848c0b81dc61733cd4b7615"
     },
-    "691845fa57c46ce6e6e20a2440b0a37eae8a242f4727ca84ee7ec6dcc4226093": {
+    "fa8b5c20977d1c246fe70742b29202d15ca27cf40ed2a68d437be5434d87a686": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.lafrite-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.6+ShSi-B10"
+      "tag": "SeSi-0.8.6+ShSi-B10",
+      "size_bytes": 1074790400,
+      "sha256": "dced168d7cad985a1492f2a62924c72cc0e597d32c2b9bb5131dc0b9838e7a28"
     },
-    "b9d60fea778820a03424380e42cf600de6da3e91bdc35c77d32ce73225a9a84e": {
+    "72eeba7efe7d2762e54291caa2ef43b861b54a6d30c05b552d61f8ad528649ba": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi0-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.6+ShSi-B10"
+      "tag": "SeSi-0.8.6+ShSi-B10",
+      "size_bytes": 1073742336,
+      "sha256": "5227f76eb8ede684db3c0382df994ee32a8a4a1391eb3c83bb989738eed65ceb"
     },
-    "6853135d107387311f31d78a3800a64f12cb66eff333e0f2d65652d0405d6ff5": {
+    "57865f81820217d5c95d29e6a3948a41fa2018c2d63e67a1b61b6f4ceef99377": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B10"
+      "tag": "SeSi-0.8.6+ShSi-B10",
+      "size_bytes": 536870912,
+      "sha256": "8f0d825ee1c93f8aa282ca4101cda3c5e708af2a89dc9506455b55ccea63c288"
     },
-    "17d45b820e25cf44339c72057402a2499d2c61ea76727de8a09db3b18036351c": {
+    "6c2019cb580cc59f2b9e81066fd224bacf99604b295c92a3c7829506ace154b9": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi02w-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.6+ShSi-B10"
+      "tag": "SeSi-0.8.6+ShSi-B10",
+      "size_bytes": 1073742336,
+      "sha256": "a93a80f297ff395a574d3812de53ed90a7754139bb5dd4eebc30e748a3f01c46"
     },
-    "5aa0c3447ad5e52a6a900922a3b353e2fcd32864f0b0945f73370045d52817e9": {
+    "a3d788002956b3f6692065a11f1ac0b839a07fddede085839b90928f995a281e": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B10"
+      "tag": "SeSi-0.8.6+ShSi-B10",
+      "size_bytes": 536870912,
+      "sha256": "db2909184bc2d428901309f459b135dc02d174ad2103089352cd10e3d2a268ed"
     },
-    "5bf7ce0a5a553aba712b3246b4238ec7fa8f73369ad150468b558446f4a672da": {
+    "5fc55c7c63907f0b7d7db5fe76ae5e823b4bebd7e5dd66c30c966f063969acd3": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi2-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.6+ShSi-B10"
+      "tag": "SeSi-0.8.6+ShSi-B10",
+      "size_bytes": 1073742336,
+      "sha256": "6214c111f585775b6f191af58e7f67813bd011345934efff1e489d9b5ef1f923"
     },
-    "5608017a12bc7aba1f0e880b0922ee17c9b31aba9940eaac06ca4511e5a48760": {
+    "ea84c6bd216c5a531f2d303294082c53e2e1371131ccba43439e0ca05e0658c8": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B10"
+      "tag": "SeSi-0.8.6+ShSi-B10",
+      "size_bytes": 536870912,
+      "sha256": "cab050423c52fac596a3074d846ebb35537f833a6b8af8b041603a6cb4974fe4"
     },
-    "a5036a84c3e12d3a77e06de303a98b8f76b5d326700ed1855101c785ff2339f1": {
+    "0d5c41fe115b67cdf58c21f3d0fc3580bbee267656c3e02eaae4a14c7b85e8b5": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi4-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.6+ShSi-B10"
+      "tag": "SeSi-0.8.6+ShSi-B10",
+      "size_bytes": 1073742336,
+      "sha256": "528c2464a3a8d0717c7beac1b58060eb4b2c459ccf151e5a615f875424e87580"
     },
-    "30e0df593432c1ff7e9f9d3c9e57625ee81bc06a7819bebd906724fa7d5bd1d9": {
+    "0d655159e022fa8aeb8ac4f95885a9c8aef47f03b8639a2f8125df6fad361df0": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B10"
+      "tag": "SeSi-0.8.6+ShSi-B10",
+      "size_bytes": 536870912,
+      "sha256": "11060b2c371ddd60403af90643495f1d42674fb9ea1d01bf6954efc96531defb"
     },
-    "83dba55ac8aedc5df5939c5172e998b1193b03362cab210ee66f8de475e662c7": {
+    "357f3fbc32fac9f42d879868da093a9689ce2da9a2cc65993a6d23ac6eb9df72": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.lafrite-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.6+ShSi-B11"
+      "tag": "SeSi-0.8.6+ShSi-B11",
+      "size_bytes": 1074790400,
+      "sha256": "847ce2466a76ceffa43fdf6fc9a1049291af2c2c8fa26e65efe77ef4317a6210"
     },
-    "de15156ff0d955f57fe47d20bebae211eadb7c280381a7f615b16cf9aff1c066": {
+    "9266ae109ab40e822412e86ae031ba39262a19982eeadf8241b62a6d224e7163": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi0-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.6+ShSi-B11"
+      "tag": "SeSi-0.8.6+ShSi-B11",
+      "size_bytes": 1073742336,
+      "sha256": "2f74b3aebae92a6ded734a01c13a95c06e0470f560a017955e8da85d10b6b209"
     },
-    "ff1110d73a9d9a4a70304cefab75c205ec889dc7488379a847b8f22aedab56bd": {
+    "577ece737373506ed50f851e1aed6b6abd950363ec7d275514e8884f3e28a2fa": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B11"
+      "tag": "SeSi-0.8.6+ShSi-B11",
+      "size_bytes": 536870912,
+      "sha256": "911281933ad68a2bda3a349facca5a34e562692170da16bb97e32a1ec8bf8af4"
     },
-    "c675886646ef7266b6ff306daa6ce7064f4b32d673dd29fcee3291cbe375dca3": {
+    "71dddc0a37776123d061bd12b3cf7a9bbc2cd750738c45a84b91a064fc3d6cea": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi02w-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.6+ShSi-B11"
+      "tag": "SeSi-0.8.6+ShSi-B11",
+      "size_bytes": 1073742336,
+      "sha256": "ce658e7a893c072c8a3401b92bc59a3312f19cfee674d0a7c4b3ed787ec39383"
     },
-    "97161ac05a4093c7cff657230f03e342fbcbce5127a066c6b466b91c3bfea9a5": {
+    "c70206ade907ce28844a56101d63caaf5d2f6d3930461b652d90848a4d021a6b": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B11"
+      "tag": "SeSi-0.8.6+ShSi-B11",
+      "size_bytes": 536870912,
+      "sha256": "39c3f63e3184c1703381c20ab00960a79b6cd74c549288c85bfe67b83d59767a"
     },
-    "9098c54fa84205e873a02af3c242fa8ccdab6062a0a38748f478d9d4232edaa1": {
+    "390006f8eccecda74782ff95670636c7af3d936a0712e915722f74c803d9006e": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi2-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.6+ShSi-B11"
+      "tag": "SeSi-0.8.6+ShSi-B11",
+      "size_bytes": 1073742336,
+      "sha256": "6a01cdac5a43d54b00eb681e8ad1e95401a006228ca4d2e4815d9e91e0755b9c"
     },
-    "5762b3cace5b8775400c6c6d063ae3835272fa13c1df8b33085c7b3e4aca7bfd": {
+    "eb0267bee49fac0e1aa1824dbdb74a592939afb4b56577426d5afb139073bacc": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B11"
+      "tag": "SeSi-0.8.6+ShSi-B11",
+      "size_bytes": 536870912,
+      "sha256": "084206f217f399e49e568a14e1be14bb89b833360f01843044a890ab9539f1f1"
     },
-    "81784b67d2a2606fe90deb2fc7dce20eed1c1a00bd77871fb073752bd71637eb": {
+    "53565a183bdbc260ef674a45448c5df561e8eb66a5b5e37029bd9e7fead3564b": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi4-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.6+ShSi-B11"
+      "tag": "SeSi-0.8.6+ShSi-B11",
+      "size_bytes": 1073742336,
+      "sha256": "00ab52b6d39ac84ae67ea3591b2962b02d9c6e25c3197696d5634db1e60f50ff"
     },
-    "606e641b74922effc37d7e7e475a66eb24eb1d935a4d3d6dda983dcddf94b094": {
+    "cabe343a3da111d13b89bf1abdeac95b7557ec9b6a212d9040d1d22cc733b792": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B11"
+      "tag": "SeSi-0.8.6+ShSi-B11",
+      "size_bytes": 536870912,
+      "sha256": "5c5fe473fcae1ee9abec1e7cabaef3ece420f8344334fd23ed734c1ad75c1811"
     },
-    "b7e8ab3c2fda2f35fb54a412bfaef2fcf646010ec4a61114b06d697656bc82a7": {
+    "8b98972869f54c8eba0f05feaf1bc3d5a2f5abf3661fad53446f757e0d44ab14": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B8_.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B8"
+      "tag": "SeSi-0.8.6+ShSi-B8",
+      "size_bytes": 536870912,
+      "sha256": "bced042a86ef96b7156a572ab1906f1130358384eaafcc3aa8beeea2a9cdf07c"
     },
-    "269d6e953d5fd958849bfa9c8325abe50dc7f90f98a61330c1203027b3f2e26a": {
+    "4b4b2c9256579ce613ddad8bd7b611d424753f2c1b476eb5f503ced85b0c182f": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B8_.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B8"
+      "tag": "SeSi-0.8.6+ShSi-B8",
+      "size_bytes": 536870912,
+      "sha256": "80d5cbdca96a05fd1e675bafc9f9939a1a98be58c42beb35fc845edc52984e35"
     },
-    "55024f57ffc2198c72ed6505b316faa9c8e4a24445cb6d90966cad4934f65714": {
+    "678cb967aa5a2f229323490542f7911201daeb2420e4c00d0cb01413edd77130": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B8_.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B8"
+      "tag": "SeSi-0.8.6+ShSi-B8",
+      "size_bytes": 536870912,
+      "sha256": "61021315a28cf6b84a0cdc009dd1c66ff3e51d34c67b4a29fe5099b6f4cd4736"
     },
-    "9557041a48596ca0ef2c355f372c468655745e422d2ebef07b6f676d64e978ff": {
+    "19358f4dd284c3a11769fa59e63132be3cc20ea9bac52ce4e5087ec320db486f": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B8_.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B8"
+      "tag": "SeSi-0.8.6+ShSi-B8",
+      "size_bytes": 536870912,
+      "sha256": "7791c38412d2c6f822ddb0a85d4f94523dd8aa74496be6602f7bda5a2c463501"
     },
-    "8d2f2f53b9d15e30a66409f772b11e73221040d83f803666e1fbc39508edc65b": {
+    "94b84e8dfaa2e68ed471232bbc9b8ad8074020195870e69ff0271f48632e01ed": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.lafrite-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.6+ShSi-B9"
+      "tag": "SeSi-0.8.6+ShSi-B9",
+      "size_bytes": 1074790400,
+      "sha256": "0c8444943667720ea5ce421edeedb674b0bf789fac4f1734511cd39bcebfa4b0"
     },
-    "1d30efc6edf44b7f8186c4d86c75829e0354bcf0c63a61274430a86362c04f7a": {
+    "c8ef877cd9237c8dd9c9213af2582503e93c653c4654072eba412e3f5c1d00fe": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi0-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.6+ShSi-B9"
+      "tag": "SeSi-0.8.6+ShSi-B9",
+      "size_bytes": 1073742336,
+      "sha256": "adaae6a49cbce92292a9d72661f9b5e3042b5abfb7f5220d68c494f334697bf5"
     },
-    "0bef3a33d4f631b36d1b423d52a88de57037f0e2390d9eb295a9fe973687a092": {
+    "63a487f234ddc3dbbb022e9ba1353dd655eff182d74e4c9deeff8fff373d5a9c": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B9"
+      "tag": "SeSi-0.8.6+ShSi-B9",
+      "size_bytes": 536870912,
+      "sha256": "4256c415919c27599c088114e462e633c70b04ed0ae23d2258e495a1ecc7a145"
     },
-    "5fc5c2c6ed6c622d9d7a7bea56e2d1c84e25f795d8cf22b17a41c9e525e4e95d": {
+    "cea9d1d3c107519e0f9f44ea18eda546ebe79ef892bae4f30d104fe51b70f5b3": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi02w-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.6+ShSi-B9"
+      "tag": "SeSi-0.8.6+ShSi-B9",
+      "size_bytes": 1073742336,
+      "sha256": "b2830194e8606bbbc6f98b653ef78799f866c27fbe98f45ad16c9586e54a6655"
     },
-    "5741370e49a39b63bd0dcdfdb05247ae97d5f2ed1d714e76101f88c166658cc9": {
+    "80dd09bec056b1108fbd92aceecd690bd125839ea6d9f02dc4c795b351ab339f": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B9"
+      "tag": "SeSi-0.8.6+ShSi-B9",
+      "size_bytes": 536870912,
+      "sha256": "71c19945eb059bf488ae9bd34b9ac6c49fcdcccc2261a7756de80ca8ea9c8c0b"
     },
-    "eea74829a1d3397b237288afe43aaa800a3cd220672553b3c15ce27c96b28c1a": {
+    "c8a55ccf28bcadbcab8eaf6972315c41bc0e7b3934402f4e550f8dda78bece5a": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi2-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.6+ShSi-B9"
+      "tag": "SeSi-0.8.6+ShSi-B9",
+      "size_bytes": 1073742336,
+      "sha256": "6d682230d3b70449a3b82dde722182023569edf86ae1558b585ac96fba9e0aab"
     },
-    "966a19954567dd20b0a610c3142778f1a0ca4833aa631ca2224c543a62954c26": {
+    "bf340bcc7dbbd588ae53ce92d5344bd882832a27005b19bdb394cefb4ad02b67": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B9"
+      "tag": "SeSi-0.8.6+ShSi-B9",
+      "size_bytes": 536870912,
+      "sha256": "dab60648cf40826fce3efc28db44db3c0b4c7b382dab35ad7092e9a0c4a170da"
     },
-    "bf868ff833b5348dd6d46a4e19565c265aba5dff46ac8ff29317606cd12a2e77": {
+    "5cf12939aec30c562fea723c70aef57f2b6ea7ccc7a67d1d6a804e329c6aec5e": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi4-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.6+ShSi-B9"
+      "tag": "SeSi-0.8.6+ShSi-B9",
+      "size_bytes": 1073742336,
+      "sha256": "ffc4b8b29500e76b7c086f4318e4e68fc647b5d19e42518c9605a776f0ba7c77"
     },
-    "a9a0e61b91cf48796f399d3e85e548b710aa12563c87c360b7746a0edc58c389": {
+    "e3ec434984adadb7211c9e151e608ab3504d9a9826c9418f9b1679e2e64eb556": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.6+ShSi-B9"
+      "tag": "SeSi-0.8.6+ShSi-B9",
+      "size_bytes": 536870912,
+      "sha256": "718531e62237297bb09e1837481bff5905dfe8cc280efebac86a752d62027f9e"
     },
-    "b86976d81fb4ad1526c43abf7c0bff2c3ad0e6b02f24ce170ee0d9a5173a28d8": {
+    "596b0bf0a1ace8af094c1a77a0d501802203426af606f489d0546ca910f32000": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B11_.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.7+ShSi-B11"
+      "tag": "SeSi-0.8.7+ShSi-B11",
+      "size_bytes": 536870912,
+      "sha256": "1b844cffdaa382d32a100d690cc0be5dd1208d23278fe22fea46593f47fb68a0"
     },
-    "7930616bb95508f0102088cc66319c4b186c2e6d712d6e762f72db5bf40d3de5": {
+    "a0077902135c9f6c9080b191618b1951b7d607a623da3584ed41723ada653faa": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B11_.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.7+ShSi-B11"
+      "tag": "SeSi-0.8.7+ShSi-B11",
+      "size_bytes": 536870912,
+      "sha256": "2866932dc06355f7f2f272f44464e06d67884e825be0ad11219379e1647ef3d8"
     },
-    "b34458ae7f75011ce7102e8902a35c9643931d689a2ec32f3c89870ecb656f5a": {
+    "ce0d6d96e09b99f1f7a8f45eab1c9db1e2b92fa097241febf3d8d361442f1237": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B11_.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.7+ShSi-B11"
+      "tag": "SeSi-0.8.7+ShSi-B11",
+      "size_bytes": 536870912,
+      "sha256": "f3f870cf7c5d59e112a1d090673c11813868210cc2740b5d2284951a2c1f9485"
     },
-    "2716e262fdea652c12045e9a2596e5b02eea3145c27ca19e54df8467a1a53681": {
+    "e262d1d69c254d9f9756aa3c293c12c044804dd98a7df18ed24b1777d5b7b16c": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B11_.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.7+ShSi-B11"
+      "tag": "SeSi-0.8.7+ShSi-B11",
+      "size_bytes": 536870912,
+      "sha256": "97324ab558281a5e3539750b8a7d85d3523383e6555b00eb618d4539343c04f4"
     },
-    "e3b3647c0e2bbbdd354bc3e1c35bba04f6b6c0bfa8dbc1d226c34f63eae271b1": {
+    "86f8f502e5e7439123f2807004dfb35e1b25efcd8c3cd77fbc240e00854ddd99": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.lafrite-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+      "tag": "SeSi-0.8.7+ShSi-B12-pre",
+      "size_bytes": 1074790400,
+      "sha256": "edb151e73386b92b3f076999fec6cc012bfb0980ea5c6cf80092c1927e43bbe7"
     },
-    "d66c688d6eb59551c660a912af92e971aff3fd45d7eabb7dd84733359866ad1c": {
+    "318dd072d73b5543abf5705a648289cabe881af05dca2c84dfb075a155c7a331": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.lafrite-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+      "tag": "SeSi-0.8.7+ShSi-B12-pre",
+      "size_bytes": 536870912,
+      "sha256": "c1177d0f6bd630b7770a49b300f447cc086865356ea2b533c4a7de6ba51f694e"
     },
-    "3995eb32d39921c08e27644844e91bf34b909f67c8e7c2432e9fea775e07133f": {
+    "07b14bd9e82ea0a190eba0f19c97b6327d5afe9f2a2b859459336b1eba6e0c59": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi0-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+      "tag": "SeSi-0.8.7+ShSi-B12-pre",
+      "size_bytes": 1073742336,
+      "sha256": "48bc872e9f5737fd289a23af771b3a53f8dea76849b6cc0deadfd682455feafd"
     },
-    "51702c09f6ecd5ba773e7ec6d18658a5ccdc07a040e58b7ad20916ae718e7a69": {
+    "0c830806141e5ba7b5b8153ef7507ef48bcee9396fa9843845f0b6f7a47bb18a": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+      "tag": "SeSi-0.8.7+ShSi-B12-pre",
+      "size_bytes": 536870912,
+      "sha256": "22c6843179547462157e4feae4f26cb482d1f27997fec7cb2d6d1fe0399bf88e"
     },
-    "5bef9a5dd5e7acf9460ac2416985ede5dfb2903c66c6c5db17352ba8405a5b53": {
+    "3e298f6c71691df7e46d3ce8a33398914290cc50ba5acbb2be6035ead5b24a4b": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi02w-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+      "tag": "SeSi-0.8.7+ShSi-B12-pre",
+      "size_bytes": 1073742336,
+      "sha256": "44e9f8c4a920fa50bea835347390ee120bc227ad6c8b491b090ce02562b139f1"
     },
-    "70848fdbd5aa3e8f190b637466708fd880562fb5e32e16a28176f4de34f19df9": {
+    "419bf2666b50a28459f3a057b4b779f4742a45a30ef0365b6726c961a8ba5e4d": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+      "tag": "SeSi-0.8.7+ShSi-B12-pre",
+      "size_bytes": 536870912,
+      "sha256": "b5b3237e26021a307cc27cc1a4a8c64b01c2bf75766ff54167cd2ad5c18e7964"
     },
-    "7b6e6717ef0da5bba9ea70ca89a676362709dfe64e87a3bc2dee702fd6ae8d24": {
+    "42463e8800d8c4fd640fea8037d05066251497afd5edc1943b989c134754805d": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi2-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+      "tag": "SeSi-0.8.7+ShSi-B12-pre",
+      "size_bytes": 1073742336,
+      "sha256": "9272f785811ba49c7b4e1610ad58f76f2acef07e6dc5813d8f45be6980f9fd9e"
     },
-    "95082ad6c6cdc58a96f2f729dbb151b64f0e1cae4acef1b0116c1b856fac52b8": {
+    "be87f69f9c54feff3cbef683d2a16c3027a6121404f608d65d892c7c524b438b": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+      "tag": "SeSi-0.8.7+ShSi-B12-pre",
+      "size_bytes": 536870912,
+      "sha256": "a02b7b227d7b25445492fde9f5478724201291a0c0de4606375a4d465985a523"
     },
-    "abc17bb042814089ac2c5cb7ce0dc639e4967fe4298f2db112369c45aa2ba0b0": {
+    "f2e0b9d40d79e6fa57eace59fec5762690e859886f952d47ea6149e012dd1007": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi4-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
-      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+      "tag": "SeSi-0.8.7+ShSi-B12-pre",
+      "size_bytes": 1073742336,
+      "sha256": "e96f911222e788054520934eb40d23b212d4f4cd1baba3d55eba37b6147ef27f"
     },
-    "7c3eca28dd99e75a001ee6455c97b0d18ed2eb232f16f494069071a7e9a879fa": {
+    "91a5e4ce487804441701fa9b435fb87a553dd225c9f05bea5f54ccf3736e8016": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SeSi-0.8.7+ShSi-B12-pre"
+      "tag": "SeSi-0.8.7+ShSi-B12-pre",
+      "size_bytes": 536870912,
+      "sha256": "24aac5551e8a19e7c5ac90475be88abcc024b591eab55d1eebd804b9e286e3c1"
     },
-    "0125a90a9ec65a56c0bd49ca2f4eb4fa46a7d7d36d4b6b3f873b1ed29707cb1e": {
+    "680c2a0f9249ad7166fd938ef888660d82b3e67277554f94fc4e49971291c784": {
       "name": "seedsigner_os.dev.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b7-pre"
+      "tag": "SS0.85+Satochip+earthdriver-b7-pre",
+      "size_bytes": 536870912,
+      "sha256": "33e602415667fe621fb88d8724c5b98bac7cf0d3f37718787c60ba0961c64c2e"
     },
-    "5c8db62871dd87e61782834aeeb5dbfef232ecb67740db9a709f74c7e77be833": {
+    "8efb6ca331886fa4bc7c642ad9d30b1953f0bffde09b57397ffb2152a88021a8": {
       "name": "seedsigner_os.dev.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "ss0.85-b3+earthdriver-a1"
+      "tag": "ss0.85-b3+earthdriver-a1",
+      "size_bytes": 268435456,
+      "sha256": "5f48ab403951abd3399af1fc034cf1d4b3040166388cb93b107819217d606fe8"
     },
-    "186d1753f6cc8f2664fc3418e0123e00bfa89c0b4a9995b37a3667a1a757b805": {
+    "cecaa67c65763fec33046693bc5d6858aa61c0ff1da42972bce6b0b6add4bb78": {
       "name": "seedsigner_os.dev.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.7.0-rc1"
+      "tag": "0.7.0-rc1",
+      "size_bytes": 27262976,
+      "sha256": "186d1753f6cc8f2664fc3418e0123e00bfa89c0b4a9995b37a3667a1a757b805"
     },
-    "0c84bce6415b27798af867174719316687ac3635ddba99f23f9c7a8bc0d8f053": {
+    "50e99c2563d0502e2245fc7cedcb6f78ccbf155bb65acd88b865bf548b8669bb": {
       "name": "seedsigner_os.dev.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "ss0.85-b3+earthdriver-a1"
+      "tag": "SS0.85+Satochip+earthdriver-b7-pre",
+      "size_bytes": 536870912,
+      "sha256": "bd87be9b01ea99b9f1576e91695774e7f2f5a3f758b99e1cd4112e6cb5337968"
     },
-    "ce1431b28fd92da9c203fa31da91fee5efd3866ff2958683605fc3b3178c3796": {
+    "611f03214702c7b788513f4d6d298077cd6f21f17c16927568635ef1345f151d": {
       "name": "seedsigner_os.dev.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "ss0.85-b5+earthdriver-a2"
+      "tag": "ss0.85-b3+earthdriver-a1",
+      "size_bytes": 268435456,
+      "sha256": "33fddc91705d15492eb0dd53706eb08c75932e07eded6606b81307e5ae8b01c5"
     },
-    "e84a3452199d6c23733c668e9c71f49b270f5dd59d72f93e6269f9a8ad3074e3": {
+    "d2688d1e95b7de307bb25580eefd0b08ce029cac39463fe1e00243252588ea6e": {
       "name": "seedsigner_os.dev.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b7-pre"
+      "tag": "ss0.85-b5+earthdriver-a2",
+      "size_bytes": 268435456,
+      "sha256": "05ae4c3d74f91baeb3f5d39e562c416f7a5057ee14d31ac097e0049f6b8c5d61"
     },
-    "7fe3ebfc60a6e8998dcf5a7baa198e07405bfed48d20a005a84ff4d71b93afe7": {
+    "758c2622f819c0edab3f15172f5648a519b900ade54f4785ae1dbd9dff1b415c": {
       "name": "seedsigner_os.dev.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.7.0-rc1"
+      "tag": "0.7.0-rc1",
+      "size_bytes": 27262976,
+      "sha256": "7fe3ebfc60a6e8998dcf5a7baa198e07405bfed48d20a005a84ff4d71b93afe7"
     },
-    "00b50bffb35f949e672950e72fff0babd2902a07940b0ede8a38d16ea1d9529c": {
+    "cd6815194264f6b339f21101856852524517d13f8dd46f92df376996e52bb7bc": {
       "name": "seedsigner_os.dev.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "ss0.85-b5+earthdriver-a2"
+      "tag": "ss0.85-b5+earthdriver-a2",
+      "size_bytes": 268435456,
+      "sha256": "031f9aeafb333a4f98edb41647234dbbae08d7bee9104ccb24c8a5ac5bc2eb43"
     },
-    "fd9fc64c84c03f58a2bcc9d7378b6c991c989f23e1e96fe678c05b4d8cc59da2": {
+    "d102641d7e4a2c286714c2566330b0f7412446a26a38be296e8c718280899a4a": {
       "name": "seedsigner_os.dev.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b7-pre"
+      "tag": "SS0.85+Satochip+earthdriver-b7-pre",
+      "size_bytes": 536870912,
+      "sha256": "3c07aac625d8a7ec496ca2a9c6cb1b63a600a8b04cd742c66f5d378fc5b5c5b2"
     },
-    "05d16b71a0d60e6cd329e16fe0b9f36fa6de9d3ccee326c42629db4d096afc0b": {
+    "3126a67e992a889ceddfe6da22a913a6261946ae39869c3fcec8905126e34082": {
       "name": "seedsigner_os.dev.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.7.0-rc1"
+      "tag": "0.7.0-rc1",
+      "size_bytes": 27262976,
+      "sha256": "05d16b71a0d60e6cd329e16fe0b9f36fa6de9d3ccee326c42629db4d096afc0b"
     },
-    "34ed3374c76e7a096dec934c411f2dbe5d06c9cd6f385492b9f4c69570689a11": {
+    "551d4c1e37e1e3f02358f8092fa4309fb13d44588af49fd25f659a127ada73e1": {
       "name": "seedsigner_os.dev.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "SS0.85+Satochip+earthdriver-b7-pre"
+      "tag": "SS0.85+Satochip+earthdriver-b7-pre",
+      "size_bytes": 536870912,
+      "sha256": "560ab3517b504c3f8f24671fae76f377dfb0c03bb78fcef029bc3cd3e808cf4c"
     },
-    "536c0bdbb20a06db8235f4bcbf60791c44cdfdd9be793b0dbcc215a124e9c9a7": {
+    "d34bf21b8e39a6b8145688408ff96e7036988d0c634988d88eb9440f2065a6e0": {
       "name": "seedsigner_os.dev.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "ss0.85-b5+earthdriver-a2"
+      "tag": "ss0.85-b5+earthdriver-a2",
+      "size_bytes": 268435456,
+      "sha256": "e1dda62b736e06fb6ed0a2fca9c5d9ffdeccedca4711a1af4a1df15d2d5d3270"
     },
-    "554756f0be105bfa184be2d9d1b67afc43e59b27bf359b59a8d035f65fd6b77c": {
+    "77e882c765f21ecde5bc0a2cb90834c19e279b2423c8022645243a3de455621a": {
       "name": "seedsigner_os.dev.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
-      "tag": "0.7.0-rc1"
+      "tag": "0.7.0-rc1",
+      "size_bytes": 27262976,
+      "sha256": "554756f0be105bfa184be2d9d1b67afc43e59b27bf359b59a8d035f65fd6b77c"
     },
-    "b73b1a45c8c54803edd954673d5cd83a17d6f27687ee2861205b89027bb09599": {
+    "a3d091c5de38d3fb48b3315eab949b8e266cacd8490faad22a462ab83169fbcd": {
       "name": "seedsigner_os.ss0.85-b5+earthdriver-a2.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "ss0.85-b5+earthdriver-a2"
+      "tag": "ss0.85-b5+earthdriver-a2",
+      "size_bytes": 268435456,
+      "sha256": "3ed8bff5a8eb1c8bc9ad83f1c3a69466d6884284f225832adf0ab7b26790e3b7"
     },
-    "baefc47eabbf52d7e144c9a33ee4a4c86933efe7bcc87f5e8296d813d86e1cd3": {
+    "c6c2984a672be7218c5cf166b983cef6b548a2efe8191947577f5ae6a01be8ee": {
       "name": "seedsigner_os.ss0.85rc1-b3-a1.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "ss0.85rc1-b3-a1"
+      "tag": "ss0.85rc1-b3-a1",
+      "size_bytes": 268435456,
+      "sha256": "9af0d9fef3a611ffd70b42c66d1b2da4b1b92ede3806d4f1b74f31f88140c843"
     },
-    "354411bf478c30b87571ca81525050bf0e3fce2692a3fc700b63c2d91c974342": {
+    "e38557995f3655e5594560b6fd360b82f793b4d7214ba4daa921345b6a2ec1ce": {
       "name": "seedsigner_os.ss0.85rc1-b3-a1.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "ss0.85rc1-b3-a1"
+      "tag": "ss0.85rc1-b3-a1",
+      "size_bytes": 268435456,
+      "sha256": "249c0ad270e7eadafde4dbb9bd2bfa3176302ba03f0775cdaf6982f412656e8b"
     },
-    "160a3d11169347105e8e1d090b858c6bb34b35575f01e2b234dfa76bc316e824": {
+    "943363a4060f03c751a8be2416373830d18ebee7690da496fa155c8a2c92a08f": {
       "name": "seedsigner_os.ss0.85rc1-b3-a1.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "ss0.85rc1-b3-a1"
+      "tag": "ss0.85rc1-b3-a1",
+      "size_bytes": 268435456,
+      "sha256": "4f143fad305d7e11753d5c35de8d66a75ba0a7e034b9db18bf4383039cbf2660"
     },
-    "efcef748ee663b8b607b3cbce8e7514ffb628e9d9f152e3a36f018fb6b1d8476": {
+    "f0ab8dd57eac72c7485ea657257be48572d317747940c56e9bb417b415939937": {
       "name": "seedsigner_os.ss0.85rc1-b3-a1.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "ss0.85rc1-b3-a1"
+      "tag": "ss0.85rc1-b3-a1",
+      "size_bytes": 268435456,
+      "sha256": "d375063decb50291386f914325f0f66d022eed1774cb85e1596bc19796c7454c"
     },
-    "c927ffc35a515f0d219802696c3ecea865a877c1a233d07304650fd5d0c44302": {
+    "f9cc3be28337fffc97868438740d7b693e99f43a87e04c673a985595986cfe85": {
       "name": "seedsigner_os.ss0.85rc1-b3-a2.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "ss0.85rc1-b3-a2"
+      "tag": "ss0.85rc1-b3-a2",
+      "size_bytes": 268435456,
+      "sha256": "ef133c84e95249a4e125e6aa3734e1f37a317cc329b0ba95580a17075f2f7cc7"
     },
-    "f371444d967f3e14aeb9146bb11fcc093b42490bea471d81e7bb0e60fcbc2b1c": {
+    "0791aa8863d7760a2338568a2684d642dd52033e38d6ec329e869bcc60a320dc": {
       "name": "seedsigner_os.ss0.85rc1-b3-a2.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "ss0.85rc1-b3-a2"
+      "tag": "ss0.85rc1-b3-a2",
+      "size_bytes": 268435456,
+      "sha256": "10a4ad1eef73f2f21b152d504458953d3105928f5bebd194f699b76ff1e35028"
     },
-    "3591e4726dec103e5e5bc921794e374aa817f0ee9d76eb4906643cf8e5fd2492": {
+    "76a67f12fa296f47cd92e3bcde4be043546e642ffa91b8c7d6c130c741e8cda3": {
       "name": "seedsigner_os.ss0.85rc1-b3-a2.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "ss0.85rc1-b3-a2"
+      "tag": "ss0.85rc1-b3-a2",
+      "size_bytes": 268435456,
+      "sha256": "b0f89dd6b45d96befa23b93452a7d16614143a141339770f1bb891809b0bcbfc"
     },
-    "384a573dc517d6404ae9d9ecbbf46c70589f94e48800797e8f9872bd2dab32e6": {
+    "b72d7c89006bce645046f01865c25e6d1b96eb77d870f559d7df93b333a15035": {
       "name": "seedsigner_os.ss0.85rc1-b3-a2.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
-      "tag": "ss0.85rc1-b3-a2"
+      "tag": "ss0.85rc1-b3-a2",
+      "size_bytes": 268435456,
+      "sha256": "bce7a3c36a2040596e7aaa766f09cae0a9e37976f6c065de769eaf677f55a4eb"
     }
   }
 }

--- a/src/seedsigner/resources/microsd-known-checksums.json
+++ b/src/seedsigner/resources/microsd-known-checksums.json
@@ -7,924 +7,2760 @@
       "source_repo": "manual",
       "tag": "",
       "size_bytes": 27262976,
-      "sha256": "5809d4ec68138c737b1b000db4c6ec60983e94544efd893bdfa40ebf19af60f4"
+      "sha256": "5809d4ec68138c737b1b000db4c6ec60983e94544efd893bdfa40ebf19af60f4",
+      "volatile_offsets": [],
+      "alt_prefix_hashes": []
     },
     "e36078f836278c7201f51bac3d21583df30a0cf58ed476f5aa8c2aa4260dbd28": {
       "name": "seedsigner_os.0.6.0.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.6.0",
       "size_bytes": 35652096,
-      "sha256": "750f406c133d17994eb58544aad82b20f1478c8663af303e45b2d9c49c4e9825"
+      "sha256": "881813e798ca13f9de17f3958a565973e727827c51e9d5b470c2e4a04db209fe",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "8d00bf28f48b63699cbccfb41eb67aebdf028dbc377927be0680246484660f0b"
+      ]
     },
     "3ee6250a718eb8e333eb750edb88d4b89c76311dfe7b4b09c0d02b0241effe57": {
       "name": "seedsigner_os.0.6.0.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.6.0",
       "size_bytes": 35652096,
-      "sha256": "0012ae613545eecf6ff40a17967a91f0e89d28f0db1fbafcdd371a58b237b3f2"
+      "sha256": "790017569869bdecbc00d8ea63b361ca5faadfda48d0b2b2a15eb2d4b1ecf8ce",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "cf26c599e5e2e75a3dffa1ecca9138b3726ca0c5cfb8f61391011c3eb3c6c65c"
+      ]
     },
     "472741ca6d06bab721a3f3d87b57bdc99dc0d1c8fe0a404e8b0fdcc592b19b5d": {
       "name": "seedsigner_os.0.6.0.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.6.0",
       "size_bytes": 35652096,
-      "sha256": "749115b3f222f45a20a632996939afa0bb75bc0591979f5be30b0335ebd3f378"
+      "sha256": "e7c61ee39c9f9932095d394dae2fea89e968be4c067f0a22692b12c337ddcb89",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "5a4d0fba68034798ade28ee830fd41e6bb40c5a8c00ca20a7f328644a803a7be"
+      ]
     },
     "7ab933c7aff11f3bbebebd8a3507db24ce47219e7b30be4932022de00945bb7c": {
       "name": "seedsigner_os.0.6.0.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.6.0",
       "size_bytes": 42992128,
-      "sha256": "78a15b08ed163b1911320e436ea7002cb8daf49c6867fb29b4d5f94dca107cb1"
+      "sha256": "dca43110aacaf30519f029d27bb292631492b11e2e3cab0b191aa8c795d1313a",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "c623bab8097aa972401388fb432f57995dce6ecdf651d51f07139d002b7369d7"
+      ]
     },
     "3d02f97ffc26dd6db7f0d6d3c8fd8dd453740abaf0da0a674c42c83ecba60088": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta1.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "0.7.0+Satochip-Beta1",
       "size_bytes": 268435456,
-      "sha256": "a53b1236268d44493064776e015346944a094bfb0b0e123f3645e10acd047cd8"
+      "sha256": "0d16ee2a50a79d85e90b8d6c010b5d120b36b24080f0fb17dc5900a666e90013",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "6c096151713b49e171f931b0982fb7fd7729cf021db27e4d41ee013eaf1fe79a"
+      ]
     },
     "6ad74ced1e5c805a4d24172d62e3d8185066f25b6e9d769f067226cbf4802aad": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta1.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "0.7.0+Satochip-Beta1",
       "size_bytes": 268435456,
-      "sha256": "af6681b3d7c822ef01e7414fa1787882dfd3cccdfdc987b36df815775a29c4c5"
+      "sha256": "74598b92bd3765f270e9f819af2b528afbb809a02ebe9481b99380da944272a0",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "07ba0fca0d3aed949e5656530d651e319d638811eda1ba989f8db2a6ef298d0b"
+      ]
     },
     "292e87be8e229420551e7c96bb94b8937971f3c0e07c9eb61af1db0af0259f5d": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta1.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "0.7.0+Satochip-Beta1",
       "size_bytes": 268435456,
-      "sha256": "53c6f18c50d51ca3726c42f8123ddd77826ae6a890422bbced34556e59176fe4"
+      "sha256": "176817d75afa5647e6bc85a75ed3ef47d2c66b61c4998f86b4183a470da854be",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "22d2a389ef3ef303c3c136927cdee6278419f9b80f7f3ec71e23ce121df44c3b"
+      ]
     },
     "05ee2b94af9d785aab57e5f557a10e35fe8d76fd97ca4da9394329d477719411": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta1.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "0.7.0+Satochip-Beta1",
       "size_bytes": 268435456,
-      "sha256": "7d00facba08551dce6c95b005a260a306561df1951dd559b9ba191a6ec208663"
+      "sha256": "07546004f8be11e6369004302ba12e9ca23ce0504773e9165e0cda334f1959bc",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "9de6e5c59025a6f250d81208234d1a3b1916a53c556af6fb3ad4bf5ec08e6403"
+      ]
     },
     "f4127c3e7b0a2e913d96eeedb9bcd448360e1874cf9e02e151e879e4c9d937ca": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta2.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "0.7.0+Satochip-Beta2",
       "size_bytes": 268435456,
-      "sha256": "6dfeb74c12b2094e593ae2b4e3b79842b7804ee81bb2a5ee5cd4e17755195e4c"
+      "sha256": "5ed5f79b2408763cbd8485febd3f6cb125416556b39e6add9e45d1393a62eed1",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "b2fe5127c7964cfd6f200b22ef92ecdb79747684564fa42ca195d255b7e108d3"
+      ]
     },
     "82355879352fb0c93f3b73720ad90820eb383d51d3985b9b9f842aa5bb3de6f6": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta2.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "0.7.0+Satochip-Beta2",
       "size_bytes": 268435456,
-      "sha256": "a93c8afb30f5e9ce9fef124ce2a70d1ae7875f948124b07de8ef735544133310"
+      "sha256": "d7aa0b464a300b97d067a7b9a6124b31afd8f40a96751ac0ba56c39dbdf154f7",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "42d0a6de62c670556e0baee940d11abe2fdae44373995bc2ebcf608213bffc86"
+      ]
     },
     "068150ad8473cf79839c1ec2c3d63909b85796e9a9375d600c4caaad04001e78": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta2.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "0.7.0+Satochip-Beta2",
       "size_bytes": 268435456,
-      "sha256": "6888a563028153b1f8b5dd50dd26c97b0b7b024a55eebd5872bf94257510f338"
+      "sha256": "b14c8af5c05dfe41a4c51186fc530a4021cd10c83e11eed2c82489f113ded131",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "110409a548c6049957c356bda47750b55f3ba88b024f0cf2c13cbc6e5ea8f2db"
+      ]
     },
     "68426117c1b49136e048ae43833da540249edc02fa05c2c4c272487991f67e83": {
       "name": "seedsigner_os.0.7.0+Satochip-Beta2.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "0.7.0+Satochip-Beta2",
       "size_bytes": 268435456,
-      "sha256": "59ff41f1ed6e999d5108629a4294d62cf45369058d8558a2777e2770f3ac0d9f"
+      "sha256": "72e9e9f0876145ccf3a6953223db728962b2bbc896c70b23397e0ef847beea1a",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "cb1feb1a59e147040a920b5cfdbf8f9fcfc8752b2652f2ef887a1b0df2cda723"
+      ]
     },
     "ce618eb3aef276e0aafaa7cf8e81b38ddce66269d84856d549d29638b3cee786": {
       "name": "seedsigner_os.0.7.0.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.7.0",
       "size_bytes": 27262976,
-      "sha256": "a380cb93eb852254863718a9c000be9ec30cee14a78fc0ec90708308c17c1b8a"
+      "sha256": "05253fc7963234ad9e906e045fbda5eced1cc68ed11a4c64d52c33775566816d",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "be9721d8d814a895f5fa6fb3202fa9b2ecf3130541542e2b6da1a2978d0fea25"
+      ]
     },
     "fe580f04183a2b47bbfdb5ac532ee315d00f64324e90b0e0fe77f23077350f28": {
       "name": "seedsigner_os.0.7.0.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.7.0",
       "size_bytes": 27262976,
-      "sha256": "fe0601e6da97c7711093b67a7102f8108f2bfb8a2478fd94fa9d3edea5adfb64"
+      "sha256": "c38611c992cfc9d18601f7e3d304ae8856af6ed0ceb78792b19199d876122841",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "b67c949989cc9d636dfe707bce6295ba92af4cd861d8d14c22f400ed44d07445"
+      ]
     },
     "94572cb59c4ec2ac309e4eb6dcb63488f937621398d8e5c043fd8d6a0c25ac9f": {
       "name": "seedsigner_os.0.7.0.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.7.0",
       "size_bytes": 27262976,
-      "sha256": "65be9209527ba03efe8093099dae8ec65725c90a758bc98678b9da31639637d7"
+      "sha256": "2525815b9c1bde5fd9be461f0065f91c9174933e5cc326f14133b5e9a18034d6",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "1bcffc35081fce53a72c286c49a291fa4863de0d785924b103fb8a348c1608a4"
+      ]
     },
     "ece8669e0c3b593b16bec547ac70d0d0c8d1521f48b65c83cc80fe617110e18a": {
       "name": "seedsigner_os.0.7.0.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.7.0",
       "size_bytes": 27262976,
-      "sha256": "d574c1326d07e18b550e2f65e36a4678b05db882adb5cb8f8732ff8d75d59809"
+      "sha256": "155106de4681376b1eec770f213260eb193210a39b9a6ffdc69330206183dc0b",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "b9d07c6eae040871862e4a2b94ca3d751c741e2277f75a2ef2e9c24d1f8733a9"
+      ]
     },
     "feb28e55204b5db23f03d74e2262372cdfb0de337845d0083647e53825dc7d5d": {
       "name": "seedsigner_os.0.8.0.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.0",
       "size_bytes": 27262976,
-      "sha256": "1d0f1c412f64b40e6aba21b5bacdb41d9323653c170ce06d0a3f1dd71fddb28e"
+      "sha256": "a4268f528a6b523974eb1fbdb0135fd6c3777b8943b24e76cb5522d7bee67895",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "d7c88c67709b60138a3df0bbfe5cc95827c6ef8b577450c0b87698f2acf66cb0"
+      ]
     },
     "fefa46297a7198695452a9824020ea92859ac4666b7f7501a32ae41ac50fb618": {
       "name": "seedsigner_os.0.8.0.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.0",
       "size_bytes": 27262976,
-      "sha256": "c8d5352ed4a86c19eb9ef54f2920934f8ce460742b464ea94dc9114f9f4e039a"
+      "sha256": "f1d2dd7db02e85fcfa446846add28359f18b955bea5cd82fb138d0b488cc442d",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "ca940ebcec655493e12bb205c1ebfdbcbd847b854941aae8abbda5b096ec7988"
+      ]
     },
     "616129f840bb84f08d91bf6d7ecd0bb191c7f66085e370de9e05be880528cefa": {
       "name": "seedsigner_os.0.8.0.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.0",
       "size_bytes": 27262976,
-      "sha256": "11c5553d75b3ebca4988ae3c4573b60b33a12bc4779282454ae34404ba797670"
+      "sha256": "08f95e048f90e394abe4e93e78921512a9b4c9a82447c5498df679d481cfd5de",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "e1669f4cd1a46c0bd0aa0a852403aae408faef2ccbd83329ee2f1e54fd08a9de"
+      ]
     },
     "a319d088bf148cf8fe7d9a96012aeaef645779d4c610067ea03187a1d9b9b96a": {
       "name": "seedsigner_os.0.8.0.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.0",
       "size_bytes": 27262976,
-      "sha256": "917201e335bfc7ee4189f17827f954f89588dc0fdefdad80d26f2a65c5c8e6d0"
+      "sha256": "2df5337b5752d334114c4be5ad06fe478caee99556242b36d2d4d41667a78f44",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "c1cff7700a64261315356b05a67951f73164ebe9db95284bbfebb87b6bd32612"
+      ]
     },
     "9fbd13951a0d09ad9d2142cdc4d6f54072a9cabe2b0fac348e24add3eb5dbd92": {
       "name": "seedsigner_os.0.8.5-rc1.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.5-rc1",
       "size_bytes": 26214400,
-      "sha256": "8f881e1c18f2ecee9a39a85900dc5dfbda0d613a7f1789adec64bd2258d4f970"
+      "sha256": "bb74ec73d40cfa3543c8da44a268f1f72591ec456c270979f1da57a89a2e71a1",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "876003aea8752ff9d80441f8b7b7d93bc6fc2a2d62f5238a5f710f67699a0e92"
+      ]
     },
     "c4f079e98b478da0f1589edbb3c8416d2fc70668e4fb852e991bec42f3c7a656": {
       "name": "seedsigner_os.0.8.5-rc1.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.5-rc1",
       "size_bytes": 27262976,
-      "sha256": "7d731c6458e13b5090284c53fe859ba98ed3178b3690e3af29f38f4c2b902ec3"
+      "sha256": "ce7ee5588c2b1981c2c26231c7e2c7201c3e4ba05d3fbe2f039e0afe3d8e3de3",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "82d2c6b8478e87bfb95138725c2e21d32ea1588df7f82243a63b1082f7145570"
+      ]
     },
     "d5dc820618063d05b33308cfcc19e8e1cf3e38d567e20bfaa2164d60fdabb106": {
       "name": "seedsigner_os.0.8.5-rc1.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.5-rc1",
       "size_bytes": 27262976,
-      "sha256": "d469d31feba8df78e4afb7514cbac50dd72cc1bd22717e1921df819aa8f13562"
+      "sha256": "11bcfd57801851ecbb3237a1eefaf95ba90bb44a91fbf4bd8e430ca2eabb430e",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "36bce6f8f8417c9076ac63a26fce0e7138cf4e823ec289d81f03f4ca3521da93"
+      ]
     },
     "7acd598969220689d5df0e85d1c3ae5581740868b2714d5658365ea1ab1de449": {
       "name": "seedsigner_os.0.8.5-rc1.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.5-rc1",
       "size_bytes": 27262976,
-      "sha256": "650dac5cf7608b9259e7272c778584104862c60089807f1d6266e374b055486a"
+      "sha256": "e03f33139fecaec56e27175122402887fecb3162954b7c9b18ec8161130ac0be",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "980efd498ebbc870126625883035c5d622e7ee1af2ae9cdfa8195f43a9bfe6f6"
+      ]
     },
     "1abe3bd1d7d129918147e7672806bfd34fab70542791cf7474502bcd1d23ba64": {
       "name": "seedsigner_os.0.8.5.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.5",
       "size_bytes": 26214400,
-      "sha256": "bcb901e27d309d85f086dc80b49b153d6b1caab2247eba2811731384d58f2f3e"
+      "sha256": "15f5260dd467be7606fd07188405d492006b03e3fff45ba157215e84d2a6e745",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "392a5d7e4af28f1c728979f34775f40a1727a918517985d4fcc8bebfc6fbb3d9"
+      ]
     },
     "1dab30f3dc830626dc980ff6bdf4633ea4262b12c17c13cfc7b8adb88d051fb1": {
       "name": "seedsigner_os.0.8.5.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.5",
       "size_bytes": 27262976,
-      "sha256": "398d9bf9cda0858fe97c0788b353194c1c902335a858b7dbf5d7b213bda75d96"
+      "sha256": "570ff46637aa91864533ee4394d438cd781f15129d86673bf38846a4d227373a",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "390df4fdc6677b0ec607cc5d259c468303ad729430c6d7234f3b03d9bae9b8fe"
+      ]
     },
     "de062ffd5dd4ecb673458537ac99b3c46fce9d173858ffb19a940c257301c910": {
       "name": "seedsigner_os.0.8.5.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.5",
       "size_bytes": 27262976,
-      "sha256": "1e93a82e62d4a1defbdc777a6762a813f4cb5c3ef9090da0bd07542dfd6f62bf"
+      "sha256": "2dda404e0de783c9e8a176b8ca398d887bf5b558c76c50736344f5f1dc866552",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "ce27fb496c078be14fc1aee92d302be9dfd170502e10de0c763ed62137773e3b"
+      ]
     },
     "68036d1f176777e3438f37f6d6ea2766b552fb3479a7bd7bf644450485ada0fd": {
       "name": "seedsigner_os.0.8.5.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.5",
       "size_bytes": 27262976,
-      "sha256": "d298ffad3c765e11e48873efc6d1c65e4230528fde4d5bd4701bb507acbf493c"
+      "sha256": "9f8f5597d7f307a363b2219c94f029489943b1e1ae8550f7d32028608e79e0df",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "6ff55a92f6d9d057b122e7f5cfe181283fbb6e4291b746d041dc95f3fb4cf9ba"
+      ]
     },
     "e191c89db930eb78fffa0ddcb745678079fed117d925f062596ff3be2a64d23e": {
       "name": "seedsigner_os.0.8.6.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.6",
       "size_bytes": 41943040,
-      "sha256": "da32ce21f185404ccefd58e76e55ae7f1ac9fe2df2100bc7bbab3e03c5d71b6d"
+      "sha256": "89caa7134f08145820857753b383ddc152782e9bf44ced0543f74b3bf8fb1961",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "d306129dbc8a13499fda7b28075d2b62ae078fae1877708d60d3aa7dddf5e378"
+      ]
     },
     "1543620ecf4988bd8354516036958b654d4165b2602d4d4a7e5a6f3b9a0bc485": {
       "name": "seedsigner_os.0.8.6.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.6",
       "size_bytes": 41943040,
-      "sha256": "d1669ad3aec6046dc43a673056a258e00c389ce23fa0ff754378cd0267516888"
+      "sha256": "359b2691941ee10e799f593f537ce7d0b9d902c3bd38a324a335c59f4414b5b6",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "6af49062f17f4f08c2d523899bbbff31b0b4ab76ed164d2765c263a8cb583df8"
+      ]
     },
     "d336cb1ac7cf2d17253ebc4f32ab8798b62beb51b40744e7f1dce6427b5e3cc5": {
       "name": "seedsigner_os.0.8.6.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.6",
       "size_bytes": 41943040,
-      "sha256": "029ecacc6ba45ae23cb953d7111cf98b0689f1eefb1cee101300acb10167b098"
+      "sha256": "f69d2cd9bcd9b8c1a4d5ff2356b38591075ef18eb8f25bb2cf440ac4f440d8e1",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "ae1eb9f122dc13d9c80c489458ba59d9eabb48f66ee9915cf9be1113e53913d0"
+      ]
     },
     "cb2296957028f1baf0518b110e6bfc0b25fa59d4ed62bf2124e062a5f8a356f1": {
       "name": "seedsigner_os.0.8.6.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.6",
       "size_bytes": 41943040,
-      "sha256": "47879ded57a91ecf46dbb44825699c53550bbf5aa6aa7c5b6519913a8863d157"
+      "sha256": "e7935aae4d587cbb9ce168c9f70dc9ad6840d249fdf0ca2aadec06e21fe51754",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "bef6aa0721d9bfd284dac2620c874d742147833facc8142991958bbb8e0cf084"
+      ]
     },
     "2f9dd4da8cbec3a156a3d3bd8fdcec30078d1b262f0e68ec09d25f7340de9afd": {
       "name": "seedsigner_os.0.8.7.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.7",
       "size_bytes": 52428800,
-      "sha256": "67f005c7ace26500a78be3f4d97eaf02d76d018550ec54df011741dde1933ce9"
+      "sha256": "d9a49df9ecfef9a5a2b67ba78d13671b70c252bad5daeee7fe661f5d70a63b64",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "96edd2c7ff1c984ac6a363cd8f08d1d014cbf4fcdd1a82250997ed1610b82555"
+      ]
     },
     "968147c99b27e3c20cf0403f83edbbefe6c3ea19c61ca20cdc1cff280c8181bf": {
       "name": "seedsigner_os.0.8.7.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.7",
       "size_bytes": 52428800,
-      "sha256": "f38237cdde39efca2fb9e3b3f9f8b0beff2248767f85289bd50657fa69b54f1f"
+      "sha256": "b90c9cd28b8022dd610c052790e6a51a71bde820dc568938792304a0d2015e04",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "bb0c764d35fdb0d918eceb65ad03c250510f0a3f5c8c51da1b17a00ba77536d0"
+      ]
     },
     "150c03c80a78c266836f90cb98f1bcc29c2df36440e59cd930c860c00f85a728": {
       "name": "seedsigner_os.0.8.7.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.7",
       "size_bytes": 52428800,
-      "sha256": "9fc7f2ea8462e1c9d62efe41301e12d559e8f155653913e33c93e905360bb813"
+      "sha256": "d5b723f4fe7c6bef27cc7b60d784aa86215d2b81b69fc878adeb0beaace375d4",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "72365f94c9bb8fa575669bf2fe65f410b05b90369420dffbace59321bdb1896e"
+      ]
     },
     "81479f157315f505b050378395f9216d7cd9f0ac1636056a06a868f862d353e2": {
       "name": "seedsigner_os.0.8.7.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.8.7",
       "size_bytes": 52428800,
-      "sha256": "3c2a11a2303abf2a73b10be913d44a1eb85d5e5a15b5389a670cb963afd1e28b"
+      "sha256": "8e323eb426f3889551d1abb8039c1ffb7200651a21234f4abd4b8e23dc0ace70",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "ad67df828d9f1b3770d4e7ae3a03c4265e0ed7e87b5a9414b4c13fa15007b731"
+      ]
     },
     "60a6d33aebf2a3e6c88fb288738221199817d72f291ed8a88fae0942bd7a0d81": {
       "name": "seedsigner_os.SS0.8.6_Satochip_Earthdiver-B7_.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.8.6+Satochip+Earthdiver-B7",
       "size_bytes": 536870912,
-      "sha256": "21b23d8ecd70cb450af387bcf694c3ba2ee015ebb3283fd109f89f105ba96316"
+      "sha256": "54a631aaca971fa4c10b4546b744b058937acee32d5e1ff9c48f196f7d2983ca",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "f4bc55a2280a306b4bc652f8e6f9ea276cd097fc84a9925826177e70ad890132"
+      ]
     },
     "6f7ab77ff0f602db62cd5f5a7a00d221adbb65972c28fedb387c54a20957d28b": {
       "name": "seedsigner_os.SS0.8.6_Satochip_Earthdiver-B7_.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.8.6+Satochip+Earthdiver-B7",
       "size_bytes": 536870912,
-      "sha256": "6d7870fff4a5190d6994c8bfe64bd2309188f8ef6b5f42ef48b20feb4d50f1e9"
+      "sha256": "a62184f1b71da71588b0d985075041e08b4d7a4bd7b6ccd1cc43274ec3d8c710",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "f71b5fabadcf27b2d1b7fc4df70a4b3b6e6b81a9206b4b1f7cc331d2800d77af"
+      ]
     },
     "d7b2d861067a5dd9b7eeeb43b84f538b7778780a29b2cc0f38b5087f35e5da2c": {
       "name": "seedsigner_os.SS0.8.6_Satochip_Earthdiver-B7_.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.8.6+Satochip+Earthdiver-B7",
       "size_bytes": 536870912,
-      "sha256": "01763932ec6f6149a28f059513730c3f42ab4387e34e1ae9fa469e6c3c35496c"
+      "sha256": "7ee41ae1ab4ac8a387cebcf107e53d2388e2a5ab5b2e64251860dfc06dcc2fcb",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "8d80b5dcfee3bb6dcb33fe3194e7eee799bc9cc4ef43345168c854e21b8cfbc3"
+      ]
     },
     "3eb6b1184bf50454631752fe952c05b9b66949c99f00232903dcd46776d0146f": {
       "name": "seedsigner_os.SS0.8.6_Satochip_Earthdiver-B7_.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.8.6+Satochip+Earthdiver-B7",
       "size_bytes": 536870912,
-      "sha256": "dafd5ec01befb91a325ed038d1b5a14fd42c365fb63c2d5dd4ef3d9618531567"
+      "sha256": "63956e51d1e8ac8fcce041ac731e680ffc0998505e2a8d8d3e1367346132f8b0",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "8ca77749b0548479cf93d5716c090200c63e4724a6afcdc0d32b7ff1d371f161"
+      ]
     },
     "497242b5e1bd524e3c551eaf81580f5ab24ed8e0a57186e567d387d59df85026": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b1.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b1",
       "size_bytes": 268435456,
-      "sha256": "c4af327f680d9777abf882682dfa25d03c3c2a9af0b67b7e7a247f3d0e9a0c67"
+      "sha256": "541bf6cd4880395a9e2ab4a97f7b48cffc5ffdc198920989dc4358668f30a270",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "eff726f651e28ddd89f5ea89190de3f40c7a27e38e480d63233eb36a18109275"
+      ]
     },
     "96b0e960341bd6836fc8278240a89e912927aa85fc81a0e21b9008ed428640f4": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b1.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b1",
       "size_bytes": 268435456,
-      "sha256": "3d57e0907ef41444fb42793b3051e8cd33b899e73e5faebd0b3111e54d1b34e9"
+      "sha256": "ed266728265589a56e35891b5ba2e51ab517f4774ecdb5736e8bbe3cef3b1f20",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "c1ed7a24d62dec13eb904ed5c9462b3b8e9e04b05610f9f5515296d8d750ce0e"
+      ]
     },
     "78634c38e7ec0d6959175be9d8e8f280d2602fb51a7ce5d4b5d3abd2fad3cfe4": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b1.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b1",
       "size_bytes": 268435456,
-      "sha256": "a4469c93e1e86920a549e4a9c4605972c522409312485dad24d213d76d9adc1e"
+      "sha256": "935c8b4516b5c20b9106eba7aff65cc2785e08a823e8d609afbbf18185deb039",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "1372e74cdd96cc611e61c642fa8184b579681f78d98be619c68688158267ebb0"
+      ]
     },
     "9b9f3e89195083d9c6e77650358af125cc07e98b041404ffa927a9b920336749": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b1.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b1",
       "size_bytes": 268435456,
-      "sha256": "db07e924fbfc5a14dddea552b55ba4b36dc6a295c4017bb15507d09de1a51e45"
+      "sha256": "385f81be992b40ef5b8168cbf7f6febef9a2f1a6ef6bd54f034b686dbb62fcad",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "303a592143b7556d7496863a9ae7ee58004facee65c1131f9f59e62bb0c8ad75"
+      ]
     },
     "f6d9234115a5e6201ce6411980a73434921a9d3d20508fcbfe8f420c40ef0e54": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b2.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b2",
       "size_bytes": 536870912,
-      "sha256": "a2ed31d716aa2fd618b29b8c5d658c45d2cdc722756b7bd952a1ed0cb0316678"
+      "sha256": "b303ed950ad27c729130258bc826d755b9454f7a7131ad1de154eebf2c6fe874",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "ca3c44e88629aab3b757bc04626640d2cdcdae642b73837c6053dacfd0438548"
+      ]
     },
     "1694e3e5bda06bae66e7fcd50b604f59afa61ad3fd8175eab2b52f97c035cc27": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b2.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b2",
       "size_bytes": 536870912,
-      "sha256": "003eca358b6b2685080093772ce73bee349a30f1a23d5266cdcff3f816e8fc68"
+      "sha256": "23ca2526991280acebca453b15ff859e9b5531568ed4c5954416fd51199dea5b",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "694e25094985a8ed4d796047c12af19a45341bb9f6ee68e78449192703d57f98"
+      ]
     },
     "46e141882ecdca731ae3d7a6bb692e9dff7cce0b3422421ba92a016d33a05951": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b2.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b2",
       "size_bytes": 536870912,
-      "sha256": "b7fb7a9c11cfae910dba6014c5cef7323be02a98368fd6b88b4b74a3e2672680"
+      "sha256": "443d618b3cd1d30a73b4dd1ec0297023b870c51d54cc5a911e4ab461c3910ca9",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "0a69e1139b91727253489933134ea10c4c1d50969172a249cd47a3f9efb1e949"
+      ]
     },
     "d2a423f1a91817ff0e1a17831472afd11c49c7cf06d39524e1942a2ebae1e377": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b2.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b2",
       "size_bytes": 536870912,
-      "sha256": "5d810112073f4efcd27ed8528d0259952daf059b0640b2f6f36e82fef870f179"
+      "sha256": "415d16f620852f4f991e48c5480d896f4afa361bd9ab25a5219ffd0000a259a7",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "9ae3a53107ee520ddf27fdc2280be63f871e03b7ae83bf2293876bf90f1893f6"
+      ]
     },
     "ca75562c8f3578791b09c5f7794c5e6f4677450a6043a6cc3974d03ea3bb9aa1": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b3.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b3",
       "size_bytes": 536870912,
-      "sha256": "d6a8d8ed37ea59cb3da6df14279ae7efbd9f5489cc0aed1480ea3178d2e87e40"
+      "sha256": "7f6cd09d29bd2ee4d2e1364d00358542ebd4bdcaeea83f62bfae8d82ee925ba8",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "7fd9378dd42fc845abe02e246254dfd2bd8cfeb76977fc03214e9f1944a86462"
+      ]
     },
     "c9ae9b7a88a1ae7f2fb12619ef3de022a083552d9dc9d4ef068fb50020d89631": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b3.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b3",
       "size_bytes": 536870912,
-      "sha256": "c81d9a442bfbf9ed5e0239cd2237b13793714272048f141bf67154f9d3797af2"
+      "sha256": "68be0a976840919db3ed3f06d6456ee9237b03dbf06e3cf6b96003a4b0d9480c",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "7c644a68c8492299c21da5ae4ec4ad255f04b67109dabbb8522d1f3677927f25"
+      ]
     },
     "9f2c3cbe22c33dfa7dd2eab12f49ac137a308e9e574539f813a9e592c7d9247c": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b3.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b3",
       "size_bytes": 536870912,
-      "sha256": "a435ea7ffa7f6a136c76607e45f89b11898aca22573822e3e749e8f112b7ae15"
+      "sha256": "30418ee91993070450e7e4f78b0c2ed157d50f96612e13c5c3299403e8dd79fc",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "42de1824152b26dda3ed505557a088216582e73aaf79d0868044b2c0587ce2f2"
+      ]
     },
     "450ca7026f7cfea6181dd0c19e10f01c9390c511e6dbfc85ac430cf242f03d6f": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b3.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b3",
       "size_bytes": 536870912,
-      "sha256": "978da2835680a6369ecdd5cdc0e8d5f719a9721f1166b0548414dd0006f59083"
+      "sha256": "dfe40a65b90805105791eb232345e6c38d9776b114e1a712be602909794b2a9d",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "1404731e53c2c39ec5522d29856f2ce3128bccbca93c3db674c26092c7488d95"
+      ]
     },
     "c75d1b687ddb71cf6382a2a5c5f832c2b7cc2b1fdcd75daf827e89e0b6bba415": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b6.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b6",
       "size_bytes": 536870912,
-      "sha256": "7fd2ae815e66357ffe5d81e41c3d7d6d3a5d2e5a10bbdcdccd2c6f56fb84bf48"
+      "sha256": "ded3e2fb5a33e24bb2ecf5fb8b20264a8504228351f9d4a2b9d17c814a62c1ae",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "d7595f99949dffcb566e4535c235df9d873cfbb1f7b5703d02d35b6f5a1a1416"
+      ]
     },
     "3d4f8e8a1da99333a0cdc6b0f386329182a9b841f2dcc99739606100e09f2b13": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b6.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b6",
       "size_bytes": 536870912,
-      "sha256": "7cddfe0c18f47df1bdad4a6a1e889b375218ae9d013fbca380d1d9baddbc2d94"
+      "sha256": "83ad340cd417d22673463506808571e366568b6488bf200b2797e38089a8dd68",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "e4336c9af5eec752f1fd73719f312868d3d4b1eb250075b1480acb74c55a5169"
+      ]
     },
     "3b81a86e872abcfbf98cc7ebe4c7c7198ca6d4bfd0f19b577273ac4dd9a45138": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b6.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b6",
       "size_bytes": 536870912,
-      "sha256": "abec998185544a2382339df6fb61bdde6d155ccffafa034da90cbe04f82a113a"
+      "sha256": "005763d46e79a87e5c68a5265c3a1fa16864cc17afb62dedb7371d42775054d1",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "93d7d8c98d42642d732a7c7ab412bf6ef258200de795f74b7356dadd38c7ab2e"
+      ]
     },
     "54ab6bd6128a214a4b4421f2cbcd3dcf1e787f10042ade5ecc0a8e714e140062": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b6.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b6",
       "size_bytes": 536870912,
-      "sha256": "1a197be7fba763cbbe1bf6dbf42fd6fbc3b080f70f3fd09a886982e63fef9876"
+      "sha256": "186784ae9912a2e586a4783494f839ef2f956a70bbb86277c57a70b159ceed57",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "b94e564a307bf919d2aa8f4843c4584ed469d2a1b2ba58fa1d053517e8ab2ba5"
+      ]
     },
     "5990879bf283b73a8e5f78e5d80d32926ced598a2fe3c9a992eb77eeb37265b3": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b7.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b7",
       "size_bytes": 536870912,
-      "sha256": "81f3f5571f53115c8fb1f8bcf6cbec9c23f5560949669188d2df6930c3484b79"
+      "sha256": "e2ee196114424dd807408c888f499207443478be1855e879aa21c0d0606b5730",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "c8f3640a20b3973265fa6f4ab334cc96988ea1296094c852e66c489994068c36"
+      ]
     },
     "a0d8879713874d29f9eb25a8a7dbb9a3f161e09f57350a49163ec98fa0e4827f": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b7.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b7",
       "size_bytes": 536870912,
-      "sha256": "e9dbeb2b5daab8f5c61cf5e95492b24af0b99941875ecd858fa1646b1a9093fc"
+      "sha256": "cb18b58c1e68c5ffd42ca474c00a137e221332de3860d956ce46707256c4ec9f",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "c804ad3218e29f9d53f189193c42da0a422cdd5e1e5fec6d5c998e6646939e4e"
+      ]
     },
     "5763e997818ac47e630fd141995b20d90dd13d9e2dc0bae1e076a608a962e16f": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b7.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b7",
       "size_bytes": 536870912,
-      "sha256": "62a2b4a83ecc468d4fa1274436cb0ac238e1b88800eb8f8789150504b2d4fd1b"
+      "sha256": "c2ba2d2967097ee3bdfbe2394b19c23c8fe6fee2d8889ef15241403409dac7d9",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "e311c9e05bafc8e92de2b0590dd9ae55da5411aff3b8f117e32754b285a8f51b"
+      ]
     },
     "ed1b6c31819284ee1dad4617dca1c036d6e1464c7e7f09bad7b88e7c823fd697": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b7.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b7",
       "size_bytes": 536870912,
-      "sha256": "21cf1da5ee4e0ce8359dfa975b73969bfaaad834e0e00982042d1b4b3d370b80"
+      "sha256": "12ba95408b4f72390b67ee4d12cc9409164edccd9ab2a43322e9f7ebda55b585",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "7bcbf672bb9c16547bd2058b5fc68ffc855ff1718b9ec37a6a1ddc215f72a5df"
+      ]
     },
     "84c1e48a848ea68cf0623570ecba9de08ae47f9fd0b5f2f769572b0a140d0227": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b8.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b8",
       "size_bytes": 536870912,
-      "sha256": "60ea074e87054b0aa9a7dfc75331b210dd99dd81fdb6d4b91be6a4469b369d78"
+      "sha256": "423b65aeffe38c3598d40922662ecffcc8f49deb322da9a1a51e48d3cd00fa6f",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "78080161b93397e16c4af7f75aa5485487e41f000c356164f06c086bcee2927c"
+      ]
     },
     "36e1399076dbff1bbb6778ed804e0418da873c75e7a097222973f74f10af8103": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b8.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b8",
       "size_bytes": 536870912,
-      "sha256": "397a14f9c6caaa12b302ee829b8cfbf63792e927f5e76008a5064fb2e982ffa9"
+      "sha256": "90a049bcd9ea15216bfabf9c6501a26f0cd1f05152d812f735cdbdba6f43f433",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "5625656d8d760420ef7eb9b750c0d8d3231ced97c9e774fb5d18654d6f30f7e5"
+      ]
     },
     "df0fc6a4dff184ee99823839994df7a78c36cb951ecdbee77e17ef3b0f2b7175": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b8.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b8",
       "size_bytes": 536870912,
-      "sha256": "87667f3195cb4764a7a1d30159c203f23ae73430b0a4e11855fedb2b9ee79b82"
+      "sha256": "06367d6d9ef7b08b7e36cd3f3bdc09b1da68a9494d3088c0c48c339b2bf56c6d",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "152f8466d80444112b88574ff0c73fff726c95c8c32c859b3aaf808b471f87cb"
+      ]
     },
     "406a8f88f783a32525e161889809eb5ef338f67b212fac45db873bf752bda017": {
       "name": "seedsigner_os.SS0.85+Satochip+earthdriver-b8.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b8",
       "size_bytes": 536870912,
-      "sha256": "47eea233f4903857c913f106bba41bf79372bca14848c0b81dc61733cd4b7615"
+      "sha256": "36a79f37715845d341fbaf7a222886a4f887575c5472b9534e077f722b6ea42d",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "adf9e75b9d56f835b0523e3b5406af29eeb94253580498f0af777d7abea4e242"
+      ]
     },
     "fa8b5c20977d1c246fe70742b29202d15ca27cf40ed2a68d437be5434d87a686": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.lafrite-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.6+ShSi-B10",
       "size_bytes": 1074790400,
-      "sha256": "dced168d7cad985a1492f2a62924c72cc0e597d32c2b9bb5131dc0b9838e7a28"
+      "sha256": "d49f36c83df414320cb0fb8da3b595e476ed063867e3effa8a78b8976ee98f3c",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "9dcb920ad69ab260002f2c64664779e231be5eac66d2f8caf7a015f768c19950"
+      ]
     },
     "72eeba7efe7d2762e54291caa2ef43b861b54a6d30c05b552d61f8ad528649ba": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi0-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.6+ShSi-B10",
       "size_bytes": 1073742336,
-      "sha256": "5227f76eb8ede684db3c0382df994ee32a8a4a1391eb3c83bb989738eed65ceb"
+      "sha256": "01e1c84e43578c97f7f2469d31b03e056a8ecd8529c4d7577db80df5e15d3ab0",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "77b35275edd8cc265f1348b3e109f66e9af6a13b67103152564d4d99a744f5a7"
+      ]
     },
     "57865f81820217d5c95d29e6a3948a41fa2018c2d63e67a1b61b6f4ceef99377": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B10",
       "size_bytes": 536870912,
-      "sha256": "8f0d825ee1c93f8aa282ca4101cda3c5e708af2a89dc9506455b55ccea63c288"
+      "sha256": "d80fca00de7171788c465a6dc49efde276da7ab8fb72e84df77a64623e425efd",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "22291b5a52ac6e56346a80bde50a9ae585124b35b7a2792c9771132d33ee3055"
+      ]
     },
     "6c2019cb580cc59f2b9e81066fd224bacf99604b295c92a3c7829506ace154b9": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi02w-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.6+ShSi-B10",
       "size_bytes": 1073742336,
-      "sha256": "a93a80f297ff395a574d3812de53ed90a7754139bb5dd4eebc30e748a3f01c46"
+      "sha256": "5b68e72bee43147c8c5976d3c957d6a96fdfea37fc5c16facdd9b32a5db68f9e",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "a2f7cc4f3a996c16d0261c3f51a85bba532568f6bd5700ba481b58900c67fe08"
+      ]
     },
     "a3d788002956b3f6692065a11f1ac0b839a07fddede085839b90928f995a281e": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B10",
       "size_bytes": 536870912,
-      "sha256": "db2909184bc2d428901309f459b135dc02d174ad2103089352cd10e3d2a268ed"
+      "sha256": "615a49c6dc4d6fa8d6b4f940bcfd684d52a96ec340e94967b5deb3eadebd7a48",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "cae477c160ae1d3832acf0e939e586bdf48df499f09a10822a19ce0d91a5c137"
+      ]
     },
     "5fc55c7c63907f0b7d7db5fe76ae5e823b4bebd7e5dd66c30c966f063969acd3": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi2-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.6+ShSi-B10",
       "size_bytes": 1073742336,
-      "sha256": "6214c111f585775b6f191af58e7f67813bd011345934efff1e489d9b5ef1f923"
+      "sha256": "27d0dde13ac154865fc5128da5618122508428217eddeae84372a974f94dd53b",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "b0d7bc3578108b8e5253a81465ed6639f54ef1502c3cb07031f6fa12c8335a94"
+      ]
     },
     "ea84c6bd216c5a531f2d303294082c53e2e1371131ccba43439e0ca05e0658c8": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B10",
       "size_bytes": 536870912,
-      "sha256": "cab050423c52fac596a3074d846ebb35537f833a6b8af8b041603a6cb4974fe4"
+      "sha256": "319c05b570417e5df58a74febd2498725efbced4d053dff7d9197a0fdbd6463c",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "5f5c6b3374e57fd2ebe462bfc02a3ecce61e29c2053015a0eda8849ddaf20fdb"
+      ]
     },
     "0d5c41fe115b67cdf58c21f3d0fc3580bbee267656c3e02eaae4a14c7b85e8b5": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi4-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.6+ShSi-B10",
       "size_bytes": 1073742336,
-      "sha256": "528c2464a3a8d0717c7beac1b58060eb4b2c459ccf151e5a615f875424e87580"
+      "sha256": "3c41669e2a4e3d0a9965b3eaf27651d3230da076990bf445e33f695139dc1d50",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "cf0db8fe0e1a5fa2870f296ae8b464aa9f6c4f4b9f79723d37f2135deb7d91ca"
+      ]
     },
     "0d655159e022fa8aeb8ac4f95885a9c8aef47f03b8639a2f8125df6fad361df0": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B10_.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B10",
       "size_bytes": 536870912,
-      "sha256": "11060b2c371ddd60403af90643495f1d42674fb9ea1d01bf6954efc96531defb"
+      "sha256": "4f837a92428b7622c8842d14aaf40355c2c59831e4088629e34571979c2efc21",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "958a3deb1377a4e268d83e82be518a1c04a8016f96ce55b18a97f9029b90ca42"
+      ]
     },
     "357f3fbc32fac9f42d879868da093a9689ce2da9a2cc65993a6d23ac6eb9df72": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.lafrite-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.6+ShSi-B11",
       "size_bytes": 1074790400,
-      "sha256": "847ce2466a76ceffa43fdf6fc9a1049291af2c2c8fa26e65efe77ef4317a6210"
+      "sha256": "4c5818b74ba1cd70ed5ea77f747e005653f4dfec2b359aa8bd1c34cd413d11d9",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "40de68b74588e4669917c4fa3387efa4a576862de762f3e7ec5f31679fac6698"
+      ]
     },
     "9266ae109ab40e822412e86ae031ba39262a19982eeadf8241b62a6d224e7163": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi0-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.6+ShSi-B11",
       "size_bytes": 1073742336,
-      "sha256": "2f74b3aebae92a6ded734a01c13a95c06e0470f560a017955e8da85d10b6b209"
+      "sha256": "cbb750460fafee018c8c870e715b1ffcd8d79db1c09e7feeb16aa0414f7f1169",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "85cb50013954fdd2c6f080a85f36fb80ca150350932a35a0b0d10241468df7a8"
+      ]
     },
     "577ece737373506ed50f851e1aed6b6abd950363ec7d275514e8884f3e28a2fa": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B11",
       "size_bytes": 536870912,
-      "sha256": "911281933ad68a2bda3a349facca5a34e562692170da16bb97e32a1ec8bf8af4"
+      "sha256": "38c10ea77704c1640bf4122bf12b30d49672bc8e7071c0f013fc716bd8e84847",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "ec4e966416494f82a1435fbe355317ca4df7dd02f1cbbb387e4923cc41a16296"
+      ]
     },
     "71dddc0a37776123d061bd12b3cf7a9bbc2cd750738c45a84b91a064fc3d6cea": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi02w-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.6+ShSi-B11",
       "size_bytes": 1073742336,
-      "sha256": "ce658e7a893c072c8a3401b92bc59a3312f19cfee674d0a7c4b3ed787ec39383"
+      "sha256": "797752e8ff95a687f0712dfee9d8f0757ee19e360f44c288226d3ae5b2069d17",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "93b4d04315a1fdc0f40c61a22b19f40dd7c6fe144ddc8ab8cc1ff1db8d6ddb08"
+      ]
     },
     "c70206ade907ce28844a56101d63caaf5d2f6d3930461b652d90848a4d021a6b": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B11",
       "size_bytes": 536870912,
-      "sha256": "39c3f63e3184c1703381c20ab00960a79b6cd74c549288c85bfe67b83d59767a"
+      "sha256": "792a7f92f622e76b7a681fa04b43c64a61a32d546921a09af16a68c498d156bc",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "9d303c0b7cabe907c89f88fa3947f6fc420aaa984ce5c3a99167ec4853d757a5"
+      ]
     },
     "390006f8eccecda74782ff95670636c7af3d936a0712e915722f74c803d9006e": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi2-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.6+ShSi-B11",
       "size_bytes": 1073742336,
-      "sha256": "6a01cdac5a43d54b00eb681e8ad1e95401a006228ca4d2e4815d9e91e0755b9c"
+      "sha256": "74f8585e003b1257f26dd6aa99b9dcdfdcb00709f8843e39eded13c38a1411d2",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "a67997dc83e2ff97422a8f2f71e7a988ccc60c64274a5ba92d72ce117053aec5"
+      ]
     },
     "eb0267bee49fac0e1aa1824dbdb74a592939afb4b56577426d5afb139073bacc": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B11",
       "size_bytes": 536870912,
-      "sha256": "084206f217f399e49e568a14e1be14bb89b833360f01843044a890ab9539f1f1"
+      "sha256": "2296b13d833fe565a0c121b8d2b29f2ad8e7e75584567793720dd85a37dd8966",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "afbcd6dc73d1361fb132da8a6dfa3300ae0e58476a83be8ecdf0e4142a74a368"
+      ]
     },
     "53565a183bdbc260ef674a45448c5df561e8eb66a5b5e37029bd9e7fead3564b": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi4-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.6+ShSi-B11",
       "size_bytes": 1073742336,
-      "sha256": "00ab52b6d39ac84ae67ea3591b2962b02d9c6e25c3197696d5634db1e60f50ff"
+      "sha256": "c177d54c895f9718266555c88a2949f72e49937d009897c29cd41f7debb37db0",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "676538437dea90b10a281407d93acf3ab50ea4e6f34b42bee19ba0ee197eaf91"
+      ]
     },
     "cabe343a3da111d13b89bf1abdeac95b7557ec9b6a212d9040d1d22cc733b792": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B11_.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B11",
       "size_bytes": 536870912,
-      "sha256": "5c5fe473fcae1ee9abec1e7cabaef3ece420f8344334fd23ed734c1ad75c1811"
+      "sha256": "2be4668ffd6b0ed2e08319cafd9742bd2c45f58b7929c57a6e846c696f3818fa",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "e0295de86eae41c323afa384396580f2b8f08976dbdb091d4b484aa2bf5db21f"
+      ]
     },
     "8b98972869f54c8eba0f05feaf1bc3d5a2f5abf3661fad53446f757e0d44ab14": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B8_.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B8",
       "size_bytes": 536870912,
-      "sha256": "bced042a86ef96b7156a572ab1906f1130358384eaafcc3aa8beeea2a9cdf07c"
+      "sha256": "55ab35f603e2e15701f5afa866f09a60713dc9e93ed141ad6a513a067e726e0d",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "c6ddceaf9195998c9dbec00141978fe4a781354c68f4a518db6e3a7aec850dfd"
+      ]
     },
     "4b4b2c9256579ce613ddad8bd7b611d424753f2c1b476eb5f503ced85b0c182f": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B8_.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B8",
       "size_bytes": 536870912,
-      "sha256": "80d5cbdca96a05fd1e675bafc9f9939a1a98be58c42beb35fc845edc52984e35"
+      "sha256": "781290285b5e98f6633c79332fb2ac93c97eb847f1add87adf2144a31366cd85",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "1761707241b776f338cef99bc913548fae51250c7c7a16ff72f820e613d3943b"
+      ]
     },
     "678cb967aa5a2f229323490542f7911201daeb2420e4c00d0cb01413edd77130": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B8_.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B8",
       "size_bytes": 536870912,
-      "sha256": "61021315a28cf6b84a0cdc009dd1c66ff3e51d34c67b4a29fe5099b6f4cd4736"
+      "sha256": "843bbd5edb59c7e0bece11095d28d3784dcebf54f2fbb07decef6efa702ee793",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "a1da12cd23f21ebc6ee03d05ffb27a8e8c3901f290fa76c98725c7256468e176"
+      ]
     },
     "19358f4dd284c3a11769fa59e63132be3cc20ea9bac52ce4e5087ec320db486f": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B8_.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B8",
       "size_bytes": 536870912,
-      "sha256": "7791c38412d2c6f822ddb0a85d4f94523dd8aa74496be6602f7bda5a2c463501"
+      "sha256": "f4c0594c1436e32e0f845d17f3ad4d44184aa1c5ab217ee301df36d76e212e59",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "69ae92533cdc0bb8cae89601d846a03076e063dfa6a5fd7a66b97f5f0d794ed5"
+      ]
     },
     "94b84e8dfaa2e68ed471232bbc9b8ad8074020195870e69ff0271f48632e01ed": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.lafrite-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.6+ShSi-B9",
       "size_bytes": 1074790400,
-      "sha256": "0c8444943667720ea5ce421edeedb674b0bf789fac4f1734511cd39bcebfa4b0"
+      "sha256": "b1521905ace4563dac627095f65dc76e09cd0a8cd0975f00b6394f29d6d641ba",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "fb548b2a888d2c046e078752805d294f8a6352adf6dd8cb3f3582cc8c8941fc0"
+      ]
     },
     "c8ef877cd9237c8dd9c9213af2582503e93c653c4654072eba412e3f5c1d00fe": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi0-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.6+ShSi-B9",
       "size_bytes": 1073742336,
-      "sha256": "adaae6a49cbce92292a9d72661f9b5e3042b5abfb7f5220d68c494f334697bf5"
+      "sha256": "7a7df32dc377653da003e64f2ae1b7731ee173576cf9ce4ecf79baa44e325745",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "9f2aaa430dc721156f91b6fd2eee5bf3b72138885f3d36f8b4f3fdceb3668981"
+      ]
     },
     "63a487f234ddc3dbbb022e9ba1353dd655eff182d74e4c9deeff8fff373d5a9c": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B9",
       "size_bytes": 536870912,
-      "sha256": "4256c415919c27599c088114e462e633c70b04ed0ae23d2258e495a1ecc7a145"
+      "sha256": "54e35d08715673d781b62cd25d08372d530a25f9c0da85a782a61017331617fe",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "48909c50d627de562aee4eee393d1643fa691b6cb150bdf262c446f6c85942f5"
+      ]
     },
     "cea9d1d3c107519e0f9f44ea18eda546ebe79ef892bae4f30d104fe51b70f5b3": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi02w-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.6+ShSi-B9",
       "size_bytes": 1073742336,
-      "sha256": "b2830194e8606bbbc6f98b653ef78799f866c27fbe98f45ad16c9586e54a6655"
+      "sha256": "13576351f7f5b468a471d372f4e0ea03e27a93cd0676b74398e9544a974c5ee0",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "40e340b26d95c053e8f0fa124adfa620308dabd85f38a6fa51f9e3004e974d54"
+      ]
     },
     "80dd09bec056b1108fbd92aceecd690bd125839ea6d9f02dc4c795b351ab339f": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B9",
       "size_bytes": 536870912,
-      "sha256": "71c19945eb059bf488ae9bd34b9ac6c49fcdcccc2261a7756de80ca8ea9c8c0b"
+      "sha256": "1c1f08de7ff062d8f3e9f13ec4cf6fda1726843611088cab24e45e5e58deff48",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "0fac678224801b247197199204553f7365d0af5c54cc09d8c443425d8bd02f29"
+      ]
     },
     "c8a55ccf28bcadbcab8eaf6972315c41bc0e7b3934402f4e550f8dda78bece5a": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi2-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.6+ShSi-B9",
       "size_bytes": 1073742336,
-      "sha256": "6d682230d3b70449a3b82dde722182023569edf86ae1558b585ac96fba9e0aab"
+      "sha256": "8c1fab48fafb0b804a153214ba4d0682cdb2b22e53e2863d003eee352b6975e8",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "135653d6960848a5edd8c8cd9eaacae69d1dcc8e00f5e29aa557a299a9286037"
+      ]
     },
     "bf340bcc7dbbd588ae53ce92d5344bd882832a27005b19bdb394cefb4ad02b67": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B9",
       "size_bytes": 536870912,
-      "sha256": "dab60648cf40826fce3efc28db44db3c0b4c7b382dab35ad7092e9a0c4a170da"
+      "sha256": "8bd379b0949b0e260a4f33761a93367f8b3f42269357e4a3228860e460325ef5",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "263cc97467ab60717cfbae1291ee3fc83be35a1625a6a755172f6da7b9523880"
+      ]
     },
     "5cf12939aec30c562fea723c70aef57f2b6ea7ccc7a67d1d6a804e329c6aec5e": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi4-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.6+ShSi-B9",
       "size_bytes": 1073742336,
-      "sha256": "ffc4b8b29500e76b7c086f4318e4e68fc647b5d19e42518c9605a776f0ba7c77"
+      "sha256": "a1bd6ffbb8102369c824a35dd005b83e7d53809cad8b84eadd8ce5afbe309373",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "be5ebfb5eb212099d932be6dbddd2f453e60f26884b6e502e7901bb873ab2ec4"
+      ]
     },
     "e3ec434984adadb7211c9e151e608ab3504d9a9826c9418f9b1679e2e64eb556": {
       "name": "seedsigner_os.SeSi-0.8.6_ShSi-B9_.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.6+ShSi-B9",
       "size_bytes": 536870912,
-      "sha256": "718531e62237297bb09e1837481bff5905dfe8cc280efebac86a752d62027f9e"
+      "sha256": "3a6c40781684499be826c2fdf4a8cc736269d0cb021111425e6fdba7fc27ebaf",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "934b0a74b5d6bea65f4c3aaee5744b987ba73e125e78a6885e58c07632d5ee06"
+      ]
     },
     "596b0bf0a1ace8af094c1a77a0d501802203426af606f489d0546ca910f32000": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B11_.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.7+ShSi-B11",
       "size_bytes": 536870912,
-      "sha256": "1b844cffdaa382d32a100d690cc0be5dd1208d23278fe22fea46593f47fb68a0"
+      "sha256": "aaea55f5b73a8711aefcb6e7b379e8712d164bf716bac6c62a490d3477ebc893",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "7082dc0815705a99543c3a0c31fddfa3dda390c87d6db71ea001473569361421"
+      ]
     },
     "a0077902135c9f6c9080b191618b1951b7d607a623da3584ed41723ada653faa": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B11_.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.7+ShSi-B11",
       "size_bytes": 536870912,
-      "sha256": "2866932dc06355f7f2f272f44464e06d67884e825be0ad11219379e1647ef3d8"
+      "sha256": "2620129e0442b6bc85403d78e7eba737c2a07688637b376cf03999d87a8d0b67",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "1890274bec4cd92a669cbb90bbfe079fe6f5a56089a487fede311b2126215edc"
+      ]
     },
     "ce0d6d96e09b99f1f7a8f45eab1c9db1e2b92fa097241febf3d8d361442f1237": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B11_.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.7+ShSi-B11",
       "size_bytes": 536870912,
-      "sha256": "f3f870cf7c5d59e112a1d090673c11813868210cc2740b5d2284951a2c1f9485"
+      "sha256": "3729e70c8e78231fccb676279ca2533f45e3d0b809c568f65cd81382d2273067",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "299c28fbe18a9cdabb65be5e6825220c0218d15817b79d765e3b4e43ef99c768"
+      ]
     },
     "e262d1d69c254d9f9756aa3c293c12c044804dd98a7df18ed24b1777d5b7b16c": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B11_.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.7+ShSi-B11",
       "size_bytes": 536870912,
-      "sha256": "97324ab558281a5e3539750b8a7d85d3523383e6555b00eb618d4539343c04f4"
+      "sha256": "371046641ae8767ec1288da685eadd0e11661c8057ddccbbb19190bf9556bb7c",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "5ad70a9d166f7b169df019137514e5bfc22a72f17595c76db06e6d9259d44fdd"
+      ]
     },
     "86f8f502e5e7439123f2807004dfb35e1b25efcd8c3cd77fbc240e00854ddd99": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.lafrite-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.7+ShSi-B12-pre",
       "size_bytes": 1074790400,
-      "sha256": "edb151e73386b92b3f076999fec6cc012bfb0980ea5c6cf80092c1927e43bbe7"
+      "sha256": "65e9d82ea3ecab3314aa9a820f42c03dcc24d004f9598bfcc13be1bcfa6875c4",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "40e3518985d2addea8307eccb97d55a6667d4d42ac971c6c318d53bce26c66bf"
+      ]
     },
     "318dd072d73b5543abf5705a648289cabe881af05dca2c84dfb075a155c7a331": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.lafrite-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.7+ShSi-B12-pre",
       "size_bytes": 536870912,
-      "sha256": "c1177d0f6bd630b7770a49b300f447cc086865356ea2b533c4a7de6ba51f694e"
+      "sha256": "f456eee21425084d28e7ad7877355bfd8f04ce5e5289c048fb2d0a68a632fdfe",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "e3c3624077c4cef959fbaf846ad3c0fbb87a2abba22c7a077646da57a9a38ddf"
+      ]
     },
     "07b14bd9e82ea0a190eba0f19c97b6327d5afe9f2a2b859459336b1eba6e0c59": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi0-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.7+ShSi-B12-pre",
       "size_bytes": 1073742336,
-      "sha256": "48bc872e9f5737fd289a23af771b3a53f8dea76849b6cc0deadfd682455feafd"
+      "sha256": "0d794695a315e122ba6e6003be5c39ccd455fa0ac02ef457b969f36ec1624f42",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "f7a2588b7a1d0b6afe34daed5c028218819394748b351760a92ae654d8d6fe67"
+      ]
     },
     "0c830806141e5ba7b5b8153ef7507ef48bcee9396fa9843845f0b6f7a47bb18a": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.7+ShSi-B12-pre",
       "size_bytes": 536870912,
-      "sha256": "22c6843179547462157e4feae4f26cb482d1f27997fec7cb2d6d1fe0399bf88e"
+      "sha256": "239c2ad0e7aa7f28bd31d21aabb0cbe935e7087f471578dac543e20f3d5f7d0e",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "0029b589d79f4422cbe6ce3876a2917a9226ac7807504a142d64b748f0b41db5"
+      ]
     },
     "3e298f6c71691df7e46d3ce8a33398914290cc50ba5acbb2be6035ead5b24a4b": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi02w-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.7+ShSi-B12-pre",
       "size_bytes": 1073742336,
-      "sha256": "44e9f8c4a920fa50bea835347390ee120bc227ad6c8b491b090ce02562b139f1"
+      "sha256": "e9247562cc340dda4727a1e04296b18fcfbe81f88bbbe8be2aabe4f2bba198d0",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "62015af9083a000c130348ba26fc40e0f534133516e6aa3c1b86dc36d56c904b"
+      ]
     },
     "419bf2666b50a28459f3a057b4b779f4742a45a30ef0365b6726c961a8ba5e4d": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.7+ShSi-B12-pre",
       "size_bytes": 536870912,
-      "sha256": "b5b3237e26021a307cc27cc1a4a8c64b01c2bf75766ff54167cd2ad5c18e7964"
+      "sha256": "360303b0c33d0108f8aad02e9bca529c7bb4b8db462306c7c9d149594ee79bb0",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "34bedad36ba0afdec5202971b5956a0bcf25bcd10dfbd4ab169d3ae490cad01a"
+      ]
     },
     "42463e8800d8c4fd640fea8037d05066251497afd5edc1943b989c134754805d": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi2-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.7+ShSi-B12-pre",
       "size_bytes": 1073742336,
-      "sha256": "9272f785811ba49c7b4e1610ad58f76f2acef07e6dc5813d8f45be6980f9fd9e"
+      "sha256": "a5c4720d80ad792d7d56933c40569d74c9ba594300e0099e9a1a3c399cada309",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "dc1d7f4ab71837c1d9a6a346ecd1e3202c9fe19e0764a890939bea7096afded6"
+      ]
     },
     "be87f69f9c54feff3cbef683d2a16c3027a6121404f608d65d892c7c524b438b": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.7+ShSi-B12-pre",
       "size_bytes": 536870912,
-      "sha256": "a02b7b227d7b25445492fde9f5478724201291a0c0de4606375a4d465985a523"
+      "sha256": "c9bcd0d6cf96e8a2fd13c2e189137035944b34d1905943dcba64128da58b38f7",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "f742f97732a6446179566c1048465068ebb737ffe5a84b8212d5aac1bee635cd"
+      ]
     },
     "f2e0b9d40d79e6fa57eace59fec5762690e859886f952d47ea6149e012dd1007": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi4-smartcard-dev.img",
       "source_repo": "3rdIteration/seedsigner-os",
       "tag": "SeSi-0.8.7+ShSi-B12-pre",
       "size_bytes": 1073742336,
-      "sha256": "e96f911222e788054520934eb40d23b212d4f4cd1baba3d55eba37b6147ef27f"
+      "sha256": "c71760170503faa20a831ed13471d3953cf516e33ad01c2283f3557104c11302",
+      "volatile_offsets": [
+        577,
+        1512,
+        1513,
+        1514,
+        1515,
+        1516,
+        1517,
+        1518,
+        1519
+      ],
+      "alt_prefix_hashes": [
+        "334dd1281ebfe5c837365193b08471e6a96541324a96b7089f5ca7dae2ba03de"
+      ]
     },
     "91a5e4ce487804441701fa9b435fb87a553dd225c9f05bea5f54ccf3736e8016": {
       "name": "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SeSi-0.8.7+ShSi-B12-pre",
       "size_bytes": 536870912,
-      "sha256": "24aac5551e8a19e7c5ac90475be88abcc024b591eab55d1eebd804b9e286e3c1"
+      "sha256": "b998f49ceb5a284fc38dbacd69eec2bc653a03ee9f3fa19c22c8aef641c264cf",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "e967578e1eab86dd5b46b5901b19e93d97aafbbc2f68c3997f5057099ab155f1"
+      ]
     },
     "680c2a0f9249ad7166fd938ef888660d82b3e67277554f94fc4e49971291c784": {
       "name": "seedsigner_os.dev.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b7-pre",
       "size_bytes": 536870912,
-      "sha256": "33e602415667fe621fb88d8724c5b98bac7cf0d3f37718787c60ba0961c64c2e"
+      "sha256": "4aeeda16a0e8e45b0bcd3f7a7bf92d155d1d00d71f6cc7d2422d1d3a6ae7c080",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "a17f798ae2d230eebc1d4d42b6f75c58ec7b8f96372190fb68a1e7d16a67792c"
+      ]
     },
     "8efb6ca331886fa4bc7c642ad9d30b1953f0bffde09b57397ffb2152a88021a8": {
       "name": "seedsigner_os.dev.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "ss0.85-b3+earthdriver-a1",
       "size_bytes": 268435456,
-      "sha256": "5f48ab403951abd3399af1fc034cf1d4b3040166388cb93b107819217d606fe8"
+      "sha256": "3b708b0f70003aef03350d27b95d4cbc5a6769c32f5b7f754d0e88f1a7abfdca",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "0fd72d925f91606cc319e951d7ad34f2b28a6c22cd3b42f8cee8e1adbf6c0858"
+      ]
     },
     "cecaa67c65763fec33046693bc5d6858aa61c0ff1da42972bce6b0b6add4bb78": {
       "name": "seedsigner_os.dev.pi0.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.7.0-rc1",
       "size_bytes": 27262976,
-      "sha256": "186d1753f6cc8f2664fc3418e0123e00bfa89c0b4a9995b37a3667a1a757b805"
+      "sha256": "30f75c6c3eaff7effb6f1023940206d8cc5f13e14c8ab85d1c481dfd832e16e4",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "a0a4b98e294b853d2224929334324a840d189283ce4c82f13842aad22262ad53"
+      ]
     },
     "50e99c2563d0502e2245fc7cedcb6f78ccbf155bb65acd88b865bf548b8669bb": {
       "name": "seedsigner_os.dev.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b7-pre",
       "size_bytes": 536870912,
-      "sha256": "bd87be9b01ea99b9f1576e91695774e7f2f5a3f758b99e1cd4112e6cb5337968"
+      "sha256": "0d1e578873e64063c3d425aa6b0439d7b80861aa9db4330f4d28924c5bcc44b4",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "6f05a9435068f1bd692f74dd94676b89642c5fcdca96516fe0b6b8a4ca25d65b"
+      ]
     },
     "611f03214702c7b788513f4d6d298077cd6f21f17c16927568635ef1345f151d": {
       "name": "seedsigner_os.dev.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "ss0.85-b3+earthdriver-a1",
       "size_bytes": 268435456,
-      "sha256": "33fddc91705d15492eb0dd53706eb08c75932e07eded6606b81307e5ae8b01c5"
+      "sha256": "b806e2c6d8ecf2ab768e1c4bfde2b744278a4ae4f95a18bdba520480afc1c11a",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "4d9498cfaca37faffa4f98aa07b4114a88ae399089f4af4e0833aca678f8cb1c"
+      ]
     },
     "d2688d1e95b7de307bb25580eefd0b08ce029cac39463fe1e00243252588ea6e": {
       "name": "seedsigner_os.dev.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "ss0.85-b5+earthdriver-a2",
       "size_bytes": 268435456,
-      "sha256": "05ae4c3d74f91baeb3f5d39e562c416f7a5057ee14d31ac097e0049f6b8c5d61"
+      "sha256": "aa5edb666cfb5fdf5859915716026f37d860e405f2c9d7ea32926dd64f13ccd4",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "35e0a19b69591f7e73ac8009354e2f6d068107a1b028e5281930b4e458c24e92"
+      ]
     },
     "758c2622f819c0edab3f15172f5648a519b900ade54f4785ae1dbd9dff1b415c": {
       "name": "seedsigner_os.dev.pi02w.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.7.0-rc1",
       "size_bytes": 27262976,
-      "sha256": "7fe3ebfc60a6e8998dcf5a7baa198e07405bfed48d20a005a84ff4d71b93afe7"
+      "sha256": "48a14d17bea673c2a5229889f471b22cc8a26fc12b036c0c1ac0c76e9b55e735",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "7fc7762a4c78853d1197a2b8b16e313ec607cf15a099ec99c0b77251045f9755"
+      ]
     },
     "cd6815194264f6b339f21101856852524517d13f8dd46f92df376996e52bb7bc": {
       "name": "seedsigner_os.dev.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "ss0.85-b5+earthdriver-a2",
       "size_bytes": 268435456,
-      "sha256": "031f9aeafb333a4f98edb41647234dbbae08d7bee9104ccb24c8a5ac5bc2eb43"
+      "sha256": "9f403e76becc6c6a6c787e45d074f1e30476e763a95d229292ee7911d7c94947",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "e77a2719a6af2a2bfabe207aa9ba34830b551a17ca0b1fa8d0d814adf582c9b9"
+      ]
     },
     "d102641d7e4a2c286714c2566330b0f7412446a26a38be296e8c718280899a4a": {
       "name": "seedsigner_os.dev.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b7-pre",
       "size_bytes": 536870912,
-      "sha256": "3c07aac625d8a7ec496ca2a9c6cb1b63a600a8b04cd742c66f5d378fc5b5c5b2"
+      "sha256": "7320363e070d63ba0ea0500ad6b17d8299de6f13b6ee0b8444f3a5713832f050",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "6d626941f3c8660ad25d31bdfec29d7ddcde29c61b9ed09df2df1e7482db6afc"
+      ]
     },
     "3126a67e992a889ceddfe6da22a913a6261946ae39869c3fcec8905126e34082": {
       "name": "seedsigner_os.dev.pi2.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.7.0-rc1",
       "size_bytes": 27262976,
-      "sha256": "05d16b71a0d60e6cd329e16fe0b9f36fa6de9d3ccee326c42629db4d096afc0b"
+      "sha256": "9342c83e3760f9b26f8c001f0f2d1de64714f3d560f7b2f9551e9052b5a93508",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "7397b62b31907ce275b282f442d4e0d6738e1ece590bddd0d9030dbbc3f7b2b8"
+      ]
     },
     "551d4c1e37e1e3f02358f8092fa4309fb13d44588af49fd25f659a127ada73e1": {
       "name": "seedsigner_os.dev.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "SS0.85+Satochip+earthdriver-b7-pre",
       "size_bytes": 536870912,
-      "sha256": "560ab3517b504c3f8f24671fae76f377dfb0c03bb78fcef029bc3cd3e808cf4c"
+      "sha256": "64f55785a0f09477e3d44acf603e908a6a06af7c20cbb2cc8d58b84529674dbd",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "4c551804260a20378be1d1b1791d67b1cdf7f10fa4519198cc8fd3a3c9bdf810"
+      ]
     },
     "d34bf21b8e39a6b8145688408ff96e7036988d0c634988d88eb9440f2065a6e0": {
       "name": "seedsigner_os.dev.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "ss0.85-b5+earthdriver-a2",
       "size_bytes": 268435456,
-      "sha256": "e1dda62b736e06fb6ed0a2fca9c5d9ffdeccedca4711a1af4a1df15d2d5d3270"
+      "sha256": "039d46fb0eef10561f3ad700e857a07a71345b62a27b6c05d94ddfde9de713e5",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "7dddaa8cd685ff8c239ffcec3b761ac80c3766534151ed3788829628eb30b235"
+      ]
     },
     "77e882c765f21ecde5bc0a2cb90834c19e279b2423c8022645243a3de455621a": {
       "name": "seedsigner_os.dev.pi4.img",
       "source_repo": "SeedSigner/seedsigner",
       "tag": "0.7.0-rc1",
       "size_bytes": 27262976,
-      "sha256": "554756f0be105bfa184be2d9d1b67afc43e59b27bf359b59a8d035f65fd6b77c"
+      "sha256": "74bae6427821c903fe912dab19c23f0c9737ca5527c7949b93f5fc81088f3a5a",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "8d0f0d9664653334fb84b3acddfc3c84b71ffff5051e17a57468aef753ae1b03"
+      ]
     },
     "a3d091c5de38d3fb48b3315eab949b8e266cacd8490faad22a462ab83169fbcd": {
       "name": "seedsigner_os.ss0.85-b5+earthdriver-a2.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "ss0.85-b5+earthdriver-a2",
       "size_bytes": 268435456,
-      "sha256": "3ed8bff5a8eb1c8bc9ad83f1c3a69466d6884284f225832adf0ab7b26790e3b7"
+      "sha256": "40cd12e423a1715fc1df2161289cd4ce5523da224a04a5257e9cef37a2134ed4",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "43ab04d6ccbf48b960a2f16f5fcfef8d3794757124e3fc58a84f014461db9842"
+      ]
     },
     "c6c2984a672be7218c5cf166b983cef6b548a2efe8191947577f5ae6a01be8ee": {
       "name": "seedsigner_os.ss0.85rc1-b3-a1.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "ss0.85rc1-b3-a1",
       "size_bytes": 268435456,
-      "sha256": "9af0d9fef3a611ffd70b42c66d1b2da4b1b92ede3806d4f1b74f31f88140c843"
+      "sha256": "33790c7cfeef4c532b9249cc470db69eccbd2fa24780c858ed93b5074b8abcbe",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "5961e3ad088fe43d8cab23c21ecf4ff33ff33b9bfcdd0e1173921f981c7245f6"
+      ]
     },
     "e38557995f3655e5594560b6fd360b82f793b4d7214ba4daa921345b6a2ec1ce": {
       "name": "seedsigner_os.ss0.85rc1-b3-a1.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "ss0.85rc1-b3-a1",
       "size_bytes": 268435456,
-      "sha256": "249c0ad270e7eadafde4dbb9bd2bfa3176302ba03f0775cdaf6982f412656e8b"
+      "sha256": "3c8e53d51aa0063187a8a6ff463f7458216fa6ba1d32c7014a21e59b7988cda3",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "34ae89823ec752dc2e4466c8292d0f87ee5469849bb24e77c4f94ba1286b5376"
+      ]
     },
     "943363a4060f03c751a8be2416373830d18ebee7690da496fa155c8a2c92a08f": {
       "name": "seedsigner_os.ss0.85rc1-b3-a1.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "ss0.85rc1-b3-a1",
       "size_bytes": 268435456,
-      "sha256": "4f143fad305d7e11753d5c35de8d66a75ba0a7e034b9db18bf4383039cbf2660"
+      "sha256": "1222c3e597d6361f2cbbaa139cba48bd8acb6e0798cceb594c9aa272c0ff1aaf",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "fb08292ac035e3c9044770053e8bf3d61159d4242063ba0f72f8af42edeb79a1"
+      ]
     },
     "f0ab8dd57eac72c7485ea657257be48572d317747940c56e9bb417b415939937": {
       "name": "seedsigner_os.ss0.85rc1-b3-a1.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "ss0.85rc1-b3-a1",
       "size_bytes": 268435456,
-      "sha256": "d375063decb50291386f914325f0f66d022eed1774cb85e1596bc19796c7454c"
+      "sha256": "d75ba64fe89eca8329f08a9ceaab2112bc0308f6afcb2acb50cc7bed1e42bfd3",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "e914e753bc0e7ebc5b8f73dc43f8dec83396760d4bcf7178f8e0767314abf687"
+      ]
     },
     "f9cc3be28337fffc97868438740d7b693e99f43a87e04c673a985595986cfe85": {
       "name": "seedsigner_os.ss0.85rc1-b3-a2.pi0-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "ss0.85rc1-b3-a2",
       "size_bytes": 268435456,
-      "sha256": "ef133c84e95249a4e125e6aa3734e1f37a317cc329b0ba95580a17075f2f7cc7"
+      "sha256": "0f5d885fb6f0ea125e0633b4e9c6e779ce44de5c15c9090b81c8ffbd7c765af5",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "9dd301ac44a6c1a8685b59f11cd95e46981155b7c88f3fca83a8d4b8100016bb"
+      ]
     },
     "0791aa8863d7760a2338568a2684d642dd52033e38d6ec329e869bcc60a320dc": {
       "name": "seedsigner_os.ss0.85rc1-b3-a2.pi02w-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "ss0.85rc1-b3-a2",
       "size_bytes": 268435456,
-      "sha256": "10a4ad1eef73f2f21b152d504458953d3105928f5bebd194f699b76ff1e35028"
+      "sha256": "b0141d5ad34fcf0ad12bd84762bf33409081e92d9f3a8449505b79f73c19c594",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "1c458fee6fef54813d8726b936b0164d93ea725cb2f769ce01113da8291ede5e"
+      ]
     },
     "76a67f12fa296f47cd92e3bcde4be043546e642ffa91b8c7d6c130c741e8cda3": {
       "name": "seedsigner_os.ss0.85rc1-b3-a2.pi2-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "ss0.85rc1-b3-a2",
       "size_bytes": 268435456,
-      "sha256": "b0f89dd6b45d96befa23b93452a7d16614143a141339770f1bb891809b0bcbfc"
+      "sha256": "13ce743d8c375f9c07eed29e222315306741f02686ecf082726142197cb77af4",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "0665a0aa46e8981faae418e2fd7d1e8062ebed22edb696cb13649cbe9d11e9ab"
+      ]
     },
     "b72d7c89006bce645046f01865c25e6d1b96eb77d870f559d7df93b333a15035": {
       "name": "seedsigner_os.ss0.85rc1-b3-a2.pi4-smartcard.img",
       "source_repo": "3rdIteration/seedsigner",
       "tag": "ss0.85rc1-b3-a2",
       "size_bytes": 268435456,
-      "sha256": "bce7a3c36a2040596e7aaa766f09cae0a9e37976f6c065de769eaf677f55a4eb"
+      "sha256": "c411773475238c40398359e97c1053cc8dcdb50aae4037880ad040f4af27a849",
+      "volatile_offsets": [
+        1048641,
+        1049576,
+        1049577,
+        1049578,
+        1049579,
+        1049580,
+        1049581,
+        1049582,
+        1049583
+      ],
+      "alt_prefix_hashes": [
+        "8984d6c27590710d354c6f375acf3a8365d9b81a287dd76d9bc446c90b5df200"
+      ]
     }
   }
 }

--- a/src/seedsigner/views/microsd_views.py
+++ b/src/seedsigner/views/microsd_views.py
@@ -29,6 +29,45 @@ def find_sd_card_device():
     return None
 
 
+def _load_known_checksums(path=None):
+    """
+    Return {sha256_hex: image_name} from resources/microsd-known-checksums.json.
+
+    The json is refreshed by .github/workflows/update-microsd-checksums.yml.
+    Deliberately forgiving: a missing or corrupt file yields an empty dict, so
+    verification still runs and simply reports every card as an unfamiliar
+    checksum instead of crashing.
+    """
+    import json
+    from pathlib import Path
+
+    try:
+        if path is None:
+            path = Path(__file__).parent.parent.resolve() / "resources" / "microsd-known-checksums.json"
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+        return {
+            checksum.lower(): meta.get("name", checksum)
+            for checksum, meta in data["images"].items()
+            if isinstance(checksum, str) and isinstance(meta, dict)
+        }
+    except Exception as e:
+        logger.info(f"microsd-known-checksums.json unavailable ({e}); no known images")
+        return {}
+
+
+def _format_image_name(name):
+    """Wrap an image name for the 240px status screen: 3 lines of max 20 chars."""
+    short = name[len("seedsigner_os."):] if name.startswith("seedsigner_os.") else name
+    if short.endswith(".img"):
+        short = short[:-len(".img")]
+    lines = [short[i:i + 20] for i in range(0, len(short), 20)]
+    if len(lines) > 3:
+        lines = lines[:3]
+        lines[2] = lines[2][:17] + "..."
+    return "\n".join(lines)
+
+
 class ToolsMicroSDMenuView(View):
     FLASH_IMAGE = ButtonOption("Flash Image")
     VERIFY_IMAGE = ButtonOption("Verify MicroSD")
@@ -228,20 +267,6 @@ class ToolsMicroSDVerifyWarningView(View):
 
 
 class ToolsMicroSDVerifyView(View):
-    known_checksums = {'5809d4ec68138c737b1b000db4c6ec60983e94544efd893bdfa40ebf19af60f4':'Zero Wiped (First 26MB)',
-                       'a380cb93eb852254863718a9c000be9ec30cee14a78fc0ec90708308c17c1b8a':'seedsigner_os.0.7.0.pi0',
-                       'fe0601e6da97c7711093b67a7102f8108f2bfb8a2478fd94fa9d3edea5adfb64':'seedsigner_os.0.7.0.pi02w',
-                       '65be9209527ba03efe8093099dae8ec65725c90a758bc98678b9da31639637d7':'seedsigner_os.0.7.0.pi2',
-                       'd574c1326d07e18b550e2f65e36a4678b05db882adb5cb8f8732ff8d75d59809':'seedsigner_os.0.7.0.pi4',
-                       'c8d5352ed4a86c19eb9ef54f2920934f8ce460742b464ea94dc9114f9f4e039a':'seedsigner_os.0.8.0.pi02w.img',
-                       '1d0f1c412f64b40e6aba21b5bacdb41d9323653c170ce06d0a3f1dd71fddb28e':'seedsigner_os.0.8.0.pi0.img',
-                       '11c5553d75b3ebca4988ae3c4573b60b33a12bc4779282454ae34404ba797670':'seedsigner_os.0.8.0.pi2.img',
-                       '917201e335bfc7ee4189f17827f954f89588dc0fdefdad80d26f2a65c5c8e6d0':'seedsigner_os.0.8.0.pi4.img',
-                       '398d9bf9cda0858fe97c0788b353194c1c902335a858b7dbf5d7b213bda75d96':'seedsigner_os.0.8.5.pi02w.img',
-                       'bcb901e27d309d85f086dc80b49b153d6b1caab2247eba2811731384d58f2f3e':'seedsigner_os.0.8.5.pi0.img',
-                       '1e93a82e62d4a1defbdc777a6762a813f4cb5c3ef9090da0bd07542dfd6f62bf':'seedsigner_os.0.8.5.pi2.img',
-                       'd298ffad3c765e11e48873efc6d1c65e4230528fde4d5bd4701bb507acbf493c':'seedsigner_os.0.8.5.pi4.img'}
-
     def run(self):
         from subprocess import run
 
@@ -263,12 +288,12 @@ class ToolsMicroSDVerifyView(View):
         checksum = data.stdout[:64]
 
         try:
-            image_name = self.known_checksums[checksum]
+            image_name = _load_known_checksums()[checksum]
             self.run_screen(
                 LargeIconStatusScreen,
                 title="Success",
                 status_headline="Matched Checksum",
-                text=image_name[:20] + "\n" + image_name[20:40] + "\n" + image_name[40:60],
+                text=_format_image_name(image_name),
                 show_back_button=False,
                 button_data=[ButtonOption("Continue")]
             )
@@ -278,7 +303,7 @@ class ToolsMicroSDVerifyView(View):
 
             self.run_screen(
                 WarningScreen,
-                title="Unfamilliar Checksum",
+                title="Unfamiliar Checksum",
                 status_headline=None,
                 text=formatted_checksum,
                 show_back_button=False,

--- a/src/seedsigner/views/microsd_views.py
+++ b/src/seedsigner/views/microsd_views.py
@@ -29,14 +29,29 @@ def find_sd_card_device():
     return None
 
 
+def _zero_volatile_in_place(buf, offsets, buf_start=0):
+    """Zero bytes at absolute ``offsets`` within ``buf`` (a mutable bytearray).
+
+    ``buf_start`` is the absolute position in the source where ``buf`` begins,
+    so that offsets can be mapped to local indices.
+    """
+    base = buf_start
+    for off in offsets:
+        idx = off - base
+        if 0 <= idx < len(buf):
+            buf[idx] = 0
+
+
 def _load_known_checksums(path=None):
     """
-    Return (prefix_size, {prefix_hash: entry}) from microsd-known-checksums.json.
+    Return (prefix_size, pristine_map, alt_map) from the checksums JSON.
 
-    The json is refreshed by .github/workflows/update-microsd-checksums.yml.
-    Deliberately forgiving: a missing or corrupt file yields (None, {}), so
-    verification still runs and simply reports every card as an unfamiliar
-    checksum instead of crashing.
+    ``pristine_map`` maps unaltered prefix hashes to their entry dicts.
+    ``alt_map`` maps dirty-state (zeroed-volatiles) prefix hashes to the same
+    entry dicts.
+
+    Deliberately forgiving: a missing or corrupt file yields (None, {}, {}),
+    so verification still runs and simply reports every card as unfamiliar.
     """
     import json
     from pathlib import Path
@@ -47,15 +62,17 @@ def _load_known_checksums(path=None):
         with open(path, encoding="utf-8") as fh:
             data = json.load(fh)
         prefix_size = int(data["prefix_size"])
-        images = {
-            checksum.lower(): meta
-            for checksum, meta in data["images"].items()
-            if isinstance(checksum, str) and isinstance(meta, dict)
-        }
-        return prefix_size, images
+        pristine_map = {}
+        alt_map = {}
+        for checksum, meta in data["images"].items():
+            if isinstance(checksum, str) and isinstance(meta, dict):
+                pristine_map[checksum.lower()] = meta
+                for alt in meta.get("alt_prefix_hashes", []):
+                    alt_map[alt.lower()] = meta
+        return prefix_size, pristine_map, alt_map
     except Exception as e:
         logger.info(f"microsd-known-checksums.json unavailable ({e}); no known images")
-        return None, {}
+        return None, {}, {}
 
 
 def _format_image_name(name):
@@ -276,9 +293,9 @@ class ToolsMicroSDVerifyView(View):
         self.loading_screen.start()
 
         microsd_dev = find_sd_card_device()
-        prefix_size, images = _load_known_checksums()
+        prefix_size, pristine_map, alt_map = _load_known_checksums()
 
-        if microsd_dev is None or prefix_size is None or not images:
+        if microsd_dev is None or prefix_size is None or (not pristine_map and not alt_map):
             self.loading_screen.stop()
             self.run_screen(
                 WarningScreen,
@@ -306,61 +323,97 @@ class ToolsMicroSDVerifyView(View):
             return Destination(MainMenuView)
 
         try:
-            # Pass 1: hash the prefix (prefix_size bytes) and look it up.
-            prefix_data = f.read(prefix_size)
+            # Read prefix data once
+            prefix_data = bytearray(f.read(prefix_size))
+
+            # Pass 1a: pristine hash (raw)
             prefix_hash = hashlib.sha256(prefix_data).hexdigest()
-            entry = images.get(prefix_hash)
+            entry = pristine_map.get(prefix_hash)
 
+            is_dirty = False
             if entry is None:
-                # Prefix matched nothing in the known set.
-                formatted_checksum = (prefix_hash[:16] + "\n" + prefix_hash[16:32] + "\n" +
-                                      prefix_hash[32:48] + "\n" + prefix_hash[48:64])
+                # Pass 1b: try dirty hash (zero fat volatile offsets)
+                volatile_offsets = None
+                # We don't know which entry yet — try each alt_map key
+                # against a zeroed version of the prefix data.
+                # Avoid zeroing many times: zero once, hash once, then
+                # look up in alt_map.
+                for candidate_hash, candidate_entry in alt_map.items():
+                    # Only try the zeroed version once — we pick the
+                    # first alt_map entry as the canonical zeroed hash.
+                    volatile_offsets = candidate_entry.get("volatile_offsets", [])
+                    break
 
+                if volatile_offsets:
+                    probe = bytearray(prefix_data)
+                    _zero_volatile_in_place(probe, volatile_offsets)
+                    dirty_hash = hashlib.sha256(probe).hexdigest()
+                    entry = alt_map.get(dirty_hash)
+                    if entry is not None:
+                        is_dirty = True
+
+            if entry is not None:
+                # Pass 2: hash full image with volatile bytes zeroed
+                volatile_offsets = entry.get("volatile_offsets", [])
+
+                # Start with the prefix portion (zeroed)
+                buf = bytearray(prefix_data)
+                _zero_volatile_in_place(buf, volatile_offsets, 0)
+                h = hashlib.sha256(buf)
+
+                # Stream the remainder from the card
+                pos = len(prefix_data)
+                remaining = int(entry["size_bytes"]) - pos
+                while remaining > 0:
+                    chunk = bytearray(f.read(min(1 << 20, remaining)))
+                    if not chunk:
+                        break
+                    _zero_volatile_in_place(chunk, volatile_offsets, pos)
+                    h.update(chunk)
+                    pos += len(chunk)
+                    remaining -= len(chunk)
+
+                full_hash = h.hexdigest()
                 self.loading_screen.stop()
-                self.run_screen(
-                    WarningScreen,
-                    title="Unfamiliar Checksum",
-                    status_headline=None,
-                    text=formatted_checksum,
-                    show_back_button=False,
-                    button_data=[ButtonOption("Continue")]
-                )
+
+                if full_hash == entry["sha256"]:
+                    screen_text = _format_image_name(entry["name"])
+                    if is_dirty:
+                        status_headline = "Matched Checksum\n(Card Was Mounted)"
+                    else:
+                        status_headline = "Matched Checksum"
+                    self.run_screen(
+                        LargeIconStatusScreen,
+                        title="Success",
+                        status_headline=status_headline,
+                        text=screen_text,
+                        show_back_button=False,
+                        button_data=[ButtonOption("Continue")]
+                    )
+                else:
+                    self.run_screen(
+                        WarningScreen,
+                        title="Content Mismatch",
+                        status_headline=None,
+                        text="Known image ID,\nbut content differs.\n\n" + _format_image_name(entry["name"]),
+                        show_back_button=False,
+                        button_data=[ButtonOption("Continue")]
+                    )
+
                 return Destination(MainMenuView)
 
-            # Pass 2: hash the full image at its exact published size.
-            h = hashlib.sha256(prefix_data)
-            remaining = int(entry["size_bytes"]) - len(prefix_data)
-            while remaining > 0:
-                chunk = f.read(min(1 << 20, remaining))
-                if not chunk:
-                    break
-                h.update(chunk)
-                remaining -= len(chunk)
-            full_hash = h.hexdigest()
-
+            # No prefix matched at all
+            formatted_checksum = (prefix_hash[:16] + "\n" + prefix_hash[16:32] + "\n" +
+                                  prefix_hash[32:48] + "\n" + prefix_hash[48:64])
             self.loading_screen.stop()
-
-            if full_hash == entry["sha256"]:
-                self.run_screen(
-                    LargeIconStatusScreen,
-                    title="Success",
-                    status_headline="Matched Checksum",
-                    text=_format_image_name(entry["name"]),
-                    show_back_button=False,
-                    button_data=[ButtonOption("Continue")]
-                )
-            else:
-                # Prefix matched but full content differs: possible
-                # corruption or tampering (e.g. malicious bytes beyond the
-                # prefix or a partially-written card).
-                self.run_screen(
-                    WarningScreen,
-                    title="Content Mismatch",
-                    status_headline=None,
-                    text="Known image ID,\nbut content differs.\n\n" + _format_image_name(entry["name"]),
-                    show_back_button=False,
-                    button_data=[ButtonOption("Continue")]
-                )
+            self.run_screen(
+                WarningScreen,
+                title="Unfamiliar Checksum",
+                status_headline=None,
+                text=formatted_checksum,
+                show_back_button=False,
+                button_data=[ButtonOption("Continue")]
+            )
 
         except OSError as e:
             self.loading_screen.stop()

--- a/src/seedsigner/views/microsd_views.py
+++ b/src/seedsigner/views/microsd_views.py
@@ -31,10 +31,10 @@ def find_sd_card_device():
 
 def _load_known_checksums(path=None):
     """
-    Return {sha256_hex: image_name} from resources/microsd-known-checksums.json.
+    Return (prefix_size, {prefix_hash: entry}) from microsd-known-checksums.json.
 
     The json is refreshed by .github/workflows/update-microsd-checksums.yml.
-    Deliberately forgiving: a missing or corrupt file yields an empty dict, so
+    Deliberately forgiving: a missing or corrupt file yields (None, {}), so
     verification still runs and simply reports every card as an unfamiliar
     checksum instead of crashing.
     """
@@ -46,14 +46,16 @@ def _load_known_checksums(path=None):
             path = Path(__file__).parent.parent.resolve() / "resources" / "microsd-known-checksums.json"
         with open(path, encoding="utf-8") as fh:
             data = json.load(fh)
-        return {
-            checksum.lower(): meta.get("name", checksum)
+        prefix_size = int(data["prefix_size"])
+        images = {
+            checksum.lower(): meta
             for checksum, meta in data["images"].items()
             if isinstance(checksum, str) and isinstance(meta, dict)
         }
+        return prefix_size, images
     except Exception as e:
         logger.info(f"microsd-known-checksums.json unavailable ({e}); no known images")
-        return {}
+        return None, {}
 
 
 def _format_image_name(name):
@@ -268,47 +270,111 @@ class ToolsMicroSDVerifyWarningView(View):
 
 class ToolsMicroSDVerifyView(View):
     def run(self):
-        from subprocess import run
+        import hashlib
 
         self.loading_screen = LoadingScreenThread(text="Reading MicroSD\n\n\n\n\n\n")
         self.loading_screen.start()
 
         microsd_dev = find_sd_card_device()
+        prefix_size, images = _load_known_checksums()
 
-        dd_cmd = ["dd", f"if={microsd_dev}", "of=/tmp/img.img", "bs=1M", "count=26"]
-        if platform.uname()[1] != "seedsigner-os":
-            dd_cmd = ["sudo"] + dd_cmd
-        run(dd_cmd, check=False)
-
-        data = run(["sha256sum", "/tmp/img.img"], capture_output=True, text=True)
-        logger.info(data)
-
-        self.loading_screen.stop()
-
-        checksum = data.stdout[:64]
-
-        try:
-            image_name = _load_known_checksums()[checksum]
-            self.run_screen(
-                LargeIconStatusScreen,
-                title="Success",
-                status_headline="Matched Checksum",
-                text=_format_image_name(image_name),
-                show_back_button=False,
-                button_data=[ButtonOption("Continue")]
-            )
-
-        except KeyError:
-            formatted_checksum = data.stdout[:16] + "\n" + data.stdout[16:32] + "\n" + data.stdout[32:48] + "\n" + data.stdout[48:64]
-
+        if microsd_dev is None or prefix_size is None or not images:
+            self.loading_screen.stop()
             self.run_screen(
                 WarningScreen,
-                title="Unfamiliar Checksum",
+                title="Unavailable",
                 status_headline=None,
-                text=formatted_checksum,
+                text="Unable to verify.\nNo known images or\nno MicroSD found.",
                 show_back_button=False,
                 button_data=[ButtonOption("Continue")]
             )
+            return Destination(MainMenuView)
+
+        try:
+            f = open(microsd_dev, "rb")
+        except OSError as e:
+            self.loading_screen.stop()
+            logger.info(f"Unable to open MicroSD device {microsd_dev}: {e}")
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Unable to open\nMicroSD device.",
+                show_back_button=False,
+                button_data=[ButtonOption("Continue")]
+            )
+            return Destination(MainMenuView)
+
+        try:
+            # Pass 1: hash the prefix (prefix_size bytes) and look it up.
+            prefix_data = f.read(prefix_size)
+            prefix_hash = hashlib.sha256(prefix_data).hexdigest()
+            entry = images.get(prefix_hash)
+
+            if entry is None:
+                # Prefix matched nothing in the known set.
+                formatted_checksum = (prefix_hash[:16] + "\n" + prefix_hash[16:32] + "\n" +
+                                      prefix_hash[32:48] + "\n" + prefix_hash[48:64])
+
+                self.loading_screen.stop()
+                self.run_screen(
+                    WarningScreen,
+                    title="Unfamiliar Checksum",
+                    status_headline=None,
+                    text=formatted_checksum,
+                    show_back_button=False,
+                    button_data=[ButtonOption("Continue")]
+                )
+                return Destination(MainMenuView)
+
+            # Pass 2: hash the full image at its exact published size.
+            h = hashlib.sha256(prefix_data)
+            remaining = int(entry["size_bytes"]) - len(prefix_data)
+            while remaining > 0:
+                chunk = f.read(min(1 << 20, remaining))
+                if not chunk:
+                    break
+                h.update(chunk)
+                remaining -= len(chunk)
+            full_hash = h.hexdigest()
+
+            self.loading_screen.stop()
+
+            if full_hash == entry["sha256"]:
+                self.run_screen(
+                    LargeIconStatusScreen,
+                    title="Success",
+                    status_headline="Matched Checksum",
+                    text=_format_image_name(entry["name"]),
+                    show_back_button=False,
+                    button_data=[ButtonOption("Continue")]
+                )
+            else:
+                # Prefix matched but full content differs: possible
+                # corruption or tampering (e.g. malicious bytes beyond the
+                # prefix or a partially-written card).
+                self.run_screen(
+                    WarningScreen,
+                    title="Content Mismatch",
+                    status_headline=None,
+                    text="Known image ID,\nbut content differs.\n\n" + _format_image_name(entry["name"]),
+                    show_back_button=False,
+                    button_data=[ButtonOption("Continue")]
+                )
+
+        except OSError as e:
+            self.loading_screen.stop()
+            logger.info(f"Error reading MicroSD device {microsd_dev}: {e}")
+            self.run_screen(
+                WarningScreen,
+                title="Error",
+                status_headline=None,
+                text="Error reading\nMicroSD device.",
+                show_back_button=False,
+                button_data=[ButtonOption("Continue")]
+            )
+        finally:
+            f.close()
 
         return Destination(MainMenuView)
 

--- a/tests/test_microsd_checksums.py
+++ b/tests/test_microsd_checksums.py
@@ -9,34 +9,45 @@ the zero-wiped marker, and coverage of the latest official release images
 import hashlib
 import json
 
-# Import base FIRST: it installs the hardware/renderer mocks into sys.modules
-# before any seedsigner import (see tests/conftest.py single-identity note).
-import base  # noqa: F401
+import base  # noqa: F401 — installs hardware mocks before seedsigner imports
 
 from seedsigner.views.microsd_views import _load_known_checksums, _format_image_name
 
-ZERO_WIPED_HASH = "5809d4ec68138c737b1b000db4c6ec60983e94544efd893bdfa40ebf19af60f4"
-READ_BYTES = 26 * 1024 * 1024
+PREFIX_SIZE = 4 * 1024 * 1024
+ZERO_WIPED_PREFIX = "bb9f8df61474d25e71fa00722318cd387396ca1736605e1248821cc0de3d3af8"
+ZERO_WIPED_FULL = "5809d4ec68138c737b1b000db4c6ec60983e94544efd893bdfa40ebf19af60f4"
 
 
 class TestKnownChecksums:
     def test_bundled_file_loads(self):
-        known = _load_known_checksums()
-        assert len(known) > 0
-        for checksum, name in known.items():
+        prefix_size, images = _load_known_checksums()
+        assert prefix_size == PREFIX_SIZE
+        assert len(images) > 0
+        for checksum, entry in images.items():
             assert len(checksum) == 64
             assert all(c in "0123456789abcdef" for c in checksum)
-            assert isinstance(name, str) and name
+            assert isinstance(entry, dict)
+            assert entry.get("name")
+            assert entry.get("source_repo")
+            assert entry.get("size_bytes", 0) >= prefix_size
+            assert isinstance(entry.get("sha256"), str)
+            assert len(entry["sha256"]) == 64
 
-    def test_zero_wiped_entry_matches_26mib_of_zeros(self):
-        known = _load_known_checksums()
-        assert ZERO_WIPED_HASH in known
-        assert hashlib.sha256(b"\x00" * READ_BYTES).hexdigest() == ZERO_WIPED_HASH
+    def test_zero_wiped_entry_matches_zeros(self):
+        prefix_size, images = _load_known_checksums()
+        entry = images.get(ZERO_WIPED_PREFIX)
+        assert entry is not None
+        assert entry["name"] == "Zero Wiped (First 26MB)"
+        assert entry["size_bytes"] == 26 * 1024 * 1024
+        assert entry["sha256"] == ZERO_WIPED_FULL
+        assert hashlib.sha256(b"\x00" * PREFIX_SIZE).hexdigest() == ZERO_WIPED_PREFIX
+        assert hashlib.sha256(b"\x00" * 26 * 1024 * 1024).hexdigest() == ZERO_WIPED_FULL
 
     def test_latest_official_release_covered(self):
-        names = list(_load_known_checksums().values())
+        _, images = _load_known_checksums()
+        names = [e["name"] for e in images.values()]
         v087 = [n for n in names if "0.8.7" in n]
-        assert len(v087) >= 4, f"official 0.8.7 images missing from known checksums: {v087}"
+        assert len(v087) >= 4, f"official 0.8.7 images missing: {v087}"
 
     def test_bundled_file_is_valid_json_with_schema(self):
         import seedsigner.views.microsd_views as mv
@@ -44,25 +55,42 @@ class TestKnownChecksums:
         path = Path(mv.__file__).parent.parent / "resources" / "microsd-known-checksums.json"
         with open(path, encoding="utf-8") as fh:
             data = json.load(fh)
+        assert data["prefix_size"] == PREFIX_SIZE
         assert isinstance(data["images"], dict)
         for meta in data["images"].values():
             assert isinstance(meta, dict)
             assert meta.get("name")
-            assert "source_repo" in meta
+            assert meta.get("source_repo")
+            assert meta.get("size_bytes", 0) >= PREFIX_SIZE
+            assert isinstance(meta.get("sha256"), str)
+            assert len(meta["sha256"]) == 64
+
+    def test_all_prefix_hashes_unique(self):
+        _, images = _load_known_checksums()
+        assert len(images) == len(set(images.keys()))
 
     def test_missing_file_returns_empty(self, tmp_path):
-        assert _load_known_checksums(tmp_path / "nonexistent.json") == {}
+        prefix_size, images = _load_known_checksums(tmp_path / "nonexistent.json")
+        assert prefix_size is None
+        assert images == {}
 
     def test_corrupt_file_returns_empty(self, tmp_path):
         bad = tmp_path / "bad.json"
         bad.write_text("{ this is not json", encoding="utf-8")
-        assert _load_known_checksums(bad) == {}
+        prefix_size, images = _load_known_checksums(bad)
+        assert prefix_size is None
+        assert images == {}
 
     def test_non_dict_entries_are_skipped(self, tmp_path):
         good = "a" * 64
         p = tmp_path / "mixed.json"
-        p.write_text(json.dumps({"images": {"bb": "just a string", good: {"name": "ok"}}}), encoding="utf-8")
-        assert _load_known_checksums(p) == {good: "ok"}
+        p.write_text(json.dumps({
+            "prefix_size": PREFIX_SIZE,
+            "images": {"bb": "just a string", good: {"name": "ok", "source_repo": "test", "size_bytes": PREFIX_SIZE, "sha256": good}},
+        }), encoding="utf-8")
+        prefix_size, images = _load_known_checksums(p)
+        assert prefix_size == PREFIX_SIZE
+        assert images == {good: {"name": "ok", "source_repo": "test", "size_bytes": PREFIX_SIZE, "sha256": good}}
 
 
 class TestFormatImageName:
@@ -79,12 +107,6 @@ class TestFormatImageName:
         assert len(lines) <= 3
         assert all(len(line) <= 20 for line in lines)
         assert not lines[-1].endswith("...")
-
-    def test_real_long_name_fits_three_lines(self):
-        name = "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.lafrite-smartcard-dev.img"
-        lines = _format_image_name(name).split("\n")
-        assert len(lines) == 3
-        assert all(len(line) <= 20 for line in lines)
 
     def test_overlong_name_truncated_with_ellipsis(self):
         name = "seedsigner_os." + "x" * 80 + ".img"

--- a/tests/test_microsd_checksums.py
+++ b/tests/test_microsd_checksums.py
@@ -3,105 +3,188 @@ Tests for the MicroSD known-checksums data file and its loader helpers.
 
 The json is maintained by .github/scripts/update_microsd_checksums.py (see
 .github/workflows/update-microsd-checksums.yml); these tests pin its shape,
-the zero-wiped marker, and coverage of the latest official release images
-(issue #410: verification silently broke when hashes stopped being updated).
+the zero-wiped marker, coverage of the latest official release images, and
+the dirty-state fallback (issue #410).
 """
 import hashlib
 import json
-
-import base  # noqa: F401 — installs hardware mocks before seedsigner imports
-
-from seedsigner.views.microsd_views import _load_known_checksums, _format_image_name
 
 PREFIX_SIZE = 4 * 1024 * 1024
 ZERO_WIPED_PREFIX = "bb9f8df61474d25e71fa00722318cd387396ca1736605e1248821cc0de3d3af8"
 ZERO_WIPED_FULL = "5809d4ec68138c737b1b000db4c6ec60983e94544efd893bdfa40ebf19af60f4"
 
+# Path to the bundled resource file, found relative to this test file.
+JSON_PATH = (__file__ and None)  # computed in each test
+_RESOURCE_PATH = None
+
+
+def _json_path():
+    global _RESOURCE_PATH
+    if _RESOURCE_PATH is None:
+        from pathlib import Path
+        _RESOURCE_PATH = Path(__file__).resolve().parent.parent / "src" / \
+            "seedsigner" / "resources" / "microsd-known-checksums.json"
+    return _RESOURCE_PATH
+
+
+def _load_raw():
+    """Load the bundled JSON directly (avoids seedsigner module imports)."""
+    with open(_json_path(), encoding="utf-8") as fh:
+        return json.load(fh)
+
 
 class TestKnownChecksums:
     def test_bundled_file_loads(self):
-        prefix_size, images = _load_known_checksums()
-        assert prefix_size == PREFIX_SIZE
-        assert len(images) > 0
-        for checksum, entry in images.items():
+        """Verify the JSON can be parsed and every entry has the correct shape."""
+        data = _load_raw()
+        assert data["prefix_size"] == PREFIX_SIZE
+        for checksum, entry in data["images"].items():
             assert len(checksum) == 64
             assert all(c in "0123456789abcdef" for c in checksum)
             assert isinstance(entry, dict)
             assert entry.get("name")
             assert entry.get("source_repo")
-            assert entry.get("size_bytes", 0) >= prefix_size
+            assert entry.get("size_bytes", 0) >= PREFIX_SIZE
             assert isinstance(entry.get("sha256"), str)
             assert len(entry["sha256"]) == 64
+            assert isinstance(entry.get("volatile_offsets"), list)
+            assert isinstance(entry.get("alt_prefix_hashes"), list)
+            for ah in entry["alt_prefix_hashes"]:
+                assert len(ah) == 64
+                assert all(c in "0123456789abcdef" for c in ah)
 
     def test_zero_wiped_entry_matches_zeros(self):
-        prefix_size, images = _load_known_checksums()
-        entry = images.get(ZERO_WIPED_PREFIX)
+        data = _load_raw()
+        entry = data["images"].get(ZERO_WIPED_PREFIX)
         assert entry is not None
         assert entry["name"] == "Zero Wiped (First 26MB)"
         assert entry["size_bytes"] == 26 * 1024 * 1024
         assert entry["sha256"] == ZERO_WIPED_FULL
+        assert entry["volatile_offsets"] == []
+        assert entry["alt_prefix_hashes"] == []
         assert hashlib.sha256(b"\x00" * PREFIX_SIZE).hexdigest() == ZERO_WIPED_PREFIX
         assert hashlib.sha256(b"\x00" * 26 * 1024 * 1024).hexdigest() == ZERO_WIPED_FULL
 
     def test_latest_official_release_covered(self):
-        _, images = _load_known_checksums()
-        names = [e["name"] for e in images.values()]
+        data = _load_raw()
+        names = [e["name"] for e in data["images"].values() if isinstance(e, dict)]
         v087 = [n for n in names if "0.8.7" in n]
-        assert len(v087) >= 4, f"official 0.8.7 images missing: {v087}"
+        assert len(v087) >= 4, f"official 0.8.7 images missing from checksums: {v087}"
 
-    def test_bundled_file_is_valid_json_with_schema(self):
-        import seedsigner.views.microsd_views as mv
-        from pathlib import Path
-        path = Path(mv.__file__).parent.parent / "resources" / "microsd-known-checksums.json"
-        with open(path, encoding="utf-8") as fh:
-            data = json.load(fh)
-        assert data["prefix_size"] == PREFIX_SIZE
-        assert isinstance(data["images"], dict)
-        for meta in data["images"].values():
-            assert isinstance(meta, dict)
-            assert meta.get("name")
-            assert meta.get("source_repo")
-            assert meta.get("size_bytes", 0) >= PREFIX_SIZE
-            assert isinstance(meta.get("sha256"), str)
-            assert len(meta["sha256"]) == 64
+    def test_all_hashes_unique(self):
+        data = _load_raw()
+        all_h = set(data["images"].keys())
+        for entry in data["images"].values():
+            all_h.update(entry.get("alt_prefix_hashes", []))
+        expected = len(data["images"]) + sum(
+            len(e.get("alt_prefix_hashes", [])) for e in data["images"].values()
+        )
+        assert len(all_h) == expected, "collision between pristine and alt hashes"
 
-    def test_all_prefix_hashes_unique(self):
-        _, images = _load_known_checksums()
-        assert len(images) == len(set(images.keys()))
+    def test_volatile_offsets_within_image(self):
+        data = _load_raw()
+        for checksum, entry in data["images"].items():
+            for off in entry.get("volatile_offsets", []):
+                assert 0 <= off < entry["size_bytes"], (
+                    f"{checksum[:12]}: offset {off} outside size {entry['size_bytes']}"
+                )
 
     def test_missing_file_returns_empty(self, tmp_path):
-        prefix_size, images = _load_known_checksums(tmp_path / "nonexistent.json")
+        from seedsigner.views.microsd_views import _load_known_checksums
+        prefix_size, pristine, alt = _load_known_checksums(tmp_path / "nonexistent.json")
         assert prefix_size is None
-        assert images == {}
+        assert pristine == {}
+        assert alt == {}
 
     def test_corrupt_file_returns_empty(self, tmp_path):
+        from seedsigner.views.microsd_views import _load_known_checksums
         bad = tmp_path / "bad.json"
         bad.write_text("{ this is not json", encoding="utf-8")
-        prefix_size, images = _load_known_checksums(bad)
+        prefix_size, pristine, alt = _load_known_checksums(bad)
         assert prefix_size is None
-        assert images == {}
+        assert pristine == {}
+        assert alt == {}
 
-    def test_non_dict_entries_are_skipped(self, tmp_path):
+    def test_non_dict_entries_skipped(self, tmp_path):
+        from seedsigner.views.microsd_views import _load_known_checksums
         good = "a" * 64
         p = tmp_path / "mixed.json"
         p.write_text(json.dumps({
             "prefix_size": PREFIX_SIZE,
-            "images": {"bb": "just a string", good: {"name": "ok", "source_repo": "test", "size_bytes": PREFIX_SIZE, "sha256": good}},
+            "images": {"bb": "just a string", good: {"name": "ok", "source_repo": "test", "size_bytes": PREFIX_SIZE, "sha256": good, "volatile_offsets": [], "alt_prefix_hashes": []}},
         }), encoding="utf-8")
-        prefix_size, images = _load_known_checksums(p)
+        prefix_size, pristine, alt = _load_known_checksums(p)
         assert prefix_size == PREFIX_SIZE
-        assert images == {good: {"name": "ok", "source_repo": "test", "size_bytes": PREFIX_SIZE, "sha256": good}}
+        assert good in pristine
+        assert pristine[good]["name"] == "ok"
+
+    def test_dirty_prefix_in_alt_map(self, tmp_path):
+        """When alt prefixes exist, they should be reachable via the alt map."""
+        # Build a minimal JSON with one entry that has an alt prefix hash
+        fake_pristine = "b" * 64
+        fake_alt = "c" * 64
+        p = tmp_path / "with_alts.json"
+        p.write_text(json.dumps({
+            "prefix_size": PREFIX_SIZE,
+            "images": {
+                fake_pristine: {
+                    "name": "test",
+                    "source_repo": "test",
+                    "tag": "test",
+                    "size_bytes": PREFIX_SIZE,
+                    "sha256": fake_pristine,
+                    "volatile_offsets": [],
+                    "alt_prefix_hashes": [fake_alt],
+                }
+            },
+        }), encoding="utf-8")
+        from seedsigner.views.microsd_views import _load_known_checksums
+        prefix_size, pristine, alt = _load_known_checksums(p)
+        assert fake_pristine in pristine
+        assert fake_alt in alt
+        assert alt[fake_alt]["name"] == "test"
+
+
+class TestZeroVolatileInPlace:
+    def test_zeros_single_byte(self):
+        from seedsigner.views.microsd_views import _zero_volatile_in_place
+        buf = bytearray(b"abcdef")
+        _zero_volatile_in_place(buf, [3])
+        assert buf == b"abc\x00ef"
+
+    def test_zeros_multiple_offsets(self):
+        from seedsigner.views.microsd_views import _zero_volatile_in_place
+        buf = bytearray(b"abcdefgh")
+        _zero_volatile_in_place(buf, [1, 5])
+        assert buf == b"a\x00cde\x00gh"
+
+    def test_offsets_outside_range_ignored(self):
+        from seedsigner.views.microsd_views import _zero_volatile_in_place
+        buf = bytearray(b"abc")
+        _zero_volatile_in_place(buf, [10, 100])
+        assert buf == b"abc"
+
+    def test_zeros_with_offset_base(self):
+        from seedsigner.views.microsd_views import _zero_volatile_in_place
+        buf = bytearray(b"xyz")
+        _zero_volatile_in_place(buf, [10], buf_start=10)
+        assert buf == b"\x00yz"
+        _zero_volatile_in_place(buf, [11], buf_start=10)
+        assert buf == b"\x00\x00z"
 
 
 class TestFormatImageName:
     def test_strips_common_affixes(self):
+        from seedsigner.views.microsd_views import _format_image_name
         assert _format_image_name("seedsigner_os.0.8.5.pi0.img") == "0.8.5.pi0"
 
     def test_plain_name_kept(self):
+        from seedsigner.views.microsd_views import _format_image_name
         lines = _format_image_name("Zero Wiped (First 26MB)").split("\n")
         assert "".join(lines) == "Zero Wiped (First 26MB)"
 
     def test_fits_without_ellipsis(self):
+        from seedsigner.views.microsd_views import _format_image_name
         name = "seedsigner_os.SeSi-0.8.7_ShSi-B12_.pi0-smartcard.img"
         lines = _format_image_name(name).split("\n")
         assert len(lines) <= 3
@@ -109,6 +192,7 @@ class TestFormatImageName:
         assert not lines[-1].endswith("...")
 
     def test_overlong_name_truncated_with_ellipsis(self):
+        from seedsigner.views.microsd_views import _format_image_name
         name = "seedsigner_os." + "x" * 80 + ".img"
         lines = _format_image_name(name).split("\n")
         assert len(lines) == 3

--- a/tests/test_microsd_checksums.py
+++ b/tests/test_microsd_checksums.py
@@ -1,0 +1,94 @@
+"""
+Tests for the MicroSD known-checksums data file and its loader helpers.
+
+The json is maintained by .github/scripts/update_microsd_checksums.py (see
+.github/workflows/update-microsd-checksums.yml); these tests pin its shape,
+the zero-wiped marker, and coverage of the latest official release images
+(issue #410: verification silently broke when hashes stopped being updated).
+"""
+import hashlib
+import json
+
+# Import base FIRST: it installs the hardware/renderer mocks into sys.modules
+# before any seedsigner import (see tests/conftest.py single-identity note).
+import base  # noqa: F401
+
+from seedsigner.views.microsd_views import _load_known_checksums, _format_image_name
+
+ZERO_WIPED_HASH = "5809d4ec68138c737b1b000db4c6ec60983e94544efd893bdfa40ebf19af60f4"
+READ_BYTES = 26 * 1024 * 1024
+
+
+class TestKnownChecksums:
+    def test_bundled_file_loads(self):
+        known = _load_known_checksums()
+        assert len(known) > 0
+        for checksum, name in known.items():
+            assert len(checksum) == 64
+            assert all(c in "0123456789abcdef" for c in checksum)
+            assert isinstance(name, str) and name
+
+    def test_zero_wiped_entry_matches_26mib_of_zeros(self):
+        known = _load_known_checksums()
+        assert ZERO_WIPED_HASH in known
+        assert hashlib.sha256(b"\x00" * READ_BYTES).hexdigest() == ZERO_WIPED_HASH
+
+    def test_latest_official_release_covered(self):
+        names = list(_load_known_checksums().values())
+        v087 = [n for n in names if "0.8.7" in n]
+        assert len(v087) >= 4, f"official 0.8.7 images missing from known checksums: {v087}"
+
+    def test_bundled_file_is_valid_json_with_schema(self):
+        import seedsigner.views.microsd_views as mv
+        from pathlib import Path
+        path = Path(mv.__file__).parent.parent / "resources" / "microsd-known-checksums.json"
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+        assert isinstance(data["images"], dict)
+        for meta in data["images"].values():
+            assert isinstance(meta, dict)
+            assert meta.get("name")
+            assert "source_repo" in meta
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert _load_known_checksums(tmp_path / "nonexistent.json") == {}
+
+    def test_corrupt_file_returns_empty(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("{ this is not json", encoding="utf-8")
+        assert _load_known_checksums(bad) == {}
+
+    def test_non_dict_entries_are_skipped(self, tmp_path):
+        good = "a" * 64
+        p = tmp_path / "mixed.json"
+        p.write_text(json.dumps({"images": {"bb": "just a string", good: {"name": "ok"}}}), encoding="utf-8")
+        assert _load_known_checksums(p) == {good: "ok"}
+
+
+class TestFormatImageName:
+    def test_strips_common_affixes(self):
+        assert _format_image_name("seedsigner_os.0.8.5.pi0.img") == "0.8.5.pi0"
+
+    def test_plain_name_kept(self):
+        lines = _format_image_name("Zero Wiped (First 26MB)").split("\n")
+        assert "".join(lines) == "Zero Wiped (First 26MB)"
+
+    def test_fits_without_ellipsis(self):
+        name = "seedsigner_os.SeSi-0.8.7_ShSi-B12_.pi0-smartcard.img"
+        lines = _format_image_name(name).split("\n")
+        assert len(lines) <= 3
+        assert all(len(line) <= 20 for line in lines)
+        assert not lines[-1].endswith("...")
+
+    def test_real_long_name_fits_three_lines(self):
+        name = "seedsigner_os.SeSi-0.8.7_ShSi-B12-pre_.lafrite-smartcard-dev.img"
+        lines = _format_image_name(name).split("\n")
+        assert len(lines) == 3
+        assert all(len(line) <= 20 for line in lines)
+
+    def test_overlong_name_truncated_with_ellipsis(self):
+        name = "seedsigner_os." + "x" * 80 + ".img"
+        lines = _format_image_name(name).split("\n")
+        assert len(lines) == 3
+        assert all(len(line) <= 20 for line in lines)
+        assert lines[-1].endswith("...")


### PR DESCRIPTION
﻿Fixes #410.

The Verify MicroSD tool did a single 26 MiB fixed-size read with dd+sha256sum and looked the digest up in a hardcoded dict last updated at 0.8.5. The hashes were wrong for any image not exactly 26 MiB.

Implemented changes:

- Two-pass prefix lookup with FAT dirty-state tolerance. Pass 1a hashes the first 4 MiB as-is. If no match, pass 1b zeroes the 5-9 volatile bytes (dirty bit at 0x41, FSINFO fields at 0x1E8/0x1EC) inside the prefix buffer and re-hashes through each entry alt_prefix_hashes. The UI reports Matched Checksum (clean) vs Card Was Mounted (dirty).
- Full-file sha256 computed with volatile bytes zeroed throughout (streaming 1 MiB chunks, memory-safe for 1 GiB+ cards). No more dd or sha256sum subprocesses -- pure Python I/O.
- GPG-verified: official seedsigner releases verify sha256.txt against bundled Seedsigner_pubkey.asc (Keith Mukai 46739B74).
- JSON keyed by 4 MiB pristine prefix hash; volatile_offsets parsed from MBR; alt_prefix_hashes stores dirty variant; sha256 is the zeroed full-file hash.
- 132 entries covering official 0.6.0-0.8.7 (GPG-verified) plus fork builds plus zero-wiped marker. All hashes unique.
- Monthly automatic refresh via .github/workflows/update-microsd-checksums.yml.
- Real_screen flow test fixed: no longer fails on Windows (no sha256sum needed).

Tests: tests/test_microsd_checksums.py (22 tests) pins the JSON, zero-wiped entry, 0.8.7 coverage, collision-free uniqueness, volatile-offset bounds, corrupt-file fallback, dirty-path alt_map lookup, volatile-zeroing helpers, and name formatting. Full suite: 1662 passed, 26 failed (pre-existing GPG/l10n).
