### PR TITLE
ci: pass build_rust_from_source to the Luckfox build as a real boolean

### DIFF
--- a/.github/workflows/build-luckfox.yml
+++ b/.github/workflows/build-luckfox.yml
@@ -140,7 +140,7 @@ on:
         description: 'Build Rust toolchain from source (ignore cached binary). Use when updating the Rust version'
         required: false
         type: boolean
-        default: 'false'
+        default: false
       release_tag:
         description: Upload artifacts to a GitHub Release with this tag (leave empty to skip release upload)
         required: false
@@ -214,7 +214,12 @@ jobs:
       testing_build: ${{ github.event.inputs['testing-build'] }}
       seedsigner_repo_url: https://github.com/${{ github.event.inputs['app-repo'] }}
       seedsigner_branch: ${{ github.event.inputs['source-ref'] }}
-      build_rust_from_source: ${{ github.event.inputs['build-rust-from-source'] }}
+      # github.event.inputs values are ALWAYS strings, even for a boolean
+      # input -- an unchecked box is the string "false". The callee declares
+      # build_rust_from_source as type: boolean and tests it with
+      # `!= true`, so compare here to produce a real boolean. Passing the
+      # raw value fails input evaluation before any job starts.
+      build_rust_from_source: ${{ github.event.inputs['build-rust-from-source'] == 'true' }}
       seedsigner_os_repo: ${{ github.event.inputs['os-repo'] }}
       seedsigner_os_ref: ${{ github.event.inputs['os-ref'] }}
       release_tag: ${{ github.event.inputs.release_tag }}


### PR DESCRIPTION
## Description

### Problem or Issue being addressed

Every `workflow_dispatch` ("Run workflow") build of `build-luckfox.yml` has failed since #429 landed. The run dies in ~90s having never created a single job — e.g. [run 34169307485](https://github.com/3rdIteration/seedsigner/actions/runs/34169307485), a Pico Mini / SPI_NAND testing build:

```
load job template context: load reusable workflow context:
evaluate reusable workflow inputs:
.github/workflows/build-luckfox.yml (Line: 217, Col: 31): Unexpected value 'false'
```

Line 217 was the `build_rust_from_source` pass-through added in #429:

```yaml
build_rust_from_source: ${{ github.event.inputs['build-rust-from-source'] }}
```

`github.event.inputs.*` values are **always strings**, even for an input declared `type: boolean` — an unchecked box yields the string `"false"`. The reusable workflow `3rdIteration/seedsigner-os/.github/workflows/build-luckfox.yml@main` declares `build_rust_from_source` as a genuine `type: boolean` and consumes it strictly (`if: ${{ inputs.build_rust_from_source != true }}`), so the string was rejected while evaluating the called workflow's inputs. That happens at run-setup time, before any job template is created, which is why the whole run died and `ci-pico-mini` was left showing as `skipped`.

Automatic PR/push CI never caught this because only the `dispatch` job passes the input — `ci-pico-mini` doesn't — so the breakage sat unnoticed from 2026-09-04 until the next manual build.

### Solution

Compare against `'true'` so the expression yields a real boolean:

```yaml
build_rust_from_source: ${{ github.event.inputs['build-rust-from-source'] == 'true' }}
```

This is the same idiom `build-buildroot.yml` already uses for all of its boolean inputs (`github.event.inputs.dev == 'true'`, `upload-release == 'true'`, etc.). A comment records *why* it is load-bearing, so it doesn't get "simplified" back.

Also unquotes the input's own `default: 'false'` → `default: false`: a string default on a `type: boolean` input is the same category of mistake, though it is not what broke the run.

No change is needed in `seedsigner-os` — its input type is correct, and the fix belongs on the caller side.

### Additional Information

Verified by re-dispatching the identical build (Pico Mini / SPI_NAND / non-dev / testing-build on) from this branch: [run 34169987864](https://github.com/3rdIteration/seedsigner/actions/runs/34169987864). The `dispatch / Build (RV1103_Luckfox_Pico_Mini / SPI_NAND)` job is created and scheduled, where the pre-fix run produced no job at all. `ci-pico-mini` correctly skips on `workflow_dispatch`.

### Screenshots

N/A — CI configuration only, no UI changes.

---

This pull request is categorized as a:

- [ ] New feature
- [x] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

---

## Checklist

#### I ran `pytest` locally
- [ ] All tests passed before submitting the PR
- [ ] I couldn't run the tests
- [x] N/A

---

#### I included screenshots of any new or modified screens

Should be part of the PR description above.
- [ ] Yes
- [ ] No
- [x] N/A

---

#### I added or updated tests

Any new or altered functionality should be covered in a unit test. Any new or updated sequences require FlowTests.
- [ ] Yes
- [ ] No, I'm a fool
- [x] N/A

---

#### I tested this PR hands-on on the following platform(s):
- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/raspberry_pi_os_build_instructions.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Emulator

Tested on GitHub Actions itself — see the linked run above.

---

#### I have reviewed these notes:
- [x] I understand

🤖 Generated with [Claude Code](https://claude.com/claude-code)
