### PR TITLE
fix: multisig PSBT signing with Keycard/Satochip cards

### DIFF
--- a/src/seedsigner/helpers/keycard_signer.py
+++ b/src/seedsigner/helpers/keycard_signer.py
@@ -4,6 +4,7 @@ import os
 import random
 from concurrent.futures import TimeoutError
 
+from embit.ec import PublicKey
 from embit.psbt import PSBT
 
 from seedsigner.helpers.iso7816 import format_sw_error
@@ -25,7 +26,9 @@ def sign_psbt_with_keycard(psbt: PSBT, connector, timeout: float | None = None) 
 
     Keycard shells may reject pubkey export for arbitrary child paths with
     SW=6982. For single-derivation inputs, this signer falls back to path-based
-    signing by setting the connector's current derivation path directly.
+    signing by setting the connector's current derivation path directly. For
+    multi-derivation (multisig) inputs, each candidate path's public key is
+    exported and matched against the derivation's public key before signing.
 
     If ``timeout`` is passed it overrides the configured setting value.
 
@@ -81,31 +84,49 @@ def sign_psbt_with_keycard(psbt: PSBT, connector, timeout: float | None = None) 
                 getattr(deriv, "fingerprint", b"").hex() if getattr(deriv, "fingerprint", None) is not None else "unknown",
             )
 
-            # Keycard backend: path-based fallback for single-derivation inputs.
             if len(inp.bip32_derivations) == 1:
+                # Keycard backend: path-based fallback for single-derivation
+                # inputs. Some Keycard shells reject extended-key export for
+                # arbitrary child paths (SW=6982), so with a single derivation
+                # there is no ambiguity: sign at the claimed path directly.
+                setattr(connector, "_last_path", path)
+                matched_or_fallback = True
+                logger.info(
+                    "Keycard signer input %d: using path-sign fallback path=%s",
+                    i,
+                    path,
+                )
+            else:
+                # Multisig: the input carries a derivation per cosigner. Only
+                # the derivation whose public key the card reproduces at that
+                # path is ours to sign.
                 try:
-                    setattr(connector, "_last_path", path)
-                    matched_or_fallback = True
-                    logger.info(
-                        "Keycard signer input %d: using path-sign fallback path=%s",
-                        i,
-                        path,
-                    )
+                    key, _chaincode = connector.card_bip32_get_extendedkey(path)
+                    card_pub = PublicKey.parse(key.get_public_key_bytes(compressed=True))
                 except Exception as e:
                     logger.info(
-                        "Keycard signer input %d: path-sign fallback failed path=%s error=%s",
+                        "Keycard signer input %d: pubkey export failed path=%s error=%s",
                         i,
                         path,
                         e,
                     )
                     continue
-            else:
-                # For multi-derivation inputs we avoid guessing.
+                if card_pub != pubkey:
+                    logger.info(
+                        "Keycard signer input %d: pubkey mismatch path=%s",
+                        i,
+                        path,
+                    )
+                    continue
+                # card_bip32_get_extendedkey already navigated the card to this
+                # path; make _last_path authoritative for the sign below.
+                setattr(connector, "_last_path", path)
+                matched_or_fallback = True
                 logger.info(
-                    "Keycard signer input %d: skipping non-single-derivation input",
+                    "Keycard signer input %d: matched card pubkey path=%s",
                     i,
+                    path,
                 )
-                continue
 
             tx_hash = psbt.sighash(i)
             extra_sigs = random.randint(1, in_tx_dummy_max) if random.random() < dummy_prob else 0

--- a/src/seedsigner/views/psbt_views.py
+++ b/src/seedsigner/views/psbt_views.py
@@ -205,7 +205,10 @@ class PSBTSelectSeedView(View):
 
             if is_multisig_psbt:
                 try:
-                    parser = PSBTParser(psbt)
+                    parser = PSBTParser(
+                        psbt,
+                        network=self.settings.get_value(SettingsConstants.SETTING__NETWORK),
+                    )
                     parser.parse()
                 except Exception as e:
                     logger.exception("Failed to parse PSBT with %s data", card_label)

--- a/tests/test_flows_psbt.py
+++ b/tests/test_flows_psbt.py
@@ -360,6 +360,56 @@ class TestPSBTSatochip(FlowTest):
         assert controller.psbt_parser is None
         assert controller.psbt_sign_with_satochip is False
 
+    def test_multisig_card_parser_uses_configured_network(self, monkeypatch):
+        """
+        A multisig PSBT signed with a smartcard (Satochip or Keycard) must be parsed
+        with the configured network rather than the parser's mainnet default. On a
+        non-mainnet network the wrong HRP silently rewrites every address shown on
+        screen (e.g. tb1q... -> bc1q...), so the parser's network and the rendered
+        destination address are both asserted here.
+        """
+        import base64
+
+        from seedsigner.views import scan_views, psbt_views
+        from seedsigner.views.view import MainMenuView
+        from seedsigner.helpers import seedkeeper_utils
+
+        psbt = PSBT.parse(a2b_base64(PSBTTestData.MULTISIG_NATIVE_SEGWIT_1_INPUT))
+        psbt.outputs.append(create_output(PSBTTestData.MULTISIG_NATIVE_SEGWIT_RECEIVE))
+        psbt_b64 = base64.b64encode(psbt.serialize()).decode()
+
+        def load_psbt_into_decoder(view: scan_views.ScanView):
+            view.decoder.add_data(psbt_b64)
+
+        class MockCard:
+            needs_2FA = False
+
+        monkeypatch.setattr(seedkeeper_utils, "init_satochip", lambda *args, **kwargs: MockCard())
+
+        controller = Controller.get_instance()
+        controller.storage.seeds = []
+        controller.psbt_parser = None
+        controller.psbt_sign_with_satochip = False
+
+        # Network on testnet -> addresses must render as tb1...
+        self.settings.set_value(SettingsConstants.SETTING__NETWORK, SettingsConstants.TESTNET)
+        self.settings.set_value(
+            SettingsConstants.SETTING__SATOCHIP_SUPPORT,
+            SettingsConstants.OPTION__ENABLED,
+        )
+
+        self.run_sequence([
+            FlowStep(MainMenuView, button_data_selection=MainMenuView.SCAN),
+            FlowStep(scan_views.ScanView, before_run=load_psbt_into_decoder),
+            FlowStep(psbt_views.PSBTSelectSeedView, button_data_selection=psbt_views.PSBTSelectSeedView.SATOCHIP),
+        ])
+
+        parser = controller.psbt_parser
+        assert parser is not None
+        assert parser.network == SettingsConstants.TESTNET
+        assert parser.is_multisig
+        assert parser.destination_addresses and parser.destination_addresses[0].startswith("tb1")
+
 
 class TestPSBTMultisigDescriptorMismatch(BaseTest):
 

--- a/tests/test_keycard_sign_psbt.py
+++ b/tests/test_keycard_sign_psbt.py
@@ -58,3 +58,109 @@ def test_sign_psbt_with_keycard_path_fallback_single_derivation(monkeypatch):
     assert not result.timed_out
     assert getattr(connector, "_last_path", None) == "m/84'/0'/0'/0/0"
     assert psbt.inputs[0].partial_sigs[pub].endswith(b"\x01")
+
+
+class _DummyKey:
+    def __init__(self, pub):
+        self._pub = pub
+
+    def get_public_key_bytes(self, compressed=True):
+        return self._pub
+
+
+class DummyMultisigKeycardConnector(DummyKeycardConnector):
+    """A Keycard whose key lives at exactly one of the input's derivations."""
+
+    def __init__(self, card_pubkey, card_path):
+        super().__init__()
+        self.card_pubkey = card_pubkey
+        self.card_path = card_path
+
+    def card_bip32_get_extendedkey(self, path):
+        if path == self.card_path:
+            return _DummyKey(self.card_pubkey), b""
+        raise Exception("pubkey export rejected")
+
+
+def test_sign_psbt_with_keycard_multisig_matches_card_pubkey(monkeypatch):
+    """
+    A multisig input carries a derivation per cosigner. The Keycard signer must
+    sign the one derivation whose public key the card reproduces, rather than
+    skipping the whole input (the pre-fix behaviour that made multisig signing
+    silently do nothing).
+    """
+    psbt = PSBT()
+    psbt.inputs = [InputScope()]
+
+    # Three cosigners on the same input, only the middle one is on the card.
+    card_priv = PrivateKey(bytes([9]) * 32)
+    card_pub = card_priv.get_public_key()
+    other_a = PrivateKey(bytes([7]) * 32).get_public_key()
+    other_b = PrivateKey(bytes([8]) * 32).get_public_key()
+
+    card_path = "m/48'/1'/0'/2'/0/0"
+    psbt.inputs[0].bip32_derivations[other_a] = DerivationPath(
+        b"\x00" * 4, [0x80000030, 0x80000001, 0x80000000, 0x80000002, 0, 0]
+    )
+    psbt.inputs[0].bip32_derivations[card_pub] = DerivationPath(
+        b"\x00" * 4, [0x80000030, 0x80000001, 0x80000000, 0x80000002, 0, 0]
+    )
+    psbt.inputs[0].bip32_derivations[other_b] = DerivationPath(
+        b"\x00" * 4, [0x80000030, 0x80000001, 0x80000000, 0x80000002, 0, 0]
+    )
+
+    psbt.sighash = types.MethodType(
+        lambda self, idx, sighash=None: bytes([idx]) * 32,
+        psbt,
+    )
+
+    connector = DummyMultisigKeycardConnector(card_pub.sec(), card_path)
+    monkeypatch.setattr(Settings, "get_instance", classmethod(lambda cls: DummySettings()))
+    random.seed(0)
+
+    result = sign_psbt_with_keycard(psbt, connector)
+
+    assert result.signed_count == 1
+    assert not result.timed_out
+    # The signature must be attached to the card's own pubkey, not a cosigner's.
+    assert card_pub in psbt.inputs[0].partial_sigs
+    assert other_a not in psbt.inputs[0].partial_sigs
+    assert other_b not in psbt.inputs[0].partial_sigs
+    assert getattr(connector, "_last_path", None) == card_path
+    assert psbt.inputs[0].partial_sigs[card_pub].endswith(b"\x01")
+
+
+def test_sign_psbt_with_keycard_multisig_skips_when_no_pubkey_matches(monkeypatch):
+    """
+    If the card cannot reproduce any of the input's cosigner pubkeys, nothing
+    is signed for that input (no guessing).
+    """
+    psbt = PSBT()
+    psbt.inputs = [InputScope()]
+
+    other_a = PrivateKey(bytes([7]) * 32).get_public_key()
+    other_b = PrivateKey(bytes([8]) * 32).get_public_key()
+    card_pub = PrivateKey(bytes([9]) * 32).get_public_key()
+
+    psbt.inputs[0].bip32_derivations[other_a] = DerivationPath(
+        b"\x00" * 4, [0x80000030, 0x80000001, 0x80000000, 0x80000002, 0, 0]
+    )
+    psbt.inputs[0].bip32_derivations[other_b] = DerivationPath(
+        b"\x00" * 4, [0x80000030, 0x80000001, 0x80000000, 0x80000002, 0, 0]
+    )
+
+    psbt.sighash = types.MethodType(
+        lambda self, idx, sighash=None: bytes([idx]) * 32,
+        psbt,
+    )
+
+    # The card's key is at a path that isn't claimed by any derivation.
+    connector = DummyMultisigKeycardConnector(card_pub.sec(), "m/48'/1'/0'/2'/9/9")
+    monkeypatch.setattr(Settings, "get_instance", classmethod(lambda cls: DummySettings()))
+    random.seed(0)
+
+    result = sign_psbt_with_keycard(psbt, connector)
+
+    assert result.signed_count == 0
+    assert not psbt.inputs[0].partial_sigs
+


### PR DESCRIPTION
## Summary

Fixes two bugs that prevented multisig PSBT signing with a smartcard signer on non-mainnet networks. Both affected Keycard and Satochip (they share the smartcard multisig path in `PSBTSelectSeedView`).

## Bug 1: wrong address HRP on testnet (bc1q... instead of tb1q...)

The multisig card flow in `PSBTSelectSeedView` created the `PSBTParser` without passing `network`, so it defaulted to mainnet. On testnet every address rendered with the mainnet HRP (e.g. a tb1q... recipient showed as bc1q...) and did not match what the coordinator (Sparrow) showed.

**Fix:** pass the configured network when pre-parsing the PSBT in the multisig card path.

## Bug 2: "Approve transaction" did nothing on multisig

`sign_psbt_with_keycard` skipped any input with more than one `bip32_derivations` entry — which is every multisig input (one derivation per cosigner). The card therefore never produced a signature, `PSBTFinalizeView` detected no new signatures, and the screen just flipped back to itself.

**Fix:** for multi-derivation inputs, export each candidate path's public key from the card and match it against the derivation's public key, then sign only the matching derivation (same pubkey-matching approach the Satochip signer already uses). Single-derivation inputs keep the existing path-sign fallback.

## Tests

- `tests/test_keycard_sign_psbt.py`: multisig input signs the card's own cosigner pubkey (not a cosigner's); signs nothing when no pubkey matches.
- `tests/test_flows_psbt.py`: the smartcard multisig flow parses with the configured network and renders `tb1...` addresses on testnet.

Regression check: `test_psbt_parser.py`, `test_psbt_test_suite.py`, `test_flows_psbt.py`, and the card-signer suites all pass.